### PR TITLE
Fix find overridee, add tests

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -76,6 +76,10 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
      * Calling `findOverridee` on `C.x` will return `B.x`.
      * Calling `findOverridee` on `C.y` will return `A.y`.
      *
+     * When there are multiple super interfaces implementing the function, the closest declaration
+     * to the current containing declaration is selected. If they are in the same level, the
+     * function of the first specified interface (in source) will be returned.
+     *
      * @return [KSFunctionDeclaration] for the original function, if overriding, otherwise null.
      * Calling [findOverridee] is expensive and should be avoided if possible.
      */

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -57,7 +57,25 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
     val parameters: List<KSValueParameter>
 
     /**
-     * Find the original overridee of this function, if overriding.
+     * Find the closest overridee of this function, if overriding.
+     *
+     * For the following input:
+     * ```
+     * abstract class A {
+     *   open fun x() {}
+     *   open fun y() {}
+     * }
+     * abstract class B : A() {
+     *   override open fun x() {}
+     * }
+     * abstract class C : B() {
+     *   override open fun x() {}
+     *   override open fun y() {}
+     * }
+     * ```
+     * Calling `findOverridee` on `C.x` will return `B.x`.
+     * Calling `findOverridee` on `C.y` will return `A.y`.
+     *
      * @return [KSFunctionDeclaration] for the original function, if overriding, otherwise null.
      * Calling [findOverridee] is expensive and should be avoided if possible.
      */

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -326,7 +326,7 @@ class ResolverImpl(
                             }
                 } else {
                     moduleClassResolver.resolveClass(JavaMethodImpl(psi).containingClass)
-                            ?.unsubstitutedMemberScope!!.getDescriptorsFiltered().single { it.findPsi() == psi }
+                            ?.unsubstitutedMemberScope!!.getDescriptorsFiltered().singleOrNull { it.findPsi() == psi }
                 }
             }
             is PsiField -> moduleClassResolver.resolveClass(JavaFieldImpl(psi).containingClass)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -30,9 +30,15 @@ class OverrideeProcessor: AbstractTestProcessor() {
     override fun toResult() = results
 
     override fun process(resolver: Resolver) {
-        logSubject(resolver, "Subject");
-        logSubject(resolver, "JavaSubject.Subject");
-        logSubject(resolver, "lib.Subject");
+        logSubject(resolver, "Subject")
+        logSubject(resolver, "JavaSubject.Subject")
+        logSubject(resolver, "lib.Subject")
+        logSubject(resolver, "ConflictingSubject1")
+        logSubject(resolver, "ConflictingSubject2")
+        logSubject(resolver, "ConflictingSubject3")
+        logSubject(resolver, "ConflictingSubject4")
+        logSubject(resolver, "OverrideOrder1")
+        logSubject(resolver, "OverrideOrder2")
     }
 
     private fun logSubject(resolver: Resolver, qName:String) {
@@ -72,4 +78,22 @@ class OverrideeProcessor: AbstractTestProcessor() {
         // ignore these methods as we receive syntetics of it from compiled code
         private val IGNORED_METHOD_NAMES = listOf("equals", "hashCode", "toString")
     }
+}
+
+interface MyInterface {
+    fun openFoo(): Int { return 1}
+    fun absFoo(): Unit
+}
+
+interface MyInterface2 {
+    fun absFoo(): Unit
+}
+
+abstract class MyAbstract: MyInterface {
+    override fun absFoo(): Unit {val a = 1}
+    override fun openFoo(): Int { return 2 }
+}
+
+class Subject2: MyInterface, MyAbstract() {
+    override fun absFoo(): Unit = TODO()
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.closestClassDeclaration
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+
+@Suppress("unused") // used by tests
+class OverrideeProcessor: AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+
+    override fun toResult() = results
+
+    override fun process(resolver: Resolver) {
+        logSubject(resolver, "Subject");
+        logSubject(resolver, "JavaSubject.Subject");
+        logSubject(resolver, "lib.Subject");
+    }
+
+    private fun logSubject(resolver: Resolver, qName:String) {
+        results.add("$qName:")
+        val subject = resolver.getClassDeclarationByName(qName)!!
+        subject.declarations.filterIsInstance<KSClassDeclaration>().forEach {
+            logClass(it)
+        }
+        logClass(subject)
+    }
+
+    private fun logClass(subject: KSClassDeclaration) {
+        subject.declarations.filterIsInstance<KSFunctionDeclaration>()
+            .filterNot { it.simpleName.asString() in IGNORED_METHOD_NAMES }
+            .forEach {
+                val signature = it.toSignature()
+                val overrideeSignature = it.findOverridee()?.toSignature()
+                results.add("$signature -> $overrideeSignature")
+            }
+    }
+
+    private fun KSFunctionDeclaration.toSignature(): String {
+        val self = this
+        return buildString {
+            append(self.closestClassDeclaration()?.simpleName?.asString())
+            append(".")
+            append(self.simpleName.asString())
+            append(
+                self.parameters.joinToString(", ", prefix = "(", postfix = ")") {
+                    "${it.name?.asString()}:${it.type.resolve().declaration.simpleName.asString()}"
+                }
+            )
+        }
+    }
+
+    companion object {
+        // ignore these methods as we receive syntetics of it from compiled code
+        private val IGNORED_METHOD_NAMES = listOf("equals", "hashCode", "toString")
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.findClosestOverridee
 import com.google.devtools.ksp.symbol.impl.toFunctionKSModifiers
 import com.google.devtools.ksp.symbol.impl.toKSFunctionDeclaration
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
@@ -39,8 +40,8 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
     }
 
     override fun findOverridee(): KSFunctionDeclaration? {
-        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.singleOrNull { it.overriddenDescriptors.isEmpty() }
-            ?.toKSFunctionDeclaration()
+        val descriptor = ResolverImpl.instance.resolveFunctionDeclaration(this)
+        return descriptor?.findClosestOverridee()?.toKSFunctionDeclaration()
     }
 
     override val typeParameters: List<KSTypeParameter> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -52,8 +52,8 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
     }
 
     override fun findOverridee(): KSFunctionDeclaration? {
-        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
-            ?.toKSFunctionDeclaration()
+        val descriptor = ResolverImpl.instance.resolveFunctionDeclaration(this)
+        return descriptor?.findClosestOverridee()?.toKSFunctionDeclaration()
     }
 
     override val declarations: List<KSDeclaration> = emptyList()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.OverridingUtil
@@ -37,8 +38,8 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
     }
 
     override fun findOverridee(): KSFunctionDeclaration? {
-        return ResolverImpl.instance.resolveFunctionDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
-            ?.toKSFunctionDeclaration()
+        val descriptor = ResolverImpl.instance.resolveFunctionDeclaration(this)
+        return descriptor?.findClosestOverridee()?.toKSFunctionDeclaration()
     }
 
     override val declarations: List<KSDeclaration> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -37,7 +37,6 @@ import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaVisibilities
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
@@ -282,4 +281,29 @@ internal fun DeclarationDescriptor.findPsi(): PsiElement? {
     // For synthetic members.
     if ((this is CallableMemberDescriptor) && this.kind != CallableMemberDescriptor.Kind.DECLARATION) return null
     return (this as? DeclarationDescriptorWithSource)?.source?.getPsi()
+}
+
+/**
+ * @see KSFunctionDeclaration.findOverridee for docs.
+ */
+internal fun FunctionDescriptor.findClosestOverridee(): FunctionDescriptor? {
+    val overriddenDescriptors = this.original.overriddenDescriptors
+    // When there is an intermediate class between the overridden and our function, we might receive
+    // a FAKE_OVERRIDE function which is not desired as we are trying to find the actual
+    // declared method.
+    // First we try to find a non-fake function and if we cannot find, then we check the overridee
+    // of the fake override.
+    overriddenDescriptors.singleOrNull {
+        it.kind != CallableMemberDescriptor.Kind.FAKE_OVERRIDE
+    }?.let {
+        // always return the original. otherwise, returned function might have type arguments
+        // substituted when the function is resolved from a `.class` file (does not happen for
+        // functions resolved from kotlin or java source code)
+        return it.original
+    }
+    // if there is no declared function, there might be a fake override and we need to find its
+    // overridee.
+    return overriddenDescriptors.singleOrNull {
+        it.kind == CallableMemberDescriptor.Kind.FAKE_OVERRIDE
+    }?.findClosestOverridee()
 }

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -157,6 +157,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/multipleModules.kt");
     }
 
+    @TestMetadata(("overridee.kt"))
+    public void testOverridee() throws Exception {
+        runTest("testData/api/overridee.kt");
+    }
+
     @TestMetadata("parameterTypes.kt")
     public void testParameterTypes() throws Exception {
         runTest("testData/api/parameterTypes.kt");

--- a/compiler-plugin/testData/api/overridee.kt
+++ b/compiler-plugin/testData/api/overridee.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: OverrideeProcessor
+// EXPECTED:
+// Subject:
+// Companion.companionMethod() -> null
+// Subject.openFun() -> Base.openFun()
+// Subject.abstractFun() -> Base.abstractFun()
+// Subject.openFunWithGenericArg(t:String) -> Base.openFunWithGenericArg(t:T)
+// Subject.abstractFunWithGenericArg(t:String) -> Base.abstractFunWithGenericArg(t:T)
+// Subject.nonOverridingMethod() -> null
+// Subject.overriddenGrandBaseFun() -> Base.overriddenGrandBaseFun()
+// Subject.overriddenAbstractGrandBaseFun() -> Base.overriddenAbstractGrandBaseFun()
+// Subject.openGrandBaseFun() -> GrandBase.openGrandBaseFun()
+// Subject.abstractGrandBaseFun() -> GrandBase.abstractGrandBaseFun()
+// JavaSubject.Subject:
+// Subject.openFun() -> Base.openFun()
+// Subject.abstractFun() -> Base.abstractFun()
+// Subject.openFunWithGenericArg(t:String) -> Base.openFunWithGenericArg(t:T)
+// Subject.abstractFunWithGenericArg(t:String) -> Base.abstractFunWithGenericArg(t:T)
+// Subject.nonOverridingMethod() -> null
+// Subject.overriddenGrandBaseFun() -> Base.overriddenGrandBaseFun()
+// Subject.overriddenAbstractGrandBaseFun() -> Base.overriddenAbstractGrandBaseFun()
+// Subject.openGrandBaseFun() -> GrandBase.openGrandBaseFun()
+// Subject.abstractGrandBaseFun() -> GrandBase.abstractGrandBaseFun()
+// Subject.staticMethod() -> null
+// lib.Subject:
+// Companion.companionMethod() -> null
+// Subject.abstractFun() -> Base.abstractFun()
+// Subject.abstractFunWithGenericArg(t:String) -> Base.abstractFunWithGenericArg(t:T)
+// Subject.abstractGrandBaseFun() -> GrandBase.abstractGrandBaseFun()
+// Subject.nonOverridingMethod() -> null
+// Subject.openFun() -> Base.openFun()
+// Subject.openFunWithGenericArg(t:String) -> Base.openFunWithGenericArg(t:T)
+// Subject.openGrandBaseFun() -> GrandBase.openGrandBaseFun()
+// Subject.overriddenAbstractGrandBaseFun() -> Base.overriddenAbstractGrandBaseFun()
+// Subject.overriddenGrandBaseFun() -> Base.overriddenGrandBaseFun()
+// END
+// MODULE: lib
+// FILE: lib.kt
+package lib;
+abstract class GrandBase {
+    open fun openGrandBaseFun() {}
+    abstract fun abstractGrandBaseFun()
+    open fun overriddenGrandBaseFun() {}
+    abstract fun overriddenAbstractGrandBaseFun()
+}
+abstract class Base<T> : GrandBase() {
+    open fun openFun() {}
+    abstract fun abstractFun():Unit
+    open fun openFunWithGenericArg(t:T):T = TODO()
+    abstract fun abstractFunWithGenericArg(t:T):T
+    override open fun overriddenGrandBaseFun() {}
+    override open fun overriddenAbstractGrandBaseFun() {}
+}
+
+abstract class Subject: Base<String>() {
+    override fun openFun() {}
+    override fun abstractFun() {}
+    override fun openFunWithGenericArg(t:String):String = TODO()
+    override fun abstractFunWithGenericArg(t:String):String = TODO()
+    fun nonOverridingMethod(): String =TODO()
+    override fun overriddenGrandBaseFun() {}
+    override fun overriddenAbstractGrandBaseFun() {}
+    override fun openGrandBaseFun() {}
+    override fun abstractGrandBaseFun() {}
+    companion object {
+        fun companionMethod(): String =TODO()
+    }
+}
+// MODULE: main(lib)
+// FILE: a.kt
+abstract class GrandBase {
+    open fun openGrandBaseFun() {}
+    abstract fun abstractGrandBaseFun()
+    open fun overriddenGrandBaseFun() {}
+    abstract fun overriddenAbstractGrandBaseFun()
+}
+abstract class Base<T> : GrandBase() {
+    open fun openFun() {}
+    abstract fun abstractFun():Unit
+    open fun openFunWithGenericArg(t:T):T = TODO()
+    abstract fun abstractFunWithGenericArg(t:T):T
+    override open fun overriddenGrandBaseFun() {}
+    override open fun overriddenAbstractGrandBaseFun() {}
+}
+
+abstract class Subject: Base<String>() {
+    override fun openFun() {}
+    override fun abstractFun() {}
+    override fun openFunWithGenericArg(t:String):String = TODO()
+    override fun abstractFunWithGenericArg(t:String):String = TODO()
+    fun nonOverridingMethod(): String =TODO()
+    override fun overriddenGrandBaseFun() {}
+    override fun overriddenAbstractGrandBaseFun() {}
+    override fun openGrandBaseFun() {}
+    override fun abstractGrandBaseFun() {}
+    companion object {
+        fun companionMethod(): String =TODO()
+    }
+}
+// FILE: JavaSubject.java
+public class JavaSubject {
+    static abstract class GrandBase {
+        void openGrandBaseFun() {}
+        abstract void abstractGrandBaseFun();
+        void overriddenGrandBaseFun() {}
+        abstract void overriddenAbstractGrandBaseFun();
+    }
+    static abstract class Base<T> extends GrandBase {
+        void openFun() {}
+        abstract void abstractFun();
+        T openFunWithGenericArg(T t) {
+            return null;
+        }
+        abstract T abstractFunWithGenericArg(T t);
+        void overriddenGrandBaseFun() {}
+        void overriddenAbstractGrandBaseFun() {}
+    }
+
+    static abstract class Subject extends Base<String> {
+        void openFun() {}
+        void abstractFun() {}
+        String openFunWithGenericArg(String t) {
+            return null;
+        }
+        String abstractFunWithGenericArg(String t) {
+            return null;
+        }
+        String nonOverridingMethod() {
+            return null;
+        }
+        void overriddenGrandBaseFun() {}
+        void overriddenAbstractGrandBaseFun() {}
+        void openGrandBaseFun() {}
+        void abstractGrandBaseFun() {}
+        static String staticMethod() {
+            return null;
+        }
+    }
+}

--- a/compiler-plugin/testData/api/overridee.kt
+++ b/compiler-plugin/testData/api/overridee.kt
@@ -51,6 +51,18 @@
 // Subject.openGrandBaseFun() -> GrandBase.openGrandBaseFun()
 // Subject.overriddenAbstractGrandBaseFun() -> Base.overriddenAbstractGrandBaseFun()
 // Subject.overriddenGrandBaseFun() -> Base.overriddenGrandBaseFun()
+// ConflictingSubject1:
+// ConflictingSubject1.absFoo() -> MyInterface.absFoo()
+// ConflictingSubject2:
+// ConflictingSubject2.absFoo() -> MyAbstract.absFoo()
+// ConflictingSubject3:
+// ConflictingSubject3.absFoo() -> MyInterface.absFoo()
+// ConflictingSubject4:
+// ConflictingSubject4.absFoo() -> MyInterface2.absFoo()
+// OverrideOrder1:
+// OverrideOrder1.foo() -> GrandBaseInterface2.foo()
+// OverrideOrder2:
+// OverrideOrder2.foo() -> GrandBaseInterface1.foo()
 // END
 // MODULE: lib
 // FILE: lib.kt
@@ -115,6 +127,58 @@ abstract class Subject: Base<String>() {
         fun companionMethod(): String =TODO()
     }
 }
+
+// FILE: conflictingOverrides.kt
+interface MyInterface {
+    fun absFoo(): Unit
+}
+
+interface MyInterface2 {
+    fun absFoo(): Unit
+}
+
+abstract class MyAbstract: MyInterface {
+    override fun absFoo(): Unit {val a = 1}
+}
+
+class ConflictingSubject1: MyInterface, MyAbstract() {
+    override fun absFoo(): Unit = TODO()
+}
+
+class ConflictingSubject2: MyAbstract(), MyInterface {
+    override fun absFoo(): Unit = TODO()
+}
+
+class ConflictingSubject3: MyInterface, MyInterface2 {
+    override fun absFoo(): Unit = TODO()
+}
+
+class ConflictingSubject4: MyInterface2, MyInterface {
+    override fun absFoo(): Unit = TODO()
+}
+
+// FILE: overrideOrder.kt
+interface GrandBaseInterface1 {
+    fun foo(): Unit
+}
+
+interface GrandBaseInterface2 {
+    fun foo(): Unit
+}
+
+interface BaseInterface1 : GrandBaseInterface1 {
+}
+
+interface BaseInterface2 : GrandBaseInterface2 {
+}
+
+class OverrideOrder1 : BaseInterface1, GrandBaseInterface2 {
+    override fun foo() = TODO()
+}
+class OverrideOrder2 : BaseInterface2, GrandBaseInterface1 {
+    override fun foo() = TODO()
+}
+
 // FILE: JavaSubject.java
 public class JavaSubject {
     static abstract class GrandBase {


### PR DESCRIPTION
This CL fixes a few problems in find overridee implementation:

a) If the method does not override anything, it would throw instead of
returning null, fixed.
b) If it overrides a method that overrides another method, it would
return null, now it returns the first actual override.
c) If it overrides a method from a GrandSuper (where super does not
override it), it would return null. Now it returns the method in
GrandSuper class.

Fixes: #150