### PR TITLE
Gradle plugin publishing setup

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -2,11 +2,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "Kotlin Symbol Processing API"
 
-val kspVersion: String by project
-
-group = "com.google.devtools.ksp"
-version = kspVersion
-
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
@@ -38,27 +33,7 @@ publishing {
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing-api")
                 description.set("Symbol processing for Kotlin")
-                url.set("https://goo.gle/ksp")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        name.set("KSP Team")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/google/ksp.git")
-                    developerConnection.set("scm:git:https://github.com/google/ksp.git")
-                    url.set("https://github.com/google/ksp")
-                }
             }
-        }
-        repositories {
-            mavenLocal()
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,8 +12,54 @@ if (!extra.has("kspVersion")) {
 }
 
 subprojects {
+    group = "com.google.devtools.ksp"
+    version = rootProject.extra.get("kspVersion") as String
     repositories {
         mavenCentral()
         maven("https://dl.bintray.com/kotlin/kotlin-eap")
+    }
+    tasks.withType<Jar>().configureEach {
+        manifest.attributes.apply {
+            put("Implementation-Vendor", "Google")
+            put("Implementation-Version", project.version)
+        }
+    }
+    pluginManager.withPlugin("maven-publish") {
+        val publishExtension = extensions.getByType<PublishingExtension>()
+        publishExtension.repositories {
+            if (extra.has("outRepo")) {
+                val outRepo = extra.get("outRepo") as String
+                maven {
+                    url = File(outRepo).toURI()
+                }
+            } else {
+                mavenLocal()
+            }
+        }
+        publishExtension.publications.whenObjectAdded {
+            check(this is MavenPublication) {
+                "unexpected publication $this"
+            }
+            val publication = this
+            publication.pom {
+                url.set("https://goo.gle/ksp")
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+                developers {
+                    developer {
+                        name.set("KSP Team")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/google/ksp.git")
+                    developerConnection.set("scm:git:https://github.com/google/ksp.git")
+                    url.set("https://github.com/google/ksp")
+                }
+            }
+        }
     }
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -12,19 +12,56 @@ tasks.withType<KotlinCompile> {
 
 plugins {
     kotlin("jvm")
+    id("java-gradle-plugin")
+    `maven-publish`
 }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinBaseVersion")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
-
-    compileOnly(gradleApi())
-
+    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
     testImplementation(gradleApi())
     testImplementation("junit:junit:$junitVersion")
 }
 
-repositories {
-    maven("https://dl.bintray.com/kotlin/kotlin-eap")
+tasks.named("validatePlugins").configure {
+    onlyIf {
+        // while traversing classpath, this hits a class not found issue.
+        // Disabled until gradle kotlin version and our kotlin version matches
+        // java.lang.ClassNotFoundException: org/jetbrains/kotlin/compilerRunner/KotlinLogger
+        false
+    }
+}
+
+gradlePlugin {
+    plugins {
+        create("symbol-processing-gradle-plugin") {
+            id = "com.google.devtools.ksp"
+            implementationClass = "com.google.devtools.ksp.gradle.KspGradleSubplugin"
+            description = "Kotlin symbol processing integration for Gradle"
+        }
+    }
+}
+
+tasks {
+    val sourcesJar by creating(Jar::class) {
+        archiveClassifier.set("sources")
+        from(project.sourceSets.main.get().allSource)
+    }
+}
+
+
+publishing {
+    publications {
+        // the name of this publication should match the name java-gradle-plugin looks up
+        // https://github.com/gradle/gradle/blob/master/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java#L73
+        this.create<MavenPublication>("pluginMaven") {
+            artifactId = "symbol-processing-gradle-plugin"
+            artifact(tasks["sourcesJar"])
+            pom {
+                name.set("symbol-processing-gradle-plugin")
+                description.set("Kotlin symbol processing integration for Gradle")
+            }
+        }
+    }
 }

--- a/gradle-plugin/src/main/resources/META-INF/gradle-plugins/symbol-processing.properties
+++ b/gradle-plugin/src/main/resources/META-INF/gradle-plugins/symbol-processing.properties
@@ -1,1 +1,0 @@
-implementation-class=com.google.devtools.ksp.gradle.KspGradleSubplugin

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -1,12 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 
-description = "Ksp - Symbol processing for Kotlin"
-
-val kspVersion: String by project
-
-group = "com.google.devtools.ksp"
-version = kspVersion
-
 plugins {
     kotlin("jvm")
     id("com.github.johnrengelman.shadow") version "6.0.0"
@@ -16,7 +9,6 @@ plugins {
 val packedJars by configurations.creating
 
 dependencies {
-    packedJars(project(":gradle-plugin")) { isTransitive = false }
     packedJars(project(":compiler-plugin")) { isTransitive = false }
     packedJars(project(":api")) { isTransitive = false }
 }
@@ -31,11 +23,6 @@ tasks.withType<ShadowJar>() {
         "META-INF/maven/org.jetbrains/annotations/*",
         "META-INF/kotlin-stdlib*"
     )
-    manifest.attributes.apply {
-        put("Implementation-Vendor", "Google")
-        put("Implementation-Title", baseName)
-        put("Implementation-Version", project.version)
-    }
 
     relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
 }
@@ -49,7 +36,6 @@ tasks {
         archiveClassifier.set("sources")
         from(project(":api").sourceSets.main.get().allSource)
         from(project(":compiler-plugin").sourceSets.main.get().allSource)
-        from(project(":gradle-plugin").sourceSets.main.get().allSource)
     }
 
     artifacts {
@@ -66,28 +52,8 @@ publishing {
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing")
                 description.set("Symbol processing for Kotlin")
-                url.set("https://goo.gle/ksp")
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        name.set("KSP Team")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:https://github.com/google/ksp.git")
-                    developerConnection.set("scm:git:https://github.com/google/ksp.git")
-                    url.set("https://github.com/google/ksp")
-                }
             }
         }
         project.shadow.component(publication)
-        repositories {
-            mavenLocal()
-        }
     }
 }


### PR DESCRIPTION
This CL updates the build to properly publish the gradle
plugin with an id to avoid the need to modify settings
gradle.

After this change, we'll have the following 4 artifacts:

symbol-processing-api: same as before
symbol-processing: does not include the the gradle-plugin anymore
symbol-processing-gradle-plugin: the gradle plugin
com.google.devtools.ksp.gradle.plugin: gradle plugin marker artifact

After this change, developer can enable KSP by:

id("com.google.devtools.ksp")
* Still needs to have google as a plugin repository.

The gradle plugin publishing model requires publishing a marker artifact
so that Gradle can find the main plugin artifact.
I've added `java-gradle-plugin` plugin to the gradle-plugin module to
enable publishing. Unfortunately, it does have a validation step which
fails while traversing kotlin classes in the classpath so I had to
disable it. We can enable it once gradle depends on kotlin 1.4.

As part of this, I've removed the gradle plugin from the
symbol-processing artifact. Instead, it is now published as
symbol-processing-gradle-plugin artifact (it is consistent with the
project's and androidx's naming scheme but open to changes).

For plugin id, I couldn't use symbol-processing because that would
require us to publish an artifact with symbol-processing group.
Instead, I've picked `com.google.devtools.ksp` which seems close to what
AGP does (com.android.application). This way, we can publish the marker
artifact in the KSP group.

I've made a couple more changes:
* Updated gradle to 6.6.1, which is the version kotlin uses
* Moved publishing setup to the main gradle file to configure common
things (pom, version etc)
* Moved the Jar manifest configuration to the main build file so that
all artifacts have it (was also a necessary change after unbundling the
gradle plugin since it uses that information to find the version).
Had to remove `Implementation-Title` as archiveBaseName is depreacted an
will be removed in 7.
* Added an `outRepo` command line argument to set the repository
location for publication. It is handy when testing with a local build.

Fixes: #203