### PR TITLE
change override checking logic to traverse CallableMemberDescriptor.overriddenDescriptors()

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.impl.binary.*
+import com.google.devtools.ksp.symbol.impl.findClosestOverridee
 import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.*
 import com.google.devtools.ksp.symbol.impl.kotlin.*
@@ -295,9 +296,7 @@ class ResolverImpl(
         incrementalContext.recordLookupForDeclaration(overrider)
         incrementalContext.recordLookupForDeclaration(overridee)
 
-        return OverridingUtil.DEFAULT.isOverridableBy(
-                superDescriptor, subDescriptor, subClassDescriptor, true
-        ).result == OverridingUtil.OverrideCompatibilityInfo.Result.OVERRIDABLE
+        return OverridingUtil.overrides(subDescriptor, superDescriptor, true, true)
     }
 
     fun evaluateConstant(expression: KtExpression?, expectedType: KotlinType): ConstantValue<*>? {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -62,12 +62,18 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         checkOverride(bazPropKt,bazPropKt)
         val JavaImpl = resolver.getClassDeclarationByName("JavaImpl")!!
         val MyInterface = resolver.getClassDeclarationByName("MyInterface")!!
+        val MyInterface2 = resolver.getClassDeclarationByName("MyInterface2")!!
+        val MyInterface2ImplWithoutType = resolver.getClassDeclarationByName("MyInterface2ImplWithoutType")!!
+        val MyInterface2ImplWithType = resolver.getClassDeclarationByName("MyInterface2ImplWithType")!!
         val getX = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getX" }
         val getY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getY" }
         val setY = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setY" }
         val setX = JavaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setX" }
         val myInterfaceX = MyInterface.declarations.first{ it.simpleName.asString() == "x" }
         val myInterfaceY = MyInterface.declarations.first{ it.simpleName.asString() == "y" }
+        val myInterface2receiveList = MyInterface2.declarations.single()
+        val myInterface2ImplWithoutTypereceiveList = MyInterface2ImplWithoutType.declarations.single()
+        val myInterface2ImplWithTypereceiveList = MyInterface2ImplWithType.declarations.single()
         checkOverride(getY, getX)
         checkOverride(getY, myInterfaceX)
         checkOverride(getX, myInterfaceX)
@@ -78,6 +84,10 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         checkOverride(myInterfaceX, getX)
         checkOverride(myInterfaceY, setY)
         checkOverride(myInterfaceY, myInterfaceY)
+        checkOverride(myInterface2receiveList, myInterface2ImplWithoutTypereceiveList)
+        checkOverride(myInterface2ImplWithoutTypereceiveList, myInterface2receiveList)
+        checkOverride(myInterface2ImplWithTypereceiveList, myInterface2receiveList)
+        checkOverride(myInterface2ImplWithTypereceiveList, myInterface2ImplWithoutTypereceiveList)
 
         val JavaDifferentReturnTypes =
             resolver.getClassDeclarationByName("JavaDifferentReturnType")!!

--- a/compiler-plugin/testData/api/checkOverride.kt
+++ b/compiler-plugin/testData/api/checkOverride.kt
@@ -37,6 +37,10 @@
 // MyInterface.x overrides JavaImpl.getX: false
 // MyInterface.y overrides JavaImpl.setY: false
 // MyInterface.y overrides MyInterface.y: false
+// MyInterface2.receiveList overrides MyInterface2ImplWithoutType.receiveList: false
+// MyInterface2ImplWithoutType.receiveList overrides MyInterface2.receiveList: true
+// MyInterface2ImplWithType.receiveList overrides MyInterface2.receiveList: true
+// MyInterface2ImplWithType.receiveList overrides MyInterface2ImplWithoutType.receiveList: true
 // JavaDifferentReturnType.foo overrides JavaList.foo: true
 // END
 // FILE: a.kt
@@ -90,6 +94,23 @@ class KotlinList2(@BazzAnno override val bazz: Int = 2): KotlinList() {
 interface MyInterface {
     val x: Int
     var y: Int
+}
+
+enum class EnumType {
+    FOO,
+    BAR;
+}
+
+interface MyInterface2<T> {
+    fun receiveList(argsInParent : List<T>):Unit
+}
+
+interface MyInterface2ImplWithoutType<T> : MyInterface2<T> {
+    override fun receiveList(argsInParent : List<T>):Unit
+}
+
+interface MyInterface2ImplWithType : MyInterface2ImplWithoutType<EnumType> {
+    override fun receiveList(argsInParent : List<EnumType>):Unit
 }
 
 // FILE: JavaList.java


### PR DESCRIPTION
Current override checking utilize `OverridingUtil` which appears to be unable to handle concrete types when overriding a member from a generic super type. After peeking into the structure of `CallableMemberDecriptor` for a while, a BFS looks promising. 