### PR TITLE
Model Java enum entries as KSClassDeclaration

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -21,6 +21,8 @@ package com.google.devtools.ksp.symbol.impl.java
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
+import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
@@ -62,33 +64,16 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
         ResolverImpl.instance.resolveJavaDeclaration(psi) as ClassDescriptor
     }
 
-    override fun getAllFunctions(): List<KSFunctionDeclaration> {
-        return descriptor?.let {
-            ResolverImpl.instance.incrementalContext.recordLookupForGetAllFunctions(it)
-            it.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.FUNCTIONS)
-                .toList()
-                .filter { (it as FunctionDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-                .plus(it.constructors)
-                .map { (it as FunctionDescriptor).toKSFunctionDeclaration() }
-        } ?: emptyList()
-    }
+    override fun getAllFunctions(): List<KSFunctionDeclaration> =
+            descriptor?.getAllFunctions(true) ?: emptyList()
 
-    override fun getAllProperties(): List<KSPropertyDeclaration> {
-        return descriptor?.let {
-            ResolverImpl.instance.incrementalContext.recordLookupForGetAllProperties(it)
-            it.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.VARIABLES)
-                    .toList()
-                    .filter { (it as PropertyDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-                    .map{ (it as PropertyDescriptor).toKSPropertyDeclaration() }
-        } ?: emptyList()
-    }
+    override fun getAllProperties(): List<KSPropertyDeclaration> =
+            descriptor?.getAllProperties() ?: emptyList()
 
     override val declarations: List<KSDeclaration> = emptyList()
 
     override val modifiers: Set<Modifier> by lazy {
-        val modifiers = mutableSetOf<Modifier>()
-        modifiers.addAll(psi.toKSModifiers())
-        modifiers
+        psi.toKSModifiers()
     }
 
     override val parentDeclaration: KSDeclaration? by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -26,6 +26,8 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
+import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
@@ -75,26 +77,11 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) : KSClas
         ResolverImpl.moduleClassResolver.resolveClass(JavaClassImpl(psi))
     }
 
-    override fun getAllFunctions(): List<KSFunctionDeclaration> {
-        return descriptor?.let {
-            ResolverImpl.instance.incrementalContext.recordLookupForGetAllFunctions(it)
-            it.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.FUNCTIONS)
-                .toList()
-                .filter { (it as FunctionDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-                .plus(it.constructors)
-                .map { (it as FunctionDescriptor).toKSFunctionDeclaration() }
-        } ?: emptyList()
-    }
+    override fun getAllFunctions(): List<KSFunctionDeclaration> =
+            descriptor?.getAllFunctions(true) ?: emptyList()
 
-    override fun getAllProperties(): List<KSPropertyDeclaration> {
-        return descriptor?.let {
-            ResolverImpl.instance.incrementalContext.recordLookupForGetAllProperties(it)
-            it.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.VARIABLES)
-                    .toList()
-                    .filter { (it as PropertyDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-                    .map{ (it as PropertyDescriptor).toKSPropertyDeclaration() }
-        } ?: emptyList()
-    }
+    override fun getAllProperties(): List<KSPropertyDeclaration> =
+            descriptor?.getAllProperties() ?: emptyList()
 
     override val declarations: List<KSDeclaration> by lazy {
         (psi.fields.map {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -24,6 +24,8 @@ import org.jetbrains.kotlin.descriptors.Visibilities
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
+import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
 import com.google.devtools.ksp.symbol.impl.synthetic.KSConstructorSyntheticImpl
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
@@ -49,19 +51,9 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
         (ktClassOrObject is KtObjectDeclaration) && (ktClassOrObject.isCompanion())
     }
 
-    override fun getAllFunctions(): List<KSFunctionDeclaration> {
-        ResolverImpl.instance.incrementalContext.recordLookupForGetAllFunctions(descriptor)
-        return descriptor.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.FUNCTIONS).toList()
-            .filter { (it as FunctionDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-            .map { (it as FunctionDescriptor).toKSFunctionDeclaration() }
-    }
+    override fun getAllFunctions(): List<KSFunctionDeclaration> = descriptor.getAllFunctions()
 
-    override fun getAllProperties(): List<KSPropertyDeclaration> {
-        ResolverImpl.instance.incrementalContext.recordLookupForGetAllProperties(descriptor)
-        return descriptor.unsubstitutedMemberScope.getDescriptorsFiltered(DescriptorKindFilter.VARIABLES).toList()
-                .filter { (it as PropertyDescriptor).visibility != DescriptorVisibilities.INVISIBLE_FAKE }
-                .map { (it as PropertyDescriptor).toKSPropertyDeclaration() }
-    }
+    override fun getAllProperties(): List<KSPropertyDeclaration> = descriptor.getAllProperties()
 
     override val declarations: List<KSDeclaration> by lazy {
         val propertiesFromConstructor = primaryConstructor?.parameters

--- a/compiler-plugin/testData/api/classKinds.kt
+++ b/compiler-plugin/testData/api/classKinds.kt
@@ -20,6 +20,7 @@
 // EXPECTED:
 // JA: ANNOTATION_CLASS
 // JC: CLASS
+// JE.ENTRY: ENUM_ENTRY
 // JE: ENUM_CLASS
 // JI: INTERFACE
 // KA: ANNOTATION_CLASS
@@ -49,4 +50,6 @@ enum class KE {
 class JC {}
 interface JI {}
 @interface JA {}
-enum JE {}
+enum JE {
+    ENTRY
+}


### PR DESCRIPTION
So that it is more consistent from Kotlin's point of view.