### PR TITLE
Use property descriptor impl for java properties

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
@@ -40,7 +40,7 @@ class AllFunctionsProcessor : AbstractTestProcessor() {
             return "${this.simpleName.asString()}" +
                     "(${this.parameters.map { 
                         buildString {
-                            append(it.type?.resolve()?.declaration?.qualifiedName?.asString())
+                            append(it.type.resolve().declaration.qualifiedName?.asString())
                             if (it.hasDefault) {
                                 append("(hasDefault)")
                             }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -275,6 +275,10 @@ internal fun PropertyDescriptor.toKSPropertyDeclaration(): KSPropertyDeclaration
         is KtProperty -> KSPropertyDeclarationImpl.getCached(psi)
         is KtParameter -> KSPropertyDeclarationParameterImpl.getCached(psi)
         is PsiField -> KSPropertyDeclarationJavaImpl.getCached(psi)
+        is PsiMethod -> {
+            // happens when a java class implements a kotlin interface that declares properties.
+            KSPropertyDeclarationDescriptorImpl.getCached(this)
+        }
         else -> throw IllegalStateException("unexpected psi: ${psi.javaClass}")
     }
 }

--- a/compiler-plugin/testData/api/allFunctions.kt
+++ b/compiler-plugin/testData/api/allFunctions.kt
@@ -18,8 +18,9 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: AllFunctionsProcessor
 // EXPECTED:
-// class: Foo
+// class: KotlinInterfaceWithProperty
 // <init>(): C
+// <init>(): JavaImplOfKotlinInterface
 // a
 // aFromC
 // aFromC
@@ -30,6 +31,8 @@
 // cFromC
 // class: C
 // class: Data
+// class: Foo
+// class: JavaImplOfKotlinInterface
 // component1(): kotlin.String
 // contains(kotlin.Number): kotlin.Boolean
 // containsAll(kotlin.collections.Collection): kotlin.Boolean
@@ -37,8 +40,12 @@
 // equals(kotlin.Any): kotlin.Boolean
 // equals(kotlin.Any): kotlin.Boolean
 // equals(kotlin.Any): kotlin.Boolean
+// equals(kotlin.Any): kotlin.Boolean
+// equals(kotlin.Any): kotlin.Boolean
 // forEach(java.util.function.Consumer): kotlin.Unit
 // get(kotlin.Int): kotlin.Number
+// hashCode(): kotlin.Int
+// hashCode(): kotlin.Int
 // hashCode(): kotlin.Int
 // hashCode(): kotlin.Int
 // hashCode(): kotlin.Int
@@ -61,6 +68,10 @@
 // toString(): kotlin.String
 // toString(): kotlin.String
 // toString(): kotlin.String
+// toString(): kotlin.String
+// toString(): kotlin.String
+// x
+// x
 // END
 // FILE: a.kt
 abstract class Foo : C(), List<out Number> {
@@ -100,5 +111,19 @@ class C {
 
     public String javaStrFun() {
         return "str"
+    }
+}
+
+// FILE: KotlinInterfaceWithProperty.kt
+interface KotlinInterfaceWithProperty {
+    var x:Int
+}
+
+// FILE: JavaImplOfKotlinInterface.java
+class JavaImplOfKotlinInterface implements KotlinInterfaceWithProperty {
+    public int getX() {
+        return 1;
+    }
+    public void setX(int value) {
     }
 }


### PR DESCRIPTION
When a java class implements a kotlin interface that declared a property,
the descriptor could resolve to a PsiMethod for which we don't have a
property implementation (because there is another matching method so single
method is not enough). For those cases, fall back to the descriptor implementation.

Test: allFunctions.kt
Fixes: #216