### PR TITLE
Fix resolveJavaDeclaration for get/set methods

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -314,7 +314,7 @@ class ResolverImpl(
             is PsiClass -> moduleClassResolver.resolveClass(JavaClassImpl(psi))
             is PsiMethod -> {
                 // TODO: get rid of hardcoded check if possible.
-                if (psi.name.startsWith("set") || psi.name.startsWith("get")) {
+                val property = if (psi.name.startsWith("set") || psi.name.startsWith("get")) {
                     moduleClassResolver
                         .resolveClass(JavaMethodImpl(psi).containingClass)
                         ?.findEnclosedDescriptor(
@@ -322,14 +322,13 @@ class ResolverImpl(
                         ) {
                             (it as? PropertyDescriptor)?.getter?.findPsi() == psi || (it as? PropertyDescriptor)?.setter?.findPsi() == psi
                         }
-                } else {
-                    moduleClassResolver
-                        .resolveClass(JavaMethodImpl(psi).containingClass)
-                        ?.findEnclosedDescriptor(
-                            kindFilter = DescriptorKindFilter.FUNCTIONS,
-                            filter = { it.findPsi() == psi }
-                        )
-                }
+                } else null
+                property ?: moduleClassResolver
+                    .resolveClass(JavaMethodImpl(psi).containingClass)
+                    ?.findEnclosedDescriptor(
+                        kindFilter = DescriptorKindFilter.FUNCTIONS,
+                        filter = { it.findPsi() == psi }
+                    )
             }
             is PsiField -> {
                 moduleClassResolver

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -31,9 +31,13 @@ class MapSignatureProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
-        val cls = resolver.getClassDeclarationByName("Cls")!!
-        result.add(resolver.mapToJvmSignature(cls))
-        cls.primaryConstructor?.let { result.add(resolver.mapToJvmSignature(it)) }
-        cls.declarations.map { result.add(resolver.mapToJvmSignature(it)) }
+        listOf("Cls", "JavaIntefaceWithVoid")
+            .map { className ->
+                resolver.getClassDeclarationByName(className)!!
+            }.forEach { subject ->
+                result.add(resolver.mapToJvmSignature(subject))
+                subject.primaryConstructor?.let { result.add(resolver.mapToJvmSignature(it)) }
+                subject.declarations.map { result.add(resolver.mapToJvmSignature(it)) }
+            }
     }
 }

--- a/compiler-plugin/testData/api/signatureMapper.kt
+++ b/compiler-plugin/testData/api/signatureMapper.kt
@@ -21,10 +21,18 @@
 // ()V
 // I
 // ()Ljava/lang/String;
+// LJavaIntefaceWithVoid;
+// ()Ljava/lang/Void;
 // END
 
+// FILE: Cls.kt
 class Cls {
     val a: Int = 1
 
     fun foo(): String { return "1" }
+}
+
+// FILE: JavaIntefaceWithVoid.java
+interface JavaIntefaceWithVoid {
+    Void getVoid();
 }


### PR DESCRIPTION
This PR fixes a bug where KSP failed to resolve the java
declaration for a java method if its name starts with get
or set.

Fixes: #200
Test: signatureMapper