### PR TITLE
Setup depenedencies in compiler plugin's POM

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -34,6 +34,7 @@ fun ModuleDependency.includeJars(vararg names: String) {
     }
 }
 
+// WARNING: remember to update the dependencies in symbol-processing as well.
 dependencies {
     implementation(kotlin("stdlib", kotlinBaseVersion))
     implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")


### PR DESCRIPTION
To be able to do composite build, KSP depends on kotlin-compiler rather
than kotlin-compiler-embeddable and uses ShadowJar to relocate some
symbols. Unfortunately, ShadowJar doesn't seem able to relocate the jar
only and generate proper dependencies in the POM. As a workaround, this
commit hard-coded the dependencies.