### PR TITLE
Expose logger statistics

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/KSPLogger.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/KSPLogger.kt
@@ -22,6 +22,12 @@ import com.google.devtools.ksp.symbol.KSNode
 
 interface KSPLogger {
 
+    val errorCount: Int
+    val warningCount: Int
+    val infoCount: Int
+    val loggingCount: Int
+    val exceptionCount: Int
+
     fun logging(message: String, symbol: KSNode? = null)
     fun info(message: String, symbol: KSNode? = null)
     fun warn(message: String, symbol: KSNode? = null)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -37,8 +37,6 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCacheManager
 import com.google.devtools.ksp.symbol.impl.java.KSFileJavaImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSFileImpl
-import org.jetbrains.kotlin.incremental.isJavaFile
-import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.BindingTrace

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
@@ -33,6 +33,21 @@ class MessageCollectorBasedKSPLogger(private val messageCollector: MessageCollec
         const val PREFIX = "[ksp] "
     }
 
+    override var errorCount = 0
+        private set
+
+    override var warningCount = 0
+        private set
+
+    override var infoCount = 0
+        private set
+
+    override var loggingCount = 0
+        private set
+
+    override var exceptionCount = 0
+        private set
+
     private fun convertMessage(message: String, symbol: KSNode?): String =
         when (val location = symbol?.location) {
             is FileLocation -> "$PREFIX${location.filePath}:${location.lineNumber}: $message"
@@ -40,22 +55,27 @@ class MessageCollectorBasedKSPLogger(private val messageCollector: MessageCollec
         }
 
     override fun logging(message: String, symbol: KSNode?) {
+        loggingCount++
         messageCollector.report(CompilerMessageSeverity.LOGGING, convertMessage(message, symbol))
     }
 
     override fun info(message: String, symbol: KSNode?) {
+        infoCount++
         messageCollector.report(CompilerMessageSeverity.INFO, convertMessage(message, symbol))
     }
 
     override fun warn(message: String, symbol: KSNode?) {
+        warningCount++
         messageCollector.report(CompilerMessageSeverity.WARNING, convertMessage(message, symbol))
     }
 
     override fun error(message: String, symbol: KSNode?) {
+        errorCount++
         messageCollector.report(CompilerMessageSeverity.ERROR, convertMessage(message, symbol))
     }
 
     override fun exception(e: Throwable) {
+        exceptionCount++
         val writer = StringWriter()
         e.printStackTrace(PrintWriter(writer))
         messageCollector.report(CompilerMessageSeverity.EXCEPTION, writer.toString())

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
@@ -32,6 +32,7 @@ class ErrorTypeProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
+
         val classC = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C"))!!
         val errorAtTop = classC.declarations.single { it.simpleName.asString() == "errorAtTop" } as KSPropertyDeclaration
         val errorInComponent = classC.declarations.single { it.simpleName.asString() == "errorInComponent" } as KSPropertyDeclaration


### PR DESCRIPTION
~~When seeing errors or exceptions in logger event, pass the original binding context back to fail compilation.~~

~~This is quite tricky since there might be errors recorded in processor that are not related to compiler errors. A better solution need to change compiler plugin extension point to support such custom 'fail on sight' style `AnalysisResult`. Alternatively it is also doable to just throw exception in KSP to fail compilation but that might be too aggressive.~~

Since error out works now, we no longer need to fail compilation here, however it is still worth to expose logger statistics for future usage.