### PR TITLE
Use class descriptor for enum entries in java files

### DIFF
--- a/compiler-plugin/testData/api/classKinds.kt
+++ b/compiler-plugin/testData/api/classKinds.kt
@@ -20,6 +20,7 @@
 // EXPECTED:
 // JA: ANNOTATION_CLASS
 // JC: CLASS
+// JE.ENTRY: ENUM_ENTRY
 // JE: ENUM_CLASS
 // JI: INTERFACE
 // KA: ANNOTATION_CLASS
@@ -49,4 +50,6 @@ enum class KE {
 class JC {}
 interface JI {}
 @interface JA {}
-enum JE {}
+enum JE {
+    ENTRY
+}


### PR DESCRIPTION
This PR fixes a bug in KSClassDeclarationJavaImpl where it would return
properties for its enum constants instead of returning class
declarations.

Unfortunately, PsiEnumConstant does not have an API to resolve it as a
class. So instead, this PR delegates to the descriptor implementation
for these fields.

Fixes: #234
Test: classKinds