### PR TITLE
Properly wrap PSIMethods that are constructors

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -31,7 +31,7 @@ class MapSignatureProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver) {
-        listOf("Cls", "JavaIntefaceWithVoid")
+        listOf("Cls", "JavaIntefaceWithVoid", "JavaClass")
             .map { className ->
                 resolver.getClassDeclarationByName(className)!!
             }.forEach { subject ->

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
@@ -45,8 +45,8 @@ class ResolveJavaTypeProcessor : AbstractTestProcessor() {
         }
 
         override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
-            if (function.simpleName.asString() == "wildcardParam") {
-                function.parameters[0].type!!.accept(this, Unit)
+            function.parameters.forEach {
+                it.type.accept(this, Unit)
             }
             function.returnType?.accept(this, Unit)
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -37,6 +37,9 @@ import com.intellij.psi.impl.source.PsiClassImpl
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaDescriptorVisibilities
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor
+import org.jetbrains.kotlin.load.java.structure.JavaMember
+import org.jetbrains.kotlin.load.java.structure.impl.JavaConstructorImpl
+import org.jetbrains.kotlin.load.java.structure.impl.JavaMethodImpl
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.descriptorUtil.getOwnerForEffectiveDispatchReceiverParameter
 import org.jetbrains.kotlin.resolve.source.getPsi
@@ -44,6 +47,7 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.TypeProjectionImpl
 import org.jetbrains.kotlin.types.replace
+import org.jetbrains.kotlin.load.java.lazy.ModuleClassResolver
 
 val jvmModifierMap = mapOf(
     JvmModifier.PUBLIC to Modifier.PUBLIC,
@@ -322,4 +326,12 @@ internal inline fun <reified T : CallableMemberDescriptor> T.findClosestOverride
         queue.addAll(overriddenDescriptors)
     }
     return null
+}
+
+fun ModuleClassResolver.resolveContainingClass(psiMethod: PsiMethod): ClassDescriptor? {
+    return if (psiMethod.isConstructor) {
+        resolveClass(JavaConstructorImpl(psiMethod).containingClass)
+    } else {
+        resolveClass(JavaMethodImpl(psiMethod).containingClass)
+    }
 }

--- a/compiler-plugin/testData/api/resolveJavaType.kt
+++ b/compiler-plugin/testData/api/resolveJavaType.kt
@@ -17,6 +17,7 @@
 
 // TEST PROCESSOR: ResolveJavaTypeProcessor
 // EXPECTED:
+// C.<init>.X?
 // kotlin.Int
 // kotlin.String?
 // kotlin.collections.MutableSet<out kotlin.Any?>?
@@ -43,6 +44,9 @@ import java.util.List;
 import java.util.Set;
 
 public class C<T> {
+    public C() {}
+    // to reproduce the case where type reference is owned by a constructor
+    public <X> C(X x) {}
     public int intFun() {}
 
     public String strFun() {}

--- a/compiler-plugin/testData/api/signatureMapper.kt
+++ b/compiler-plugin/testData/api/signatureMapper.kt
@@ -23,6 +23,8 @@
 // ()Ljava/lang/String;
 // LJavaIntefaceWithVoid;
 // ()Ljava/lang/Void;
+// LJavaClass;
+// ()V
 // END
 
 // FILE: Cls.kt
@@ -35,4 +37,9 @@ class Cls {
 // FILE: JavaIntefaceWithVoid.java
 interface JavaIntefaceWithVoid {
     Void getVoid();
+}
+
+// FILE: JavaClass.java
+class JavaClass {
+    JavaClass() {}
 }


### PR DESCRIPTION
This PR fixes a bug where we were wrapping all PsiMethods to
JavaMethodImpl without checking if they are constructors.

Both cases, we were wrapping them to find the containing class,
so I've added an extension function to ModuleClassResolver
to find containing descriptor via PsiMethod which abstracts
this resolution.

Test: extended resolveJavaType and signatureMapper tests to trigger
the crash
Fixes: #265