### PR TITLE
Set destinationDir for KotlinCompileTaskData.

### DIFF
--- a/gradle-plugin/src/main/java/com/google/devtools/ksp/gradle/InternalTrampoline.java
+++ b/gradle-plugin/src/main/java/com/google/devtools/ksp/gradle/InternalTrampoline.java
@@ -1,11 +1,15 @@
 package com.google.devtools.ksp.gradle;
 
+import org.gradle.api.provider.Provider;
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation;
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompileTaskData;
 
+import java.io.File;
+
 // FIXME: Ask upstream to open these API
 public class InternalTrampoline {
-    public static void KotlinCompileTaskData_register(String taskName, KotlinCompilation<?> kotlinCompilation) {
+    public static void KotlinCompileTaskData_register(String taskName, KotlinCompilation<?> kotlinCompilation, Provider<File> destinationDirProvider)  {
         KotlinCompileTaskData kotlinCompileTaskData = KotlinCompileTaskData.Companion.register(taskName, kotlinCompilation);
+        kotlinCompileTaskData.getDestinationDir().set(destinationDirProvider);
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -108,10 +108,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
 
         assert(kotlinCompileProvider.name.startsWith("compile"))
         val kspTaskName = kotlinCompileProvider.name.replaceFirst("compile", "ksp")
-        InternalTrampoline.KotlinCompileTaskData_register(kspTaskName, kotlinCompilation)
+        val destinationDir = File(project.buildDir, "generated/ksp")
+        InternalTrampoline.KotlinCompileTaskData_register(kspTaskName, kotlinCompilation, project.provider { destinationDir })
 
         val kspTaskProvider = project.tasks.register(kspTaskName, KspTask::class.java) { kspTask ->
-            kspTask.setDestinationDir(File(project.buildDir, "generated/ksp"))
+            kspTask.setDestinationDir(destinationDir)
             kspTask.mapClasspath { kotlinCompileProvider.get().classpath }
             kspTask.options = options
             kspTask.outputs.dirs(kotlinOutputDir, javaOutputDir, classOutputDir)


### PR DESCRIPTION
Fixes #133.