### PR TITLE
multi-module tests: make sure javaOut exists before passing to compiler

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
@@ -147,7 +147,7 @@ abstract class AbstractKotlinKSPTest : KotlinBaseTest<AbstractKotlinKSPTest.KspT
             GenerationUtils.compileFilesTo(moduleFiles.psiFiles, environment, outDir)
             if (hasJavaSources) {
                 // need to compile java sources as well
-                val javaOutDir = module.rootDir.resolve("javaOut")
+                val javaOutDir = module.rootDir.resolve("javaOut").apply { mkdirs() }
                 val classpath = (dependencies + KotlinTestUtils.getAnnotationsJar() + module.outDir)
                     .joinToString(":") { it.absolutePath }
                 val options = listOf(


### PR DESCRIPTION
Not sure why but the following error seems to appear on Linux only. This commit makes the error gone, but I'm not sure whether it is the right solution. Still investigating...

```
directory not found: /tmp/tmp170292837443557314.tmp/testRootGW4/unitTest_multipleModules/test/module1/javaOut
java.lang.IllegalStateException: directory not found: /tmp/tmp170292837443557314.tmp/testRootGW4/unitTest_multipleModules/test/module1/javaOut
	at com.sun.tools.javac.main.Main.error(Main.java:186)
	at com.sun.tools.javac.main.Main.checkDirectory(Main.java:345)
	at com.sun.tools.javac.main.Main.processArgs(Main.java:274)
	at com.sun.tools.javac.main.Main.compile(Main.java:414)
	at com.sun.tools.javac.api.JavacTaskImpl.doCall(JavacTaskImpl.java:129)
	at com.sun.tools.javac.api.JavacTaskImpl.call(JavacTaskImpl.java:138)
	at org.jetbrains.kotlin.test.KotlinTestUtils.compileJavaFiles(KotlinTestUtils.java:659)
	at org.jetbrains.kotlin.test.KotlinTestUtils.compileJavaFiles(KotlinTestUtils.java:641)
	at com.google.devtools.ksp.test.AbstractKotlinKSPTest.compileModule(AbstractKotlinKSPTest.kt:158)
	at com.google.devtools.ksp.test.AbstractKotlinKSPTest.doMultiFileTest(AbstractKotlinKSPTest.kt:63)
	at org.jetbrains.kotlin.test.KotlinBaseTest.doTest(KotlinBaseTest.kt:49)
	at org.jetbrains.kotlin.test.KotlinTestUtils.lambda$testWithCustomIgnoreDirective$6(KotlinTestUtils.java:803)
	at org.jetbrains.kotlin.test.MuteWithFileKt$testWithMuteInFile$1.invoke(muteWithFile.kt:41)
	at org.jetbrains.kotlin.test.KotlinTestUtils.runTestImpl(KotlinTestUtils.java:773)
	at org.jetbrains.kotlin.test.KotlinTestUtils.runTest(KotlinTestUtils.java:716)
	at com.google.devtools.ksp.test.KotlinKSPTestGenerated.runTest(KotlinKSPTestGenerated.java:37)
	at com.google.devtools.ksp.test.KotlinKSPTestGenerated.testMultipleModules(KotlinKSPTestGenerated.java:172)
```