### PR TITLE
Enhance document on KSPropertyAccessor on how to get full annotations for an accessor

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
@@ -20,6 +20,8 @@ package com.google.devtools.ksp.symbol
 
 /**
  * The common base of property getter and setter.
+ * Note that annotation use-site targets such as @get: @set: is not copied to accessor's annotations attribute.
+ * Use KSAnnotated.findAnnotationFromUseSiteTarget() to ensure annotations from parent is obtained.
  */
 interface KSPropertyAccessor : KSAnnotated, KSModifierListOwner {
     /**


### PR DESCRIPTION
related issue: #97 

Actually, I am not sure if this is the right way to document it. Use-site target is more than just accessors, and only documenting accessors seems not full coverage. But some use-site targets doesn't really have a place in Kotlin, such as `@field` .

We do already have documentation on `KSAnnotated.findAnnotationFromUseSiteTarget()` in utils, but I admit it is not very straightforward to find when it comes to its desired use case.

cc @yigit