### PR TITLE
allow setting env variables in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
         java-package: jdk
         architecture: x64
     - name: set JDK 6,7,8 environment variables for kotlin compiler
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: echo ::set-env name=JDK_16::$(echo $JAVA_HOME) && echo ::set-env name=JDK_17::$(echo $JAVA_HOME) && echo ::set-env name=JDK_18::$(echo $JAVA_HOME)
     - name: Setup Java 9
       uses: actions/setup-java@v1.4.3
@@ -32,6 +34,8 @@ jobs:
         java-package: jdk
         architecture: x64
     - name: set JDK_9 environment variable for kotlin compiler
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: echo ::set-env name=JDK_9::$(echo $JAVA_HOME)
 
     # Checkout


### PR DESCRIPTION
set:env is disabled due to a security warning.
We don't have anything sensitive in this build so it is fine
for us to keep using it for now.