### PR TITLE
add KSTypeAliasDescriptorImpl

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -478,6 +478,7 @@ class ResolverImpl(
             when (descriptor) {
                 is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(descriptor)
                 is TypeParameterDescriptor -> KSTypeParameterDescriptorImpl.getCached(descriptor)
+                is TypeAliasDescriptor -> KSTypeAliasDescriptorImpl.getCached(descriptor)
                 null -> throw IllegalStateException("Failed to resolve descriptor for $kotlinType")
                 else -> throw IllegalStateException("Unexpected descriptor type: ${descriptor.javaClass}, $ExceptionMessage")
             }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -21,6 +21,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 
@@ -36,6 +37,8 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
 
         val C = resolver.getClassDeclarationByName("C")!!
         C.annotations.first().arguments.map { results.add(it.value.toString()) }
+        val ThrowsClass = resolver.getClassDeclarationByName("ThrowsClass")!!
+        ThrowsClass.declarations.map { it.annotations.single().annotationType.resolve().declaration.let { results.add(it.toString()) } }
     }
 
     override fun toResult(): List<String> {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
@@ -1,0 +1,40 @@
+package com.google.devtools.ksp.symbol.impl.binary
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
+import com.google.devtools.ksp.symbol.impl.toKSModifiers
+import org.jetbrains.kotlin.descriptors.ClassKind
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+import org.jetbrains.kotlin.descriptors.MemberDescriptor
+import org.jetbrains.kotlin.descriptors.TypeAliasDescriptor
+import org.jetbrains.kotlin.types.KotlinType
+
+class KSTypeAliasDescriptorImpl(descriptor: TypeAliasDescriptor) : KSTypeAlias,
+        KSDeclarationDescriptorImpl(descriptor),
+        KSExpectActual by KSExpectActualDescriptorImpl(descriptor) {
+    companion object : KSObjectCache<TypeAliasDescriptor, KSTypeAliasDescriptorImpl>() {
+        fun getCached(descriptor: TypeAliasDescriptor) = KSTypeAliasDescriptorImpl.cache.getOrPut(descriptor) { KSTypeAliasDescriptorImpl(descriptor) }
+    }
+
+    override val name: KSName by lazy {
+        KSNameImpl.getCached(descriptor.name.asString())
+    }
+
+    override val modifiers: Set<Modifier> by lazy {
+        descriptor.toKSModifiers()
+    }
+
+    override val typeParameters: List<KSTypeParameter> by lazy {
+        descriptor.declaredTypeParameters.map { KSTypeParameterDescriptorImpl.getCached(it) }
+    }
+
+    override val type: KSTypeReference by lazy {
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.underlyingType)
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitTypeAlias(this, data)
+    }
+
+}

--- a/compiler-plugin/testData/api/annotationValue.kt
+++ b/compiler-plugin/testData/api/annotationValue.kt
@@ -37,11 +37,18 @@
 // G
 // 31
 // [warning1, warning 2]
+// Throws
 // END
 // FILE: a.kt
 
 enum class RGB {
     R, G, B
+}
+
+class ThrowsClass {
+    @Throws(Exception::class)
+    protected open fun throwsException() {
+    }
 }
 
 annotation class Foo(val s: Int)


### PR DESCRIPTION
There is implicit type aliasing happening for certain Kotlin standard library classes, if not imported explicitly for its true type, will be presented as a type alias through resolution.