### PR TITLE
Add preliminary support for kotlin expressions

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/JumpKind.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/JumpKind.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.devtools.ksp.symbol
+
+
+/**
+ * Kind of a jump keyword.
+ *
+ * @author RinOrz
+ */
+enum class JumpKind {
+    Throw, Return, Continue, Break
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnnotation.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnnotation.kt
@@ -30,9 +30,9 @@ interface KSAnnotation : KSNode {
     /**
      * The arguments applied to the constructor call to construct this annotation.
      * Must be compile time constants.
-     * @see [KSValueArgument] for operations on its values.
+     * @see [KSAnnotationValueArgument] for operations on its values.
      */
-    val arguments: List<KSValueArgument>
+    val arguments: List<KSAnnotationValueArgument>
 
     /**
      * Short name for this annotation, equivalent to the simple name of the declaration of the annotation class.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnnotationValueArgument.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnnotationValueArgument.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * The call argument of the annotation.
+ */
+interface KSAnnotationValueArgument : KSAnnotated {
+
+    /**
+     * The index of the argument in the list.
+     *
+     * @see KSAnnotation.arguments
+     */
+    val index: Int
+
+    /**
+     * The name for the named argument, or null otherwise.
+     *
+     * For example, in `ignore(id=123456)`, the name value is "id"
+     */
+    val name: KSName?
+
+    /**
+     * True if it is a spread argument (i.e., has a "*" in front of the argument).
+     */
+    val isSpread: Boolean
+
+    /**
+     * The value of the argument.
+     */
+    val value: Any?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnonymousInitializer.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSAnonymousInitializer.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * A definition of anonymous initializer block
+ *
+ * Dispatch receiver can be obtained through [parentDeclaration].
+ *
+ * This can also be viewed as an expression, like:
+ * ```
+ * class A {
+ *     init {
+ *         ...
+ *     } // here
+ * }
+ * ```
+ *
+ * @author RinOrz
+ */
+interface KSAnonymousInitializer : KSDeclaration, KSBlockExpression

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBinaryExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBinaryExpression.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression for a binary operation.
+ *
+ * @author RinOrz
+ */
+interface KSBinaryExpression : KSExpression {
+
+    /**
+     * The left side of the expression.
+     *
+     * For example, in `a * b`, the left is "a"
+     */
+    val left: KSExpression
+
+    /**
+     * The right side of the expression.
+     *
+     * For example, in `1..10`, the right is "10"
+     */
+    val right: KSExpression
+
+    /**
+     * The token that joins the [left] and [right] expressions.
+     *
+     * For example, in `a >= b`, the token is ">="
+     */
+    val token: KSToken
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBlockExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBlockExpression.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents a block of codes.
+ *
+ * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#block)
+ *
+ * @author RinOrz
+ */
+interface KSBlockExpression : KSExpression {
+
+    /**
+     * Each line of statement expression in the code block.
+     */
+    val statements: List<KSExpression>
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSCallExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSCallExpression.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents the calling property or function or constructor.
+ *
+ * @author RinOrz
+ */
+interface KSCallExpression : KSExpression {
+
+    /**
+     * The receiver expression for the call.
+     * 
+     * For example, in `boolean.toString().replace("t", "a")`, the receiver is "boolean.toString()"
+     */
+    val receiver: KSExpression?
+
+    /**
+     * The name for the calling target.
+     */
+    val name: String
+
+    /**
+     * The actual parameters of the call.
+     * When the target of the call is a property, the arguments is null.
+     */
+    val arguments: List<KSValueArgumentExpression>?
+
+    /**
+     * Try resolves to the call target declaration site.
+     *
+     * @return A declaration resolved from this expression.
+     * Calling [resolve] is expensive and should be avoided if possible.
+     *
+     * @see KSPropertyDeclaration When the target of the call is a property.
+     * @see KSFunctionDeclaration When the target of the call is a function.
+     */
+    fun resolve(): KSDeclaration?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSChainCallsExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSChainCallsExpression.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents calling a method with chaining api.
+ *
+ * Note that this expression is only valid if the number of chains called > 2,
+ * otherwise, it should be [KSCallExpression]
+ *
+ * @author RinOrz
+ */
+interface KSChainCallsExpression : KSExpression {
+
+    /**
+     * The call chains of this expression.
+     *
+     * For example, in `a().b().c()`, the arguments is "[a(), b(), c()]"
+     */
+    val chains: List<KSExpression>
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
@@ -20,8 +20,17 @@ package com.google.devtools.ksp.symbol
 
 /**
  * Models class-like declarations, including class, interface and object.
+ *
+ * This can also be viewed as an expression, such as a local class declaration:
+ * ```
+ * fun a() {
+ *     class Local {
+ *         ...
+ *     } // here
+ * }
+ * ```
  */
-interface KSClassDeclaration : KSDeclaration, KSDeclarationContainer {
+interface KSClassDeclaration : KSDeclaration, KSDeclarationContainer, KSExpression {
 
     /**
      * The Kind of the class declaration.
@@ -41,9 +50,23 @@ interface KSClassDeclaration : KSDeclaration, KSDeclarationContainer {
 
     /**
      * Determine whether this class declaration is a companion object.
-     * @see [https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html#companion-objects]
+     *
+     * [see](https://kotlinlang.org/docs/tutorials/kotlin-for-py/objects-and-companion-objects.html#companion-objects)
      */
     val isCompanionObject: Boolean
+
+    /**
+     * The initializer blocks in this class declaration.
+     *
+     * [see](https://khan.github.io/kotlin-for-python-developers/#constructors-and-initializer-blocks)
+     */
+    val initializerBlocks: List<KSAnonymousInitializer>
+
+    /**
+     * Get the all superclass declarations in the class declaration.
+     * Calling [superclassDeclarations] requires type resolution therefore is expensive and should be avoided if possible.
+     */
+    val superclassDeclarations: List<KSClassDeclaration>
 
     /**
      * Get all member functions of a class declaration, including declared and inherited.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSConstantExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSConstantExpression.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.devtools.ksp.symbol
+
+import com.google.devtools.ksp.processing.KSBuiltIns
+
+/**
+ * An expression that define the value of a constant
+ *
+ * @author RinOrz
+ */
+interface KSConstantExpression : KSExpression {
+
+    /**
+     * The parsable static value of this expression
+     *
+     * @see KSBuiltIns
+     */
+    val value: Any?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSDeclaration.kt
@@ -19,11 +19,12 @@
 package com.google.devtools.ksp.symbol
 
 /**
- * A declaration, can be function declaration, clsss declaration and property declaration, or a type alias.
+ * A declaration, can be function declaration, class declaration and property declaration, or a type alias.
  */
 interface KSDeclaration : KSModifierListOwner, KSAnnotated, KSExpectActual {
     /**
      * Simple name of this declaration, usually the name identifier at the declaration site.
+     * TODO: Anonymous function declaration have no name, so want to consider making this property nullable
      */
     val simpleName: KSName
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSDslExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSDslExpression.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents calling a method with Kotlin-DSL.
+ *
+ * @author RinOrz
+ */
+interface KSDslExpression : KSCallExpression {
+
+    /**
+     * The actual parameters to pass when calling the target method.
+     *
+     * For example, in `call(1, 2) { ... }`, the arguments is "[1, 2]"
+     */
+    override val arguments: List<KSValueArgumentExpression>
+
+    /**
+     * All lambda closures contained in the [arguments] passed at call time.
+     *
+     * For example, the closures is "[{ ... }, { print(0) }]":
+     * ```
+     * call({
+     *     ...
+     * }, {
+     *     print(0)
+     * })
+     * ```
+     */
+    val closures: List<KSLambdaExpression>
+
+    /**
+     * Try to resolves the declaration site calling the target method.
+     *
+     * @return A function declaration resolved from this expression.
+     * Calling [resolve] is expensive and should be avoided if possible.
+     */
+    override fun resolve(): KSFunctionDeclaration?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSExpression.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents any code.
+ *
+ * @author RinOrz
+ */
+interface KSExpression : KSNode {
+
+    /**
+     * Treat the expression as text
+     */
+    val text: String
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.symbol
 import com.google.devtools.ksp.processing.Resolver
+
 /**
  * A function definition
  *
@@ -26,9 +27,19 @@ import com.google.devtools.ksp.processing.Resolver
  * To obtain the function signature where type arguments are resolved as member of a given [KSType],
  * use [Resolver.asMemberOf].
  *
- * @see KSFunctionType
+ * @see KSFunction
+ *
+ *
+ * This can also be viewed as an expression, such as a local inline function declaration:
+ * ```
+ * fun a() {
+ *     fun inline() {
+ *         ...
+ *     } // here
+ * }
+ * ```
  */
-interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
+interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer, KSExpression {
     /**
      * Kind of this function.
      */
@@ -55,6 +66,11 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
      * [value parameters][KSValueParameter] of this function.
      */
     val parameters: List<KSValueParameter>
+
+    /**
+     * The body expression for this function.
+     */
+    val body: KSExpression?
 
     /**
      * Find the closest overridee of this function, if overriding.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -39,7 +39,8 @@ import com.google.devtools.ksp.processing.Resolver
  * }
  * ```
  */
-interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer, KSExpression {
+interface KSFunctionDeclaration : KSDeclaration, KSBlockExpression {
+
     /**
      * Kind of this function.
      */
@@ -66,11 +67,6 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer, KSExpre
      * [value parameters][KSValueParameter] of this function.
      */
     val parameters: List<KSValueParameter>
-
-    /**
-     * The body expression for this function.
-     */
-    val body: KSExpression?
 
     /**
      * Find the closest overridee of this function, if overriding.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSIfExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSIfExpression.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents the if-else.
+ *
+ * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#ifExpression)
+ *
+ * @author RinOrz
+ */
+interface KSIfExpression : KSExpression {
+
+    /**
+     * The condition for the if expression.
+     *
+     * For example, in `if (a == b)`, the condition is "a == b"
+     */
+    val condition: KSExpression
+
+    /**
+     * A branch of an expression that executes if the condition is `true`.
+     *
+     * For example, in `if (true) { ... }`, the `then` is "{ ... }"
+     */
+    val then: KSExpression
+
+    /**
+     * A branch of an expression that executes if the condition is `false`.
+     *
+     * For example, in `if (true) { ... } else { return }`, the otherwise is "{ return }"
+     */
+    val otherwise: KSExpression?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSJumpExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSJumpExpression.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression with a label.
+ *
+ * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#jumpExpression)
+ *
+ * @author RinOrz
+ */
+interface KSJumpExpression : KSExpression, KSLabelReferenceExpression {
+    /**
+     * Kind of jump keyword.
+     */
+    val kind: JumpKind
+
+    /**
+     * The expression after the jump keyword. (Not include: `continue`, `break`)
+     *
+     * E.g:
+     * ```
+     * throw Exception()  // body is "Exception()"
+     * return true  // body is "true"
+     * ```
+     */
+    val body: KSExpression?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLabelReferenceExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLabelReferenceExpression.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that references a label.
+ *
+ * @author RinOrz
+ */
+interface KSLabelReferenceExpression : KSExpression {
+
+    /**
+     * If the expression reference a label, its name is returned.
+     *
+     * For example, in `return@label`, the name is "label"
+     */
+    val name: String?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLabeledExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLabeledExpression.kt
@@ -19,25 +19,25 @@
 package com.google.devtools.ksp.symbol
 
 /**
- * A value argument to function / constructor calls.
+ * An expression with a label.
  *
- * Currently, only appears in annotation arguments.
+ * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#label)
+ *
+ * @author RinOrz
  */
-interface KSValueArgument : KSAnnotated {
+interface KSLabeledExpression : KSExpression, KSLabelReferenceExpression {
+
     /**
-     * The name for the named argument, or null otherwise.
+     * The label name of the expression.
      *
-     * For example, in `ignore(name=123456)`, the name value is "name"
+     * For example, in `loop@ for (i in 1..100)`, the name is "loop"
      */
-    val name: KSName?
+    override val name: String
 
     /**
-     * True if it is a spread argument (i.e., has a "*" in front of the argument).
+     * The expression after the label.
+     *
+     * For example, in `loop@ for (i in 1..100)`, the body is "for (i in 1..100)"
      */
-    val isSpread: Boolean
-
-    /**
-     * The value of the argument.
-     */
-    val value: Any?
+    val body: KSExpression
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLambdaExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSLambdaExpression.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression for a lambda.
+ *
+ * @author RinOrz
+ */
+interface KSLambdaExpression : KSBlockExpression {
+
+    /**
+     * A list of arguments to the lambda expression.
+     *
+     * For example, in `call { a, b -> ... }`, the arguments is "[a, b]"
+     */
+    val parameters: List<KSValueParameter>
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
@@ -23,16 +23,11 @@ package com.google.devtools.ksp.symbol
  * Note that annotation use-site targets such as @get: @set: is not copied to accessor's annotations attribute.
  * Use KSAnnotated.findAnnotationFromUseSiteTarget() to ensure annotations from parent is obtained.
  */
-interface KSPropertyAccessor : KSAnnotated, KSModifierListOwner {
+interface KSPropertyAccessor : KSAnnotated, KSModifierListOwner, KSBlockExpression {
     /**
      * The owner of the property accessor.
      */
     val receiver: KSPropertyDeclaration
-
-    /**
-     * The body expression for this property accessor.
-     */
-    val body: KSExpression?
 }
 
 /**

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyAccessor.kt
@@ -28,6 +28,11 @@ interface KSPropertyAccessor : KSAnnotated, KSModifierListOwner {
      * The owner of the property accessor.
      */
     val receiver: KSPropertyDeclaration
+
+    /**
+     * The body expression for this property accessor.
+     */
+    val body: KSExpression?
 }
 
 /**

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -20,8 +20,15 @@ package com.google.devtools.ksp.symbol
 
 /**
  * A property declaration, can also be used to denote a variable declaration.
+ *
+ * This can also be viewed as an expression, such as a local property declaration:
+ * ```
+ * fun a() {
+ *     val localProperty = ... // here
+ * }
+ * ```
  */
-interface KSPropertyDeclaration : KSDeclaration {
+interface KSPropertyDeclaration : KSDeclaration, KSExpression {
 
     /**
      * Getter of the property.
@@ -53,9 +60,24 @@ interface KSPropertyDeclaration : KSDeclaration {
     val isMutable: Boolean
 
     /**
+     * Initialization expression for the property.
+     */
+    val initializer: KSExpression?
+
+    /**
+     * Delegation expression for the property.
+     */
+    val delegate: KSExpression?
+
+    /**
+     * Indicates whether this is a initialized property.
+     */
+    val isInitialized: Boolean
+
+    /**
      * Indicates whether this is a delegated property.
      */
-    fun isDelegated(): Boolean
+    val isDelegated: Boolean
 
     /**
      * Find the closest overridee of this property, if overriding.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSToken.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSToken.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.google.devtools.ksp.symbol
+
+
+/**
+ * The Kotlin keywords and operators.
+ *
+ * [Grammar](https://kotlinlang.org/docs/reference/keyword-reference.html)
+ *
+ * @author RinOrz
+ */
+sealed class KSToken(val symbol: String) {
+    object Casts : KSToken("as")
+    object SafeCasts : KSToken("as?")
+
+    object Semicolon : KSToken(";")
+
+    object Unknown : KSToken("???")
+
+    sealed class Operator(symbol: String) : KSToken(symbol) {
+        object Elvis : Operator("?:")
+
+        object In : Operator("in")
+        object NotIn : Operator("!in")
+
+        object Is : Operator("is")
+        object NotIs : Operator("!is")
+
+        object Plus : Operator("+")
+        object Minus : Operator("-")
+        object Times : Operator("*")
+        object Div : Operator("/")
+        object Rem : Operator("%")
+        object Range : Operator("..")
+
+        object PlusAssign : Operator("+=")
+        object MinusAssign : Operator("-=")
+        object TimesAssign : Operator("*=")
+        object DivAssign : Operator("/=")
+        object RemAssign : Operator("%=")
+
+        object Equal : Operator("=")
+
+        object Equality : Operator("==")
+        object NotEquality : Operator("!=")
+        object ReferenceEquality : Operator("===")
+        object ReferenceNotEquality : Operator("!==")
+
+        object Increments : Operator("++")
+        object Decrements : Operator("--")
+
+        object Disjunction : Operator("||")
+        object Conjunction : Operator("&&")
+        object Negation : Operator("!")
+
+        object LessThan : Operator("<")
+        object GreaterThan : Operator(">")
+        object LessThanOrEqual : Operator("<=")
+        object GreaterThanOrEqual : Operator(">=")
+    }
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSTypeCastExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSTypeCastExpression.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression that represents a type cast.
+ *
+ * @author RinOrz
+ */
+interface KSTypeCastExpression : KSExpression {
+
+    /**
+     * The type to be casted in the expression.
+     *
+     * For example, in `a as? kotlin.String`, the type is "kotlin.String"
+     */
+    val type: KSTypeReference?
+
+    /**
+     * The type to be converted in the expression.
+     *
+     * For example, in `foo as Boolean`, the body is "foo"
+     */
+    val body: KSExpression
+
+    /**
+     * The token used for the type cast.
+     *
+     * @see KSToken.Casts `as`
+     * @see KSToken.SafeCasts `as?`
+     */
+    val token: KSToken
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSUnaryExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSUnaryExpression.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * An expression for a unary operation.
+ *
+ * @author RinOrz
+ */
+interface KSUnaryExpression : KSExpression {
+
+    /**
+     * The body expression using the [token].
+     *
+     * For example, in `-1`, the body is "1"
+     */
+    val body: KSExpression
+
+    /**
+     * The token of the prefix or postfix in this expression.
+     *
+     * For example, in `1++`, the token is "++"
+     */
+    val token: KSToken
+
+    /**
+     * Returns true if the [token] is to the right of the [body].
+     *
+     * For example, in `--a`, the isPostfixOperation is false
+     */
+    val isPostfixOperation: Boolean
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgumentExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgumentExpression.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * A value argument expression to function / constructor calls.
+ *
+ * @author RinOrz
+ */
+interface KSValueArgumentExpression : KSExpression {
+
+    /**
+     * The index of the argument in the list.
+     *
+     * @see KSCallExpression.arguments
+     */
+    val index: Int
+
+    /**
+     * The name for the named argument, or null otherwise.
+     *
+     * For example, in `ignore(id=123456)`, the name value is "id"
+     */
+    val name: String?
+
+    /**
+     * True if it is a spread argument (i.e., has a "*" in front of the argument).
+     */
+    val isSpread: Boolean
+
+    /**
+     * The value of the argument.
+     */
+    val value: KSExpression?
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueParameter.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueParameter.kt
@@ -22,15 +22,21 @@ package com.google.devtools.ksp.symbol
  * A value parameter
  */
 interface KSValueParameter : KSAnnotated {
+
     /**
      * Name of the parameter
      */
     val name: KSName?
 
     /**
-     *  The reference to the type of the parameter.
+     * The reference to the type of the parameter.
+     *
+     * Note that if this parameter is defined in an anonymous function, it should be null:
+     * ```
+     * fun(value) { ... }
+     * ```
      */
-    val type: KSTypeReference
+    val type: KSTypeReference?
 
     /**
      * True if it is a vararg.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
@@ -38,6 +38,8 @@ interface KSVisitor<D, R> {
 
     fun visitFile(file: KSFile, data: D): R
 
+    fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R
+
     fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R
 
     fun visitCallableReference(reference: KSCallableReference, data: D): R
@@ -66,7 +68,23 @@ interface KSVisitor<D, R> {
 
     fun visitValueParameter(valueParameter: KSValueParameter, data: D): R
 
-    fun visitValueArgument(valueArgument: KSValueArgument, data: D): R
+    fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: D): R
 
     fun visitClassifierReference(reference: KSClassifierReference, data: D): R
+
+    fun visitExpression(expression: KSExpression, data: D): R
+
+    fun visitChainCallsExpression(expression: KSChainCallsExpression, data: D): R
+
+    fun visitIfExpression(expression: KSIfExpression, data: D): R
+
+    fun visitDslExpression(expression: KSDslExpression, data: D): R
+
+    fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R
+
+    fun visitBlockExpression(expression: KSBlockExpression, data: D): R
+
+    fun visitWhenExpression(expression: KSWhenExpression, data: D): R
+
+    fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: D): R
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
@@ -46,6 +46,9 @@ open class KSVisitorVoid : KSVisitor<Unit, Unit> {
     override fun visitFile(file: KSFile, data: Unit) {
     }
 
+    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: Unit) {
+    }
+
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
     }
 
@@ -91,6 +94,30 @@ open class KSVisitorVoid : KSVisitor<Unit, Unit> {
     override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
     }
 
-    override fun visitValueArgument(valueArgument: KSValueArgument, data: Unit) {
+    override fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: Unit) {
+    }
+
+    override fun visitExpression(expression: KSExpression, data: Unit) {
+    }
+
+    override fun visitChainCallsExpression(expression: KSChainCallsExpression, data: Unit) {
+    }
+
+    override fun visitBlockExpression(expression: KSBlockExpression, data: Unit) {
+    }
+
+    override fun visitLabeledExpression(expression: KSLabeledExpression, data: Unit) {
+    }
+
+    override fun visitDslExpression(expression: KSDslExpression, data: Unit) {
+    }
+
+    override fun visitIfExpression(expression: KSIfExpression, data: Unit) {
+    }
+
+    override fun visitWhenExpression(expression: KSWhenExpression, data: Unit) {
+    }
+
+    override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: Unit) {
     }
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSWhenExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSWhenExpression.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+@file:Suppress("RemoveRedundantQualifierName")
+
+package com.google.devtools.ksp.symbol
+
+
+/**
+ * An expression that represents the if-else.
+ *
+ * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#ifExpression)
+ *
+ * @author RinOrz
+ */
+interface KSWhenExpression : KSExpression {
+
+    /**
+     * All branches in the `when` expression.
+     */
+    val branches: List<KSWhenExpression.Branch>
+
+    /**
+     * The subject for the when expression.
+     *
+     * For example, in `when (a)`, the subject is "a"
+     *
+     * This is also a property declaration when the expression is `when (val a = ...)`
+     */
+    val subject: KSExpression?
+
+
+    /**
+     * A node that represents a branch in the `when` expression.
+     *
+     * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#whenEntry)
+     */
+    interface Branch : KSNode {
+
+        /**
+         * The test conditions for this branch.
+         *
+         * E.g:
+         * ```
+         * when(count) {
+         *     a, b -> {}  // conditions is "a" and "b"
+         *     in 1..2 -> {}  // conditions is "in 1..2"
+         *     is String -> {}  // conditions is "String"
+         * }
+         * ```
+         *
+         * @see KSWhenExpression.Branch.RangeCondition
+         * @see KSWhenExpression.Branch.TypeCondition
+         */
+        val conditions: Array<KSExpression>
+
+        /**
+         * The body behavior of this branch.
+         *
+         * E.g:
+         * ```
+         * when {
+         *     a -> invoke()  // behavior is "invoke()"
+         *     else -> {}  // behavior is "{}"
+         * }
+         * ```
+         */
+        val body: KSExpression
+
+        /**
+         * Whether this is an `else` branch.
+         */
+        val isElse: Boolean
+
+
+        /**
+         * An expression representing a range condition.
+         *
+         * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#rangeTest)
+         */
+        interface RangeCondition : KSExpression {
+
+            /**
+             * An operator used to determine if the condition is "in range"
+             *
+             * @see KSToken.Operator.In
+             * @see KSToken.Operator.NotIn
+             */
+            val operator: KSToken.Operator
+
+            /**
+             * The range expression for this condition.
+             *
+             * For example, in `in 1..10`, the range is "1..10"
+             *
+             * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#rangeExpression)
+             */
+            val range: KSBinaryExpression
+        }
+
+        /**
+         * An expression that expresses the type judgment condition.
+         *
+         * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#typeTest)
+         */
+        interface TypeCondition : KSExpression {
+
+            /**
+             * An operator used to determine if the condition is "has a certain type"
+             *
+             * @see KSToken.Operator.Is
+             * @see KSToken.Operator.NotIs
+             */
+            val operator: KSToken.Operator
+
+            /**
+             * The type that satisfies this condition.
+             *
+             * For example, in `is String`, the type is "String"
+             */
+            val type: KSTypeReference
+        }
+    }
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSWhenExpression.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSWhenExpression.kt
@@ -31,11 +31,6 @@ package com.google.devtools.ksp.symbol
 interface KSWhenExpression : KSExpression {
 
     /**
-     * All branches in the `when` expression.
-     */
-    val branches: List<KSWhenExpression.Branch>
-
-    /**
      * The subject for the when expression.
      *
      * For example, in `when (a)`, the subject is "a"
@@ -44,13 +39,18 @@ interface KSWhenExpression : KSExpression {
      */
     val subject: KSExpression?
 
+    /**
+     * All branches in the `when` expression.
+     */
+    val branches: List<KSWhenExpression.Branch>
+
 
     /**
      * A node that represents a branch in the `when` expression.
      *
      * [Grammar](https://kotlinlang.org/docs/reference/grammar.html#whenEntry)
      */
-    interface Branch : KSNode {
+    interface Branch : KSExpression {
 
         /**
          * The test conditions for this branch.
@@ -67,7 +67,7 @@ interface KSWhenExpression : KSExpression {
          * @see KSWhenExpression.Branch.RangeCondition
          * @see KSWhenExpression.Branch.TypeCondition
          */
-        val conditions: Array<KSExpression>
+        val conditions: List<KSExpression>
 
         /**
          * The body behavior of this branch.

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -45,6 +45,31 @@ inline fun <reified T> Resolver.getClassDeclarationByName(): KSClassDeclaration?
 fun Resolver.getClassDeclarationByName(name: String): KSClassDeclaration? = getClassDeclarationByName(getKSNameFromString(name))
 
 /**
+ * Get top-level declarations in all files.
+ */
+fun Resolver.getAllTopLevelDeclarations(): Sequence<KSPropertyDeclaration> {
+    return this.getAllFiles().asSequence().flatMap { it.declarations }.filterIsInstance<KSPropertyDeclaration>()
+}
+
+/**
+ * Get top-level property members in all files.
+ *
+ * @see getAllTopLevelDeclarations
+ */
+fun Resolver.getAllTopLevelProperties(): Sequence<KSPropertyDeclaration> {
+    return this.getAllTopLevelDeclarations().filterIsInstance<KSPropertyDeclaration>()
+}
+
+/**
+ * Get top-level function members in all files.
+ *
+ * @see getAllTopLevelDeclarations
+ */
+fun Resolver.getAllTopLevelFunctions(): Sequence<KSFunctionDeclaration> {
+    return this.getAllTopLevelDeclarations().filterIsInstance<KSFunctionDeclaration>()
+}
+
+/**
  * Get functions directly declared inside the class declaration.
  *
  * What are included: member functions, extension functions declared inside it, etc.
@@ -243,5 +268,25 @@ fun KSDeclaration.isVisibleFrom(other: KSDeclaration): Boolean {
     }
 
 }
+
+/**
+ * Get the else entry in the `when` expression.
+ *
+ * ```
+ * when {
+ *     else -> {}   // here
+ * }
+ * ```
+ */
+val KSWhenExpression.elseBranch: KSWhenExpression.Branch
+    get() = branches.first { it.isElse }
+
+
+/**
+ * Returns if an initializer block exists in the class declaration.
+ */
+val KSClassDeclaration.firstInitializerBlock: KSAnonymousInitializer?
+    get() = initializerBlocks.firstOrNull()
+
 
 const val ExceptionMessage = "please file a bug at https://github.com/google/ksp/issues/new"

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -36,14 +36,14 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
-        this.visitDeclaration(initializer, data)
         this.visitBlockExpression(initializer, data)
+        this.visitDeclaration(initializer, data)
         return super.visitAnonymousInitializer(initializer, data)
     }
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
-        this.visitDeclaration(function, data)
         this.visitBlockExpression(function, data)
+        this.visitDeclaration(function, data)
         return super.visitFunctionDeclaration(function, data)
     }
 
@@ -58,8 +58,8 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: D): R {
-        this.visitDeclaration(property, data)
         this.visitExpression(property, data)
+        this.visitDeclaration(property, data)
         return super.visitPropertyDeclaration(property, data)
     }
 
@@ -86,9 +86,9 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: D): R {
+        this.visitExpression(classDeclaration, data)
         this.visitDeclaration(classDeclaration, data)
         this.visitDeclarationContainer(classDeclaration, data)
-        this.visitExpression(classDeclaration, data)
         return super.visitClassDeclaration(classDeclaration, data)
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -43,8 +43,7 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
         this.visitDeclaration(function, data)
-        this.visitDeclarationContainer(function, data)
-        this.visitExpression(function, data)
+        this.visitBlockExpression(function, data)
         return super.visitFunctionDeclaration(function, data)
     }
 
@@ -67,6 +66,7 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: D): R {
         this.visitModifierListOwner(accessor, data)
         this.visitAnnotated(accessor, data)
+        this.visitBlockExpression(accessor, data)
         return super.visitPropertyAccessor(accessor, data)
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -35,9 +35,16 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
         return super.visitFile(file, data)
     }
 
+    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
+        this.visitDeclaration(initializer, data)
+        this.visitBlockExpression(initializer, data)
+        return super.visitAnonymousInitializer(initializer, data)
+    }
+
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
         this.visitDeclaration(function, data)
         this.visitDeclarationContainer(function, data)
+        this.visitExpression(function, data)
         return super.visitFunctionDeclaration(function, data)
     }
 
@@ -53,6 +60,7 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
 
     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: D): R {
         this.visitDeclaration(property, data)
+        this.visitExpression(property, data)
         return super.visitPropertyDeclaration(property, data)
     }
 
@@ -80,6 +88,7 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: D): R {
         this.visitDeclaration(classDeclaration, data)
         this.visitDeclarationContainer(classDeclaration, data)
+        this.visitExpression(classDeclaration, data)
         return super.visitClassDeclaration(classDeclaration, data)
     }
 
@@ -99,9 +108,9 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
         return super.visitValueParameter(valueParameter, data)
     }
 
-    override fun visitValueArgument(valueArgument: KSValueArgument, data: D): R {
+    override fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: D): R {
         this.visitAnnotated(valueArgument, data)
-        return super.visitValueArgument(valueArgument, data)
+        return super.visitAnnotationValueArgument(valueArgument, data)
     }
 
     override fun visitClassifierReference(reference: KSClassifierReference, data: D): R {
@@ -143,5 +152,45 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     override fun visitReferenceElement(element: KSReferenceElement, data: D): R {
         this.visitNode(element, data)
         return super.visitReferenceElement(element, data)
+    }
+
+    override fun visitExpression(expression: KSExpression, data: D): R {
+        this.visitNode(expression, data)
+        return super.visitExpression(expression, data)
+    }
+
+    override fun visitChainCallsExpression(expression: KSChainCallsExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitChainCallsExpression(expression, data)
+    }
+
+    override fun visitBlockExpression(expression: KSBlockExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitBlockExpression(expression, data)
+    }
+
+    override fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitLabeledExpression(expression, data)
+    }
+
+    override fun visitDslExpression(expression: KSDslExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitDslExpression(expression, data)
+    }
+
+    override fun visitIfExpression(expression: KSIfExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitIfExpression(expression, data)
+    }
+
+    override fun visitWhenExpression(expression: KSWhenExpression, data: D): R {
+        this.visitExpression(expression, data)
+        return super.visitWhenExpression(expression, data)
+    }
+
+    override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: D): R {
+        this.visitNode(whenBranch, data)
+        return super.visitWhenExpressionBranch(whenBranch, data)
     }
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -36,14 +36,14 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
-        this.visitBlockExpression(initializer, data)
         this.visitDeclaration(initializer, data)
+        this.visitBlockExpression(initializer, data)
         return super.visitAnonymousInitializer(initializer, data)
     }
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
-        this.visitBlockExpression(function, data)
         this.visitDeclaration(function, data)
+        this.visitBlockExpression(function, data)
         return super.visitFunctionDeclaration(function, data)
     }
 
@@ -58,8 +58,8 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: D): R {
-        this.visitExpression(property, data)
         this.visitDeclaration(property, data)
+        this.visitExpression(property, data)
         return super.visitPropertyDeclaration(property, data)
     }
 
@@ -86,9 +86,9 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: D): R {
-        this.visitExpression(classDeclaration, data)
         this.visitDeclaration(classDeclaration, data)
         this.visitDeclarationContainer(classDeclaration, data)
+        this.visitExpression(classDeclaration, data)
         return super.visitClassDeclaration(classDeclaration, data)
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -126,6 +126,7 @@ abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
     override fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: D): R {
         return defaultHandler(valueArgument, data)
     }
+
     override fun visitExpression(expression: KSExpression, data: D): R {
         return defaultHandler(expression, data)
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -58,6 +58,11 @@ abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
         return defaultHandler(file, data)
     }
 
+    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
+        return defaultHandler(initializer, data)
+    }
+
+
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
         return defaultHandler(function, data)
     }
@@ -118,7 +123,38 @@ abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
         return defaultHandler(valueParameter, data)
     }
 
-    override fun visitValueArgument(valueArgument: KSValueArgument, data: D): R {
+    override fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: D): R {
         return defaultHandler(valueArgument, data)
+    }
+    override fun visitExpression(expression: KSExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitChainCallsExpression(expression: KSChainCallsExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitDslExpression(expression: KSDslExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitIfExpression(expression: KSIfExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitBlockExpression(expression: KSBlockExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitWhenExpression(expression: KSWhenExpression, data: D): R {
+        return defaultHandler(expression, data)
+    }
+
+    override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: D): R {
+        return defaultHandler(whenBranch, data)
     }
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -26,107 +26,182 @@ import com.google.devtools.ksp.symbol.*
  * For subclasses overriding a function, remember to call the corresponding super method.
  */
 abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
-    private fun Collection<KSNode>.accept(data: D) {
-        forEach { it.accept(this@KSTopDownVisitor, data) }
-    }
+    private fun Collection<KSNode>.accept(data: D) = forEach { it.accept(this@KSTopDownVisitor, data) }
 
     private fun KSNode.accept(data: D) = accept(this@KSTopDownVisitor, data)
 
     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: D): R {
-        property.type.accept(data)
-        property.extensionReceiver?.accept(data)
-        property.getter?.accept(data)
-        property.setter?.accept(data)
-        return super.visitPropertyDeclaration(property, data)
+        return super.visitPropertyDeclaration(property, data).also {
+            property.type.accept(data)
+            property.extensionReceiver?.accept(data)
+            property.initializer?.accept(data)
+            property.delegate?.accept(data)
+            property.getter?.accept(data)
+            property.setter?.accept(data)
+        }
     }
 
     override fun visitAnnotated(annotated: KSAnnotated, data: D): R {
-        annotated.annotations.accept(data)
-        return super.visitAnnotated(annotated, data)
+        return super.visitAnnotated(annotated, data).also {
+            annotated.annotations.accept(data)
+        }
     }
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: D): R {
-        classDeclaration.superTypes.accept(data)
-        return super.visitClassDeclaration(classDeclaration, data)
+        return super.visitClassDeclaration(classDeclaration, data).also {
+            classDeclaration.superTypes.accept(data)
+        }
     }
 
     override fun visitDeclaration(declaration: KSDeclaration, data: D): R {
-        declaration.typeParameters.accept(data)
-        return super.visitDeclaration(declaration, data)
+        return super.visitDeclaration(declaration, data).also {
+            declaration.typeParameters.accept(data)
+        }
     }
 
     override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: D): R {
-        declarationContainer.declarations.accept(data)
-        return super.visitDeclarationContainer(declarationContainer, data)
+        return super.visitDeclarationContainer(declarationContainer, data).also {
+            declarationContainer.declarations.accept(data)
+        }
     }
 
     override fun visitAnnotation(annotation: KSAnnotation, data: D): R {
-        annotation.annotationType.accept(data)
-        annotation.arguments.accept(data)
-        return super.visitAnnotation(annotation, data)
+        return super.visitAnnotation(annotation, data).also {
+            annotation.annotationType.accept(data)
+            annotation.arguments.accept(data)
+        }
     }
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: D): R {
-        function.extensionReceiver?.accept(data)
-        function.parameters.accept(data)
-        function.returnType?.accept(data)
-        return super.visitFunctionDeclaration(function, data)
+        return super.visitFunctionDeclaration(function, data).also {
+            function.extensionReceiver?.accept(data)
+            function.parameters.accept(data)
+            function.returnType?.accept(data)
+            function.body?.accept(data)
+        }
     }
 
     override fun visitCallableReference(reference: KSCallableReference, data: D): R {
-        reference.functionParameters.accept(data)
-        reference.receiverType?.accept(data)
-        reference.returnType.accept(data)
-        return super.visitCallableReference(reference, data)
+        return super.visitCallableReference(reference, data).also {
+            reference.functionParameters.accept(data)
+            reference.receiverType?.accept(data)
+            reference.returnType.accept(data)
+        }
     }
 
     override fun visitParenthesizedReference(reference: KSParenthesizedReference, data: D): R {
-        reference.element.accept(data)
-        return super.visitParenthesizedReference(reference, data)
+        return super.visitParenthesizedReference(reference, data).also {
+            reference.element.accept(data)
+        }
     }
 
     override fun visitPropertyGetter(getter: KSPropertyGetter, data: D): R {
-        getter.returnType?.accept(data)
-        return super.visitPropertyGetter(getter, data)
+        return super.visitPropertyGetter(getter, data).also {
+            getter.returnType?.accept(data)
+        }
     }
 
     override fun visitPropertySetter(setter: KSPropertySetter, data: D): R {
-        setter.parameter.accept(data)
-        return super.visitPropertySetter(setter, data)
+        return super.visitPropertySetter(setter, data).also {
+            setter.parameter.accept(data)
+        }
     }
 
     override fun visitReferenceElement(element: KSReferenceElement, data: D): R {
-        element.typeArguments.accept(data)
-        return super.visitReferenceElement(element, data)
+        return super.visitReferenceElement(element, data).also {
+            element.typeArguments.accept(data)
+        }
     }
 
     override fun visitTypeAlias(typeAlias: KSTypeAlias, data: D): R {
-        typeAlias.type.accept(data)
-        return super.visitTypeAlias(typeAlias, data)
+        return super.visitTypeAlias(typeAlias, data).also {
+            typeAlias.type.accept(data)
+        }
     }
 
     override fun visitTypeArgument(typeArgument: KSTypeArgument, data: D): R {
-        typeArgument.type?.accept(data)
-        return super.visitTypeArgument(typeArgument, data)
+        return super.visitTypeArgument(typeArgument, data).also {
+            typeArgument.type?.accept(data)
+        }
     }
 
     override fun visitTypeParameter(typeParameter: KSTypeParameter, data: D): R {
-        typeParameter.bounds.accept(data)
-        return super.visitTypeParameter(typeParameter, data)
+        return super.visitTypeParameter(typeParameter, data).also {
+            typeParameter.bounds.accept(data)
+        }
     }
 
     override fun visitTypeReference(typeReference: KSTypeReference, data: D): R {
-        typeReference.element?.accept(data)
-        return super.visitTypeReference(typeReference, data)
+        return super.visitTypeReference(typeReference, data).also {
+            typeReference.element?.accept(data)
+        }
     }
 
     override fun visitClassifierReference(reference: KSClassifierReference, data: D): R {
-        reference.qualifier?.accept(data)
-        return super.visitClassifierReference(reference, data)
+        return super.visitClassifierReference(reference, data).also {
+            reference.qualifier?.accept(data)
+        }
     }
 
     override fun visitValueParameter(valueParameter: KSValueParameter, data: D): R {
-        valueParameter.type?.accept(data)
-        return super.visitValueParameter(valueParameter, data)
+        return super.visitValueParameter(valueParameter, data).also {
+            valueParameter.type?.accept(data)
+        }
+    }
+
+    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
+        return super.visitAnonymousInitializer(initializer, data).also {
+            initializer.statements.accept(data)
+        }
+    }
+
+    override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: D): R {
+        return super.visitPropertyAccessor(accessor, data).also {
+            accessor.body?.accept(data)
+        }
+    }
+
+    override fun visitChainCallsExpression(expression: KSChainCallsExpression, data: D): R {
+        return super.visitChainCallsExpression(expression, data).also {
+            expression.chains.accept(data)
+        }
+    }
+
+    override fun visitWhenExpression(expression: KSWhenExpression, data: D): R {
+        return super.visitWhenExpression(expression, data).also {
+            expression.subject?.accept(data)
+            expression.branches.accept(data)
+        }
+    }
+
+    override fun visitDslExpression(expression: KSDslExpression, data: D): R {
+        return super.visitDslExpression(expression, data).also {
+            expression.closures.accept(data)
+        }
+    }
+
+    override fun visitBlockExpression(expression: KSBlockExpression, data: D): R {
+        return super.visitBlockExpression(expression, data).also {
+            expression.statements.accept(data)
+        }
+    }
+
+    override fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R {
+        return super.visitLabeledExpression(expression, data).also {
+            expression.body.accept(data)
+        }
+    }
+
+    override fun visitIfExpression(expression: KSIfExpression, data: D): R {
+        return super.visitIfExpression(expression, data).also {
+            expression.then.accept(data)
+            expression.otherwise?.accept(data)
+        }
+    }
+
+    override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: D): R {
+        return super.visitWhenExpressionBranch(whenBranch, data).also {
+            whenBranch.body.accept(data)
+        }
     }
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -77,7 +77,6 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
             function.extensionReceiver?.accept(data)
             function.parameters.accept(data)
             function.returnType?.accept(data)
-            function.body?.accept(data)
         }
     }
 
@@ -149,21 +148,35 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
         }
     }
 
-    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: D): R {
-        return super.visitAnonymousInitializer(initializer, data).also {
-            initializer.statements.accept(data)
-        }
-    }
-
-    override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: D): R {
-        return super.visitPropertyAccessor(accessor, data).also {
-            accessor.body?.accept(data)
+    override fun visitBlockExpression(expression: KSBlockExpression, data: D): R {
+        return super.visitBlockExpression(expression, data).also {
+            expression.statements.accept(data)
         }
     }
 
     override fun visitChainCallsExpression(expression: KSChainCallsExpression, data: D): R {
         return super.visitChainCallsExpression(expression, data).also {
             expression.chains.accept(data)
+        }
+    }
+
+    override fun visitDslExpression(expression: KSDslExpression, data: D): R {
+        return super.visitDslExpression(expression, data).also {
+            expression.closures.accept(data)
+        }
+    }
+
+    override fun visitIfExpression(expression: KSIfExpression, data: D): R {
+        return super.visitIfExpression(expression, data).also {
+            expression.condition.accept(data)
+            expression.then.accept(data)
+            expression.otherwise?.accept(data)
+        }
+    }
+
+    override fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R {
+        return super.visitLabeledExpression(expression, data).also {
+            expression.body.accept(data)
         }
     }
 
@@ -174,33 +187,9 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
         }
     }
 
-    override fun visitDslExpression(expression: KSDslExpression, data: D): R {
-        return super.visitDslExpression(expression, data).also {
-            expression.closures.accept(data)
-        }
-    }
-
-    override fun visitBlockExpression(expression: KSBlockExpression, data: D): R {
-        return super.visitBlockExpression(expression, data).also {
-            expression.statements.accept(data)
-        }
-    }
-
-    override fun visitLabeledExpression(expression: KSLabeledExpression, data: D): R {
-        return super.visitLabeledExpression(expression, data).also {
-            expression.body.accept(data)
-        }
-    }
-
-    override fun visitIfExpression(expression: KSIfExpression, data: D): R {
-        return super.visitIfExpression(expression, data).also {
-            expression.then.accept(data)
-            expression.otherwise?.accept(data)
-        }
-    }
-
     override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: D): R {
         return super.visitWhenExpressionBranch(whenBranch, data).also {
+            whenBranch.conditions.accept(data)
             whenBranch.body.accept(data)
         }
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -67,9 +67,6 @@ class KSValidateVisitor(private val predicate: (KSNode?, KSNode) -> Boolean) : K
         if (!this.visitDeclaration(function, data)) {
             return false
         }
-        if (!this.visitDeclarationContainer(function, data)) {
-            return false
-        }
         return true
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -1,6 +1,5 @@
 package com.google.devtools.ksp.visitor
 
-import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.symbol.*
 
 class KSValidateVisitor(private val predicate: (KSNode?, KSNode) -> Boolean) : KSDefaultVisitor<KSNode?, Boolean>() {
@@ -84,7 +83,14 @@ class KSValidateVisitor(private val predicate: (KSNode?, KSNode) -> Boolean) : K
         return true
     }
 
+    override fun visitAnonymousInitializer(initializer: KSAnonymousInitializer, data: KSNode?): Boolean {
+        if (!this.visitDeclaration(initializer, data)) {
+            return false
+        }
+        return true
+    }
+
     override fun visitValueParameter(valueParameter: KSValueParameter, data: KSNode?): Boolean {
-        return valueParameter.type.accept(this, valueParameter)
+        return valueParameter.type?.accept(this, valueParameter) ?: true
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -18,6 +18,15 @@
 
 package com.google.devtools.ksp
 
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.impl.CodeGeneratorImpl
+import com.google.devtools.ksp.processing.impl.ResolverImpl
+import com.google.devtools.ksp.processor.AbstractTestProcessor
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCacheManager
+import com.google.devtools.ksp.symbol.impl.java.KSFileJavaImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSFileImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.StandardFileSystems
 import com.intellij.openapi.vfs.VirtualFileManager
@@ -28,15 +37,6 @@ import org.jetbrains.kotlin.cli.jvm.plugins.ServiceLoaderLite
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
-import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.SymbolProcessor
-import com.google.devtools.ksp.processing.impl.CodeGeneratorImpl
-import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.processor.AbstractTestProcessor
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.KSObjectCacheManager
-import com.google.devtools.ksp.symbol.impl.java.KSFileJavaImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSFileImpl
 import org.jetbrains.kotlin.incremental.isJavaFile
 import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.psi.KtFile

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp
 
+import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
 import com.intellij.mock.MockProject
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.jvm.config.JavaSourceRoot
@@ -25,15 +26,13 @@ import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.CompilerConfigurationKey
-import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
-import java.io.File
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.incremental.LookupTrackerImpl
 import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import java.io.File
 
 private val KSP_OPTIONS = CompilerConfigurationKey.create<KspOptions.Builder>("Ksp options")
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/MessageCollectorBasedKSPLogger.kt
@@ -18,12 +18,12 @@
 
 package com.google.devtools.ksp.processing.impl
 
-import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.symbol.FileLocation
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.NonExistLocation
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import java.io.PrintWriter
 import java.io.StringWriter
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
@@ -20,7 +20,6 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 
 abstract class AbstractTestProcessor : SymbolProcessor {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -20,9 +20,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSValueArgument
+import com.google.devtools.ksp.symbol.KSAnnotationValueArgument
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 
 class AnnotationArgumentProcessor : AbstractTestProcessor() {
@@ -46,7 +44,7 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
     }
 
     inner class ArgumentVisitor : KSVisitorVoid() {
-        override fun visitValueArgument(valueArgument: KSValueArgument, data: Unit) {
+        override fun visitAnnotationValueArgument(valueArgument: KSAnnotationValueArgument, data: Unit) {
             results.add(valueArgument.value.toString())
         }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -3,14 +3,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSFunction
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import com.google.devtools.ksp.symbol.KSType
-import com.google.devtools.ksp.symbol.KSTypeParameter
-import com.google.devtools.ksp.symbol.Nullability
+import com.google.devtools.ksp.symbol.*
 
 @Suppress("unused") // used by generated tests
 class AsMemberOfProcessor : AbstractTestProcessor() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BuiltInTypesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BuiltInTypesProcessor.kt
@@ -19,7 +19,7 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSType
 
 open class BuiltInTypesProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ClassKindsProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ClassKindsProcessor.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 open class ClassKindsProcessor : AbstractTestProcessor() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CrossModuleTypeAliasTestProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/CrossModuleTypeAliasTestProcessor.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.BaseVisitor
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
 class CrossModuleTypeAliasTestProcessor : AbstractTestProcessor() {
     private val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ExpressionsProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ExpressionsProcessor.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.firstInitializerBlock
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+import org.jetbrains.kotlin.psi.KtStatementExpression
+
+class ExpressionsProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val visitor = Visitor()
+
+    override fun process(resolver: Resolver) {
+        resolver.getClassDeclarationByName("Expressions")?.firstInitializerBlock?.accept(visitor, Unit)
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    private fun addResult(description: String, message: Any?) {
+        /**
+         * @see KSPropertyDeclarationImpl.shouldCreateSyntheticAccessor
+         */
+        if (message == "KSPropertyAccessor") return
+
+        results += "${description.lines().let { 
+            if (it.size > 1) {
+                it.first() + " .. " + description.last()
+            } else {
+                it.first()
+            }
+        }}  =>  ${message?.toString() ?: "<Unknown Expression>"}"
+    }
+
+    inner class Visitor : KSTopDownVisitor<Unit, Unit>() {
+        override fun defaultHandler(node: KSNode, data: Unit) = Unit
+
+        override fun visitExpression(expression: KSExpression, data: Unit) {
+            addResult(expression.text, expression.getName())
+            super.visitExpression(expression, data)
+        }
+
+        override fun visitWhenExpressionBranch(whenBranch: KSWhenExpression.Branch, data: Unit) {
+            addResult(whenBranch.toString(), "KSWhenExpression.Branch, isElse: ${whenBranch.isElse}")
+            super.visitWhenExpressionBranch(whenBranch, data)
+        }
+
+        private fun KSExpression.getName() = when(this) {
+            is KSAnonymousInitializer -> "KSAnonymousInitializer"
+            is KSPropertyAccessor -> "KSPropertyAccessor"
+            is KSClassDeclaration -> "KSClassDeclaration"
+            is KSPropertyDeclaration -> "KSPropertyDeclaration"
+            is KSFunctionDeclaration -> "KSFunctionDeclaration"
+            is KSChainCallsExpression -> "KSChainCallsExpression"
+            is KSDslExpression -> "KSDslExpression"
+            is KSCallExpression -> "KSCallExpression"
+            is KSWhenExpression -> "KSWhenExpression"
+            is KSLambdaExpression -> "KSLambdaExpression"
+            is KSBlockExpression -> "KSBlockExpression"
+            is KSLabeledExpression -> "KSLabeledExpression"
+            is KSJumpExpression -> "KSJumpExpression"
+            is KSLabelReferenceExpression -> "KSLabelReferenceExpression"
+            is KSBinaryExpression -> "KSBinaryExpression"
+            is KSUnaryExpression -> "KSUnaryExpression"
+            is KSIfExpression -> "KSIfExpression"
+            is KSConstantExpression -> "KSConstantExpression"
+            is KSTypeCastExpression -> "KSTypeCastExpression"
+            is KSValueArgumentExpression -> "KSValueArgumentExpression"
+            else -> null
+        }
+    }
+}
+

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ExpressionsProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ExpressionsProcessor.kt
@@ -24,7 +24,6 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
-import org.jetbrains.kotlin.psi.KtStatementExpression
 
 class ExpressionsProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAliasProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAliasProcessor.kt
@@ -19,10 +19,9 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
-import org.jetbrains.kotlin.types.getAbbreviation
 
 open class FunctionTypeAliasProcessor: AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MakeNullableProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MakeNullableProcessor.kt
@@ -19,7 +19,7 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSType
 
 open class MakeNullableProcessor: AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
@@ -3,12 +3,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSNode
-import com.google.devtools.ksp.symbol.KSPropertyGetter
-import com.google.devtools.ksp.symbol.KSPropertySetter
-import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 @KspExperimental

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MultiModuleTestProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MultiModuleTestProcessor.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.BaseVisitor
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
 class MultiModuleTestProcessor : AbstractTestProcessor() {
     private val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -75,7 +75,7 @@ class OverrideeProcessor: AbstractTestProcessor() {
             append(self.simpleName.asString())
             append(
                 self.parameters.joinToString(", ", prefix = "(", postfix = ")") {
-                    "${it.name?.asString()}:${it.type.resolve().declaration.simpleName.asString()}"
+                    "${it.name?.asString()}:${it.type?.resolve()?.declaration?.simpleName?.asString()}"
                 }
             )
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
@@ -18,7 +18,7 @@ class ParameterTypeProcessor : AbstractTestProcessor() {
             }
 
             override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
-                result.add(valueParameter.type.resolve().toString())
+                result.add(valueParameter.type?.resolve()?.toString() ?: "<ERROR TYPE>")
             }
         }, Unit) }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
@@ -19,9 +19,8 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 open class PlatformDeclarationProcessor: AbstractTestProcessor() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
@@ -20,7 +20,10 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
 
 class RecordJavaAsMemberOfProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
 
 class RecordJavaGetAllMembersProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 
 class RecordJavaOverridesProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
@@ -20,7 +20,6 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
 
 class RecordJavaProcessor : AbstractTestProcessor() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSType
 
 class RecordJavaSupertypesProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
@@ -19,7 +19,10 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
 import com.google.devtools.ksp.visitor.KSTopDownVisitor

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
@@ -19,7 +19,10 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 open class TypeAliasComparisonProcessor : AbstractTestProcessor() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -19,7 +19,8 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeAlias
 
 open class TypeAliasProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterReferenceProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterReferenceProcessor.kt
@@ -19,10 +19,9 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
-import com.google.devtools.ksp.visitor.KSTopDownVisitor
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.Origin
 
 open class TypeParameterReferenceProcessor: AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/KSObjectCacheManager.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/KSObjectCacheManager.kt
@@ -18,9 +18,6 @@
 
 package com.google.devtools.ksp.symbol.impl
 
-import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
-import com.google.devtools.ksp.symbol.impl.binary.KSAnnotationDescriptorImpl
-
 class KSObjectCacheManager {
     companion object {
         val caches = arrayListOf<KSObjectCache<*, *>>()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -19,19 +19,19 @@
 package com.google.devtools.ksp.symbol.impl.binary
 
 import com.google.devtools.ksp.ExceptionMessage
+import com.google.devtools.ksp.processing.impl.ResolverImpl
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.findPsi
+import com.google.devtools.ksp.symbol.impl.kotlin.KSAnnotationValueArgumentLiteImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import com.intellij.psi.JavaPsiFacade
 import com.intellij.psi.PsiAnnotationMethod
 import org.jetbrains.kotlin.descriptors.ClassConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
-import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.findPsi
-import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSAnnotationValueArgumentLiteImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -30,7 +30,7 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSAnnotationValueArgumentLiteImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtParameter
@@ -50,8 +50,8 @@ class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationD
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
     }
 
-    override val arguments: List<KSValueArgument> by lazy {
-        descriptor.createKSValueArguments()
+    override val arguments: List<KSAnnotationValueArgument> by lazy {
+        descriptor.createKSAnnotationValueArguments()
     }
 
     override val shortName: KSName by lazy {
@@ -90,24 +90,27 @@ private fun <T> ConstantValue<T>.toValue(): Any? = when (this) {
     else -> value
 }
 
-fun AnnotationDescriptor.createKSValueArguments(): List<KSValueArgument> {
+fun AnnotationDescriptor.createKSAnnotationValueArguments(): List<KSAnnotationValueArgument> {
+    var index = 0
     val presentValueArguments = allValueArguments.map { (name, constantValue) ->
-        KSValueArgumentLiteImpl.getCached(
+        KSAnnotationValueArgumentLiteImpl.getCached(
+            index,
             KSNameImpl.getCached(name.asString()),
             constantValue.toValue()
-        )
+        ).also { index++ }
     }
     val presentValueArgumentNames = presentValueArguments.map { it.name.asString() }
     val argumentsFromDefault = (this.type.constructor.declarationDescriptor as? ClassDescriptor)?.constructors?.single()?.let {
-        it.getAbsentDefaultArguments(presentValueArgumentNames)
+        it.getAbsentAnnotationDefaultArguments(presentValueArgumentNames)
     } ?: emptyList()
     return presentValueArguments.plus(argumentsFromDefault)
 }
 
-fun ClassConstructorDescriptor.getAbsentDefaultArguments(excludeNames: Collection<String>): Collection<KSValueArgument> {
+fun ClassConstructorDescriptor.getAbsentAnnotationDefaultArguments(excludeNames: Collection<String>): Collection<KSAnnotationValueArgument> {
     return this.valueParameters.filterNot { param -> excludeNames.contains(param.name.asString()) || !param.hasDefaultValue() }
-        .map { param ->
-            KSValueArgumentLiteImpl.getCached(
+        .mapIndexed { index, param ->
+            KSAnnotationValueArgumentLiteImpl.getCached(
+                index,
                 KSNameImpl.getCached(param.name.asString()),
                 param.getDefaultValue()
             )
@@ -115,8 +118,7 @@ fun ClassConstructorDescriptor.getAbsentDefaultArguments(excludeNames: Collectio
 }
 
 fun ValueParameterDescriptor.getDefaultValue(): Any? {
-    val psi = this.findPsi()
-    return when (psi) {
+    return when (val psi = this.findPsi()) {
         null -> {
             // TODO: This will only work for symbols from Java class.
             ResolverImpl.instance.javaActualAnnotationArgumentExtractor.extractDefaultValue(this, this.type)?.toValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -83,6 +83,9 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
         }
     }
 
+    override val superclassDeclarations: List<KSClassDeclaration>
+        get() = superTypes.mapNotNull { it.resolve().declaration as? KSClassDeclaration }
+
     override val typeParameters: List<KSTypeParameter> by lazy {
         descriptor.declaredTypeParameters.map { KSTypeParameterDescriptorImpl.getCached(it) }
     }
@@ -119,6 +122,11 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
         }
         modifiers
     }
+
+    // FIXME: Under what conditions do we need expression support for descriptor?
+    override val initializerBlocks: List<KSAnonymousInitializer> = emptyList()
+
+    override val text: String by lazy { toString() }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType =
         getKSTypeCached(descriptor.defaultType.replaceTypeArguments(typeArguments), typeArguments)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
@@ -18,10 +18,10 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
-import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.descriptors.ClassifierDescriptor
+import org.jetbrains.kotlin.descriptors.ClassifierDescriptorWithTypeParameters
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeProjection
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
@@ -18,12 +18,12 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.backend.common.serialization.findPackage
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSExpectActualDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSExpectActualDescriptorImpl.kt
@@ -18,11 +18,11 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import com.google.devtools.ksp.processing.impl.findActualsInKSDeclaration
 import com.google.devtools.ksp.processing.impl.findExpectsInKSDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSExpectActual
+import org.jetbrains.kotlin.descriptors.MemberDescriptor
 
 class KSExpectActualDescriptorImpl(val descriptor: MemberDescriptor) : KSExpectActual {
     override val isExpect: Boolean = descriptor.isExpect

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyAccessorDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyAccessorDescriptorImpl.kt
@@ -18,15 +18,10 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.findPsi
-import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationParameterImpl
 import com.google.devtools.ksp.symbol.impl.toFunctionKSModifiers
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 
 abstract class KSPropertyAccessorDescriptorImpl(val descriptor: PropertyAccessorDescriptor) : KSPropertyAccessor {
     override val origin: Origin = Origin.CLASS
@@ -41,10 +36,11 @@ abstract class KSPropertyAccessorDescriptorImpl(val descriptor: PropertyAccessor
         descriptor.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
     }
 
+    override val statements: List<KSExpression> get() = emptyList()
+
     override val modifiers: Set<Modifier> by lazy {
-        val modifiers = mutableSetOf<Modifier>()
-        modifiers.addAll(descriptor.toKSModifiers())
-        modifiers.addAll(descriptor.toFunctionKSModifiers())
-        modifiers
+        descriptor.toKSModifiers() + descriptor.toFunctionKSModifiers()
     }
+
+    override val text: String by lazy { toString() }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -18,13 +18,15 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.*
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.*
-import org.jetbrains.kotlin.codegen.coroutines.unwrapInitialDescriptorForSuspendFunction
-import org.jetbrains.kotlin.descriptors.impl.referencedProperty
-import org.jetbrains.kotlin.psi2ir.unwrappedGetMethod
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.findClosestOverridee
+import com.google.devtools.ksp.symbol.impl.toKSModifiers
+import com.google.devtools.ksp.symbol.impl.toKSPropertyDeclaration
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyGetterDescriptor
+import org.jetbrains.kotlin.descriptors.PropertySetterDescriptor
 
 class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: PropertyDescriptor) : KSPropertyDeclaration,
     KSDeclarationDescriptorImpl(descriptor),

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
@@ -18,9 +18,11 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.PropertyGetterDescriptor
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.descriptors.PropertyGetterDescriptor
 
 class KSPropertyGetterDescriptorImpl private constructor(descriptor: PropertyGetterDescriptor) :
     KSPropertyAccessorDescriptorImpl(descriptor), KSPropertyGetter {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertySetterDescriptorImpl.kt
@@ -18,9 +18,11 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.PropertySetterDescriptor
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.descriptors.PropertySetterDescriptor
 
 class KSPropertySetterDescriptorImpl private constructor(descriptor: PropertySetterDescriptor) :
     KSPropertyAccessorDescriptorImpl(descriptor), KSPropertySetter {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
@@ -4,11 +4,7 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
-import org.jetbrains.kotlin.descriptors.ClassKind
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.descriptors.MemberDescriptor
 import org.jetbrains.kotlin.descriptors.TypeAliasDescriptor
-import org.jetbrains.kotlin.types.KotlinType
 
 class KSTypeAliasDescriptorImpl(descriptor: TypeAliasDescriptor) : KSTypeAlias,
         KSDeclarationDescriptorImpl(descriptor),

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -19,15 +19,15 @@
 package com.google.devtools.ksp.symbol.impl.binary
 
 import com.google.devtools.ksp.ExceptionMessage
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.PropertyDescriptor
-import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toKSVariance
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypeParameterDescriptor) : KSTypeParameter,

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -19,14 +19,16 @@
 package com.google.devtools.ksp.symbol.impl.binary
 
 import com.google.devtools.ksp.ExceptionMessage
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import org.jetbrains.kotlin.builtins.isSuspendFunctionTypeOrSubtype
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
-import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.Modifier
-import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
-import org.jetbrains.kotlin.types.*
+import org.jetbrains.kotlin.types.FlexibleType
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.SimpleType
+import org.jetbrains.kotlin.types.TypeUtils
 
 class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinType) : KSTypeReference {
     companion object : KSObjectCache<KotlinType, KSTypeReferenceDescriptorImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
@@ -18,10 +18,10 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.binary.getAbsentDefaultArguments
+import com.google.devtools.ksp.symbol.impl.binary.getAbsentAnnotationDefaultArguments
 import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
@@ -52,7 +52,7 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
         )
     }
 
-    override val arguments: List<KSValueArgument> by lazy {
+    override val arguments: List<KSAnnotationValueArgument> by lazy {
         val annotationConstructor =
             ((annotationType.resolve() as KSTypeImpl).kotlinType.constructor.declarationDescriptor as? ClassDescriptor)
                 ?.constructors?.single()
@@ -68,14 +68,15 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
                 } else {
                     calcValue(it.value)
                 }
-                KSValueArgumentJavaImpl.getCached(
+                KSAnnotationValueArgumentJavaImpl.getCached(
+                    index,
                     name = name?.let(KSNameImpl::getCached),
                     value = calculatedValue
                 )
             }
         val presentValueArgumentNames = presentValueArguments.map { it.name?.asString() ?: "" }
         val argumentsFromDefault = annotationConstructor?.let {
-            it.getAbsentDefaultArguments(presentValueArgumentNames)
+            it.getAbsentAnnotationDefaultArguments(presentValueArgumentNames)
         } ?: emptyList()
         presentValueArguments.plus(argumentsFromDefault)
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationValueArgumentJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationValueArgumentJavaImpl.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.java
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.kotlin.KSAnnotationValueArgumentImpl
+
+class KSAnnotationValueArgumentJavaImpl private constructor(override val index: Int, override val name: KSName?, override val value: Any?) : KSAnnotationValueArgumentImpl() {
+    companion object : KSObjectCache<Triple<Int, KSName?, Any?>, KSAnnotationValueArgumentJavaImpl>() {
+        fun getCached(index: Int, name: KSName?, value: Any?) = cache.getOrPut(Triple(index, name, value)) { KSAnnotationValueArgumentJavaImpl(index, name, value) }
+    }
+
+    override val origin = Origin.JAVA
+
+    override val location: Location = NonExistLocation
+
+    override val isSpread: Boolean = false
+
+    override val annotations: List<KSAnnotation> = emptyList()
+
+    override fun toString(): String {
+        return "${name?.asString() ?: ""}:${value.toString()}"
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -18,20 +18,17 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiClass
-import com.intellij.psi.PsiJavaFile
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.Visibilities
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
-import com.google.devtools.ksp.symbol.impl.replaceTypeArguments
-import com.google.devtools.ksp.symbol.impl.toKSFunctionDeclaration
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiJavaFile
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -133,8 +133,18 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) : KSClas
         psi.superTypes.map { KSTypeReferenceJavaImpl.getCached(it) }
     }
 
+    override val superclassDeclarations: List<KSClassDeclaration> by lazy {
+        superTypes.mapNotNull { it.resolve().declaration as? KSClassDeclaration }
+    }
+
     override val typeParameters: List<KSTypeParameter> by lazy {
         psi.typeParameters.map { KSTypeParameterJavaImpl.getCached(it) }
+    }
+
+    override val initializerBlocks: List<KSAnonymousInitializer> get() = emptyList()
+
+    override val text: String by lazy {
+        psi.text
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceJavaImpl.kt
@@ -18,12 +18,12 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiClassType
-import com.intellij.psi.PsiJavaCodeReferenceElement
-import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiClassType
+import com.intellij.psi.PsiJavaCodeReferenceElement
+import com.intellij.psi.impl.source.PsiClassReferenceType
 
 class KSClassifierReferenceJavaImpl private constructor(val psi: PsiClassType) : KSClassifierReference {
     companion object : KSObjectCache<PsiClassType, KSClassifierReferenceJavaImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFileJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFileJavaImpl.kt
@@ -18,11 +18,11 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiJavaFile
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiJavaFile
 
 class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile {
     companion object : KSObjectCache<PsiJavaFile, KSFileJavaImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -52,8 +52,6 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
         return descriptor?.findClosestOverridee()?.toKSFunctionDeclaration()
     }
 
-    override val declarations: List<KSDeclaration> = emptyList()
-
     override val extensionReceiver: KSTypeReference? = null
 
     override val functionKind: FunctionKind = if (psi.hasModifier(JvmModifier.STATIC)) FunctionKind.STATIC else FunctionKind.MEMBER
@@ -94,6 +92,13 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
 
     override val typeParameters: List<KSTypeParameter> by lazy {
         psi.typeParameters.map { KSTypeParameterJavaImpl.getCached(it) }
+    }
+
+    // TODO: Support for Java expressions
+    override val statements: List<KSExpression> get() = emptyList()
+
+    override val text: String by lazy {
+        psi.text
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -18,13 +18,15 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiField
-import com.intellij.psi.PsiJavaFile
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
-import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import com.google.devtools.ksp.symbol.impl.toKSModifiers
+import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiJavaFile
 
 class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSPropertyDeclaration, KSDeclarationJavaImpl(),
     KSExpectActual by KSExpectActualNoImpl() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 
 class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSPropertyDeclaration, KSDeclarationJavaImpl(),
     KSExpectActual by KSExpectActualNoImpl() {
@@ -53,6 +54,11 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
 
     override val setter: KSPropertySetter? = null
 
+    override val text: String by lazy {
+        psi.text
+    }
+
+
     override val modifiers: Set<Modifier> by lazy {
         psi.toKSModifiers()
     }
@@ -75,16 +81,21 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
         KSTypeReferenceJavaImpl.getCached(psi.type)
     }
 
-    override fun findOverridee(): KSPropertyDeclaration? {
-        return null
+    override val isDelegated: Boolean = false
+
+    override val isInitialized: Boolean by lazy {
+        psi.hasInitializer()
     }
 
-    override fun isDelegated(): Boolean {
-        return false
+    // TODO: Support for Java expressions
+    override val initializer: KSExpression? = null
+    override val delegate: KSExpression? = null
+
+    override fun findOverridee(): KSPropertyDeclaration? {
+        return null
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyDeclaration(this, data)
     }
-
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -18,13 +18,13 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiType
-import com.intellij.psi.PsiWildcardType
-import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiWildcardType
+import com.intellij.psi.impl.source.PsiClassReferenceType
 
 class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgumentImpl() {
     companion object : KSObjectCache<PsiType, KSTypeArgumentJavaImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
@@ -18,14 +18,14 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiJavaFile
-import com.intellij.psi.PsiTypeParameter
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiJavaFile
+import com.intellij.psi.PsiTypeParameter
 
 class KSTypeParameterJavaImpl private constructor(val psi: PsiTypeParameter) : KSTypeParameter, KSDeclarationJavaImpl(),
     KSExpectActual by KSExpectActualNoImpl() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -19,8 +19,6 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.ExceptionMessage
-import com.intellij.psi.*
-import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
@@ -29,6 +27,8 @@ import com.google.devtools.ksp.symbol.impl.binary.KSClassifierReferenceDescripto
 import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.*
+import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.descriptors.NotFoundClasses
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.Variance

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
@@ -18,11 +18,11 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
-import com.intellij.psi.PsiParameter
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiParameter
 
 class KSValueParameterJavaImpl private constructor(val psi: PsiParameter) : KSValueParameter {
     companion object : KSObjectCache<PsiParameter, KSValueParameterJavaImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -22,9 +22,10 @@ import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.binary.createKSValueArguments
+import com.google.devtools.ksp.symbol.impl.binary.createKSAnnotationValueArguments
 import com.google.devtools.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget as KtAnnotationUseSiteTarget
 
 class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEntry) : KSAnnotation {
     companion object : KSObjectCache<KtAnnotationEntry, KSAnnotationImpl>() {
@@ -41,8 +42,8 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
         KSTypeReferenceImpl.getCached(ktAnnotationEntry.typeReference!!)
     }
 
-    override val arguments: List<KSValueArgument> by lazy {
-        resolved?.createKSValueArguments() ?: listOf()
+    override val arguments: List<KSAnnotationValueArgument> by lazy {
+        resolved?.createKSAnnotationValueArguments() ?: listOf()
     }
 
     override val shortName: KSName by lazy {
@@ -52,15 +53,15 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
     override val useSiteTarget: AnnotationUseSiteTarget? by lazy {
         when (ktAnnotationEntry.useSiteTarget?.getAnnotationUseSiteTarget()) {
             null -> null
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FILE -> AnnotationUseSiteTarget.FILE
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY -> AnnotationUseSiteTarget.PROPERTY
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FIELD -> AnnotationUseSiteTarget.FIELD
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_GETTER -> AnnotationUseSiteTarget.GET
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_SETTER -> AnnotationUseSiteTarget.SET
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.RECEIVER -> AnnotationUseSiteTarget.RECEIVER
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
-            org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
+            KtAnnotationUseSiteTarget.FILE -> AnnotationUseSiteTarget.FILE
+            KtAnnotationUseSiteTarget.PROPERTY -> AnnotationUseSiteTarget.PROPERTY
+            KtAnnotationUseSiteTarget.FIELD -> AnnotationUseSiteTarget.FIELD
+            KtAnnotationUseSiteTarget.PROPERTY_GETTER -> AnnotationUseSiteTarget.GET
+            KtAnnotationUseSiteTarget.PROPERTY_SETTER -> AnnotationUseSiteTarget.SET
+            KtAnnotationUseSiteTarget.RECEIVER -> AnnotationUseSiteTarget.RECEIVER
+            KtAnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
+            KtAnnotationUseSiteTarget.SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
+            KtAnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -18,12 +18,12 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.createKSAnnotationValueArguments
 import com.google.devtools.ksp.symbol.impl.toLocation
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget as KtAnnotationUseSiteTarget
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationValueArgumentImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationValueArgumentImpl.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+
+class KSAnnotationValueArgumentLiteImpl private constructor(override val index: Int, override val name: KSName, override val value: Any?) : KSAnnotationValueArgumentImpl() {
+    companion object : KSObjectCache<Triple<Int, KSName, Any?>, KSAnnotationValueArgumentLiteImpl>() {
+        fun getCached(index: Int, name: KSName, value: Any?) = cache.getOrPut(Triple(index, name, value)) { KSAnnotationValueArgumentLiteImpl(index, name, value) }
+    }
+
+    override val origin = Origin.KOTLIN
+
+    override val location: Location = NonExistLocation
+
+    override val annotations: List<KSAnnotation> = emptyList()
+
+    override val isSpread: Boolean = false
+}
+
+abstract class KSAnnotationValueArgumentImpl : KSAnnotationValueArgument {
+    override fun hashCode(): Int {
+        return name.hashCode() * 31 + value.hashCode()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is KSAnnotationValueArgument)
+            return false
+
+        return other.name == this.name && other.value == this.value
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitAnnotationValueArgument(this, data)
+    }
+
+    override fun toString(): String {
+        return "${name?.asString() ?: ""} = ${value.toString()}"
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnonymousInitializerImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnonymousInitializerImpl.kt
@@ -18,12 +18,14 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSAnonymousInitializer
+import com.google.devtools.ksp.symbol.KSExpectActual
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import org.jetbrains.kotlin.psi.KtAnonymousInitializer
 import org.jetbrains.kotlin.psi.KtBlockExpression
-import org.jetbrains.kotlin.psi.KtClassInitializer
 
 class KSAnonymousInitializerImpl private constructor(val ktAnonymousInitializer: KtAnonymousInitializer) : KSAnonymousInitializer,
     KSDeclarationImpl(ktAnonymousInitializer), KSExpectActual by KSExpectActualImpl(ktAnonymousInitializer) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnonymousInitializerImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnonymousInitializerImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.KtAnonymousInitializer
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtClassInitializer
+
+class KSAnonymousInitializerImpl private constructor(val ktAnonymousInitializer: KtAnonymousInitializer) : KSAnonymousInitializer,
+    KSDeclarationImpl(ktAnonymousInitializer), KSExpectActual by KSExpectActualImpl(ktAnonymousInitializer) {
+    companion object : KSObjectCache<KtAnonymousInitializer, KSAnonymousInitializerImpl>() {
+        fun getCached(ktAnonymousInitializer: KtAnonymousInitializer) =
+            cache.getOrPut(ktAnonymousInitializer) { KSAnonymousInitializerImpl(ktAnonymousInitializer) }
+    }
+
+    override val statements: List<KSExpression> by lazy {
+        (ktAnonymousInitializer.body as? KtBlockExpression)?.statements?.mapNotNull {
+            it.toKSExpression()
+        } ?: emptyList()
+    }
+
+    override val text: String by lazy {
+        ktAnonymousInitializer.text
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitAnonymousInitializer(this, data)
+    }
+}
+

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBinaryExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBinaryExpressionImpl.kt
@@ -18,14 +18,12 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.KSExpression
 import com.google.devtools.ksp.symbol.KSBinaryExpression
-import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.KSExpression
 import com.google.devtools.ksp.symbol.KSToken
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import com.google.devtools.ksp.symbol.impl.toKSToken
-import org.jetbrains.kotlin.lexer.KtKeywordToken
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 
 class KSBinaryExpressionImpl private constructor(val ktBinaryExpression: KtBinaryExpression) : KSBinaryExpression, KSExpressionImpl(ktBinaryExpression) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBinaryExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBinaryExpressionImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSBinaryExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.KSToken
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.google.devtools.ksp.symbol.impl.toKSToken
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+
+class KSBinaryExpressionImpl private constructor(val ktBinaryExpression: KtBinaryExpression) : KSBinaryExpression, KSExpressionImpl(ktBinaryExpression) {
+    companion object : KSObjectCache<KtBinaryExpression, KSBinaryExpressionImpl>() {
+        fun getCached(ktBinaryExpression: KtBinaryExpression) = cache.getOrPut(ktBinaryExpression) { KSBinaryExpressionImpl(ktBinaryExpression) }
+    }
+
+    override val token: KSToken by lazy {
+        ktBinaryExpression.toKSToken()
+    }
+
+    override val left: KSExpression by lazy {
+        ktBinaryExpression.left?.toKSExpression()
+            ?: error("Cannot get the expression to the left of '${token.symbol}'.")
+    }
+
+    override val right: KSExpression by lazy {
+        ktBinaryExpression.right?.toKSExpression()
+            ?: error("Cannot get the expression to the right of '${token.symbol}'.")
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBlockExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBlockExpressionImpl.kt
@@ -23,7 +23,6 @@ import com.google.devtools.ksp.symbol.KSExpression
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
-import com.intellij.psi.PsiCodeBlock
 import org.jetbrains.kotlin.psi.KtBlockExpression
 
 class KSBlockExpressionImpl private constructor(ktBlockExpression: KtBlockExpression) : KSBlockExpression, KSExpressionImpl(ktBlockExpression) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBlockExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSBlockExpressionImpl.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSBlockExpression
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.intellij.psi.PsiCodeBlock
+import org.jetbrains.kotlin.psi.KtBlockExpression
+
+class KSBlockExpressionImpl private constructor(ktBlockExpression: KtBlockExpression) : KSBlockExpression, KSExpressionImpl(ktBlockExpression) {
+    companion object : KSObjectCache<KtBlockExpression, KSBlockExpressionImpl>() {
+        fun getCached(ktBlockExpression: KtBlockExpression) = cache.getOrPut(ktBlockExpression) { KSBlockExpressionImpl(ktBlockExpression) }
+    }
+
+    override val statements: List<KSExpression> by lazy {
+        ktBlockExpression.statements.mapNotNull { it.toKSExpression() }
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitBlockExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSCallExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSCallExpressionImpl.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.processing.impl.ResolverImpl
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.*
+
+open class KSCallExpressionImpl(ktExpression: KtExpression) : KSCallExpression, KSExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<KtExpression, KSCallExpressionImpl>() {
+        fun getCached(ktExpression: KtExpression) = cache.getOrPut(ktExpression) { KSCallExpressionImpl(ktExpression) }
+    }
+
+    override val receiver: KSExpression? by lazy {
+        callNameExpression?.getReceiverExpression()?.let {
+            when(it) {
+                is KtQualifiedExpression -> it.selectorExpression.toKSExpression()
+                else -> it.toKSExpression()
+            }
+        }
+    }
+
+    override val name: String by lazy {
+        callNameExpression?.getReferencedName()
+            ?: error("This is an incorrect call expression: ${ktExpression.text}")
+    }
+
+    override val arguments: List<KSValueArgumentExpression>? by lazy {
+        callExpression?.valueArguments?.mapIndexed { index, valueArgument ->
+            KSValueArgumentExpressionImpl.getCached(index, valueArgument)
+        }
+    }
+
+    private val callExpression get() = ktExpression as? KtCallExpression
+
+    private val callNameExpression by lazy {
+        callExpression?.getCallNameExpression() ?: ktExpression as? KtSimpleNameExpression
+    }
+
+    override fun resolve(): KSDeclaration? = ResolverImpl.instance.resolveCallDeclaration(ktExpression)
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSCallExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSCallExpressionImpl.kt
@@ -19,11 +19,18 @@
 package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSCallExpression
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSValueArgumentExpression
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
-import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.*
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 
 open class KSCallExpressionImpl(ktExpression: KtExpression) : KSCallExpression, KSExpressionImpl(ktExpression) {
     companion object : KSObjectCache<KtExpression, KSCallExpressionImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSChainCallsExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSChainCallsExpressionImpl.kt
@@ -23,7 +23,8 @@ import com.google.devtools.ksp.symbol.KSExpression
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
 
 class KSChainCallsExpressionImpl private constructor(ktExpression: KtExpression, override val chains: List<KSExpression>) :
     KSChainCallsExpression, KSExpressionImpl(ktExpression) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSChainCallsExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSChainCallsExpressionImpl.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSChainCallsExpression
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.*
+
+class KSChainCallsExpressionImpl private constructor(ktExpression: KtExpression, override val chains: List<KSExpression>) :
+    KSChainCallsExpression, KSExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<Pair<KtExpression, List<KSExpression>>, KSChainCallsExpressionImpl>() {
+        fun getCachedOrNull(ktExpression: KtExpression): KSChainCallsExpressionImpl? {
+            var base: KtExpression = ktExpression as? KtQualifiedExpression ?: return null
+            val chains = ArrayDeque<KSExpression>()
+
+            while (base is KtQualifiedExpression) {
+                base.selectorExpression.toKSExpression()?.let(chains::addFirst)
+                base = base.receiverExpression
+            }
+
+            base.toKSExpression()?.let(chains::addFirst)
+
+            return when {
+                chains.size <= 2 -> null
+                else -> cache.getOrPut(Pair(ktExpression, chains)) { KSChainCallsExpressionImpl(ktExpression, chains) }
+            }
+        }
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitChainCallsExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -41,6 +41,12 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
         fun getCached(ktClassOrObject: KtClassOrObject) = cache.getOrPut(ktClassOrObject) { KSClassDeclarationImpl(ktClassOrObject) }
     }
 
+    override val initializerBlocks: List<KSAnonymousInitializer> by lazy {
+        ktClassOrObject.getAnonymousInitializers().map {
+            KSAnonymousInitializerImpl.getCached(it)
+        }
+    }
+
     override val classKind: ClassKind by lazy {
         ktClassOrObject.getClassType()
     }
@@ -83,8 +89,15 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
         ktClassOrObject.superTypeListEntries.map { KSTypeReferenceImpl.getCached(it.typeReference!!) }
     }
 
+    override val superclassDeclarations: List<KSClassDeclaration>
+        get() = superTypes.mapNotNull { it.resolve().declaration as? KSClassDeclaration }
+
     private val descriptor: ClassDescriptor by lazy {
         (ResolverImpl.instance.resolveDeclaration(ktClassOrObject) as ClassDescriptor)
+    }
+
+    override val text: String by lazy {
+        ktClassOrObject.text
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -18,14 +18,13 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.Visibilities
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.synthetic.KSConstructorSyntheticImpl
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toLocation
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtUserType
 
 class KSClassifierReferenceImpl private constructor(val ktUserType: KtUserType) : KSClassifierReference {
     companion object : KSObjectCache<KtUserType, KSClassifierReferenceImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSConstantExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSConstantExpressionImpl.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.processing.impl.ResolverImpl
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.intellij.openapi.util.text.StringUtil
+import org.jetbrains.kotlin.psi.*
+
+
+class KSConstantExpressionImpl private constructor(ktExpression: KtExpression) : KSConstantExpression, KSExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<KtExpression, KSConstantExpressionImpl>() {
+        fun getCached(ktTypeReference: KtExpression) = cache.getOrPut(ktTypeReference) { KSConstantExpressionImpl(ktTypeReference) }
+    }
+
+    override val value: Any? by lazy {
+        when(ktExpression) {
+            is KtConstantExpression -> ResolverImpl.instance.resolveConstant(ktExpression)
+            // from: https://github.com/JetBrains/kotlin/blob/master/compiler/frontend/src/org/jetbrains/kotlin/psi/psiUtil/KtStringTemplateExpressionManipulator.kt#L53-L58
+            is KtStringTemplateExpression -> ktExpression.entries.joinToString("") { entry ->
+                when (entry) {
+                    is KtStringTemplateEntryWithExpression -> entry.text
+                    else -> StringUtil.escapeStringCharacters(entry.text)
+                }
+            }
+            else -> null
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSConstantExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSConstantExpressionImpl.kt
@@ -19,10 +19,13 @@
 package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSConstantExpression
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.intellij.openapi.util.text.StringUtil
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtConstantExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 
 
 class KSConstantExpressionImpl private constructor(ktExpression: KtExpression) : KSConstantExpression, KSExpressionImpl(ktExpression) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -32,7 +32,7 @@ abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
     }
 
     override val simpleName: KSName by lazy {
-        KSNameImpl.getCached(ktDeclaration.name!!)
+        KSNameImpl.getCached(ktDeclaration.name ?: "<anonymous>")
     }
 
     override val qualifiedName: KSName? by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -22,7 +22,9 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
 import com.google.devtools.ksp.symbol.impl.toLocation
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
 
 abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
     override val origin: Origin = Origin.KOTLIN

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDslExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDslExpressionImpl.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
+
+class KSDslExpressionImpl private constructor(
+    ktExpression: KtExpression,
+    override val closures: List<KSLambdaExpression>
+) : KSDslExpression, KSCallExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<KtExpression, KSDslExpressionImpl>() {
+        fun getCachedOrNull(ktExpression: KtExpression): KSDslExpressionImpl? {
+            val ktCallExpression = ktExpression as? KtCallExpression
+                ?: (ktExpression as? KtQualifiedExpression)?.selectorExpression as? KtCallExpression
+                ?: return null
+            val closures = ktCallExpression.valueArguments.mapNotNull {
+                (it as? KtLambdaArgument)?.getLambdaExpression()?.let(KSLambdaExpressionImpl::getCached)
+            }
+            return when {
+                closures.isEmpty() -> null
+                else -> cache.getOrPut(ktExpression) { KSDslExpressionImpl(ktExpression, closures) }
+            }
+        }
+    }
+
+    override val arguments: List<KSValueArgumentExpression> by lazy {
+        super.arguments!!
+    }
+
+    override fun resolve(): KSFunctionDeclaration? {
+        return super.resolve() as? KSFunctionDeclaration
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitDslExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDynamicReferenceImpl.kt
@@ -20,7 +20,6 @@ package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import org.jetbrains.kotlin.psi.KtUserType
 
 class KSDynamicReferenceImpl private constructor() : KSDynamicReference {
     companion object : KSObjectCache<Unit, KSDynamicReferenceImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSErrorValueParameter.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSErrorValueParameter.kt
@@ -16,26 +16,24 @@
  */
 
 
-package com.google.devtools.ksp.symbol.impl.java
+package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.kotlin.KSValueArgumentImpl
 
-class KSValueArgumentJavaImpl private constructor(override val name: KSName?, override val value: Any?) : KSValueArgumentImpl() {
-    companion object : KSObjectCache<Pair<KSName?, Any?>, KSValueArgumentJavaImpl>() {
-        fun getCached(name: KSName?, value: Any?) = cache.getOrPut(Pair(name, value)) { KSValueArgumentJavaImpl(name, value) }
-    }
-
-    override val origin = Origin.JAVA
-
+object KSErrorValueParameter : KSValueParameter {
+    override val name: KSName? = null
+    override val type: KSTypeReference? = null
+    override val isVararg: Boolean = false
+    override val isNoInline: Boolean = false
+    override val isCrossInline: Boolean = false
+    override val isVal: Boolean = false
+    override val isVar: Boolean = false
+    override val hasDefault: Boolean = false
+    override val annotations: List<KSAnnotation> get() = emptyList()
+    override val origin: Origin = Origin.SYNTHETIC
     override val location: Location = NonExistLocation
 
-    override val isSpread: Boolean = false
-
-    override val annotations: List<KSAnnotation> = emptyList()
-
-    override fun toString(): String {
-        return "${name?.asString() ?: ""}:${value.toString()}"
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitValueParameter(this, data)
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSExpectActualImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSExpectActualImpl.kt
@@ -18,12 +18,12 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.processing.impl.findActualsInKSDeclaration
 import com.google.devtools.ksp.processing.impl.findExpectsInKSDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSExpectActual
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.hasActualModifier

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSExpressionImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toLocation
+import org.jetbrains.kotlin.psi.KtExpression
+
+open class KSExpressionImpl(val ktExpression: KtExpression) : KSExpression {
+    companion object : KSObjectCache<KtExpression, KSExpressionImpl>() {
+        fun getCached(expression: KtExpression) = cache.getOrPut(expression) { KSExpressionImpl(expression) }
+    }
+
+    override val text: String by lazy {
+        ktExpression.text
+    }
+
+    override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        ktExpression.toLocation()
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitExpression(this, data)
+    }
+
+    override fun toString(): String = text
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -19,18 +19,16 @@
 package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.ExceptionMessage
-import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import com.google.devtools.ksp.isOpen
-import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
-import com.google.devtools.ksp.symbol.impl.*
-import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.findClosestOverridee
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.google.devtools.ksp.symbol.impl.toKSFunctionDeclaration
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
-import java.lang.IllegalStateException
 
 class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) : KSFunctionDeclaration, KSDeclarationImpl(ktFunction),
     KSExpectActual by KSExpectActualImpl(ktFunction) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -43,14 +43,6 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
         return descriptor?.findClosestOverridee()?.toKSFunctionDeclaration()
     }
 
-    override val declarations: List<KSDeclaration> by lazy {
-        if (!ktFunction.hasBlockBody()) {
-            emptyList()
-        } else {
-            ktFunction.bodyBlockExpression?.statements?.getKSDeclarations() ?: emptyList()
-        }
-    }
-
     override val extensionReceiver: KSTypeReference? by lazy {
         if (ktFunction.receiverTypeReference != null) {
             KSTypeReferenceImpl.getCached(ktFunction.receiverTypeReference!!)
@@ -90,6 +82,18 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
                 getKSTypeCached(desc.returnTypeOrNothing)
             }
         }
+    }
+
+    override val statements: List<KSExpression> by lazy {
+        val expression = ktFunction.bodyBlockExpression
+                ?: ktFunction.bodyExpression
+        expression.toKSExpression()?.let {
+            (it as? KSBlockExpression)?.statements ?: listOf(it)
+        } ?: emptyList()
+    }
+
+    override val text: String by lazy {
+        ktFunction.text
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
@@ -16,8 +16,8 @@
  */
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionImpl.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeParameterDescriptorImpl
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
-import java.util.Objects
+import java.util.*
 
 class KSFunctionImpl(val descriptor: CallableDescriptor) : KSFunction {
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSIfExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSIfExpressionImpl.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSIfExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.KtIfExpression
+
+class KSIfExpressionImpl private constructor(ktIfExpression: KtIfExpression) : KSIfExpression, KSExpressionImpl(ktIfExpression) {
+    companion object : KSObjectCache<KtIfExpression, KSIfExpressionImpl>() {
+        fun getCached(ktIfExpression: KtIfExpression) = cache.getOrPut(ktIfExpression) { KSIfExpressionImpl(ktIfExpression) }
+    }
+
+    override val condition: KSExpression by lazy {
+        ktIfExpression.condition?.toKSExpression()
+            ?: error("Failed to get the if expression condition.")
+    }
+
+    override val then: KSExpression by lazy {
+        ktIfExpression.then?.toKSExpression()
+            ?: error("Failed to get the true branch in the if expression.")
+    }
+
+    override val otherwise: KSExpression? by lazy {
+        ktIfExpression.`else`?.toKSExpression()
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitIfExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSJumpExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSJumpExpressionImpl.kt
@@ -18,7 +18,9 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.JumpKind
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSJumpExpression
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import org.jetbrains.kotlin.psi.*

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSJumpExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSJumpExpressionImpl.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.*
+
+class KSJumpExpressionImpl private constructor(ktExpression: KtExpression) : KSJumpExpression, KSLabelReferenceExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<KtExpression, KSJumpExpressionImpl>() {
+        fun getCached(ktExpression: KtExpression) = cache.getOrPut(ktExpression) { KSJumpExpressionImpl(ktExpression) }
+    }
+
+    override val kind: JumpKind by lazy {
+        when(ktExpression) {
+            is KtContinueExpression -> JumpKind.Continue
+            is KtBreakExpression -> JumpKind.Break
+            is KtReturnExpression -> JumpKind.Return
+            is KtThrowExpression -> JumpKind.Throw
+            else -> error("Unknown kind of jump expression: ${ktExpression.javaClass.name}")
+        }
+    }
+
+    override val body: KSExpression? by lazy {
+        when(ktExpression) {
+            is KtReturnExpression -> ktExpression.returnedExpression?.toKSExpression()
+            is KtThrowExpression -> ktExpression.thrownExpression?.toKSExpression()
+            else -> null
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabelReferenceExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabelReferenceExpressionImpl.kt
@@ -19,7 +19,6 @@
 package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.KSLabelReferenceExpression
-import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtExpressionWithLabel

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabelReferenceExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabelReferenceExpressionImpl.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSLabelReferenceExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtExpressionWithLabel
+
+open class KSLabelReferenceExpressionImpl(ktExpression: KtExpression) : KSLabelReferenceExpression, KSExpressionImpl(ktExpression) {
+    companion object : KSObjectCache<KtExpression, KSLabelReferenceExpressionImpl>() {
+        fun getCached(ktExpression: KtExpression) = cache.getOrPut(ktExpression) { KSLabelReferenceExpressionImpl(ktExpression) }
+    }
+
+    override val name: String? by lazy {
+        (ktExpression as? KtExpressionWithLabel)?.getLabelName()
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabeledExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabeledExpressionImpl.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSLabelReferenceExpression
+import com.google.devtools.ksp.symbol.KSLabeledExpression
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtExpressionWithLabel
+import org.jetbrains.kotlin.psi.KtLabeledExpression
+
+open class KSLabeledExpressionImpl(ktLabeledExpression: KtLabeledExpression) : KSLabeledExpression, KSLabelReferenceExpressionImpl(ktLabeledExpression) {
+    companion object : KSObjectCache<KtLabeledExpression, KSLabeledExpressionImpl>() {
+        fun getCached(ktLabeledExpression: KtLabeledExpression) = cache.getOrPut(ktLabeledExpression) { KSLabeledExpressionImpl(ktLabeledExpression) }
+    }
+
+    override val name: String by lazy {
+        super.name ?: error("Unable to get label name from ${ktLabeledExpression.text}")
+    }
+
+    override val body: KSExpression by lazy {
+        ktLabeledExpression.baseExpression?.toKSExpression()
+            ?: error("Unable to get labeled expression from ${ktLabeledExpression.text}")
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitLabeledExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabeledExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLabeledExpressionImpl.kt
@@ -19,13 +19,10 @@
 package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.KSExpression
-import com.google.devtools.ksp.symbol.KSLabelReferenceExpression
 import com.google.devtools.ksp.symbol.KSLabeledExpression
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtExpressionWithLabel
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 
 open class KSLabeledExpressionImpl(ktLabeledExpression: KtLabeledExpression) : KSLabeledExpression, KSLabelReferenceExpressionImpl(ktLabeledExpression) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLambdaExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLambdaExpressionImpl.kt
@@ -21,8 +21,6 @@ package com.google.devtools.ksp.symbol.impl.kotlin
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
-import com.intellij.psi.PsiCodeBlock
-import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 
 class KSLambdaExpressionImpl private constructor(ktLambdaExpression: KtLambdaExpression) : KSLambdaExpression,

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLambdaExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSLambdaExpressionImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.intellij.psi.PsiCodeBlock
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
+
+class KSLambdaExpressionImpl private constructor(ktLambdaExpression: KtLambdaExpression) : KSLambdaExpression,
+    KSExpressionImpl(ktLambdaExpression), KSBlockExpression {
+    companion object : KSObjectCache<KtLambdaExpression, KSLambdaExpressionImpl>() {
+        fun getCached(ktLambdaExpression: KtLambdaExpression) =
+            cache.getOrPut(ktLambdaExpression) { KSLambdaExpressionImpl(ktLambdaExpression) }
+    }
+
+    override val parameters: List<KSValueParameter> by lazy {
+        ktLambdaExpression.valueParameters.map {
+            KSValueParameterImpl.getCached(it)
+        }
+    }
+
+    override val statements: List<KSExpression> by lazy {
+        ktLambdaExpression.bodyExpression?.statements?.mapNotNull { it.toKSExpression() }
+            ?: error("Unable to get code block from lambda expression, this is an incorrect expression: \n${ktLambdaExpression.text}")
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitBlockExpression(this, data)
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -29,9 +29,7 @@ import com.google.devtools.ksp.symbol.impl.synthetic.KSPropertySetterSyntheticIm
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import com.google.devtools.ksp.symbol.impl.toKSPropertyDeclaration
 import org.jetbrains.kotlin.descriptors.VariableDescriptorWithAccessors
-import org.jetbrains.kotlin.js.translate.declaration.hasCustomGetter
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.psi.KtPropertyDelegate
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 
 class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration, KSDeclarationImpl(ktProperty),

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
@@ -18,14 +18,13 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
-import com.google.devtools.ksp.symbol.impl.toKSModifiers
-import com.google.devtools.ksp.symbol.impl.toLocation
-import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
 class KSPropertyGetterImpl private constructor(ktPropertyGetter: KtPropertyAccessor) : KSPropertyAccessorImpl(ktPropertyGetter),

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertySetterImpl.kt
@@ -18,7 +18,9 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeAliasImpl.kt
@@ -20,10 +20,7 @@ package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.findParentDeclaration
-import com.google.devtools.ksp.symbol.impl.toKSModifiers
-import com.google.devtools.ksp.symbol.impl.toLocation
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtTypeAlias
 
 class KSTypeAliasImpl private constructor(val ktTypeAlias: KtTypeAlias) : KSTypeAlias, KSDeclarationImpl(ktTypeAlias),
     KSExpectActual by KSExpectActualImpl(ktTypeAlias) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeCastExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeCastExpressionImpl.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.google.devtools.ksp.symbol.impl.toKSToken
+import org.jetbrains.kotlin.lexer.KtKeywordToken
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+
+class KSTypeCastExpressionImpl private constructor(val ktBinaryExpressionWithTypeRHS: KtBinaryExpressionWithTypeRHS) :
+    KSTypeCastExpression, KSExpressionImpl(ktBinaryExpressionWithTypeRHS) {
+    companion object : KSObjectCache<KtBinaryExpressionWithTypeRHS, KSTypeCastExpressionImpl>() {
+        fun getCached(ktBinaryExpressionWithTypeRHS: KtBinaryExpressionWithTypeRHS) =
+            cache.getOrPut(ktBinaryExpressionWithTypeRHS) { KSTypeCastExpressionImpl(ktBinaryExpressionWithTypeRHS) }
+    }
+
+    override val token: KSToken by lazy {
+        ktBinaryExpressionWithTypeRHS.toKSToken()
+    }
+
+    override val type: KSTypeReference? by lazy {
+        ktBinaryExpressionWithTypeRHS.right?.let(KSTypeReferenceImpl::getCached)
+    }
+    override val body: KSExpression by lazy {
+        ktBinaryExpressionWithTypeRHS.left.toKSExpression()
+            ?: error("Cannot get the expression to the left of '${token.symbol}'.")
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeCastExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeCastExpressionImpl.kt
@@ -18,12 +18,13 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSToken
+import com.google.devtools.ksp.symbol.KSTypeCastExpression
+import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import com.google.devtools.ksp.symbol.impl.toKSToken
-import org.jetbrains.kotlin.lexer.KtKeywordToken
-import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
 
 class KSTypeCastExpressionImpl private constructor(val ktBinaryExpressionWithTypeRHS: KtBinaryExpressionWithTypeRHS) :

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeParameterImpl.kt
@@ -21,11 +21,8 @@ package com.google.devtools.ksp.symbol.impl.kotlin
 import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.toKSModifiers
-import com.google.devtools.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
-import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 
 class KSTypeParameterImpl private constructor(val ktTypeParameter: KtTypeParameter, val owner: KtTypeParameterListOwner) : KSTypeParameter,
     KSDeclarationImpl(ktTypeParameter),

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeReferenceImpl.kt
@@ -25,7 +25,6 @@ import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
 import com.google.devtools.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.psi.*
-import java.lang.IllegalStateException
 
 class KSTypeReferenceImpl private constructor(val ktTypeReference: KtTypeReference) : KSTypeReference {
     companion object : KSObjectCache<KtTypeReference, KSTypeReferenceImpl>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSUnaryExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSUnaryExpressionImpl.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.KSExpression
+import com.google.devtools.ksp.symbol.KSToken
+import com.google.devtools.ksp.symbol.KSUnaryExpression
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.google.devtools.ksp.symbol.impl.toKSToken
+import org.jetbrains.kotlin.psi.KtPostfixExpression
+import org.jetbrains.kotlin.psi.KtUnaryExpression
+
+class KSUnaryExpressionImpl private constructor(ktUnaryExpression: KtUnaryExpression) : KSUnaryExpression, KSExpressionImpl(ktUnaryExpression) {
+    companion object : KSObjectCache<KtUnaryExpression, KSUnaryExpressionImpl>() {
+        fun getCached(ktUnaryExpression: KtUnaryExpression) = cache.getOrPut(ktUnaryExpression) { KSUnaryExpressionImpl(ktUnaryExpression) }
+    }
+
+    override val isPostfixOperation: Boolean by lazy {
+        ktUnaryExpression is KtPostfixExpression
+    }
+
+    override val token: KSToken by lazy {
+        ktUnaryExpression.toKSToken()
+    }
+
+    override val body: KSExpression by lazy {
+        ktUnaryExpression.baseExpression.toKSExpression() ?: error("Unexpected unary expression: ${ktUnaryExpression.text}")
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -61,8 +61,11 @@ class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : K
         }
     }
 
-    override val type: KSTypeReference by lazy {
-        ktParameter.typeReference?.let { KSTypeReferenceImpl.getCached(it) } ?: findPropertyForAccessor()?.type ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType)
+    override val type: KSTypeReference? by lazy {
+        ktParameter.typeReference?.let { KSTypeReferenceImpl.getCached(it) }
+            ?: findPropertyForAccessor()?.type
+//            Parameter type in anonymous function can be null
+//            ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType)
     }
 
     override val hasDefault: Boolean = ktParameter.hasDefaultValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -20,8 +20,6 @@ package com.google.devtools.ksp.symbol.impl.kotlin
 
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
-import com.google.devtools.ksp.symbol.impl.findParentDeclaration
-import com.google.devtools.ksp.symbol.impl.synthetic.KSTypeReferenceSyntheticImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
 import org.jetbrains.kotlin.lexer.KtTokens.CROSSINLINE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.NOINLINE_KEYWORD

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSWhenExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSWhenExpressionImpl.kt
@@ -22,7 +22,6 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.toKSExpression
 import com.google.devtools.ksp.symbol.impl.toLocation
-import com.intellij.util.containers.map2Array
 import org.jetbrains.kotlin.psi.*
 
 class KSWhenExpressionImpl private constructor(ktWhenExpression: KtWhenExpression) : KSWhenExpression,

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSWhenExpressionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSWhenExpressionImpl.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.symbol.impl.kotlin
+
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.util.containers.map2Array
+import org.jetbrains.kotlin.psi.*
+
+class KSWhenExpressionImpl private constructor(ktWhenExpression: KtWhenExpression) : KSWhenExpression,
+    KSExpressionImpl(ktWhenExpression) {
+    companion object : KSObjectCache<KtWhenExpression, KSWhenExpressionImpl>() {
+        fun getCached(ktWhenExpression: KtWhenExpression) =
+            cache.getOrPut(ktWhenExpression) { KSWhenExpressionImpl(ktWhenExpression) }
+    }
+
+    override val branches: List<KSWhenExpression.Branch> by lazy {
+        ktWhenExpression.entries.map(Branch::getCached)
+    }
+
+    override val subject: KSExpression? by lazy {
+        ktWhenExpression.subjectExpression?.toKSExpression()
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitWhenExpression(this, data)
+    }
+
+    class Branch private constructor(ktWhenEntry: KtWhenEntry) : KSWhenExpression.Branch, KSExpression {
+        companion object : KSObjectCache<KtWhenEntry, Branch>() {
+            fun getCached(ktWhenEntry: KtWhenEntry) = cache.getOrPut(ktWhenEntry) { Branch(ktWhenEntry) }
+        }
+
+        override val conditions: List<KSExpression> by lazy {
+            ktWhenEntry.conditions.map {
+                when(it) {
+                    is KtWhenConditionInRange -> RangeCondition.getCached(it)
+                    is KtWhenConditionIsPattern -> TypeCondition.getCached(it)
+                    else -> (it as? KtWhenConditionWithExpression)?.expression?.toKSExpression()
+                        ?: error("An unexpected conditional expression was found: ${it.text}")
+                }
+            }
+        }
+
+        override val body: KSExpression by lazy {
+            ktWhenEntry.expression?.toKSExpression()
+                ?: error("Unable to get conditional branching behavior from ${ktWhenEntry.text}.")
+        }
+
+        override val isElse: Boolean by lazy {
+            ktWhenEntry.isElse
+        }
+
+        override val origin = Origin.KOTLIN
+
+        override val location: Location by lazy {
+            ktWhenEntry.toLocation()
+        }
+
+        override val text: String by lazy {
+            ktWhenEntry.text
+        }
+
+        override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+            return visitor.visitWhenExpressionBranch(this, data)
+        }
+
+        override fun toString(): String = text
+
+
+        open class Condition(ktWhenCondition: KtWhenCondition) : KSExpression {
+            companion object : KSObjectCache<KtWhenCondition, Condition>() {
+                fun getCached(ktWhenCondition: KtWhenCondition) =
+                    cache.getOrPut(ktWhenCondition) { Condition(ktWhenCondition) }
+            }
+
+            override val text: String by lazy {
+                ktWhenCondition.text
+            }
+
+            override val origin = Origin.KOTLIN
+
+            override val location: Location by lazy {
+                ktWhenCondition.toLocation()
+            }
+
+            override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+                return visitor.visitExpression(this, data)
+            }
+
+            override fun toString(): String = text
+        }
+
+        class RangeCondition private constructor(ktWhenCondition: KtWhenConditionInRange) :
+            KSWhenExpression.Branch.RangeCondition, Condition(ktWhenCondition) {
+            companion object : KSObjectCache<KtWhenConditionInRange, RangeCondition>() {
+                fun getCached(ktWhenCondition: KtWhenConditionInRange) = cache.getOrPut(ktWhenCondition) { RangeCondition(ktWhenCondition) }
+            }
+
+            override val operator: KSToken.Operator by lazy {
+                if (ktWhenCondition.isNegated) {
+                    KSToken.Operator.NotIn
+                } else {
+                    KSToken.Operator.In
+                }
+            }
+
+            override val range: KSBinaryExpression by lazy {
+                (ktWhenCondition.rangeExpression as? KtBinaryExpression)?.let(KSBinaryExpressionImpl::getCached)
+                    ?: error("Could not get the range expression for the ${ktWhenCondition.text}")
+            }
+        }
+
+        class TypeCondition private constructor(ktWhenCondition: KtWhenConditionIsPattern) :
+            KSWhenExpression.Branch.TypeCondition, Condition(ktWhenCondition) {
+            companion object : KSObjectCache<KtWhenCondition, TypeCondition>() {
+                fun getCached(ktWhenCondition: KtWhenConditionIsPattern) = cache.getOrPut(ktWhenCondition) { TypeCondition(ktWhenCondition) }
+            }
+
+            override val operator: KSToken.Operator by lazy {
+                if (ktWhenCondition.isNegated) {
+                    KSToken.Operator.NotIs
+                } else {
+                    KSToken.Operator.Is
+                }
+            }
+
+            override val type: KSTypeReference by lazy {
+                if (ktWhenCondition.typeReference != null) {
+                    KSTypeReferenceImpl.getCached(ktWhenCondition.typeReference!!)
+                } else {
+                    KSTypeReferenceDeferredImpl.getCached { KSErrorType }
+                }
+            }
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
@@ -32,7 +32,7 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
 
     override val extensionReceiver: KSTypeReference? = null
 
-    override val parameters: List<KSValueParameter> = emptyList()
+    override val parameters: List<KSValueParameter> get() = emptyList()
 
     override val functionKind: FunctionKind = FunctionKind.MEMBER
 
@@ -44,7 +44,7 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
         KSNameImpl.getCached("<init>")
     }
 
-    override val typeParameters: List<KSTypeParameter> = emptyList()
+    override val typeParameters: List<KSTypeParameter> get() = emptyList()
 
     override val containingFile: KSFile? by lazy {
         ksClassDeclaration.containingFile
@@ -56,21 +56,23 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
 
     override val returnType: KSTypeReference? = null
 
-    override val annotations: List<KSAnnotation> = emptyList()
+    override val annotations: List<KSAnnotation> get() = emptyList()
 
     override val isActual: Boolean = false
 
     override val isExpect: Boolean = false
 
-    override val declarations: List<KSDeclaration> = emptyList()
+    override val statements: List<KSExpression> get() = emptyList()
 
     override val location: Location by lazy {
         ksClassDeclaration.location
     }
 
-    override val modifiers: Set<Modifier> = emptySet()
+    override val modifiers: Set<Modifier> get() = emptySet()
 
     override val origin: Origin = Origin.SYNTHETIC
+
+    override val text: String by lazy { toString() }
 
     override fun findOverridee(): KSFunctionDeclaration? = null
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
@@ -23,13 +23,10 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 
 object KSErrorTypeClassDeclaration : KSClassDeclaration {
-    override val annotations: List<KSAnnotation> = emptyList()
 
     override val classKind: ClassKind = ClassKind.CLASS
 
     override val containingFile: KSFile? = null
-
-    override val declarations: List<KSDeclaration> = emptyList()
 
     override val isActual: Boolean = false
 
@@ -39,11 +36,7 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
 
     override val location: Location = NonExistLocation
 
-    override val modifiers: Set<Modifier> = emptySet()
-
     override val origin: Origin = Origin.SYNTHETIC
-
-    override val packageName: KSName = KSNameImpl.getCached("")
 
     override val parentDeclaration: KSDeclaration? = null
 
@@ -51,11 +44,25 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
 
     override val qualifiedName: KSName? = null
 
+    override val packageName: KSName get() = KSNameImpl.getCached("")
+
     override val simpleName: KSName = KSNameImpl.getCached("<Error>")
 
-    override val superTypes: List<KSTypeReference> = emptyList()
+    override val superTypes: List<KSTypeReference> get() = emptyList()
 
-    override val typeParameters: List<KSTypeParameter> = emptyList()
+    override val superclassDeclarations: List<KSClassDeclaration> get() = emptyList()
+
+    override val modifiers: Set<Modifier> get() = emptySet()
+
+    override val annotations: List<KSAnnotation> get() = emptyList()
+
+    override val declarations: List<KSDeclaration> get() = emptyList()
+
+    override val initializerBlocks: List<KSAnonymousInitializer> get() = emptyList()
+
+    override val typeParameters: List<KSTypeParameter> get() = emptyList()
+
+    override val text: String = ""
 
     override fun asStarProjectedType(): KSType {
         return ResolverImpl.instance.builtIns.nothingType

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyAccessorSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyAccessorSyntheticImpl.kt
@@ -33,6 +33,11 @@ abstract class KSPropertyAccessorSyntheticImpl(ksPropertyDeclaration: KSProperty
 
     override val receiver: KSPropertyDeclaration = ksPropertyDeclaration
 
+    // TODO: Should we add expression support to synthetic implementation?
+    override val statements: List<KSExpression> = emptyList()
+
+    override val text: String by lazy { toString() }
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyAccessor(this, data)
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
@@ -18,14 +18,14 @@
 
 package com.google.devtools.ksp.symbol.impl.synthetic
 
-import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import com.google.devtools.ksp.symbol.KSPropertyGetter
-import com.google.devtools.ksp.symbol.KSTypeReference
-import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
 class KSPropertyGetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclaration) :
     KSPropertyAccessorSyntheticImpl(ksPropertyDeclaration), KSPropertyGetter {
@@ -34,16 +34,12 @@ class KSPropertyGetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclara
             KSPropertyGetterSyntheticImpl.cache.getOrPut(ksPropertyDeclaration) { KSPropertyGetterSyntheticImpl(ksPropertyDeclaration) }
     }
 
-    private val descriptor: PropertyAccessorDescriptor by lazy {
-        ResolverImpl.instance.resolvePropertyDeclaration(ksPropertyDeclaration)!!.getter!!
+    private val descriptor: PropertyAccessorDescriptor? by lazy {
+        ResolverImpl.instance.resolvePropertyDeclaration(ksPropertyDeclaration)?.getter
     }
 
     override val returnType: KSTypeReference? by lazy {
-        if (descriptor.returnType != null) {
-            KSTypeReferenceDescriptorImpl.getCached(descriptor.returnType!!)
-        } else {
-            null
-        }
+        descriptor?.returnType?.let(KSTypeReferenceDescriptorImpl::getCached)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
@@ -19,13 +19,13 @@
 package com.google.devtools.ksp.symbol.impl.synthetic
 
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
-import com.google.devtools.ksp.symbol.impl.toKSExpression
 import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
 class KSPropertyGetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclaration) :
     KSPropertyAccessorSyntheticImpl(ksPropertyDeclaration), KSPropertyGetter {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertySetterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertySetterSyntheticImpl.kt
@@ -18,15 +18,15 @@
 
 package com.google.devtools.ksp.symbol.impl.synthetic
 
-import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.KSValueParameterDescriptorImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorValueParameter
-import com.google.devtools.ksp.symbol.impl.toKSExpression
-import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
+import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 
 class KSPropertySetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclaration) :
     KSPropertyAccessorSyntheticImpl(ksPropertyDeclaration), KSPropertySetter {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertySetterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertySetterSyntheticImpl.kt
@@ -20,12 +20,13 @@ package com.google.devtools.ksp.symbol.impl.synthetic
 
 import org.jetbrains.kotlin.descriptors.PropertyAccessorDescriptor
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import com.google.devtools.ksp.symbol.KSPropertySetter
-import com.google.devtools.ksp.symbol.KSValueParameter
-import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.binary.KSValueParameterDescriptorImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorValueParameter
+import com.google.devtools.ksp.symbol.impl.toKSExpression
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.resolve.DescriptorToSourceUtils
 
 class KSPropertySetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclaration) :
     KSPropertyAccessorSyntheticImpl(ksPropertyDeclaration), KSPropertySetter {
@@ -34,13 +35,13 @@ class KSPropertySetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclara
             KSPropertySetterSyntheticImpl.cache.getOrPut(ksPropertyDeclaration) { KSPropertySetterSyntheticImpl(ksPropertyDeclaration) }
     }
 
-    private val descriptor: PropertyAccessorDescriptor by lazy {
-        ResolverImpl.instance.resolvePropertyDeclaration(ksPropertyDeclaration)!!.setter!!
+    private val descriptor: PropertyAccessorDescriptor? by lazy {
+        ResolverImpl.instance.resolvePropertyDeclaration(ksPropertyDeclaration)?.setter
     }
 
     override val parameter: KSValueParameter by lazy {
-        descriptor.valueParameters.singleOrNull()?.let { KSValueParameterDescriptorImpl.getCached(it) }
-                ?: throw IllegalStateException("Failed to resolve property type")
+        descriptor?.valueParameters?.singleOrNull()?.let { KSValueParameterDescriptorImpl.getCached(it) }
+                ?: KSErrorValueParameter
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -19,9 +19,6 @@
 package com.google.devtools.ksp.symbol.impl
 
 import com.google.devtools.ksp.ExceptionMessage
-import com.intellij.lang.jvm.JvmModifier
-import com.intellij.psi.*
-import org.jetbrains.kotlin.descriptors.*
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.ClassKind
@@ -33,7 +30,10 @@ import com.google.devtools.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSTypeArgumentJavaImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.*
+import com.intellij.lang.jvm.JvmModifier
+import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassImpl
+import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaDescriptorVisibilities
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -26,7 +26,6 @@ import org.junit.runner.RunWith;
 
 import java.io.File;
 import java.util.List;
-import java.util.regex.Pattern;
 
 @SuppressWarnings("all")
 @TestMetadata("testData/api")

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -262,6 +262,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/visibilities.kt");
     }
 
+    @TestMetadata("expressions.kt")
+    public void testExpressions() throws Exception {
+        runTest("testData/api/expressions.kt");
+    }
+
     @Override
     protected @NotNull List<KspTestFile> createTestFilesFromFile(@NotNull File file, @NotNull String expectedText) {
         return TestFiles.createTestFiles(file.getName(), expectedText, new TestFiles.TestFileFactory<TestModule, KspTestFile>() {

--- a/compiler-plugin/testData/api/expressions.kt
+++ b/compiler-plugin/testData/api/expressions.kt
@@ -1,0 +1,80 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: ExpressionsProcessor
+// EXPECTED:
+// init { .. }  =>  KSAnonymousInitializer
+// var a = 0  =>  KSPropertyDeclaration
+// 0  =>  KSConstantExpression
+// val map = hashMapOf("one" to 1)  =>  KSPropertyDeclaration
+// hashMapOf("one" to 1)  =>  KSCallExpression
+// var one: Int by map  =>  KSPropertyDeclaration
+// map  =>  KSCallExpression
+// Builder(one).a().b().build()  =>  KSChainCallsExpression
+// Builder(one)  =>  KSCallExpression
+// a()  =>  KSCallExpression
+// b()  =>  KSCallExpression
+// build()  =>  KSCallExpression
+// 1 * 2 + 3 - 4  =>  KSBinaryExpression
+// 1 in 1..10  =>  KSBinaryExpression
+// a++  =>  KSUnaryExpression
+// --a  =>  KSUnaryExpression
+// a as? String  =>  KSTypeCastExpression
+// 1?.toString()  =>  KSCallExpression
+// 2.toString()  =>  KSCallExpression
+// when (val x = 5) { .. }  =>  KSWhenExpression
+// val x = 5  =>  KSPropertyDeclaration
+// 5  =>  KSConstantExpression
+// is Any -> {}  =>  KSWhenExpression.Branch, isElse: false
+// is Any  =>  <Unknown Expression>
+// {}  =>  KSBlockExpression
+// else -> print()  =>  KSWhenExpression.Branch, isElse: true
+// print()  =>  KSCallExpression
+// map.forEach { (_, value) -> .. }  =>  KSDslExpression
+// { (_, value) -> .. }  =>  KSLambdaExpression
+// if (value == null) { .. }  =>  KSIfExpression
+// value == null  =>  KSBinaryExpression
+// { .. }  =>  KSBlockExpression
+// a = util.fetch(value)  =>  KSBinaryExpression
+// require(util.check())  =>  KSCallExpression
+// return  =>  KSJumpExpression
+// throw Exception()  =>  KSJumpExpression
+// loop@ run { .. }  =>  KSLabeledExpression
+// run { .. }  =>  KSDslExpression
+// { .. }  =>  KSLambdaExpression
+// break@loop  =>  KSJumpExpression
+// END
+class Expressions {
+    init {
+        var a = 0
+        val map = hashMapOf("one" to 1)
+        var one: Int by map
+        Builder(one).a().b().build()
+        1 * 2 + 3 - 4
+        1 in 1..10
+        a++
+        --a
+        a as? String
+        1?.toString()
+        2.toString()
+        when (val x = 5) {
+            is Any -> {}
+            else -> print()
+        }
+        map.forEach { (_, value) ->
+            if (value == null) {
+                a = util.fetch(value)
+                require(util.check())
+            }
+        }
+        return
+        throw Exception()
+        loop@ run {
+            break@loop
+        }
+    }
+
+    class Builder(int: Int) {
+        fun a(): Builder = apply {  }
+        fun b(): Builder = apply {  }
+        fun build() = apply {  }
+    }
+}

--- a/compiler-plugin/testData/api/expressions.kt
+++ b/compiler-plugin/testData/api/expressions.kt
@@ -41,10 +41,6 @@
 // run { .. }  =>  KSDslExpression
 // { .. }  =>  KSLambdaExpression
 // break@loop  =>  KSJumpExpression
-// fun inline() {}  =>  KSFunctionDeclaration
-// class Class { val a = "b" }  =>  KSClassDeclaration
-// val a = "b"  =>  KSPropertyDeclaration
-// "b"  =>  KSConstantExpression
 // END
 class Expressions {
     init {
@@ -74,8 +70,6 @@ class Expressions {
         loop@ run {
             break@loop
         }
-        fun inline() {}
-        class Class { val a = "b" }
     }
 
     class Builder(int: Int) {

--- a/compiler-plugin/testData/api/expressions.kt
+++ b/compiler-plugin/testData/api/expressions.kt
@@ -41,6 +41,10 @@
 // run { .. }  =>  KSDslExpression
 // { .. }  =>  KSLambdaExpression
 // break@loop  =>  KSJumpExpression
+// fun inline() {}  =>  KSFunctionDeclaration
+// val a = "b"  =>  KSPropertyDeclaration
+// "b"  =>  KSConstantExpression
+// class Class { val a = "b" }  =>  KSClassDeclaration
 // END
 class Expressions {
     init {
@@ -70,6 +74,8 @@ class Expressions {
         loop@ run {
             break@loop
         }
+        fun inline() {}
+        class Class { val a = "b" }
     }
 
     class Builder(int: Int) {

--- a/compiler-plugin/testData/api/expressions.kt
+++ b/compiler-plugin/testData/api/expressions.kt
@@ -41,6 +41,10 @@
 // run { .. }  =>  KSDslExpression
 // { .. }  =>  KSLambdaExpression
 // break@loop  =>  KSJumpExpression
+// fun inline() {}  =>  KSFunctionDeclaration
+// class Class { val a = "b" }  =>  KSClassDeclaration
+// val a = "b"  =>  KSPropertyDeclaration
+// "b"  =>  KSConstantExpression
 // END
 class Expressions {
     init {
@@ -70,6 +74,8 @@ class Expressions {
         loop@ run {
             break@loop
         }
+        fun inline() {}
+        class Class { val a = "b" }
     }
 
     class Builder(int: Int) {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -27,16 +27,10 @@ import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
-import org.jetbrains.kotlin.gradle.plugin.FilesSubpluginOption
-import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
-import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
-import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
-import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
-import org.jetbrains.kotlin.gradle.plugin.mapClasspath
+import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaCompilation
-import org.jetbrains.kotlin.gradle.tasks.KOTLIN_BUILD_DIR_NAME
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import org.jetbrains.kotlin.incremental.ChangedFiles
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/builder/KspModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/builder/KspModelBuilder.kt
@@ -18,11 +18,11 @@
 
 package com.google.devtools.ksp.gradle.model.builder
 
+import com.google.devtools.ksp.gradle.KspExtension
+import com.google.devtools.ksp.gradle.model.Ksp
+import com.google.devtools.ksp.gradle.model.impl.KspImpl
 import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilder
-import com.google.devtools.ksp.gradle.KspExtension
-import com.google.devtools.ksp.gradle.model.impl.KspImpl
-import com.google.devtools.ksp.gradle.model.Ksp
 
 /**
  * [ToolingModelBuilder] for [Ksp] models.


### PR DESCRIPTION
At present, I have only completed most of the expression parse of the Kotlin Language part (it should work well), and I have used some ideas to make kotlinc's original expressions less complicated, which means that developers should use expressions easily .

This is a tedious task. Due to time and personal reasons not to use Java for the time being, the expressions of the Java language have not yet been supported. Of course, if you agree with this pr, I think I will continue to complete it~

Fixes #191  (I think even if the expression function is not the focus of KSP, it should have