### PR TITLE
Add APIs to get JVM names of functions and property accessors

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/KspExperimental.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/KspExperimental.kt
@@ -3,4 +3,4 @@ package com.google.devtools.ksp
 @RequiresOptIn(message = "This API is experimental." +
     "It may be changed in the future without notice or might be removed.")
 @Retention(AnnotationRetention.BINARY)
-annotation class KspExperimental // Opt-in requirement annotation
+annotation class KspExperimental

--- a/api/src/main/kotlin/com/google/devtools/ksp/KspExperimental.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/KspExperimental.kt
@@ -1,0 +1,6 @@
+package com.google.devtools.ksp
+
+@RequiresOptIn(message = "This API is experimental." +
+    "It may be changed in the future without notice or might be removed.")
+@Retention(AnnotationRetention.BINARY)
+annotation class KspExperimental // Opt-in requirement annotation

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -147,10 +147,10 @@ interface Resolver {
      *
      * Note that this might be different from the name declared in the Kotlin source code in two cases:
      * a) If the function receives or returns an internal class, its name will be mangled according to
-     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling
+     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling.
      * b) If the function is declared as internal, it will include a suffix with the module name.
      *
-     * NOTE: As inline classes are an experimental feature, the result of this function might changed based on the
+     * NOTE: As inline classes are an experimental feature, the result of this function might change based on the
      * kotlin version used in the project.
      */
     fun getJvmName(declaration: KSFunctionDeclaration): String
@@ -162,10 +162,10 @@ interface Resolver {
      * https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties.
      * Note that the result of this function might be different from that name in two cases:
      * a) If the property's type is an internal class, accessor's name will be mangled according to
-     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling
+     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling.
      * b) If the function is declared as internal, it will include a suffix with the module name.
      *
-     * NOTE: As inline classes are an experimental feature, the result of this function might changed based on the
+     * NOTE: As inline classes are an experimental feature, the result of this function might change based on the
      * kotlin version used in the project.
      * see: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties
      */

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -145,8 +145,12 @@ interface Resolver {
     /**
      * Returns the jvm name of the given function.
      *
+     * The jvm name of a function might depend on the Kotlin Compiler version hence it is not guaranteed to be
+     * compatible between different compiler versions except for the rules outlined in the Java interoperability
+     * documentation: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html.
+     *
      * Note that this might be different from the name declared in the Kotlin source code in two cases:
-     * a) If the function receives or returns an internal class, its name will be mangled according to
+     * a) If the function receives or returns an inline class, its name will be mangled according to
      * https://kotlinlang.org/docs/reference/inline-classes.html#mangling.
      * b) If the function is declared as internal, it will include a suffix with the module name.
      *
@@ -157,6 +161,10 @@ interface Resolver {
 
     /**
      * Returns the jvm name of the given property accessor.
+     *
+     * The jvm name of an accessor might depend on the Kotlin Compiler version hence it is not guaranteed to be
+     * compatible between different compiler versions except for the rules outlined in the Java interoperability
+     * documentation: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html.
      *
      * By default, this name will match the name calculated according to
      * https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties.

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -143,10 +143,31 @@ interface Resolver {
     ): KSFunction
 
     /**
-     * Returns the mangled name for the given name.
-     * Returns the declared name if no mangling is necessary.
+     * Returns the jvm name of the given function.
+     *
+     * Note that this might be different from the name declared in the Kotlin source code in two cases:
+     * a) If the function receives or returns an internal class, its name will be mangled according to
+     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling
+     * b) If the function is declared as internal, it will include a suffix with the module name.
+     *
+     * NOTE: As inline classes are an experimental feature, the result of this function might changed based on the
+     * kotlin version used in the project.
      */
     fun getJvmName(declaration: KSFunctionDeclaration): String
 
+    /**
+     * Returns the jvm name of the given property accessor.
+     *
+     * By default, this name will match the name calculated according to
+     * https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties.
+     * Note that the result of this function might be different from that name in two cases:
+     * a) If the property's type is an internal class, accessor's name will be mangled according to
+     * https://kotlinlang.org/docs/reference/inline-classes.html#mangling
+     * b) If the function is declared as internal, it will include a suffix with the module name.
+     *
+     * NOTE: As inline classes are an experimental feature, the result of this function might changed based on the
+     * kotlin version used in the project.
+     * see: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties
+     */
     fun getJvmName(accessor: KSPropertyAccessor): String
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.processing
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.symbol.*
 
 /**
@@ -74,6 +75,7 @@ interface Resolver {
     /**
      * map a declaration to jvm signature.
      */
+    @KspExperimental
     fun mapToJvmSignature(declaration: KSDeclaration): String
 
     /**
@@ -159,6 +161,7 @@ interface Resolver {
      * NOTE: As inline classes are an experimental feature, the result of this function might change based on the
      * kotlin version used in the project.
      */
+    @KspExperimental
     fun getJvmName(declaration: KSFunctionDeclaration): String
 
     /**
@@ -181,5 +184,6 @@ interface Resolver {
      * kotlin version used in the project.
      * see: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties
      */
+    @KspExperimental
     fun getJvmName(accessor: KSPropertyAccessor): String
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -141,4 +141,12 @@ interface Resolver {
         function: KSFunctionDeclaration,
         containing: KSType
     ): KSFunction
+
+    /**
+     * Returns the mangled name for the given name.
+     * Returns the declared name if no mangling is necessary.
+     */
+    fun getJvmName(declaration: KSFunctionDeclaration): String
+
+    fun getJvmName(accessor: KSPropertyAccessor): String
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -149,6 +149,8 @@ interface Resolver {
      * compatible between different compiler versions except for the rules outlined in the Java interoperability
      * documentation: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html.
      *
+     * If the [declaration] is annotated with [JvmName], that name will be returned from this function.
+     *
      * Note that this might be different from the name declared in the Kotlin source code in two cases:
      * a) If the function receives or returns an inline class, its name will be mangled according to
      * https://kotlinlang.org/docs/reference/inline-classes.html#mangling.
@@ -165,6 +167,8 @@ interface Resolver {
      * The jvm name of an accessor might depend on the Kotlin Compiler version hence it is not guaranteed to be
      * compatible between different compiler versions except for the rules outlined in the Java interoperability
      * documentation: https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html.
+     *
+     * If the [accessor] is annotated with [JvmName], that name will be returned from this function.
      *
      * By default, this name will match the name calculated according to
      * https://kotlinlang.org/docs/reference/java-to-kotlin-interop.html#properties.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.processing.impl
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.isOpen
 import com.google.devtools.ksp.isVisibleFrom
@@ -232,6 +233,7 @@ class ResolverImpl(
         return KSTypeReferenceSyntheticImpl.getCached(type)
     }
 
+    @KspExperimental
     override fun mapToJvmSignature(declaration: KSDeclaration): String {
         return when (declaration) {
             is KSClassDeclaration -> resolveClassDeclaration(declaration)?.let { typeMapper.mapType(it).descriptor } ?: ""
@@ -485,6 +487,7 @@ class ResolverImpl(
         }
     }
 
+    @KspExperimental
     override fun getJvmName(accessor: KSPropertyAccessor) :String {
         val descriptor = resolvePropertyAccessorDeclaration(accessor)
 
@@ -494,6 +497,7 @@ class ResolverImpl(
         } ?: error("Cannot find descriptor for $accessor")
     }
 
+    @KspExperimental
     override fun getJvmName(declaration: KSFunctionDeclaration) :String {
         // function names might be mangled if they receive inline class parameters or they are internal
         val descriptor = resolveFunctionDeclaration(declaration)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -494,7 +494,7 @@ class ResolverImpl(
     }
 
     override fun getJvmName(declaration: KSFunctionDeclaration) :String {
-        // function names might be mangled if they receive inline class parameters
+        // function names might be mangled if they receive inline class parameters or they are internal
         val descriptor = resolveFunctionDeclaration(declaration)
         return descriptor?.let {
             typeMapper.mapFunctionName(descriptor, declaration.findOwnerKind())

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -489,16 +489,18 @@ class ResolverImpl(
         val descriptor = resolvePropertyAccessorDeclaration(accessor)
 
         return descriptor?.let {
-            typeMapper.mapFunctionName(descriptor, accessor.receiver.findOwnerKind())
-        } ?: TODO("?")
+            // KotlinTypeMapper.mapSignature always uses OwnerKind.IMPLEMENTATION
+            typeMapper.mapFunctionName(descriptor, OwnerKind.IMPLEMENTATION)
+        } ?: error("Cannot find descriptor for $accessor")
     }
 
     override fun getJvmName(declaration: KSFunctionDeclaration) :String {
         // function names might be mangled if they receive inline class parameters or they are internal
         val descriptor = resolveFunctionDeclaration(declaration)
         return descriptor?.let {
-            typeMapper.mapFunctionName(descriptor, declaration.findOwnerKind())
-        } ?: declaration.simpleName.asString()
+            // KotlinTypeMapper.mapSignature always uses OwnerKind.IMPLEMENTATION
+            typeMapper.mapFunctionName(descriptor, OwnerKind.IMPLEMENTATION)
+        } ?: error("Cannot find descriptor for $declaration")
     }
 
     override fun getTypeArgument(typeRef: KSTypeReference, variance: Variance): KSTypeArgument {
@@ -656,14 +658,6 @@ private fun KotlinType.createTypeSubstitutor(): NewTypeSubstitutor {
     return SubstitutionUtils.buildDeepSubstitutor(this).toNewSubstitutor()
 }
 
-private fun KSDeclaration.findOwnerKind() : OwnerKind {
-    val containingClass = closestClassDeclaration()
-    return if (containingClass == null) {
-        OwnerKind.PACKAGE
-    } else {
-        OwnerKind.IMPLEMENTATION
-    }
-}
 /**
  * Extracts the identifier from a module Name.
  *

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
@@ -10,6 +11,8 @@ import com.google.devtools.ksp.symbol.KSPropertySetter
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
+@KspExperimental
+@Suppress("unused") // used by the test code
 class MangledNamesProcessor : AbstractTestProcessor() {
     private val results = mutableListOf<String>()
     override fun toResult() = results

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
@@ -47,6 +47,7 @@ class MangledNamesProcessor : AbstractTestProcessor() {
                 // do not visit inline classes
                 return
             }
+            // put a header for readable output
             data[classDeclaration.qualifiedName!!.asString()] = "declarations"
             super.visitClassDeclaration(classDeclaration, data)
         }
@@ -68,6 +69,7 @@ class MangledNamesProcessor : AbstractTestProcessor() {
         }
 
         companion object {
+            // do not report these functions as they are generated only in byte code and do not affect the test.
             val IGNORED_FUNCTIONS = listOf("equals", "hashCode", "toString")
         }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
@@ -1,0 +1,49 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyAccessor
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class MangledNamesProcessor : AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+    override fun toResult() = results
+
+    override fun process(resolver: Resolver) {
+        val mangledNames = mutableMapOf<String, String>()
+        resolver.getAllFiles().forEach {
+            it.accept(MangledNamesVisitor(resolver), mangledNames)
+        }
+        results.addAll(
+            mangledNames.entries.map {(decl, name) ->
+                "${decl} -> $name"
+            }
+        )
+    }
+
+    private class MangledNamesVisitor(
+        val resolver: Resolver
+    ) : KSTopDownVisitor<MutableMap<String, String>, Unit>() {
+        override fun defaultHandler(node: KSNode, data: MutableMap<String, String>) {
+
+        }
+
+        override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: MutableMap<String, String>) {
+            super.visitFunctionDeclaration(function, data)
+            data[function.simpleName.asString()] = resolver.getJvmName(function)
+        }
+
+        override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: MutableMap<String, String>) {
+            super.visitPropertyAccessor(accessor, data)
+            val key = if (accessor is KSPropertySetter) {
+                "set-${accessor.receiver.simpleName.asString()}"
+            } else {
+                "get-${accessor.receiver.simpleName.asString()}"
+            }
+            data[key] = resolver.getJvmName(accessor)
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -18,9 +18,11 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 
+@KspExperimental
 class MapSignatureProcessor : AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -132,6 +132,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/makeNullable.kt");
     }
 
+    @TestMetadata("mangledNames.kt")
+    public void testMangledNames() throws Exception {
+        runTest("testData/api/mangledNames.kt");
+    }
+
     @TestMetadata(("multipleModules.kt"))
     public void testMultipleModules() throws Exception {
         runTest("testData/api/multipleModules.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
@@ -134,7 +134,6 @@ abstract class AbstractKotlinKSPTest : KotlinBaseTest<AbstractKotlinKSPTest.KspT
         } else {
             GenerationUtils.compileFilesTo(moduleFiles.psiFiles, environment, outDir)
         }
-        println(outDir)
     }
 
     /**

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
@@ -134,6 +134,7 @@ abstract class AbstractKotlinKSPTest : KotlinBaseTest<AbstractKotlinKSPTest.KspT
         } else {
             GenerationUtils.compileFilesTo(moduleFiles.psiFiles, environment, outDir)
         }
+        println(outDir)
     }
 
     /**

--- a/compiler-plugin/testData/api/mangledNames.kt
+++ b/compiler-plugin/testData/api/mangledNames.kt
@@ -18,41 +18,82 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: MangledNamesProcessor
 // EXPECTED:
-// get-value -> getValue
-// get-name -> getName
-// get-inlineProp -> getInlineProp-uW2R4Lc
-// get-internalProp -> getInternalProp$myModuleName
-// get-internalInlineProp -> getInternalInlineProp-uW2R4Lc$myModuleName
+// mainPackage.Foo -> declarations
+// get-normalProp -> getNormalProp
+// set-normalProp -> setNormalProp
+// get-inlineProp -> getInlineProp-HRn7Rpw
+// set-inlineProp -> setInlineProp-E03SJzc
+// get-internalProp -> getInternalProp$mainModule
+// set-internalProp -> setInternalProp$mainModule
+// get-internalInlineProp -> getInternalInlineProp-HRn7Rpw$mainModule
+// set-internalInlineProp -> setInternalInlineProp-E03SJzc$mainModule
 // normalFun -> normalFun
-// inlineReceivingFun -> inlineReceivingFun-9XlVjhY
-// inlineReturningFun -> inlineReturningFun-uW2R4Lc
+// inlineReceivingFun -> inlineReceivingFun-E03SJzc
+// inlineReturningFun -> inlineReturningFun-HRn7Rpw
+// internalInlineReceivingFun -> internalInlineReceivingFun-E03SJzc$mainModule
+// internalInlineReturningFun -> internalInlineReturningFun-HRn7Rpw$mainModule
+// fileLevelInternalFun -> fileLevelInternalFun
+// fileLevelInlineReceivingFun -> fileLevelInlineReceivingFun-E03SJzc
+// fileLevelInlineReturningFun -> fileLevelInlineReturningFun
+// fileLevelInternalInlineReceivingFun -> fileLevelInternalInlineReceivingFun-E03SJzc
+// fileLevelInternalInlineReturningFun -> fileLevelInternalInlineReturningFun
+// libPackage.Foo -> declarations
+// get-inlineProp -> getInlineProp-b_MPbnQ
+// set-inlineProp -> setInlineProp-mQ73O9w
+// get-internalInlineProp -> getInternalInlineProp-b_MPbnQ$lib
+// set-internalInlineProp -> setInternalInlineProp-mQ73O9w$lib
+// get-internalProp -> getInternalProp$lib
+// set-internalProp -> setInternalProp$lib
+// get-normalProp -> getNormalProp
+// set-normalProp -> setNormalProp
+// inlineReceivingFun -> inlineReceivingFun-mQ73O9w
+// inlineReturningFun -> inlineReturningFun-b_MPbnQ
+// internalInlineReceivingFun -> internalInlineReceivingFun-mQ73O9w$lib
+// internalInlineReturningFun -> internalInlineReturningFun-b_MPbnQ$lib
+// normalFun -> normalFun
 // END
 // MODULE: lib
 // FILE: input.kt
 /**
  * control group
  */
-package foo.bar;
+package libPackage;
 inline class Inline1(val value:String)
 class Foo {
-    val name:String = TODO()
-    val inlineProp: Inline1 = TODO()
-    internal val internalProp: String = TODO()
-    internal val internalInlineProp: Inline1 = TODO()
+    var normalProp:String = TODO()
+    var inlineProp: Inline1 = TODO()
+    internal var internalProp: String = TODO()
+    internal var internalInlineProp: Inline1 = TODO()
     fun normalFun() {}
     fun inlineReceivingFun(value: Inline1) {}
     fun inlineReturningFun(): Inline1 = TODO()
+    internal fun internalInlineReceivingFun(value: Inline1) {}
+    internal fun internalInlineReturningFun(): Inline1 = TODO()
 }
-// MODULE: myModuleName
+
+internal fun fileLevelInternalFun(): Unit = TODO()
+fun fileLevelInlineReceivingFun(inline1: Inline1): Unit = TODO()
+fun fileLevelInlineReturningFun(): Inline1 = TODO()
+fun fileLevelInternalInlineReceivingFun(inline1: Inline1): Unit = TODO()
+fun fileLevelInternalInlineReturningFun(): Inline1 = TODO()
+// MODULE: mainModule(lib)
 // FILE: input.kt
-package foo.bar;
+package mainPackage;
 inline class Inline1(val value:String)
 class Foo {
-    val name:String = TODO()
-    val inlineProp: Inline1 = TODO()
-    internal val internalProp: String = TODO()
-    internal val internalInlineProp: Inline1 = TODO()
+    var normalProp:String = TODO()
+    var inlineProp: Inline1 = TODO()
+    internal var internalProp: String = TODO()
+    internal var internalInlineProp: Inline1 = TODO()
     fun normalFun() {}
     fun inlineReceivingFun(value: Inline1) {}
     fun inlineReturningFun(): Inline1 = TODO()
+    internal fun internalInlineReceivingFun(value: Inline1) {}
+    internal fun internalInlineReturningFun(): Inline1 = TODO()
 }
+
+internal fun fileLevelInternalFun(): Unit = TODO()
+fun fileLevelInlineReceivingFun(inline1: Inline1): Unit = TODO()
+fun fileLevelInlineReturningFun(): Inline1 = TODO()
+fun fileLevelInternalInlineReceivingFun(inline1: Inline1): Unit = TODO()
+fun fileLevelInternalInlineReturningFun(): Inline1 = TODO()

--- a/compiler-plugin/testData/api/mangledNames.kt
+++ b/compiler-plugin/testData/api/mangledNames.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: MangledNamesProcessor
+// EXPECTED:
+// get-value -> getValue
+// get-name -> getName
+// get-inlineProp -> getInlineProp-uW2R4Lc
+// get-internalProp -> getInternalProp$myModuleName
+// get-internalInlineProp -> getInternalInlineProp-uW2R4Lc$myModuleName
+// normalFun -> normalFun
+// inlineReceivingFun -> inlineReceivingFun-9XlVjhY
+// inlineReturningFun -> inlineReturningFun-uW2R4Lc
+// END
+// MODULE: lib
+// FILE: input.kt
+/**
+ * control group
+ */
+package foo.bar;
+inline class Inline1(val value:String)
+class Foo {
+    val name:String = TODO()
+    val inlineProp: Inline1 = TODO()
+    internal val internalProp: String = TODO()
+    internal val internalInlineProp: Inline1 = TODO()
+    fun normalFun() {}
+    fun inlineReceivingFun(value: Inline1) {}
+    fun inlineReturningFun(): Inline1 = TODO()
+}
+// MODULE: myModuleName
+// FILE: input.kt
+package foo.bar;
+inline class Inline1(val value:String)
+class Foo {
+    val name:String = TODO()
+    val inlineProp: Inline1 = TODO()
+    internal val internalProp: String = TODO()
+    internal val internalInlineProp: Inline1 = TODO()
+    fun normalFun() {}
+    fun inlineReceivingFun(value: Inline1) {}
+    fun inlineReturningFun(): Inline1 = TODO()
+}

--- a/compiler-plugin/testData/api/mangledNames.kt
+++ b/compiler-plugin/testData/api/mangledNames.kt
@@ -71,11 +71,6 @@ class Foo {
     internal fun internalInlineReturningFun(): Inline1 = TODO()
 }
 
-internal fun fileLevelInternalFun(): Unit = TODO()
-fun fileLevelInlineReceivingFun(inline1: Inline1): Unit = TODO()
-fun fileLevelInlineReturningFun(): Inline1 = TODO()
-fun fileLevelInternalInlineReceivingFun(inline1: Inline1): Unit = TODO()
-fun fileLevelInternalInlineReturningFun(): Inline1 = TODO()
 // MODULE: mainModule(lib)
 // FILE: input.kt
 package mainPackage;

--- a/compiler-plugin/testData/api/mangledNames.kt
+++ b/compiler-plugin/testData/api/mangledNames.kt
@@ -27,7 +27,10 @@
 // set-internalProp -> setInternalProp$mainModule
 // get-internalInlineProp -> getInternalInlineProp-HRn7Rpw$mainModule
 // set-internalInlineProp -> setInternalInlineProp-E03SJzc$mainModule
+// get-jvmNameProp -> explicitGetterName
+// set-jvmNameProp -> explicitSetterName
 // normalFun -> normalFun
+// hasJvmName -> explicitJvmName
 // inlineReceivingFun -> inlineReceivingFun-E03SJzc
 // inlineReturningFun -> inlineReturningFun-HRn7Rpw
 // internalInlineReceivingFun -> internalInlineReceivingFun-E03SJzc$mainModule
@@ -44,8 +47,11 @@
 // set-internalInlineProp -> setInternalInlineProp-mQ73O9w$lib
 // get-internalProp -> getInternalProp$lib
 // set-internalProp -> setInternalProp$lib
+// get-jvmNameProp -> explicitGetterName
+// set-jvmNameProp -> explicitSetterName
 // get-normalProp -> getNormalProp
 // set-normalProp -> setNormalProp
+// hasJvmName -> explicitJvmName
 // inlineReceivingFun -> inlineReceivingFun-mQ73O9w
 // inlineReturningFun -> inlineReturningFun-b_MPbnQ
 // internalInlineReceivingFun -> internalInlineReceivingFun-mQ73O9w$lib
@@ -64,7 +70,12 @@ class Foo {
     var inlineProp: Inline1 = TODO()
     internal var internalProp: String = TODO()
     internal var internalInlineProp: Inline1 = TODO()
+    @get:JvmName("explicitGetterName")
+    @set:JvmName("explicitSetterName")
+    var jvmNameProp:String
     fun normalFun() {}
+    @JvmName("explicitJvmName")
+    fun hasJvmName() {}
     fun inlineReceivingFun(value: Inline1) {}
     fun inlineReturningFun(): Inline1 = TODO()
     internal fun internalInlineReceivingFun(value: Inline1) {}
@@ -80,7 +91,12 @@ class Foo {
     var inlineProp: Inline1 = TODO()
     internal var internalProp: String = TODO()
     internal var internalInlineProp: Inline1 = TODO()
+    @get:JvmName("explicitGetterName")
+    @set:JvmName("explicitSetterName")
+    var jvmNameProp:String
     fun normalFun() {}
+    @JvmName("explicitJvmName")
+    fun hasJvmName() {}
     fun inlineReceivingFun(value: Inline1) {}
     fun inlineReturningFun(): Inline1 = TODO()
     internal fun internalInlineReceivingFun(value: Inline1) {}


### PR DESCRIPTION
This PR adds a new API `getJvmName` to get the jvm name of a method or accessor.

This is crucial for annotation processors that generate java source code as they might need to access internal methods in the same module compilation (as it works w/ KAPT).

Fixes #129