### PR TITLE
FIx findOverridee for properties, fixes #174

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -58,8 +58,30 @@ interface KSPropertyDeclaration : KSDeclaration {
     fun isDelegated(): Boolean
 
     /**
-     * Find the original overridee of this property, if overriding.
-     * @return [KSPropertyDeclaration] for the original property, if overriding, otherwise null.
+     * Find the closest overridee of this property, if overriding.
+     *
+     * For the following input:
+     * ```
+     * abstract class A {
+     *   open val x:Int
+     *   open val y:Int
+     * }
+     * abstract class B : A() {
+     *   override val x:Int
+     * }
+     * abstract class C : B() {
+     *   override val x:Int
+     *   override val y:Int
+     * }
+     * ```
+     * Calling `findOverridee` on `C.x` will return `B.x`.
+     * Calling `findOverridee` on `C.y` will return `A.y`.
+     *
+     * When there are multiple super classes / interfaces with the property, the closest declaration
+     * to the current containing declaration is selected. If they are in the same level, the
+     * property of the first specified interface (in source) will be returned.
+     *
+     * @return [KSPropertyDeclaration] for the overridden property, if overriding, otherwise null.
      * Calling [findOverridee] is expensive and should be avoided if possible.
      */
     fun findOverridee(): KSPropertyDeclaration?

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -22,6 +22,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
 @Suppress("unused") // used by tests
 class OverrideeProcessor: AbstractTestProcessor() {
@@ -51,6 +52,12 @@ class OverrideeProcessor: AbstractTestProcessor() {
     }
 
     private fun logClass(subject: KSClassDeclaration) {
+        subject.declarations.filterIsInstance<KSPropertyDeclaration>()
+            .forEach {
+                val signature = it.toSignature()
+                val overrideeSignature = it.findOverridee()?.toSignature()
+                results.add("$signature -> $overrideeSignature")
+            }
         subject.declarations.filterIsInstance<KSFunctionDeclaration>()
             .filterNot { it.simpleName.asString() in IGNORED_METHOD_NAMES }
             .forEach {
@@ -71,6 +78,15 @@ class OverrideeProcessor: AbstractTestProcessor() {
                     "${it.name?.asString()}:${it.type.resolve().declaration.simpleName.asString()}"
                 }
             )
+        }
+    }
+
+    private fun KSPropertyDeclaration.toSignature(): String {
+        val self = this
+        return buildString {
+            append(self.closestClassDeclaration()?.simpleName?.asString())
+            append(".")
+            append(self.simpleName.asString())
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -86,8 +86,8 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     }
 
     override fun findOverridee(): KSPropertyDeclaration? {
-        return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
-            ?.toKSPropertyDeclaration()
+        val propertyDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(this)
+        return propertyDescriptor?.findClosestOverridee()?.toKSPropertyDeclaration()
     }
 
     override fun isDelegated(): Boolean {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -104,8 +104,8 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
     override fun isDelegated(): Boolean = ktProperty.hasDelegate()
 
     override fun findOverridee(): KSPropertyDeclaration? {
-        return ResolverImpl.instance.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors?.single { it.overriddenDescriptors.isEmpty() }
-            ?.toKSPropertyDeclaration()
+        val propertyDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(this)
+        return propertyDescriptor?.findClosestOverridee()?.toKSPropertyDeclaration()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -285,9 +285,9 @@ internal fun DeclarationDescriptor.findPsi(): PsiElement? {
 }
 
 /**
- * @see KSFunctionDeclaration.findOverridee for docs.
+ * @see KSFunctionDeclaration.findOverridee / [KSPropertyDeclaration.findOverridee] for docs.
  */
-internal fun FunctionDescriptor.findClosestOverridee(): FunctionDescriptor? {
+internal inline fun <reified T : CallableMemberDescriptor> T.findClosestOverridee(): T? {
     // When there is an intermediate class between the overridden and our function, we might receive
     // a FAKE_OVERRIDE function which is not desired as we are trying to find the actual
     // declared method.
@@ -296,16 +296,16 @@ internal fun FunctionDescriptor.findClosestOverridee(): FunctionDescriptor? {
     // class / interface method OR in case of equal distance (e.g. diamon dinheritance), pick the
     // one declared first in the code.
 
-    val queue = ArrayDeque<FunctionDescriptor>()
+    val queue = ArrayDeque<T>()
     queue.add(this)
 
     while (queue.isNotEmpty()) {
         val current = queue.removeFirst()
-        val overriddenDescriptors = current.original.overriddenDescriptors
+        val overriddenDescriptors: Collection<T> = current.original.overriddenDescriptors.filterIsInstance<T>()
         overriddenDescriptors.firstOrNull {
             it.kind != CallableMemberDescriptor.Kind.FAKE_OVERRIDE
         }?.let {
-            return it.original
+            return it.original as T?
         }
         // if all methods are fake, add them to the queue
         queue.addAll(overriddenDescriptors)

--- a/compiler-plugin/testData/api/overridee.kt
+++ b/compiler-plugin/testData/api/overridee.kt
@@ -20,6 +20,13 @@
 // EXPECTED:
 // Subject:
 // Companion.companionMethod() -> null
+// Subject.notOverridingProp -> null
+// Subject.overriddenBaseProp -> Base.overriddenBaseProp
+// Subject.overriddenAbstractBaseProp -> Base.overriddenAbstractBaseProp
+// Subject.openGrandBaseProp -> GrandBase.openGrandBaseProp
+// Subject.abstractGrandBaseProp -> GrandBase.abstractGrandBaseProp
+// Subject.overriddenGrandBaseProp -> Base.overriddenGrandBaseProp
+// Subject.overriddenAbstractGrandBaseProp -> Base.overriddenAbstractGrandBaseProp
 // Subject.openFun() -> Base.openFun()
 // Subject.abstractFun() -> Base.abstractFun()
 // Subject.openFunWithGenericArg(t:String) -> Base.openFunWithGenericArg(t:T)
@@ -42,6 +49,13 @@
 // Subject.staticMethod() -> null
 // lib.Subject:
 // Companion.companionMethod() -> null
+// Subject.abstractGrandBaseProp -> GrandBase.abstractGrandBaseProp
+// Subject.notOverridingProp -> null
+// Subject.openGrandBaseProp -> GrandBase.openGrandBaseProp
+// Subject.overriddenAbstractBaseProp -> Base.overriddenAbstractBaseProp
+// Subject.overriddenAbstractGrandBaseProp -> Base.overriddenAbstractGrandBaseProp
+// Subject.overriddenBaseProp -> Base.overriddenBaseProp
+// Subject.overriddenGrandBaseProp -> Base.overriddenGrandBaseProp
 // Subject.abstractFun() -> Base.abstractFun()
 // Subject.abstractFunWithGenericArg(t:String) -> Base.abstractFunWithGenericArg(t:T)
 // Subject.abstractGrandBaseFun() -> GrandBase.abstractGrandBaseFun()
@@ -68,12 +82,20 @@
 // FILE: lib.kt
 package lib;
 abstract class GrandBase {
+    open var openGrandBaseProp: Int = 0
+    abstract var abstractGrandBaseProp: Int
+    open var overriddenGrandBaseProp: Int = 0
+    abstract var overriddenAbstractGrandBaseProp: Int
     open fun openGrandBaseFun() {}
     abstract fun abstractGrandBaseFun()
     open fun overriddenGrandBaseFun() {}
     abstract fun overriddenAbstractGrandBaseFun()
 }
 abstract class Base<T> : GrandBase() {
+    open var overriddenBaseProp: Int = 0
+    abstract var overriddenAbstractBaseProp: Int
+    override var overriddenGrandBaseProp:Int = 0
+    override var overriddenAbstractGrandBaseProp: Int = 0
     open fun openFun() {}
     abstract fun abstractFun():Unit
     open fun openFunWithGenericArg(t:T):T = TODO()
@@ -83,6 +105,13 @@ abstract class Base<T> : GrandBase() {
 }
 
 abstract class Subject: Base<String>() {
+    var notOverridingProp: Int = 0
+    override open var overriddenBaseProp: Int = 0
+    override var overriddenAbstractBaseProp: Int = 0
+    override open var openGrandBaseProp: Int = 0
+    override var abstractGrandBaseProp: Int = 0
+    override var overriddenGrandBaseProp:Int = 0
+    override var overriddenAbstractGrandBaseProp: Int = 0
     override fun openFun() {}
     override fun abstractFun() {}
     override fun openFunWithGenericArg(t:String):String = TODO()
@@ -99,12 +128,20 @@ abstract class Subject: Base<String>() {
 // MODULE: main(lib)
 // FILE: a.kt
 abstract class GrandBase {
+    open var openGrandBaseProp: Int = 0
+    abstract var abstractGrandBaseProp: Int = 0
+    open var overriddenGrandBaseProp: Int = 0
+    abstract var overriddenAbstractGrandBaseProp: Int = 0
     open fun openGrandBaseFun() {}
     abstract fun abstractGrandBaseFun()
     open fun overriddenGrandBaseFun() {}
     abstract fun overriddenAbstractGrandBaseFun()
 }
 abstract class Base<T> : GrandBase() {
+    open var overriddenBaseProp: Int = 0
+    var overriddenAbstractBaseProp: Int = 0
+    override var overriddenGrandBaseProp:Int = 0
+    override var overriddenAbstractGrandBaseProp: Int = 0
     open fun openFun() {}
     abstract fun abstractFun():Unit
     open fun openFunWithGenericArg(t:T):T = TODO()
@@ -114,6 +151,13 @@ abstract class Base<T> : GrandBase() {
 }
 
 abstract class Subject: Base<String>() {
+    var notOverridingProp: Int = 0
+    override open var overriddenBaseProp: Int = 0
+    override var overriddenAbstractBaseProp: Int = 0
+    override open var openGrandBaseProp: Int = 0
+    override var abstractGrandBaseProp: Int = 0
+    override var overriddenGrandBaseProp:Int = 0
+    override var overriddenAbstractGrandBaseProp: Int = 0
     override fun openFun() {}
     override fun abstractFun() {}
     override fun openFunWithGenericArg(t:String):String = TODO()


### PR DESCRIPTION
This CL updates KSPropertyDecl.findOverridee to use the same infra
that is used by KSFunctionDeclaration.

Fixes: #174