### PR TITLE
Fine tuning contents of symbol-processing.jar

### DIFF
--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -16,7 +16,9 @@ dependencies {
 
 tasks.withType<ShadowJar>() {
     archiveClassifier.set("")
-    from(packedJars)
+    // ShadowJar picks up the `compile` configuration by default and pulls stdlib in.
+    // Therefore, specifying another configuration instead.
+    configurations = listOf(packedJars)
     relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
 }
 


### PR DESCRIPTION
ShadowJar picks up the `compile` configuration by default and pulls
stdlib in (when using `from` without changing `configurations`).