### PR TITLE
Refactor override checking API, fix override checking for property accessors from Java.

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -75,4 +75,12 @@ interface Resolver {
      * map a declaration to jvm signature.
      */
     fun mapToJvmSignature(declaration: KSDeclaration): String
+
+    /**
+     * @param overrider the candidate overriding declaration being checked.
+     * @param overridee the candidate overridden declaration being checked.
+     * @return boolean value indicating whether [overrider] overrides [overridee]
+     * Calling [overrides] is expensive and should be avoided if possible.
+     */
+    fun overrides(overrider: KSDeclaration, overridee: KSDeclaration): Boolean
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -52,14 +52,6 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
     val parameters: List<KSValueParameter>
 
     /**
-     * Checks if this function overrides another function.
-     * @param overridee the candidate overridden function being checked.
-     * @return boolean value indicating whether this function overrides [overridee]
-     * Calling [overrides] is expensive and should be avoided if possible.
-     */
-    fun overrides(overridee: KSFunctionDeclaration): Boolean
-
-    /**
      * Find the original overridee of this function, if overriding.
      * @return [KSFunctionDeclaration] for the original function, if overriding, otherwise null.
      * Calling [findOverridee] is expensive and should be avoided if possible.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -58,14 +58,6 @@ interface KSPropertyDeclaration : KSDeclaration {
     fun isDelegated(): Boolean
 
     /**
-     * Checks if this property overrides another property.
-     * @param overridee the candidate overridden property being checked.
-     * @return boolean value indicating whether this function overrides [overridee]
-     * Calling [overrides] is expensive and should be avoided if possible.
-     */
-    fun overrides(overridee: KSPropertyDeclaration): Boolean
-
-    /**
      * Find the original overridee of this property, if overriding.
      * @return [KSPropertyDeclaration] for the original property, if overriding, otherwise null.
      * Calling [findOverridee] is expensive and should be avoided if possible.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -45,13 +45,13 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         val baz2PropKt = resolver.getSymbolsWithAnnotation("Baz2Anno").single() as KSPropertyDeclaration
         val bazzPropKt = resolver.getSymbolsWithAnnotation("BazzAnno").single() as KSPropertyDeclaration
         val bazz2PropKt = resolver.getSymbolsWithAnnotation("Bazz2Anno").single() as KSPropertyDeclaration
-        results.add("${getFunKt.qualifiedName?.asString()} overrides ${getFunJava.qualifiedName?.asString()}: ${getFunKt.overrides(getFunJava)}")
-        results.add("${fooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${fooFunKt.overrides(fooFunJava)}")
-        results.add("${foooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${foooFunKt.overrides(fooFunJava)}")
-        results.add("${equalFunKt.qualifiedName?.asString()} overrides ${equalFunJava.qualifiedName?.asString()}: ${equalFunKt.overrides(equalFunJava)}")
-        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${bazPropKt.overrides(baz2PropKt)}")
-        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${bazPropKt.overrides(bazz2PropKt)}")
-        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${bazzPropKt.overrides(bazz2PropKt)}")
-        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${bazzPropKt.overrides(baz2PropKt)}")
+        results.add("${getFunKt.qualifiedName?.asString()} overrides ${getFunJava.qualifiedName?.asString()}: ${resolver.overrides(getFunKt,getFunJava)}")
+        results.add("${fooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${resolver.overrides(fooFunKt,fooFunJava)}")
+        results.add("${foooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${resolver.overrides(foooFunKt,fooFunJava)}")
+        results.add("${equalFunKt.qualifiedName?.asString()} overrides ${equalFunJava.qualifiedName?.asString()}: ${resolver.overrides(equalFunKt,equalFunJava)}")
+        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazPropKt,baz2PropKt)}")
+        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazPropKt,bazz2PropKt)}")
+        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazzPropKt,bazz2PropKt)}")
+        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazzPropKt,baz2PropKt)}")
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -18,9 +18,11 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
@@ -32,6 +34,9 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
+        fun checkOverride(overrider: KSDeclaration, overridee: KSDeclaration) {
+            results.add("${overrider.qualifiedName?.asString()} overrides ${overridee.qualifiedName?.asString()}: ${resolver.overrides(overrider, overridee)}")
+        }
         val javaList = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaList")) as KSClassDeclaration
         val kotlinList = resolver.getClassDeclarationByName(resolver.getKSNameFromString("KotlinList")) as KSClassDeclaration
         val getFunKt = resolver.getSymbolsWithAnnotation("GetAnno").single() as KSFunctionDeclaration
@@ -45,13 +50,24 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         val baz2PropKt = resolver.getSymbolsWithAnnotation("Baz2Anno").single() as KSPropertyDeclaration
         val bazzPropKt = resolver.getSymbolsWithAnnotation("BazzAnno").single() as KSPropertyDeclaration
         val bazz2PropKt = resolver.getSymbolsWithAnnotation("Bazz2Anno").single() as KSPropertyDeclaration
-        results.add("${getFunKt.qualifiedName?.asString()} overrides ${getFunJava.qualifiedName?.asString()}: ${resolver.overrides(getFunKt,getFunJava)}")
-        results.add("${fooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${resolver.overrides(fooFunKt,fooFunJava)}")
-        results.add("${foooFunKt.qualifiedName?.asString()} overrides ${fooFunJava.qualifiedName?.asString()}: ${resolver.overrides(foooFunKt,fooFunJava)}")
-        results.add("${equalFunKt.qualifiedName?.asString()} overrides ${equalFunJava.qualifiedName?.asString()}: ${resolver.overrides(equalFunKt,equalFunJava)}")
-        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazPropKt,baz2PropKt)}")
-        results.add("${bazPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazPropKt,bazz2PropKt)}")
-        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${bazz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazzPropKt,bazz2PropKt)}")
-        results.add("${bazzPropKt.qualifiedName?.asString()} overrides ${baz2PropKt.qualifiedName?.asString()}: ${resolver.overrides(bazzPropKt,baz2PropKt)}")
+        checkOverride(getFunKt,getFunJava)
+        checkOverride(fooFunKt,fooFunJava)
+        checkOverride(foooFunKt,fooFunJava)
+        checkOverride(equalFunKt,equalFunJava)
+        checkOverride(bazPropKt,baz2PropKt)
+        checkOverride(bazPropKt,bazz2PropKt)
+        checkOverride(bazzPropKt,bazz2PropKt)
+        checkOverride(bazzPropKt,baz2PropKt)
+        val JavaImpl = resolver.getClassDeclarationByName("JavaImpl")!!
+        val MyInterface = resolver.getClassDeclarationByName("MyInterface")!!
+        val getX = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getX" }
+        val getY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getY" }
+        val setY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setY" }
+        val myInterfaceX = MyInterface.declarations.first{ it.simpleName.asString() == "x" }
+        val myInterfaceY = MyInterface.declarations.first{ it.simpleName.asString() == "y" }
+        checkOverride(getY, getX)
+        checkOverride(getY, myInterfaceX)
+        checkOverride(getX, myInterfaceX)
+        checkOverride(setY, myInterfaceY)
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -43,17 +43,6 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
             ?.toKSFunctionDeclaration()
     }
 
-    override fun overrides(overridee: KSFunctionDeclaration): Boolean {
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        val superDescriptor = ResolverImpl.instance.resolveFunctionDeclaration(overridee) ?: return false
-        return OverridingUtil.DEFAULT.isOverridableBy(
-            superDescriptor, descriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override val typeParameters: List<KSTypeParameter> by lazy {
         descriptor.typeParameters.map { KSTypeParameterDescriptorImpl.getCached(it) }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -82,19 +82,6 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
     }
 
-    override fun overrides(overridee: KSPropertyDeclaration): Boolean {
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        if (overridee.origin == Origin.JAVA)
-            return false
-        val superDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(overridee) ?: return false
-        return OverridingUtil.DEFAULT.isOverridableBy(
-                superDescriptor, descriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override fun findOverridee(): KSPropertyDeclaration? {
         return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
             ?.toKSPropertyDeclaration()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -56,18 +56,6 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
             ?.toKSFunctionDeclaration()
     }
 
-    override fun overrides(overridee: KSFunctionDeclaration): Boolean {
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        val superDescriptor = ResolverImpl.instance.resolveFunctionDeclaration(overridee) ?: return false
-        val subDescriptor = ResolverImpl.instance.resolveJavaDeclaration(psi) as? FunctionDescriptor ?: return false
-        return OverridingUtil.DEFAULT.isOverridableBy(
-            superDescriptor, subDescriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override val declarations: List<KSDeclaration> = emptyList()
 
     override val extensionReceiver: KSTypeReference? = null

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -75,10 +75,6 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
         KSTypeReferenceJavaImpl.getCached(psi.type)
     }
 
-    override fun overrides(overridee: KSPropertyDeclaration): Boolean {
-        return false
-    }
-
     override fun findOverridee(): KSPropertyDeclaration? {
         return null
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -41,20 +41,6 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
             ?.toKSFunctionDeclaration()
     }
 
-    override fun overrides(overridee: KSFunctionDeclaration): Boolean {
-        if (!this.modifiers.contains(Modifier.OVERRIDE))
-            return false
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        val superDescriptor = ResolverImpl.instance.resolveFunctionDeclaration(overridee) ?: return false
-        val subDescriptor = ResolverImpl.instance.resolveDeclaration(ktFunction) as FunctionDescriptor
-        return OverridingUtil.DEFAULT.isOverridableBy(
-            superDescriptor, subDescriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override val declarations: List<KSDeclaration> by lazy {
         if (!ktFunction.hasBlockBody()) {
             emptyList()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -103,22 +103,6 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
 
     override fun isDelegated(): Boolean = ktProperty.hasDelegate()
 
-    override fun overrides(overridee: KSPropertyDeclaration): Boolean {
-        if (!this.modifiers.contains(Modifier.OVERRIDE))
-            return false
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        if (overridee.origin == Origin.JAVA)
-            return false
-        val superDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(overridee) ?: return false
-        val subDescriptor = ResolverImpl.instance.resolveDeclaration(ktProperty) as PropertyDescriptor
-        return OverridingUtil.DEFAULT.isOverridableBy(
-                superDescriptor, subDescriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override fun findOverridee(): KSPropertyDeclaration? {
         return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
             ?.toKSPropertyDeclaration()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -82,22 +82,6 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
             ?.toKSPropertyDeclaration()
     }
 
-    override fun overrides(overridee: KSPropertyDeclaration): Boolean {
-        if (!this.modifiers.contains(Modifier.OVERRIDE))
-            return false
-        if (!overridee.isOpen())
-            return false
-        if (!overridee.isVisibleFrom(this))
-            return false
-        if (overridee.origin == Origin.JAVA)
-            return false
-        val superDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(overridee) ?: return false
-        val subDescriptor = ResolverImpl.instance.resolveDeclaration(ktParameter) as PropertyDescriptor
-        return OverridingUtil.DEFAULT.isOverridableBy(
-            superDescriptor, subDescriptor, null
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
-    }
-
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyDeclaration(this, data)
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
@@ -72,8 +72,6 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
 
     override val origin: Origin = Origin.SYNTHETIC
 
-    override fun overrides(overridee: KSFunctionDeclaration): Boolean = false
-
     override fun findOverridee(): KSFunctionDeclaration? = null
 
     override fun findActuals(): List<KSDeclaration> {

--- a/compiler-plugin/testData/api/checkOverride.kt
+++ b/compiler-plugin/testData/api/checkOverride.kt
@@ -25,6 +25,10 @@
 // KotlinList2.baz overrides KotlinList.bazz: false
 // KotlinList2.bazz overrides KotlinList.bazz: true
 // KotlinList2.bazz overrides KotlinList.baz: false
+// JavaImpl.getY overrides JavaImpl.getX: false
+// JavaImpl.getY overrides MyInterface.x: false
+// JavaImpl.getX overrides MyInterface.x: true
+// JavaImpl.setY overrides MyInterface.y: true
 // END
 // FILE: a.kt
 
@@ -74,6 +78,11 @@ class KotlinList2(@BazzAnno override val bazz: Int = 2): KotlinList() {
     }
 }
 
+interface MyInterface {
+    val x: Int
+    var y: Int
+}
+
 // FILE: JavaList.java
 
 import java.util.*;
@@ -86,5 +95,21 @@ public class JavaList extends List<String> {
 
     protected int foo() {
         return 1;
+    }
+}
+
+// FILE: JavaImpl.java
+
+public class JavaImpl implements MyInterface {
+    public int getX() {
+        return 1;
+    }
+
+    public int getY() {
+        return 1;
+    }
+
+    public void setY(int value) {
+
     }
 }


### PR DESCRIPTION
Although Java does not have property concept, Kotlin compiler still generate for them for certain functions obeying naming convention.