### PR TITLE
Check for type hierarchy while checking overrides

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -53,21 +53,36 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         checkOverride(getFunKt,getFunJava)
         checkOverride(fooFunKt,fooFunJava)
         checkOverride(foooFunKt,fooFunJava)
+        checkOverride(fooFunKt,fooFunKt)
         checkOverride(equalFunKt,equalFunJava)
         checkOverride(bazPropKt,baz2PropKt)
         checkOverride(bazPropKt,bazz2PropKt)
         checkOverride(bazzPropKt,bazz2PropKt)
         checkOverride(bazzPropKt,baz2PropKt)
+        checkOverride(bazPropKt,bazPropKt)
         val JavaImpl = resolver.getClassDeclarationByName("JavaImpl")!!
         val MyInterface = resolver.getClassDeclarationByName("MyInterface")!!
         val getX = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getX" }
         val getY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getY" }
         val setY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setY" }
+        val setX = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setX" }
         val myInterfaceX = MyInterface.declarations.first{ it.simpleName.asString() == "x" }
         val myInterfaceY = MyInterface.declarations.first{ it.simpleName.asString() == "y" }
         checkOverride(getY, getX)
         checkOverride(getY, myInterfaceX)
         checkOverride(getX, myInterfaceX)
         checkOverride(setY, myInterfaceY)
+        checkOverride(setX, myInterfaceX)
+        checkOverride(getY, getY)
+        checkOverride(myInterfaceX, getY)
+        checkOverride(myInterfaceX, getX)
+        checkOverride(myInterfaceY, setY)
+        checkOverride(myInterfaceY, myInterfaceY)
+
+        val JavaDifferentReturnTypes =
+            resolver.getClassDeclarationByName("JavaDifferentReturnType")!!
+        val diffGetX = JavaDifferentReturnTypes.getDeclaredFunctions()
+            .first { it.simpleName.asString() == "foo" }
+        checkOverride(diffGetX, fooFunJava)
     }
 }

--- a/compiler-plugin/testData/api/checkOverride.kt
+++ b/compiler-plugin/testData/api/checkOverride.kt
@@ -20,15 +20,24 @@
 // KotlinList.get overrides JavaList.get: false
 // KotlinList.foo overrides JavaList.foo: true
 // KotlinList.fooo overrides JavaList.foo: false
+// KotlinList.foo overrides KotlinList.foo: false
 // KotlinList.equals overrides JavaList.equals: true
 // KotlinList2.baz overrides KotlinList.baz: true
 // KotlinList2.baz overrides KotlinList.bazz: false
 // KotlinList2.bazz overrides KotlinList.bazz: true
 // KotlinList2.bazz overrides KotlinList.baz: false
+// KotlinList2.baz overrides KotlinList2.baz: false
 // JavaImpl.getY overrides JavaImpl.getX: false
 // JavaImpl.getY overrides MyInterface.x: false
 // JavaImpl.getX overrides MyInterface.x: true
 // JavaImpl.setY overrides MyInterface.y: true
+// JavaImpl.setX overrides MyInterface.x: false
+// JavaImpl.getY overrides JavaImpl.getY: false
+// MyInterface.x overrides JavaImpl.getY: false
+// MyInterface.x overrides JavaImpl.getX: false
+// MyInterface.y overrides JavaImpl.setY: false
+// MyInterface.y overrides MyInterface.y: false
+// JavaDifferentReturnType.foo overrides JavaList.foo: true
 // END
 // FILE: a.kt
 
@@ -111,5 +120,18 @@ public class JavaImpl implements MyInterface {
 
     public void setY(int value) {
 
+    }
+
+    // intentional override check for a val property
+    public void setX(int value) {
+        return value;
+    }
+}
+
+// FILE: JavaDifferentReturnType.java
+public abstract class JavaDifferentReturnType extends JavaList {
+    // intentional different return type
+    protected String foo() {
+        return "";
     }
 }


### PR DESCRIPTION
This PR fixes a bug where override would return `true` if base method is sent as the overrider.
Similarly, it was also returning true when override is called with the same function itself.

I've also changed the override util call to also check for return type.

Fixes: #123