### PR TITLE
Report INNER modifier for class descriptors

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
@@ -30,8 +30,13 @@ class JavaModifierProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
-        val symbol = resolver.getSymbolsWithAnnotation("Test").single() as KSClassDeclaration
-        symbol.superTypes.single().resolve()!!.declaration.accept(ModifierVisitor(), Unit)
+        resolver.getSymbolsWithAnnotation("Test")
+            .map {
+                it as KSClassDeclaration
+            }
+            .forEach {
+                it.superTypes.single().resolve().declaration.accept(ModifierVisitor(), Unit)
+            }
     }
 
     inner class ModifierVisitor : KSTopDownVisitor<Unit, Unit>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -117,6 +117,9 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
         if (descriptor.kind == KtClassKind.ANNOTATION_CLASS) {
             modifiers.add(Modifier.ANNOTATION)
         }
+        if (descriptor.isInner) {
+            modifiers.add(Modifier.INNER)
+        }
         modifiers
     }
 

--- a/compiler-plugin/testData/api/javaModifiers.kt
+++ b/compiler-plugin/testData/api/javaModifiers.kt
@@ -21,9 +21,35 @@
 // staticStr: PRIVATE
 // s1: FINAL JAVA_TRANSIENT
 // i1: PROTECTED JAVA_STATIC JAVA_VOLATILE
+// NestedC: PUBLIC JAVA_STATIC
+// InnerC: PUBLIC
 // intFun: JAVA_SYNCHRONIZED JAVA_DEFAULT
 // foo: ABSTRACT JAVA_STRICT
+// OuterJavaClass: PUBLIC
+// InnerJavaClass: PUBLIC
+// NestedJavaClass: PUBLIC JAVA_STATIC
+// OuterKotlinClass: OPEN
+// InnerKotlinClass: INNER
+// NestedKotlinClass: OPEN
+// DependencyOuterJavaClass: OPEN PUBLIC
+// DependencyNestedJavaClass: OPEN PUBLIC
+// DependencyInnerJavaClass: OPEN PUBLIC INNER
+// DependencyOuterKotlinClass: OPEN PUBLIC
+// DependencyInnerKotlinClass: FINAL PUBLIC INNER
+// DependencyNestedKotlinClass: OPEN PUBLIC
 // END
+// MODULE: module1
+// FILE: DependencyOuterJavaClass.java
+public class DependencyOuterJavaClass {
+    public class DependencyInnerJavaClass {}
+    public static class DependencyNestedJavaClass {}
+}
+// FILE: DependencyOuterKotlinClass.kt
+open class DependencyOuterKotlinClass {
+    inner class DependencyInnerKotlinClass
+    open class DependencyNestedKotlinClass
+}
+// MODULE: main(module1)
 // FILE: a.kt
 annotation class Test
 
@@ -31,6 +57,18 @@ annotation class Test
 class Foo : C() {
 
 }
+
+@Test
+class Bar : OuterJavaClass()
+
+@Test
+class Baz : OuterKotlinClass()
+
+@Test
+class JavaDependency : DependencyOuterJavaClass()
+
+@Test
+class KotlinDependency : DependencyOuterKotlinClass()
 
 // FILE: C.java
 
@@ -47,4 +85,23 @@ public abstract class C {
     }
 
     abstract strictfp void foo() {}
+
+    public static class NestedC {
+
+    }
+
+    public class InnerC {
+
+    }
+}
+
+// FILE: OuterJavaClass.java
+public class OuterJavaClass {
+    public class InnerJavaClass {}
+    public static class NestedJavaClass {}
+}
+// FILE: OuterKotlinClass.kt
+open class OuterKotlinClass {
+    inner class InnerKotlinClass
+    open class NestedKotlinClass
 }


### PR DESCRIPTION
This PR fixes a bug where the inner modifier would be lost if the
kotlin sources is in dependencies (when wrapped in a descriptor).

Unfortunately, for descriptors, there is no easy way to distinguish
between JAVA_STATIC and INNER. That is, if a java nested class that is
annotated with STATIC is compiled, descriptor API will no longer report
any modifiers for it. Similarly, if a Java inner class (that has no
static annotation) is compiled, we'll start reporting INNER for it.
Even though this is slightly confusing, it is at least consistent from a
kotlin perspective.

Also fixed a bug in multi-module testing setup where we were NOT
compiling java sources in test modules.

Fixes: #231
Test: javaModifiers

more test cases

report inner for descriptors