### PR TITLE
return primary constructor in declarations for KSClassDeclarationImpl

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -46,9 +46,12 @@ class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
 
     private fun KSAnnotated.toSignature(): String {
         return when(this) {
-            is KSClassDeclaration -> (qualifiedName ?: simpleName).asString()
-            is KSDeclaration -> simpleName.asString()
-            is KSValueParameter -> name?.asString() ?: "no-name-value-parameter"
+            is KSClassDeclaration -> "class " + (qualifiedName ?: simpleName).asString()
+            is KSPropertyDeclaration -> "property ${simpleName.asString()}"
+            is KSFunctionDeclaration -> "function ${simpleName.asString()}"
+            is KSValueParameter -> name?.let {
+                "parameter ${it.asString()}"
+            } ?: "no-name-value-parameter"
             is KSPropertyAccessor -> receiver.toSignature()
             else -> {
                 error("unexpected annotated")

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
@@ -21,6 +21,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.*
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
@@ -41,7 +42,14 @@ class DeclarationCollector : KSTopDownVisitor<MutableCollection<String>, Unit>()
     override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
     }
 
+    private fun KSDeclaration.toSignature() : String {
+        qualifiedName?.let {
+            return it.asString()
+        }
+        val parentSignature = parentDeclaration?.toSignature() ?: ""
+        return "$parentSignature / ${simpleName.asString()}"
+    }
     override fun visitDeclaration(declaration: KSDeclaration, data: MutableCollection<String>) {
-        data.add("${declaration.qualifiedName?.asString() ?: "<simple name: ${declaration.simpleName.asString()}>"}: ${declaration.isInternal()}: ${declaration.isLocal()}: ${declaration.isPrivate()}: ${declaration.isProtected()}: ${declaration.isPublic()}: ${declaration.isOpen()}")
+        data.add("${declaration.toSignature()}: ${declaration.isInternal()}: ${declaration.isLocal()}: ${declaration.isPrivate()}: ${declaration.isProtected()}: ${declaration.isPublic()}: ${declaration.isOpen()}")
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -60,8 +60,13 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
         val propertiesFromConstructor = primaryConstructor?.parameters
             ?.filter { it.isVar || it.isVal }
             ?.map { KSPropertyDeclarationParameterImpl.getCached((it as KSValueParameterImpl).ktParameter) } ?: emptyList()
-        val result = ktClassOrObject.declarations.getKSDeclarations().toMutableList()
+        val result = ktClassOrObject.declarations.getKSDeclarations().toMutableList<KSDeclaration>()
         result.addAll(propertiesFromConstructor)
+        primaryConstructor?.let { primaryConstructor: KSDeclaration ->
+            if (!result.contains(primaryConstructor)) {
+                result.add(primaryConstructor)
+            }
+        }
         if (classKind != ClassKind.INTERFACE) {
             // check if we need to add a synthetic constructor
             val hasConstructor = result.any {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -62,8 +62,10 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
             ?.map { KSPropertyDeclarationParameterImpl.getCached((it as KSValueParameterImpl).ktParameter) } ?: emptyList()
         val result = ktClassOrObject.declarations.getKSDeclarations().toMutableList<KSDeclaration>()
         result.addAll(propertiesFromConstructor)
-        primaryConstructor?.let { primaryConstructor: KSDeclaration ->
-            if (!result.contains(primaryConstructor)) {
+        primaryConstructor?.let { primaryConstructor: KSFunctionDeclaration ->
+            // if primary constructor is from source, it won't show up in declarations
+            // hence add it as well.
+            if (primaryConstructor.origin == Origin.KOTLIN) {
                 result.add(primaryConstructor)
             }
         }

--- a/compiler-plugin/testData/api/annotationInDependencies.kt
+++ b/compiler-plugin/testData/api/annotationInDependencies.kt
@@ -19,53 +19,59 @@
 // TEST PROCESSOR: AnnotationsInDependenciesProcessor
 // EXPECTED:
 // main.KotlinClass ->
-// main.KotlinClass : annotations.ClassTarget{[value = onClass]}
-// main.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
-// myFun : annotations.FunctionTarget{[value = onMyFun]}
-// myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
-// param1 : annotations.NoTargetAnnotation{[value = onParam1]}
-// param1 : annotations.ValueParameterTarget{[value = onParam1]}
-// param2 : annotations.NoTargetAnnotation{[value = onParam2]}
-// param2 : annotations.ValueParameterTarget{[value = onParam2]}
-// prop : annotations.FieldTarget2{[value = field:]}
-// prop : annotations.FieldTarget{[value = onProp]}
-// prop : annotations.NoTargetAnnotation{[value = onProp]}
-// prop : annotations.PropertyGetterTarget{[value = get:]}
-// prop : annotations.PropertySetterTarget{[value = set:]}
-// prop : annotations.PropertyTarget{[value = onProp]}
+// class main.KotlinClass : annotations.ClassTarget{[value = onClass]}
+// class main.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
+// function myFun : annotations.FunctionTarget{[value = onMyFun]}
+// function myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
+// parameter param1 : annotations.NoTargetAnnotation{[value = onParam1]}
+// parameter param1 : annotations.ValueParameterTarget{[value = onParam1]}
+// parameter param2 : annotations.NoTargetAnnotation{[value = onParam2]}
+// parameter param2 : annotations.ValueParameterTarget{[value = onParam2]}
+// property prop : annotations.FieldTarget2{[value = field:]}
+// property prop : annotations.FieldTarget{[value = onProp]}
+// property prop : annotations.NoTargetAnnotation{[value = onProp]}
+// property prop : annotations.PropertyGetterTarget{[value = get:]}
+// property prop : annotations.PropertySetterTarget{[value = set:]}
+// property prop : annotations.PropertyTarget{[value = onProp]}
 // lib.KotlinClass ->
-// lib.KotlinClass : annotations.ClassTarget{[value = onClass]}
-// lib.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
-// myFun : annotations.FunctionTarget{[value = onMyFun]}
-// myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
-// param1 : annotations.NoTargetAnnotation{[value = onParam1]}
-// param1 : annotations.ValueParameterTarget{[value = onParam1]}
-// param2 : annotations.NoTargetAnnotation{[value = onParam2]}
-// param2 : annotations.ValueParameterTarget{[value = onParam2]}
-// prop : annotations.FieldTarget2{[value = field:]}
-// prop : annotations.FieldTarget{[value = onProp]}
-// prop : annotations.NoTargetAnnotation{[value = onProp]}
-// prop : annotations.PropertyGetterTarget{[value = get:]}
-// prop : annotations.PropertySetterTarget{[value = set:]}
-// prop : annotations.PropertyTarget{[value = onProp]}
+// class lib.KotlinClass : annotations.ClassTarget{[value = onClass]}
+// class lib.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
+// function myFun : annotations.FunctionTarget{[value = onMyFun]}
+// function myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
+// parameter param1 : annotations.NoTargetAnnotation{[value = onParam1]}
+// parameter param1 : annotations.ValueParameterTarget{[value = onParam1]}
+// parameter param2 : annotations.NoTargetAnnotation{[value = onParam2]}
+// parameter param2 : annotations.ValueParameterTarget{[value = onParam2]}
+// property prop : annotations.FieldTarget2{[value = field:]}
+// property prop : annotations.FieldTarget{[value = onProp]}
+// property prop : annotations.NoTargetAnnotation{[value = onProp]}
+// property prop : annotations.PropertyGetterTarget{[value = get:]}
+// property prop : annotations.PropertySetterTarget{[value = set:]}
+// property prop : annotations.PropertyTarget{[value = onProp]}
 // main.DataClass ->
-// constructorParam : annotations.FieldTarget2{[value = field:]}
-// constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
-// constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
-// constructorParam : annotations.PropertyGetterTarget{[value = get:]}
-// constructorParam : annotations.PropertySetterTarget{[value = set:]}
-// constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
-// main.DataClass : annotations.ClassTarget{[value = onDataClass]}
-// main.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// class main.DataClass : annotations.ClassTarget{[value = onDataClass]}
+// class main.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// parameter constructorParam : annotations.FieldTarget2{[value = field:]}
+// parameter constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
+// parameter constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
+// parameter constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// parameter constructorParam : annotations.PropertySetterTarget{[value = set:]}
+// parameter constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
+// property constructorParam : annotations.FieldTarget2{[value = field:]}
+// property constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
+// property constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
+// property constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// property constructorParam : annotations.PropertySetterTarget{[value = set:]}
+// property constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
 // lib.DataClass ->
-// constructorParam : annotations.FieldTarget2{[value = field:]}
-// constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
-// constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
-// constructorParam : annotations.PropertyGetterTarget{[value = get:]}
-// constructorParam : annotations.PropertySetterTarget{[value = set:]}
-// constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
-// lib.DataClass : annotations.ClassTarget{[value = onDataClass]}
-// lib.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// class lib.DataClass : annotations.ClassTarget{[value = onDataClass]}
+// class lib.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// parameter constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
+// property constructorParam : annotations.FieldTarget2{[value = field:]}
+// property constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
+// property constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// property constructorParam : annotations.PropertySetterTarget{[value = set:]}
+// property constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
 // END
 // MODULE: annotations
 // FILE: Annotations.kt

--- a/compiler-plugin/testData/api/constructorDeclarations.kt
+++ b/compiler-plugin/testData/api/constructorDeclarations.kt
@@ -54,10 +54,32 @@
 // <init>(): lib.AbstractKotlinClassWithMultipleConstructors1
 // <init>(kotlin.Int): lib.AbstractKotlinClassWithMultipleConstructors1
 // <init>(kotlin.String): lib.AbstractKotlinClassWithMultipleConstructors1
+// class: AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.Float): AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.Int): AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.String): AbstractKotlinClassWithMultipleConstructors2
+// class: lib.AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.Float): lib.AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.Int): lib.AbstractKotlinClassWithMultipleConstructors2
+// <init>(kotlin.String): lib.AbstractKotlinClassWithMultipleConstructors2
+// class: AbstractKotlinClassWithPrimaryConstructor
+// <init>(kotlin.Int): AbstractKotlinClassWithPrimaryConstructor
+// class: lib.AbstractKotlinClassWithPrimaryConstructor
+// <init>(kotlin.Int): lib.AbstractKotlinClassWithPrimaryConstructor
 // class: AbstractKotlinClassWithoutExplicitConstructor
 // <init>(): AbstractKotlinClassWithoutExplicitConstructor
 // class: lib.AbstractKotlinClassWithoutExplicitConstructor
 // <init>(): lib.AbstractKotlinClassWithoutExplicitConstructor
+// class: DataClass
+// <init>(kotlin.Int,kotlin.String): DataClass
+// class: lib.DataClass
+// <init>(kotlin.Int,kotlin.String): lib.DataClass
+// class: DataClassWithSecondaryConstructor
+// <init>(kotlin.Int): DataClassWithSecondaryConstructor
+// <init>(kotlin.Int,kotlin.String): DataClassWithSecondaryConstructor
+// class: lib.DataClassWithSecondaryConstructor
+// <init>(kotlin.Int): lib.DataClassWithSecondaryConstructor
+// <init>(kotlin.Int,kotlin.String): lib.DataClassWithSecondaryConstructor
 // class: JavaAnnotation
 // <init>(): JavaAnnotation
 // class: lib.JavaAnnotation
@@ -108,10 +130,22 @@
 // <init>(): lib.KotlinClassWithMultipleConstructors1
 // <init>(kotlin.Int): lib.KotlinClassWithMultipleConstructors1
 // <init>(kotlin.String): lib.KotlinClassWithMultipleConstructors1
+// class: KotlinClassWithMultipleConstructors2
+// <init>(kotlin.Float): KotlinClassWithMultipleConstructors2
+// <init>(kotlin.Int): KotlinClassWithMultipleConstructors2
+// <init>(kotlin.String): KotlinClassWithMultipleConstructors2
+// class: lib.KotlinClassWithMultipleConstructors2
+// <init>(kotlin.Float): lib.KotlinClassWithMultipleConstructors2
+// <init>(kotlin.Int): lib.KotlinClassWithMultipleConstructors2
+// <init>(kotlin.String): lib.KotlinClassWithMultipleConstructors2
 // class: KotlinClassWithNamedCompanion
 // <init>(): KotlinClassWithNamedCompanion
 // class: lib.KotlinClassWithNamedCompanion
 // <init>(): lib.KotlinClassWithNamedCompanion
+// class: KotlinClassWithPrimaryConstructor
+// <init>(kotlin.Int): KotlinClassWithPrimaryConstructor
+// class: lib.KotlinClassWithPrimaryConstructor
+// <init>(kotlin.Int): lib.KotlinClassWithPrimaryConstructor
 // class: KotlinClassWithoutExplicitConstructor
 // <init>(): KotlinClassWithoutExplicitConstructor
 // class: lib.KotlinClassWithoutExplicitConstructor
@@ -181,6 +215,8 @@ interface KotlinInterface {}
 class KotlinClassWithoutExplicitConstructor {
 }
 class KotlinClassWithExplicitEmptyConstructor() {}
+class KotlinClassWithPrimaryConstructor(x:Int) {
+}
 class KotlinClassWithExplicitConstructor {
     constructor(x:Int) {}
 }
@@ -189,7 +225,13 @@ class KotlinClassWithMultipleConstructors1 {
     constructor(y:Int): this() {}
     constructor(x: String) : this() {}
 }
+class KotlinClassWithMultipleConstructors2(z:Float) {
+    constructor(y:Int): this(0f) {}
+    constructor(x: String) : this(0f) {}
+}
 abstract class AbstractKotlinClassWithoutExplicitConstructor {
+}
+abstract class AbstractKotlinClassWithPrimaryConstructor(x:Int) {
 }
 abstract class AbstractKotlinClassWithExplicitEmptyConstructor() {}
 abstract class AbstractKotlinClassWithExplicitConstructor {
@@ -200,6 +242,10 @@ abstract class AbstractKotlinClassWithMultipleConstructors1 {
     constructor(y:Int): this() {}
     constructor(x: String) : this() {}
 }
+abstract class AbstractKotlinClassWithMultipleConstructors2(z:Float) {
+    constructor(y:Int): this(0f) {}
+    constructor(x: String) : this(0f) {}
+}
 annotation class KotlinAnnotation
 object KotlinObject {}
 class KotlinClassWithCompanion {
@@ -207,6 +253,10 @@ class KotlinClassWithCompanion {
 }
 class KotlinClassWithNamedCompanion {
     companion object MyCompanion
+}
+data class DataClass(val x:Int, var y:String)
+data class DataClassWithSecondaryConstructor(val x:Int, val y:String) {
+    constructor(x:Int) : this(x, "")
 }
 // MODULE: main(lib)
 // FILE: JavaInterface.java
@@ -254,6 +304,8 @@ interface KotlinInterface {}
 class KotlinClassWithoutExplicitConstructor {
 }
 class KotlinClassWithExplicitEmptyConstructor() {}
+class KotlinClassWithPrimaryConstructor(x:Int) {
+}
 class KotlinClassWithExplicitConstructor {
     constructor(x:Int) {}
 }
@@ -262,7 +314,13 @@ class KotlinClassWithMultipleConstructors1 {
     constructor(y:Int): this() {}
     constructor(x: String) : this() {}
 }
+class KotlinClassWithMultipleConstructors2(z:Float) {
+    constructor(y:Int): this(0f) {}
+    constructor(x: String) : this(0f) {}
+}
 abstract class AbstractKotlinClassWithoutExplicitConstructor {
+}
+abstract class AbstractKotlinClassWithPrimaryConstructor(x:Int) {
 }
 abstract class AbstractKotlinClassWithExplicitEmptyConstructor() {}
 abstract class AbstractKotlinClassWithExplicitConstructor {
@@ -273,6 +331,10 @@ abstract class AbstractKotlinClassWithMultipleConstructors1 {
     constructor(y:Int): this() {}
     constructor(x: String) : this() {}
 }
+abstract class AbstractKotlinClassWithMultipleConstructors2(z:Float) {
+    constructor(y:Int): this(0f) {}
+    constructor(x: String) : this(0f) {}
+}
 annotation class KotlinAnnotation
 object KotlinObject {}
 class KotlinClassWithCompanion {
@@ -280,4 +342,8 @@ class KotlinClassWithCompanion {
 }
 class KotlinClassWithNamedCompanion {
     companion object MyCompanion
+}
+data class DataClass(val x:Int, var y:String)
+data class DataClassWithSecondaryConstructor(val x:Int, val y:String) {
+    constructor(x:Int) : this(x, "")
 }

--- a/compiler-plugin/testData/api/declarationUtil.kt
+++ b/compiler-plugin/testData/api/declarationUtil.kt
@@ -19,20 +19,21 @@
 // FORMAT: <name>: isInternal: isLocal: isPrivate: isProtected: isPublic: isOpen
 // EXPECTED:
 // Cls: true: false: false: false: false: false
-// <simple name: <init>>: false: false: false: false: true: false
-// <simple name: aaa>: false: true: false: false: false: false
+// Cls / <init>: false: false: false: false: true: false
+// Cls / <init> / aaa: false: true: false: false: false: false
 // Cls.prop: false: false: false: false: true: true
 // Cls.protectedProp: false: false: false: true: false: true
 // Cls.abstractITFFun: false: false: false: false: true: true
 // Cls.pri: false: false: true: false: false: false
 // Cls.b: false: false: false: false: true: true
+// Cls / <init>: false: false: false: false: true: false
 // ITF: false: false: false: false: true: true
 // ITF.prop: false: false: false: false: true: true
 // ITF.protectedProp: false: false: false: true: false: true
 // ITF.b: false: false: false: false: true: true
 // ITF.abstractITFFun: false: false: false: false: true: true
 // ITF.nonAbstractITFFun: false: false: false: false: true: true
-// <simple name: aa>: false: true: false: false: false: false
+// ITF.nonAbstractITFFun / aa: false: true: false: false: false: false
 // END
 // FILE: a.kt
 internal class Cls(override val b: Int) : ITF {

--- a/compiler-plugin/testData/api/implicitElements.kt
+++ b/compiler-plugin/testData/api/implicitElements.kt
@@ -26,7 +26,7 @@
 // readOnly.getter.owner: readOnly: KOTLIN
 // readWrite.get(): KOTLIN
 // readWrite.set(): SYNTHETIC annotations from property: SetAnno
-// synthetic constructor for Data
+// <init>
 // comp1.get(): SYNTHETIC
 // comp2.get(): SYNTHETIC
 // comp2.set(): SYNTHETIC


### PR DESCRIPTION
PR #275 made different class declaration backends more consistent
by adding constructor into declarations and making getConstructors
return based on that.
Unfortunately, it missed primary constructor, causing missing
constructors OR even worse, return an empty constructor
instead of the primary constructor.

This PR fixes that issue and also extends the test case to
cover it.

Fixes: #279