### PR TITLE
Set task outputs to kotlin output dir

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -109,10 +109,13 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         assert(kotlinCompileProvider.name.startsWith("compile"))
         val kspTaskName = kotlinCompileProvider.name.replaceFirst("compile", "ksp")
         val destinationDir = File(project.buildDir, "generated/ksp")
-        InternalTrampoline.KotlinCompileTaskData_register(kspTaskName, kotlinCompilation, project.provider { destinationDir })
+        InternalTrampoline.KotlinCompileTaskData_register(
+            kspTaskName,
+            kotlinCompilation,
+            project.provider { kotlinOutputDir })
 
         val kspTaskProvider = project.tasks.register(kspTaskName, KspTask::class.java) { kspTask ->
-            kspTask.setDestinationDir(destinationDir)
+            kspTask.setDestinationDir(kotlinOutputDir)
             kspTask.mapClasspath { kotlinCompileProvider.get().classpath }
             kspTask.options = options
             kspTask.outputs.dirs(kotlinOutputDir, javaOutputDir, classOutputDir)


### PR DESCRIPTION
This PR is meant as a draft for discussion. I am not sure it is the correct way to do things, but it solves #157.