### PR TITLE
Handle unresolved types for types from Java symbols.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
@@ -34,27 +35,27 @@ class ErrorTypeProcessor : AbstractTestProcessor() {
         val classC = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C"))!!
         val errorAtTop = classC.declarations.single { it.simpleName.asString() == "errorAtTop" } as KSPropertyDeclaration
         val errorInComponent = classC.declarations.single { it.simpleName.asString() == "errorInComponent" } as KSPropertyDeclaration
-        result.add(errorAtTop.type?.resolve()?.print() ?: "")
-        result.add(errorInComponent.type?.resolve()?.print() ?: "")
-        errorInComponent.type!!.resolve()!!.arguments.map { result.add(it.type!!.resolve()!!.print()) }
+        result.add(errorAtTop.type.resolve().print() ?: "")
+        result.add(errorInComponent.type.resolve().print() ?: "")
+        errorInComponent.type.resolve().arguments.map { result.add(it.type!!.resolve().print()) }
         result.add(
             "errorInComponent is assignable from errorAtTop: ${
-                errorAtTop.type!!.resolve()!!.isAssignableFrom(errorAtTop.type!!.resolve()!!)
+                errorAtTop.type.resolve().isAssignableFrom(errorAtTop.type.resolve())
             }"
         )
         result.add(
             "errorInComponent is assignable from class C: ${
-                errorAtTop.type!!.resolve()!!.isAssignableFrom(classC.asStarProjectedType())
+                errorAtTop.type.resolve().isAssignableFrom(classC.asStarProjectedType())
             }"
         )
         result.add(
             "Any is assignable from errorInComponent: ${
-                ResolverImpl.instance.builtIns.anyType.isAssignableFrom(errorAtTop.type!!.resolve()!!)
+                ResolverImpl.instance.builtIns.anyType.isAssignableFrom(errorAtTop.type.resolve())
             }"
         )
         result.add(
             "class C is assignable from errorInComponent: ${
-                classC.asStarProjectedType().isAssignableFrom(errorAtTop.type!!.resolve()!!)
+                classC.asStarProjectedType().isAssignableFrom(errorAtTop.type.resolve())
             }"
         )
         result.add(
@@ -62,6 +63,9 @@ class ErrorTypeProcessor : AbstractTestProcessor() {
                 ResolverImpl.instance.builtIns.anyType.isAssignableFrom(classC.asStarProjectedType())
             }"
         )
+        val Cls = resolver.getClassDeclarationByName("Cls")!!
+        val type = Cls.superTypes[0].resolve()
+        result.add("Cls's super type is Error type: ${type.isError}")
     }
 
     private fun KSType.print(): String {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -23,8 +23,11 @@ import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.binary.KSClassDeclarationDescriptorImpl
 import com.google.devtools.ksp.symbol.impl.binary.KSClassifierReferenceDescriptorImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.toLocation
+import org.jetbrains.kotlin.descriptors.NotFoundClasses
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.Variance
 
@@ -87,7 +90,10 @@ class KSTypeReferenceJavaImpl private constructor(val psi: PsiType) : KSTypeRefe
     }
 
     override fun resolve(): KSType {
-        return ResolverImpl.instance.resolveUserType(this)
+        val resolvedType = ResolverImpl.instance.resolveUserType(this)
+        return if ((resolvedType.declaration as? KSClassDeclarationDescriptorImpl)?.descriptor is NotFoundClasses.MockClassDescriptor) {
+            KSErrorType
+        } else resolvedType
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/testData/api/allFunctions.kt
+++ b/compiler-plugin/testData/api/allFunctions.kt
@@ -45,8 +45,8 @@
 // indexOf(kotlin.Number): kotlin.Int
 // isEmpty(): kotlin.Boolean
 // iterator(): kotlin.collections.Iterator
-// javaListFun(): Collection
 // javaListFun(): kotlin.collections.List
+// javaListFun(): kotlin.collections.MutableCollection
 // javaPrivateFun(): kotlin.Unit
 // javaStrFun(): kotlin.String
 // javaStrFun(): kotlin.String
@@ -84,6 +84,8 @@ data class Data(val a: String) {
 }
 
 // FILE: C.java
+import java.util.Collection;
+
 class C {
     public int aFromC = 1;
     private int bFromC = 2;
@@ -92,7 +94,7 @@ class C {
 
     }
 
-    protected Collection<Int> javaListFun() {
+    protected Collection<Integer> javaListFun() {
         return Arrays.asList(1,2,3)
     }
 

--- a/compiler-plugin/testData/api/errorTypes.kt
+++ b/compiler-plugin/testData/api/errorTypes.kt
@@ -27,9 +27,16 @@
 // Any is assignable from errorInComponent: false
 // class C is assignable from errorInComponent: false
 // Any is assignable from class C: true
+// Cls's super type is Error type: true
 // END
 // FILE: a.kt
 class C {
     val errorAtTop = mutableMapOf<String, NonExistType>()
     val errorInComponent: Map<String, NonExistType>
+}
+
+// FILE: Cls.java
+
+public class Cls extends NonExistType {
+
 }


### PR DESCRIPTION
KotlinType is making such error type into a flexible type, need to
check if the declaration of the bounds of this flexible type is an
instance of NotFoundClasses.MockClassDescriptor.

It might be a temporary workaround as it appears to be `resolveJavaType()` not handling all error types, could have something to do with the `JavaType` construction before delegating to compiler API.