### PR TITLE
Tests for incremental processing

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalIT.kt
@@ -1,0 +1,145 @@
+package com.google.devtools.ksp.test
+
+import Artifact
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class IncrementalIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("incremental")
+
+    val src2Dirty = listOf(
+            "workload/src/main/java/p1/J1.java" to setOf(
+                    "w: [ksp] p1/TestK2J.kt",
+                    "w: [ksp] p1/TestJ2J.java",
+                    "w: [ksp] p1/J1.java",
+            ),
+            "workload/src/main/java/p1/J2.java" to setOf(
+                    "w: [ksp] p1/J2.java",
+            ),
+            "workload/src/main/java/p1/TestJ2J.java" to setOf(
+                    "w: [ksp] p1/TestJ2J.java",
+            ),
+            "workload/src/main/java/p1/TestJ2K.java" to setOf(
+                    "w: [ksp] p1/TestJ2K.java",
+            ),
+            "workload/src/main/java/p2/J2.java" to setOf(
+                    "w: [ksp] p1/TestK2J.kt",
+                    "w: [ksp] p2/J2.java",
+                    "w: [ksp] p1/TestJ2J.java",
+            ),
+            "workload/src/main/java/p3/J1.java" to setOf(
+                    "w: [ksp] p3/J1.java",
+            ),
+            "workload/src/main/java/p3/J2.java" to setOf(
+                    "w: [ksp] p3/J2.java",
+            ),
+            "workload/src/main/java/p3/J3.java" to setOf(
+                    "w: [ksp] p1/TestK2J.kt",
+                    "w: [ksp] p1/TestJ2J.java",
+                    "w: [ksp] p3/J3.java",
+            ),
+            "workload/src/main/kotlin/p1/K1.kt" to setOf(
+                    "w: [ksp] <root>/K1.kt",
+            ),
+            "workload/src/main/kotlin/p1/K2.kt" to setOf(
+                    "w: [ksp] <root>/K2.kt",
+            ),
+            "workload/src/main/kotlin/p1/TestK2J.kt" to setOf(
+                    "w: [ksp] p1/TestK2J.kt",
+            ),
+            "workload/src/main/kotlin/p1/TestK2K.kt" to setOf(
+                    "w: [ksp] p1/TestK2K.kt",
+            ),
+            "workload/src/main/kotlin/p2/K2.kt" to setOf(
+                    "w: [ksp] p1/TestK2K.kt",
+                    "w: [ksp] p2/K2.kt",
+                    "w: [ksp] p1/TestJ2K.java",
+            ),
+            "workload/src/main/kotlin/p3/K1.kt" to setOf(
+                    "w: [ksp] p1/TestK2K.kt",
+                    "w: [ksp] p3/K1.kt",
+                    "w: [ksp] p1/TestJ2K.java",
+            ),
+            "workload/src/main/kotlin/p3/K2.kt" to setOf(
+                    "w: [ksp] p3/K2.kt",
+            ),
+            "workload/src/main/kotlin/p3/K3.kt" to setOf(
+                    "w: [ksp] p1/TestK2K.kt",
+                    "w: [ksp] p3/K3.kt",
+                    "w: [ksp] p1/TestJ2K.java",
+            )
+    )
+
+    @Test
+    fun testUpToDate() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
+        }
+    }
+
+    @Test
+    fun testIsolating() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+        val cleanArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+
+        src2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).appendText("\n\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.split("\n").filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(dirties, expectedDirties)
+            }
+        }
+        val incrementalArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+        Assert.assertEquals(cleanArtifact, incrementalArtifact)
+    }
+
+    @Test
+    fun testArgChange() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+        val cleanArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+
+        val expectedDirties = src2Dirty.map { it.second }.flatten().toSet()
+        fun buildAndCheck() {
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.split("\n").filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(dirties, expectedDirties)
+            }
+            val incrementalArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+            Assert.assertEquals(cleanArtifact, incrementalArtifact)
+        }
+
+        File(project.root, "workload/build.gradle.kts").appendText("\nksp { arg(\"option1\", \"value1\") }\n")
+        buildAndCheck()
+
+        project.restore("workload/build.gradle.kts")
+        File(project.root, "workload/build.gradle.kts").appendText("\nksp { arg(\"option1\", \"value2\") }\n")
+        buildAndCheck()
+
+        File(project.root, "workload/build.gradle.kts").appendText("\nksp { arg(\"option2\", \"value2\") }\n")
+        buildAndCheck()
+
+        project.restore("workload/build.gradle.kts")
+        buildAndCheck()
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
@@ -1,0 +1,57 @@
+package com.google.devtools.ksp.test
+
+import Artifact
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class OutputDepsIt {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("output-deps")
+
+    val src2Dirty = listOf(
+            "workload/src/main/java/p1/J1.java" to setOf(
+                    "w: [ksp] p1/J1.java",
+                    "w: [ksp] p1/K1.kt",
+                    "w: [ksp] p1/K2.kt",
+            ),
+            "workload/src/main/java/p1/J2.java" to setOf(
+                    "w: [ksp] p1/J2.java",
+            ),
+            "workload/src/main/kotlin/p1/K1.kt" to setOf(
+                    "w: [ksp] p1/J1.java",
+                    "w: [ksp] p1/K1.kt",
+                    "w: [ksp] p1/K2.kt",
+            ),
+            "workload/src/main/kotlin/p1/K2.kt" to setOf(
+                    "w: [ksp] p1/J1.java",
+                    "w: [ksp] p1/K1.kt",
+                    "w: [ksp] p1/K2.kt",
+            ),
+    )
+
+    @Test
+    fun testOutputDeps() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+        val cleanArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+
+        src2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).appendText("\n\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.split("\n").filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(expectedDirties, dirties)
+            }
+        }
+        val incrementalArtifact = Artifact(File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar"))
+        Assert.assertEquals(cleanArtifact, incrementalArtifact)
+    }
+}

--- a/integration-tests/src/test/resources/incremental/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+

--- a/integration-tests/src/test/resources/incremental/gradle.properties
+++ b/integration-tests/src/test/resources/incremental/gradle.properties
@@ -1,0 +1,2 @@
+ksp.incremental=true
+ksp.incremental.log=true

--- a/integration-tests/src/test/resources/incremental/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = "incremental-test"
+
+include(":workload")
+include(":validator")

--- a/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
@@ -1,0 +1,25 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}
+

--- a/integration-tests/src/test/resources/incremental/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental/validator/src/main/kotlin/Validator.kt
@@ -1,0 +1,47 @@
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import com.google.devtools.ksp.visitor.KSDefaultVisitor
+import java.io.File
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+
+
+class Validator : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.codeGenerator = codeGenerator
+        this.logger = logger
+    }
+
+    override fun finish() = Unit
+
+    override fun process(resolver: Resolver) {
+        val validator = object : KSDefaultVisitor<OutputStreamWriter, Unit>() {
+            override fun defaultHandler(node: KSNode, data: OutputStreamWriter) = Unit
+
+            override fun visitDeclaration(declaration: KSDeclaration, data: OutputStreamWriter) {
+                data.write(declaration.qualifiedName?.asString() ?: declaration.simpleName.asString())
+                declaration.validate()
+            }
+        }
+
+        val files = resolver.getAllFiles()
+        files.forEach { file ->
+            logger.warn("${file.packageName.asString()}/${file.fileName}")
+            val output = OutputStreamWriter(codeGenerator.createNewFile(Dependencies(false, file), file.packageName.asString(), file.fileName, "log"))
+            file.declarations.forEach {
+                it.accept(validator, output)
+            }
+            output.close()
+        }
+    }
+}
+
+

--- a/integration-tests/src/test/resources/incremental/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
+++ b/integration-tests/src/test/resources/incremental/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
@@ -1,0 +1,1 @@
+Validator

--- a/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
@@ -1,0 +1,22 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":validator"))
+    testImplementation("junit:junit:4.12")
+    ksp(project(":validator"))
+}
+

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/J1.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/J1.java
@@ -1,0 +1,3 @@
+package p1;
+
+public class J1 {}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/J2.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/J2.java
@@ -1,0 +1,4 @@
+package p1;
+
+public class J2 {
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/TestJ2J.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/TestJ2J.java
@@ -1,0 +1,11 @@
+package p1;
+
+import p2.J2;
+import p3.*;
+
+public class TestJ2J {
+    J1 j1 = null;
+    J2 j2 = null;
+    J3 j3 = null;
+}
+

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/TestJ2K.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p1/TestJ2K.java
@@ -1,0 +1,10 @@
+package p1;
+
+import p2.K2;
+import p3.*;
+
+public class TestJ2K {
+    K1 k1 = null;
+    K2 k2 = null;
+    K3 k3 = null;
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p2/J2.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p2/J2.java
@@ -1,0 +1,4 @@
+package p2;
+
+public class J2 {
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J1.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J1.java
@@ -1,0 +1,4 @@
+package p3;
+
+public class J1 {
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J2.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J2.java
@@ -1,0 +1,4 @@
+package p3;
+
+public class J2 {
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J3.java
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/java/p3/J3.java
@@ -1,0 +1,4 @@
+package p3;
+
+public class J3 {
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/K1.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/K1.kt
@@ -1,0 +1,1 @@
+open class K1

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/K2.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/K2.kt
@@ -1,0 +1,1 @@
+open class K2

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/TestK2J.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/TestK2J.kt
@@ -1,0 +1,10 @@
+package p1
+
+import p2.J2
+import p3.*
+
+open class TestK2J() {
+    val v1: J1 = TODO()
+    val v2: J2 = TODO()
+    val v3: J3 = TODO()
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/TestK2K.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p1/TestK2K.kt
@@ -1,0 +1,10 @@
+package p1
+
+import p2.K2
+import p3.*
+
+open class TestK2K() {
+    val v1: K1 = TODO()
+    val v2: K2 = TODO()
+    val v3: K3 = TODO()
+}

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p2/K2.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p2/K2.kt
@@ -1,0 +1,3 @@
+package p2
+
+open class K2

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K1.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K1.kt
@@ -1,0 +1,3 @@
+package p3
+
+open class K1

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K2.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K2.kt
@@ -1,0 +1,4 @@
+package p3
+
+open class K2
+

--- a/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K3.kt
+++ b/integration-tests/src/test/resources/incremental/workload/src/main/kotlin/p3/K3.kt
@@ -1,0 +1,4 @@
+package p3
+
+open class K3
+

--- a/integration-tests/src/test/resources/output-deps/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+

--- a/integration-tests/src/test/resources/output-deps/gradle.properties
+++ b/integration-tests/src/test/resources/output-deps/gradle.properties
@@ -1,0 +1,2 @@
+ksp.incremental=true
+ksp.incremental.log=true

--- a/integration-tests/src/test/resources/output-deps/settings.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = "incremental-test"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
@@ -1,0 +1,25 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}
+

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,43 @@
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.KSPLogger
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import com.google.devtools.ksp.visitor.KSDefaultVisitor
+import java.io.File
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+
+class TestProcessor : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.codeGenerator = codeGenerator
+        this.logger = logger
+    }
+
+    override fun finish() = Unit
+
+    override fun process(resolver: Resolver) {
+        fun outputForAnno(anno: String) {
+            val annoFiles = resolver.getSymbolsWithAnnotation(anno).map { (it as KSDeclaration).containingFile!! }
+            codeGenerator.createNewFile(Dependencies(false, *annoFiles.toTypedArray()), "", anno, "log").use { output ->
+                OutputStreamWriter(output).use { writer ->
+                    writer.write(annoFiles.map { it.fileName }.joinToString(", "))
+                }
+            }
+        }
+
+        outputForAnno("p1.Anno1")
+        outputForAnno("p1.Anno2")
+
+        resolver.getAllFiles().forEach { file ->
+            logger.warn("${file.packageName.asString()}/${file.fileName}")
+        }
+    }
+}
+
+

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
@@ -1,0 +1,1 @@
+TestProcessor

--- a/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
@@ -1,0 +1,20 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    ksp(project(":test-processor"))
+}
+

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/java/p1/J1.java
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/java/p1/J1.java
@@ -1,0 +1,5 @@
+package p1;
+
+@Anno2
+public class J1 {
+}

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/java/p1/J2.java
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/java/p1/J2.java
@@ -1,0 +1,4 @@
+package p1;
+
+public class J2 {
+}

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/Anno1.kt
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/Anno1.kt
@@ -1,0 +1,2 @@
+package p1
+annotation class Anno1

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/Anno2.kt
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/Anno2.kt
@@ -1,0 +1,2 @@
+package p1
+annotation class Anno2

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/K1.kt
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/K1.kt
@@ -1,0 +1,4 @@
+package p1
+
+@Anno1
+open class K1

--- a/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/K2.kt
+++ b/integration-tests/src/test/resources/output-deps/workload/src/main/kotlin/p1/K2.kt
@@ -1,0 +1,5 @@
+package p1
+
+@Anno1
+@Anno2
+open class K2


### PR DESCRIPTION
How to review:
* Main test logic  are in `IncrementalIT.kt` and `OutputDepsIt.kt`
* In `integration-tests/src/test/resources/incremental`, `Validator` tries to validate all declarations and therefore impose dependencies caused by resolutions.
* In `integration-tests/src/test/resources/output-deps`, `TestProcessor` impose dependencies by outputs.