### PR TITLE
Do not register resources as Java sources

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -119,7 +119,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             val generatedJavaSources = javaCompile.project.fileTree(javaOutputDir)
             generatedJavaSources.include("**/*.java")
             javaCompile.source(generatedJavaSources)
-            javaCompile.source(resourceOutputDir)
             javaCompile.classpath += project.files(classOutputDir)
         }
 


### PR DESCRIPTION
JavaCompile task will process only *.java files,
and resources need to registered using different
mechanism.

This fixes https://github.com/google/ksp/issues/244.