### PR TITLE
fix property backing field annotations

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -1,0 +1,84 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+    override fun toResult() = results
+
+    override fun process(resolver: Resolver) {
+        // NOTE: There are two cases this test ignores.
+        // a) For property annotations with target, they get added to the property getter/setter whereas it would show
+        //    on the property if it was in kotlin source. This test ignores it by using the property name as key for
+        //    property getters/setters
+        // b) When an annotation without a target is used in a constructor (with field), that annotation is not copied
+        //    to the backing field for .class files. The assertion line in test ignores it (see the NoTargetAnnotation
+        //    output difference for the DataClass)
+        addToResults(resolver, "main.KotlinClass")
+        addToResults(resolver, "lib.KotlinClass")
+        addToResults(resolver, "main.DataClass")
+        addToResults(resolver, "lib.DataClass")
+    }
+
+    private fun addToResults(resolver: Resolver, qName: String) {
+        results.add("$qName ->")
+        val collected = collectAnnotations(resolver, qName)
+        val signatures = collected.flatMap {(annotated, annotations) ->
+            val annotatedSignature = annotated.toSignature()
+            annotations.map {
+                "$annotatedSignature : ${it.toSignature()}"
+            }
+        }.sorted()
+        results.addAll(signatures)
+    }
+
+    private fun collectAnnotations(resolver: Resolver, qName: String) : Map<KSAnnotated, List<KSAnnotation>> {
+        val output = mutableMapOf<KSAnnotated, List<KSAnnotation>>()
+        resolver.getClassDeclarationByName(qName)?.accept(
+            AnnotationVisitor(),
+            output
+        )
+        return output
+    }
+
+    private fun KSAnnotated.toSignature(): String {
+        return when(this) {
+            is KSClassDeclaration -> (qualifiedName ?: simpleName).asString()
+            is KSDeclaration -> simpleName.asString()
+            is KSValueParameter -> name?.asString() ?: "no-name-value-parameter"
+            is KSPropertyAccessor -> receiver.toSignature()
+            else -> {
+                error("unexpected annotated")
+            }
+        }
+    }
+
+    private fun KSAnnotation.toSignature(): String {
+        val type = this.annotationType.resolve().declaration.let {
+            (it.qualifiedName ?: it.simpleName).asString()
+        }
+        val args = this.arguments.map {
+            "[${it.name?.asString()} = ${it.value}]"
+        }.joinToString(",")
+        return "$type{$args}"
+    }
+
+    class AnnotationVisitor : KSTopDownVisitor<MutableMap<KSAnnotated, List<KSAnnotation>>, Unit>() {
+        override fun defaultHandler(node: KSNode, data: MutableMap<KSAnnotated, List<KSAnnotation>>) {
+        }
+
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableMap<KSAnnotated, List<KSAnnotation>>) {
+            if (annotated.annotations.isNotEmpty()) {
+                data[annotated] = annotated.annotations
+            }
+            super.visitAnnotated(annotated, data)
+        }
+
+        override fun visitTypeReference(typeReference: KSTypeReference, data: MutableMap<KSAnnotated, List<KSAnnotation>>) {
+            // don't traverse type references
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -19,15 +19,9 @@
 package com.google.devtools.ksp.symbol.impl.binary
 
 import org.jetbrains.kotlin.descriptors.*
-import com.google.devtools.ksp.isOpen
-import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
-import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
-import org.jetbrains.kotlin.resolve.OverridingUtil
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 
 class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: PropertyDescriptor) : KSPropertyDeclaration,
     KSDeclarationDescriptorImpl(descriptor),
@@ -42,6 +36,15 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         } else {
             null
         }
+    }
+
+    override val annotations: List<KSAnnotation> by lazy {
+        // annotations on backing field will not visible in the property declaration so we query it directly to load
+        // its annotations as well.
+        val backingFieldAnnotations = descriptor.backingField?.annotations?.map {
+            KSAnnotationDescriptorImpl.getCached(it)
+        }.orEmpty()
+        super.annotations + backingFieldAnnotations
     }
 
     override val isMutable: Boolean by lazy {

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -42,6 +42,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/allFunctions.kt");
     }
 
+    @TestMetadata("annotationInDependencies.kt")
+    public void testAnnotationsInDependencies() throws Exception {
+        runTest("testData/api/annotationInDependencies.kt");
+    }
+
     @TestMetadata("annotationValue.kt")
     public void testAnnotationValue() throws Exception {
         runTest("testData/api/annotationValue.kt");

--- a/compiler-plugin/testData/api/annotationInDependencies.kt
+++ b/compiler-plugin/testData/api/annotationInDependencies.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: AnnotationsInDependenciesProcessor
+// EXPECTED:
+// main.KotlinClass ->
+// main.KotlinClass : annotations.ClassTarget{[value = onClass]}
+// main.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
+// myFun : annotations.FunctionTarget{[value = onMyFun]}
+// myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
+// param1 : annotations.NoTargetAnnotation{[value = onParam1]}
+// param1 : annotations.ValueParameterTarget{[value = onParam1]}
+// param2 : annotations.NoTargetAnnotation{[value = onParam2]}
+// param2 : annotations.ValueParameterTarget{[value = onParam2]}
+// prop : annotations.FieldTarget2{[value = field:]}
+// prop : annotations.FieldTarget{[value = onProp]}
+// prop : annotations.NoTargetAnnotation{[value = onProp]}
+// prop : annotations.PropertyGetterTarget{[value = get:]}
+// prop : annotations.PropertySetterTarget{[value = set:]}
+// prop : annotations.PropertyTarget{[value = onProp]}
+// lib.KotlinClass ->
+// lib.KotlinClass : annotations.ClassTarget{[value = onClass]}
+// lib.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
+// myFun : annotations.FunctionTarget{[value = onMyFun]}
+// myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
+// param1 : annotations.NoTargetAnnotation{[value = onParam1]}
+// param1 : annotations.ValueParameterTarget{[value = onParam1]}
+// param2 : annotations.NoTargetAnnotation{[value = onParam2]}
+// param2 : annotations.ValueParameterTarget{[value = onParam2]}
+// prop : annotations.FieldTarget2{[value = field:]}
+// prop : annotations.FieldTarget{[value = onProp]}
+// prop : annotations.NoTargetAnnotation{[value = onProp]}
+// prop : annotations.PropertyGetterTarget{[value = get:]}
+// prop : annotations.PropertySetterTarget{[value = set:]}
+// prop : annotations.PropertyTarget{[value = onProp]}
+// main.DataClass ->
+// constructorParam : annotations.FieldTarget2{[value = field:]}
+// constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
+// constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
+// constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// constructorParam : annotations.PropertySetterTarget{[value = set:]}
+// constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
+// main.DataClass : annotations.ClassTarget{[value = onDataClass]}
+// main.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// lib.DataClass ->
+// constructorParam : annotations.FieldTarget2{[value = field:]}
+// constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
+// constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// constructorParam : annotations.PropertySetterTarget{[value = set:]}
+// constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
+// lib.DataClass : annotations.ClassTarget{[value = onDataClass]}
+// lib.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// END
+// MODULE: annotations
+// FILE: Annotations.kt
+package annotations;
+annotation class NoTargetAnnotation(val value:String)
+
+@Target(AnnotationTarget.FIELD)
+annotation class FieldTarget(val value:String)
+
+@Target(AnnotationTarget.FIELD)
+annotation class FieldTarget2(val value:String)
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class PropertyTarget(val value:String)
+
+@Target(AnnotationTarget.PROPERTY_SETTER)
+annotation class PropertySetterTarget(val value:String)
+
+@Target(AnnotationTarget.PROPERTY_GETTER)
+annotation class PropertyGetterTarget(val value:String)
+
+@Target(AnnotationTarget.CLASS)
+annotation class ClassTarget(val value:String)
+
+@Target(AnnotationTarget.FUNCTION)
+annotation class FunctionTarget(val value:String)
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+annotation class ValueParameterTarget(val value:String)
+// MODULE: lib(annotations)
+// FILE: ClassInLib.kt
+package lib;
+import annotations.*;
+@NoTargetAnnotation("onClass")
+@ClassTarget("onClass")
+class KotlinClass {
+    @NoTargetAnnotation("onProp")
+    @FieldTarget("onProp")
+    @PropertyTarget("onProp")
+    @set:PropertySetterTarget("set:")
+    @get:PropertyGetterTarget("get:")
+    @field:FieldTarget2("field:")
+    var prop : String = ""
+
+    @NoTargetAnnotation("onMyFun")
+    @FunctionTarget("onMyFun")
+    fun myFun(
+        @NoTargetAnnotation("onParam1")
+        @ValueParameterTarget("onParam1")
+        param1: String,
+        @NoTargetAnnotation("onParam2")
+        @ValueParameterTarget("onParam2")
+        param2: Int
+    ) {
+    }
+}
+
+@NoTargetAnnotation("onDataClass")
+@ClassTarget("onDataClass")
+class DataClass(
+    @NoTargetAnnotation("onConstructorParam")
+    @FieldTarget("onConstructorParam")
+    @PropertyTarget("onConstructorParam")
+    @set:PropertySetterTarget("set:")
+    @get:PropertyGetterTarget("get:")
+    @field:FieldTarget2("field:")
+    var constructorParam : String = ""
+)
+// FILE: lib/JavaClass.java
+package lib;
+import annotations.*;
+public class JavaClass {}
+// MODULE: main(lib, annotations)
+// FILE: ClassInModule2.kt
+package main;
+import annotations.*;
+@NoTargetAnnotation("onClass")
+@ClassTarget("onClass")
+class KotlinClass {
+    @NoTargetAnnotation("onProp")
+    @FieldTarget("onProp")
+    @PropertyTarget("onProp")
+    @set:PropertySetterTarget("set:")
+    @get:PropertyGetterTarget("get:")
+    @field:FieldTarget2("field:")
+    var prop : String = ""
+
+    @NoTargetAnnotation("onMyFun")
+    @FunctionTarget("onMyFun")
+    fun myFun(
+        @NoTargetAnnotation("onParam1")
+        @ValueParameterTarget("onParam1")
+        param1: String,
+        @NoTargetAnnotation("onParam2")
+        @ValueParameterTarget("onParam2")
+        param2: Int
+    ) {
+    }
+}
+
+@NoTargetAnnotation("onDataClass")
+@ClassTarget("onDataClass")
+class DataClass(
+    @NoTargetAnnotation("onConstructorParam")
+    @FieldTarget("onConstructorParam")
+    @PropertyTarget("onConstructorParam")
+    @set:PropertySetterTarget("set:")
+    @get:PropertyGetterTarget("get:")
+    @field:FieldTarget2("field:")
+    var constructorParam : String = ""
+)
+// FILE: main/JavaClassInModule2.java
+pakage main;
+import annotations.*;
+@NoTargetAnnotation
+class JavaClassInMain {
+}


### PR DESCRIPTION
This commit fixes an issue where KSP would drop annotations
on properties if the property is read from a compiled code and
the annotation has field target. I fixed it by also reading
annotations on the backing field for compiled classes.

Unfortunately, the way KSP reports a kotlin class coming from
source vs compiled code is still not the same. In compiled code,
annotations that target getter/setters are reported via the generated
synthetic in .class files vs they are reported on the property in
source files.

So added tests with data class and changed the test to
ignore the difference between getting a targeted annotation
on a property vs on its getter/setter.

We might want to change it going forward but either case it would probably
be difficult to distinguish. This is luckily is not the case for field
targeting annotations as they will only be visible in backing field which
is not visible in .class files.

cleanup