### PR TITLE
Fix various java annotation parsing issues

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -29,9 +29,11 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
     val visitor = ArgumentVisitor()
 
     override fun process(resolver: Resolver) {
-        val symbol = resolver.getSymbolsWithAnnotation("Bar", true).single()
-        val annotation = (symbol as KSClassDeclaration).annotations.single()
-        annotation.arguments.map { it.accept(visitor, Unit) }
+        resolver.getSymbolsWithAnnotation("Bar", true).forEach {
+            val annotation = it.annotations.single()
+            annotation.arguments.map { it.accept(visitor, Unit) }
+        }
+
         val C = resolver.getClassDeclarationByName("C")!!
         C.annotations.first().arguments.map { results.add(it.value.toString()) }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
@@ -18,10 +18,11 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
+class AnnotationArrayValueProcessor : AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -29,15 +30,25 @@ class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
-        val ktClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("A"))!!
+        val ktClass = resolver.getClassDeclarationByName("KotlinAnnotated")!!
         logAnnotations(ktClass)
-        val javaClass = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaAnnotated"))!!
+        val javaClass = resolver.getClassDeclarationByName("JavaAnnotated")!!
         logAnnotations(javaClass)
     }
 
     private fun logAnnotations(classDeclaration: KSClassDeclaration) {
+        result.add(classDeclaration.qualifiedName!!.asString())
         classDeclaration.annotations.forEach { annotation ->
-            result.add("${annotation.shortName.asString()} -> ${annotation.arguments.map { "${it.name?.asString()}:${it.value}" }.joinToString(",")}")
+            result.add("${annotation.shortName.asString()} ->")
+            annotation.arguments.forEach {
+                val value = it.value
+                val key = it.name?.asString()
+                if (value is Array<*>) {
+                    result.add("$key = [${value.joinToString(", ")}]")
+                } else {
+                    result.add("$key = ${it.value}")
+                }
+            }
         }
     }
 }

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -47,6 +47,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/annotationValue.kt");
     }
 
+    @TestMetadata("annotationWithArrayValue.kt")
+    public void testAnnotationWithArrayValue() throws Exception {
+        runTest("testData/api/annotationWithArrayValue.kt");
+    }
+
     @TestMetadata("annotationWithDefault.kt")
     public void testAnnotationWithDefault() throws Exception {
         runTest("testData/api/annotationWithDefault.kt");

--- a/compiler-plugin/testData/api/annotationValue.kt
+++ b/compiler-plugin/testData/api/annotationValue.kt
@@ -27,8 +27,16 @@
 // @Suppress
 // G
 // 31
-// warning1
-// warning 2
+// Str
+// 42
+// Foo
+// File
+// <ERROR TYPE>
+// @Foo
+// @Suppress
+// G
+// 31
+// [warning1, warning 2]
 // END
 // FILE: a.kt
 
@@ -51,7 +59,7 @@ annotation class Bar(
 )
 
 fun Fun() {
-    @Bar("Str", 42, Foo::class, java.io.File::class, Local::class, Foo(17), Suppress("name1", "name2"), RGB.G)
+    @Bar("Str", 40 + 2, Foo::class, java.io.File::class, Local::class, Foo(17), Suppress("name1", "name2"), RGB.G)
     class Local
 }
 
@@ -61,4 +69,13 @@ fun Fun() {
 class C {
 
 }
-
+// FILE: JavaAnnotated.java
+@Bar(argStr = "Str",
+    argInt = 40 + 2,
+    argClsUser = Foo.class,
+    argClsLib = java.io.File.class,
+    argClsLocal = Local.class, // intentional error type
+    argAnnoUser = @Foo(s = 17),
+    argAnnoLib = @Suppress(names = {"name1", "name2"}),
+    argEnum = RGB.G)
+public class JavaAnnotated {}

--- a/compiler-plugin/testData/api/annotationWithArrayValue.kt
+++ b/compiler-plugin/testData/api/annotationWithArrayValue.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// TEST PROCESSOR: AnnotationArrayValueProcessor
+// EXPECTED:
+// KotlinAnnotated
+// KotlinAnnotation ->
+// stringArray = [a, b, null, c]
+// classArray = [Any, List<*>]
+// JavaAnnotation ->
+// stringArray = [x, y, null, z]
+// classArray = [String, Long]
+// JavaAnnotated
+// KotlinAnnotation ->
+// stringArray = [j-a, j-b, null, j-c]
+// classArray = [Object, List<*>]
+// JavaAnnotation ->
+// stringArray = [j-x, j-y, null, j-z]
+// classArray = [Integer, Character]
+// END
+// FILE: a.kt
+
+annotation class KotlinAnnotation(val stringArray: Array<String?>, val classArray: Array<KClass<*>?>)
+
+@KotlinAnnotation(
+    stringArray = ["a", "b", null, "c"],
+    classArray = [Any::class, List::class]
+)
+@JavaAnnotation(
+    stringArray = ["x", "y", null, "z"],
+    classArray = [String::class, Long::class]
+)
+class KotlinAnnotated
+
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    String[] stringArray();
+    Class[] classArray();
+}
+
+// FILE: JavaAnnotated.java
+import java.util.*;
+@KotlinAnnotation(
+    stringArray = {"j-a", "j-b", null, "j-c"},
+    classArray = {Object.class, List.class}
+)
+@JavaAnnotation(
+    stringArray = {"j-x", "j-y", null, "j-z"},
+    classArray = {Integer.class, Character.class}
+)
+public class JavaAnnotated {
+}

--- a/compiler-plugin/testData/api/annotationWithDefault.kt
+++ b/compiler-plugin/testData/api/annotationWithDefault.kt
@@ -19,15 +19,22 @@
 // EXPECTED:
 // KotlinAnnotation -> a:debugKt,b:default
 // JavaAnnotation -> debug:debug,withDefaultValue:OK
+// JavaAnnotation2 -> y:y-kotlin,x:x-kotlin,z:z-default
+// KotlinAnnotation2 -> y:y-kotlin,x:x-kotlin,z:z-default
 // KotlinAnnotation -> a:debugJava,b:default
 // JavaAnnotation -> debug:debugJava2,withDefaultValue:OK
+// JavaAnnotation2 -> y:y-java,x:x-java,z:z-default
+// KotlinAnnotation2 -> y:y-java,x:x-java,z:z-default
 // END
 // FILE: a.kt
 
 annotation class KotlinAnnotation(val a: String, val b:String = "default")
+annotation class KotlinAnnotation2(val x: String, val y:String = "y-default", val z:String = "z-default")
 
 @KotlinAnnotation("debugKt")
 @JavaAnnotation("debug")
+@JavaAnnotation2(y="y-kotlin", x="x-kotlin")
+@KotlinAnnotation2(y="y-kotlin", x="x-kotlin")
 class A
 
 // FILE: JavaAnnotation.java
@@ -36,10 +43,19 @@ public @interface JavaAnnotation {
     String withDefaultValue()  default "OK";
 }
 
+// FILE: JavaAnnotation2.java
+public @interface JavaAnnotation2 {
+    String x() default "x-default";
+    String y() default "y-default";
+    String z() default "z-default";
+}
+
 // FILE: JavaAnnotated.java
 
 @KotlinAnnotation("debugJava")
 @JavaAnnotation("debugJava2")
+@JavaAnnotation2(y="y-java", x="x-java")
+@KotlinAnnotation2(y="y-java", x="x-java")
 public class JavaAnnotated {
 
 }


### PR DESCRIPTION
This commit fixes multiple issues in annotation parsing for java code

1) When getting annotation names, it was always using the index instead
of the name. I changed it to default to name and only use index if
name is not provided.

2) Array values in annotations were repoted as a list of pairs instead
of 1 key and multiple values, fixed.

3) When the annotation value is a type, it was not returning a KSType
but instead returning a PsiType, fixed.

4) When the annotation value is another annotation, it was not returning
a KSAnnotation, fixed.

5) For expressions resolving to literals, it was returning the PsiLiteral
instead of the value of it.

6) TypeReferences (relevant in enum values) were not being resolved.

Updated/added tests for all cases above.

The enum fix for java source is not great right now because seems like
evaluator does not resolve it, hence I implemented a manual resolution that
is very similar to the implementation in KSAnnotationImpl.