### PR TITLE
Rename reports of integration tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,5 +71,5 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v2
       with:
-        name: test-reports
+        name: integration-tests-reports
         path: integration-tests/build/reports


### PR DESCRIPTION
Unfortunately I forgot to change the name of upload when copying the entries from test and the report of test was overwritten.