### PR TITLE
Fix java annotation name parsing

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -29,9 +29,11 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
     val visitor = ArgumentVisitor()
 
     override fun process(resolver: Resolver) {
-        val symbol = resolver.getSymbolsWithAnnotation("Bar").single()
-        val annotation = (symbol as KSClassDeclaration).annotations.single()
-        annotation.arguments.map { it.accept(visitor, Unit) }
+        resolver.getSymbolsWithAnnotation("Bar").forEach {
+            val annotation = it.annotations.single()
+            annotation.arguments.map { it.accept(visitor, Unit) }
+        }
+
         val C = resolver.getClassDeclarationByName("C")!!
         C.annotations.first().arguments.map { results.add(it.value.toString()) }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
@@ -42,8 +42,7 @@ class AnnotationArrayValueProcessor : AbstractTestProcessor() {
             result.add("${annotation.shortName.asString()} ->")
             annotation.arguments.forEach {
                 val value = it.value
-                // log type of value as well. see issue:#135
-                val key = "${it.name?.asString()}: ${value!!::class.simpleName}"
+                val key = it.name?.asString()
                 if (value is Array<*>) {
                     result.add("$key = [${value.joinToString(", ")}]")
                 } else {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+class AnnotationArrayValueProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver) {
+        val ktClass = resolver.getClassDeclarationByName("KotlinAnnotated")!!
+        logAnnotations(ktClass)
+        val javaClass = resolver.getClassDeclarationByName("JavaAnnotated")!!
+        logAnnotations(javaClass)
+    }
+
+    private fun logAnnotations(classDeclaration: KSClassDeclaration) {
+        result.add(classDeclaration.qualifiedName!!.asString())
+        classDeclaration.annotations.forEach { annotation ->
+            result.add("${annotation.shortName.asString()} ->")
+            annotation.arguments.forEach {
+                val value = it.value
+                // log type of value as well. see issue:#135
+                val key = "${it.name?.asString()}: ${value!!::class.simpleName}"
+                if (value is Array<*>) {
+                    result.add("$key = [${value.joinToString(", ")}]")
+                } else {
+                    result.add("$key = ${it.value}")
+                }
+            }
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValueProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValueProcessor.kt
@@ -19,6 +19,7 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 
 class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
     val result = mutableListOf<String>()
@@ -29,14 +30,14 @@ class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
 
     override fun process(resolver: Resolver) {
         val ktClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("A"))!!
-        var ktAnno = ktClass.annotations[0]
-        var javaAnno = ktClass.annotations[1]
-        result.add("${ktAnno.shortName.asString()} -> ${ktAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
-        result.add("${javaAnno.shortName.asString()} -> ${javaAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        logAnnotations(ktClass)
         val javaClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaAnnotated"))!!
-        ktAnno = javaClass.annotations[0]
-        javaAnno = javaClass.annotations[1]
-        result.add("${ktAnno.shortName.asString()} -> ${ktAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
-        result.add("${javaAnno.shortName.asString()} -> ${javaAnno.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        logAnnotations(javaClass)
+    }
+
+    private fun logAnnotations(classDeclaration: KSClassDeclaration) {
+        classDeclaration.annotations.forEach { annotation ->
+            result.add("${annotation.shortName.asString()} -> ${annotation.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+        }
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -31,10 +31,13 @@ import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
+import com.intellij.openapi.module.ModuleUtil
+import com.intellij.util.containers.toArray
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.constants.*
+import org.jetbrains.kotlin.resolve.source.getPsi
 
 class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationDescriptor) : KSAnnotation {
     companion object : KSObjectCache<AnnotationDescriptor, KSAnnotationDescriptorImpl>() {
@@ -77,7 +80,9 @@ private fun ClassId.findKSType(): KSType? = findKSClassDeclaration()?.asStarProj
 
 private fun <T> ConstantValue<T>.toValue(): Any? = when (this) {
     is AnnotationValue -> KSAnnotationDescriptorImpl.getCached(value)
-    is ArrayValue -> value.map { it.toValue() }.toTypedArray()
+    is ArrayValue -> {
+        value.map { it.toValue() }
+    }
     is EnumValue -> value.first.findKSClassDeclaration()?.declarations?.find {
         it is KSClassDeclaration && it.classKind == ClassKind.ENUM_ENTRY && it.simpleName.asString() == value.second.asString()
     }?.let { (it as KSClassDeclaration).asStarProjectedType() }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -77,7 +77,7 @@ private fun ClassId.findKSType(): KSType? = findKSClassDeclaration()?.asStarProj
 
 private fun <T> ConstantValue<T>.toValue(): Any? = when (this) {
     is AnnotationValue -> KSAnnotationDescriptorImpl.getCached(value)
-    is ArrayValue -> value.map { it.toValue() }
+    is ArrayValue -> value.map { it.toValue() }.toTypedArray()
     is EnumValue -> value.first.findKSClassDeclaration()?.declarations?.find {
         it is KSClassDeclaration && it.classKind == ClassKind.ENUM_ENTRY && it.simpleName.asString() == value.second.asString()
     }?.let { (it as KSClassDeclaration).asStarProjectedType() }

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -47,7 +47,8 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/annotationValue.kt");
     }
 
-    @TestMetadata("annotationWithArrayValue.kt")
+    @TestMetadata("annotationWithArrayValue" +
+            ".kt")
     public void testAnnotationWithArrayValue() throws Exception {
         runTest("testData/api/annotationWithArrayValue.kt");
     }

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -47,6 +47,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/annotationValue.kt");
     }
 
+    @TestMetadata("annotationWithArrayValue.kt")
+    public void testAnnotationWithArrayValue() throws Exception {
+        runTest("testData/api/annotationWithArrayValue.kt");
+    }
+
     @TestMetadata("annotationWithDefault.kt")
     public void testAnnotationWithDefault() throws Exception {
         runTest("testData/api/annotationWithDefault.kt");

--- a/compiler-plugin/testData/api/annotationValue.kt
+++ b/compiler-plugin/testData/api/annotationValue.kt
@@ -27,8 +27,16 @@
 // @Suppress
 // G
 // 31
-// warning1
-// warning 2
+// Str
+// 42
+// Foo
+// File
+// <ERROR TYPE>
+// @Foo
+// @Suppress
+// G
+// 31
+// [warning1, warning 2]
 // END
 // FILE: a.kt
 
@@ -51,7 +59,7 @@ annotation class Bar(
 )
 
 fun Fun() {
-    @Bar("Str", 42, Foo::class, java.io.File::class, Local::class, Foo(17), Suppress("name1", "name2"), RGB.G)
+    @Bar("Str", 40 + 2, Foo::class, java.io.File::class, Local::class, Foo(17), Suppress("name1", "name2"), RGB.G)
     class Local
 }
 
@@ -61,4 +69,13 @@ fun Fun() {
 class C {
 
 }
-
+// FILE: JavaAnnotated.java
+@Bar(argStr = "Str",
+    argInt = 40 + 2,
+    argClsUser = Foo.class,
+    argClsLib = java.io.File.class,
+    argClsLocal = Local.class, // intentional error type
+    argAnnoUser = @Foo(s = 17),
+    argAnnoLib = @Suppress(names = {"name1", "name2"}),
+    argEnum = RGB.G)
+public class JavaAnnotated {}

--- a/compiler-plugin/testData/api/annotationWithArrayValue.kt
+++ b/compiler-plugin/testData/api/annotationWithArrayValue.kt
@@ -1,5 +1,3 @@
-import kotlin.reflect.KClass
-
 /*
  * Copyright 2020 Google LLC
  * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
@@ -16,23 +14,22 @@ import kotlin.reflect.KClass
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 // TEST PROCESSOR: AnnotationArrayValueProcessor
 // EXPECTED:
 // KotlinAnnotated
 // KotlinAnnotation ->
-// stringArray: Array = [a, b, null, c]
-// classArray: Array = [Any, List<*>]
+// stringArray = [a, b, null, c]
+// classArray = [Any, List<*>]
 // JavaAnnotation ->
-// stringArray: Array = [x, y, null, z]
-// classArray: Array = [String, Long]
+// stringArray = [x, y, null, z]
+// classArray = [String, Long]
 // JavaAnnotated
 // KotlinAnnotation ->
-// stringArray: Array = [j-a, j-b, null, j-c]
-// classArray: Array = [Object, List<*>]
+// stringArray = [j-a, j-b, null, j-c]
+// classArray = [Object, List<*>]
 // JavaAnnotation ->
-// stringArray: Array = [j-x, j-y, null, j-z]
-// classArray: Array = [Integer, Character]
+// stringArray = [j-x, j-y, null, j-z]
+// classArray = [Integer, Character]
 // END
 // FILE: a.kt
 

--- a/compiler-plugin/testData/api/annotationWithArrayValue.kt
+++ b/compiler-plugin/testData/api/annotationWithArrayValue.kt
@@ -1,0 +1,68 @@
+import kotlin.reflect.KClass
+
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotationArrayValueProcessor
+// EXPECTED:
+// KotlinAnnotated
+// KotlinAnnotation ->
+// stringArray: Array = [a, b, null, c]
+// classArray: Array = [Any, List<*>]
+// JavaAnnotation ->
+// stringArray: Array = [x, y, null, z]
+// classArray: Array = [String, Long]
+// JavaAnnotated
+// KotlinAnnotation ->
+// stringArray: Array = [j-a, j-b, null, j-c]
+// classArray: Array = [Object, List<*>]
+// JavaAnnotation ->
+// stringArray: Array = [j-x, j-y, null, j-z]
+// classArray: Array = [Integer, Character]
+// END
+// FILE: a.kt
+
+annotation class KotlinAnnotation(val stringArray: Array<String?>, val classArray: Array<KClass<*>?>)
+
+@KotlinAnnotation(
+    stringArray = ["a", "b", null, "c"],
+    classArray = [Any::class, List::class]
+)
+@JavaAnnotation(
+    stringArray = ["x", "y", null, "z"],
+    classArray = [String::class, Long::class]
+)
+class KotlinAnnotated
+
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    String[] stringArray();
+    Class[] classArray();
+}
+
+// FILE: JavaAnnotated.java
+import java.util.*;
+@KotlinAnnotation(
+    stringArray = {"j-a", "j-b", null, "j-c"},
+    classArray = {Object.class, List.class}
+)
+@JavaAnnotation(
+    stringArray = {"j-x", "j-y", null, "j-z"},
+    classArray = {Integer.class, Character.class}
+)
+public class JavaAnnotated {
+}

--- a/compiler-plugin/testData/api/annotationWithDefault.kt
+++ b/compiler-plugin/testData/api/annotationWithDefault.kt
@@ -19,15 +19,22 @@
 // EXPECTED:
 // KotlinAnnotation -> a:debugKt,b:default
 // JavaAnnotation -> debug:debug,withDefaultValue:OK
+// JavaAnnotation2 -> y:y-kotlin,x:x-kotlin,z:z-default
+// KotlinAnnotation2 -> y:y-kotlin,x:x-kotlin,z:z-default
 // KotlinAnnotation -> a:debugJava,b:default
 // JavaAnnotation -> debug:debugJava2,withDefaultValue:OK
+// JavaAnnotation2 -> y:y-java,x:x-java,z:z-default
+// KotlinAnnotation2 -> y:y-java,x:x-java,z:z-default
 // END
 // FILE: a.kt
 
 annotation class KotlinAnnotation(val a: String, val b:String = "default")
+annotation class KotlinAnnotation2(val x: String, val y:String = "y-default", val z:String = "z-default")
 
 @KotlinAnnotation("debugKt")
 @JavaAnnotation("debug")
+@JavaAnnotation2(y="y-kotlin", x="x-kotlin")
+@KotlinAnnotation2(y="y-kotlin", x="x-kotlin")
 class A
 
 // FILE: JavaAnnotation.java
@@ -36,10 +43,19 @@ public @interface JavaAnnotation {
     String withDefaultValue()  default "OK";
 }
 
+// FILE: JavaAnnotation2.java
+public @interface JavaAnnotation2 {
+    String x() default "x-default";
+    String y() default "y-default";
+    String z() default "z-default";
+}
+
 // FILE: JavaAnnotated.java
 
 @KotlinAnnotation("debugJava")
 @JavaAnnotation("debugJava2")
+@JavaAnnotation2(y="y-java", x="x-java")
+@KotlinAnnotation2(y="y-java", x="x-java")
 public class JavaAnnotated {
 
 }


### PR DESCRIPTION
This CL fixes a bug in java annotation parsing where it was always using
the index in java instead of the key. This change makes it default
to explicit name and only use index if name is not present.