### PR TITLE
Register generated java sources with AGP

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
     # Run ksp generated tests
     - name: test
-      run: ./gradlew --info :compiler-plugin:test --tests "com.google.devtools.ksp.test.KotlinKSPTestGenerated.*" -PcompilerTestEnabled=true
+      run: ./gradlew --stacktrace --info :compiler-plugin:test --tests "com.google.devtools.ksp.test.KotlinKSPTestGenerated.*" -PcompilerTestEnabled=true
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v2
@@ -66,7 +66,7 @@ jobs:
         path: compiler-plugin/build/reports
     # Run ksp integration tests
     - name: integration tests
-      run: ./gradlew --info :integration-tests:test
+      run: ./gradlew --stacktrace --info :integration-tests:test
     - name: Upload integration test results
       if: always()
       uses: actions/upload-artifact@v2
@@ -75,7 +75,7 @@ jobs:
         path: integration-tests/build/reports
     # Run gradle plugin tests
     - name: gradle plugin tests
-      run: ./gradlew --info :gradle-plugin:test
+      run: ./gradlew --stacktrace --info :gradle-plugin:test
     - name: Upload gradle plugin test results
       if: always()
       uses: actions/upload-artifact@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,12 @@ jobs:
       env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: echo ::set-env name=JDK_9::$(echo $JAVA_HOME)
-
+    - name: Setup Java 11
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '11'
+        java-package: jdk
+        architecture: x64
     # Checkout
     - uses: actions/checkout@v2
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ subprojects {
         mavenCentral()
         google()
         maven("https://dl.bintray.com/kotlin/kotlin-eap")
+        jcenter()
     }
     tasks.withType<Jar>().configureEach {
         manifest.attributes.apply {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -22,7 +22,8 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinBaseVersion")
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
-    compileOnly("com.android.tools.build:gradle-api:$agpBaseVersion")
+    // replace AGP dependency w/ gradle-api when we have source registering API available.
+    compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
     testImplementation(gradleApi())
     testImplementation(project(":api"))
     testImplementation("junit:junit:$junitVersion")

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -21,6 +21,9 @@ import com.android.build.api.dsl.CommonExtension
 import com.google.devtools.ksp.gradle.KspGradleSubplugin.Companion.KSP_MAIN_CONFIGURATION_NAME
 import org.gradle.api.Project
 import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.TaskProvider
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
+import java.io.File
 import java.util.*
 
 /**
@@ -61,5 +64,20 @@ class AndroidPluginIntegration(
                 }
             }
         }
+    }
+
+    fun registerGeneratedJavaSources(
+        project: Project,
+        kotlinCompilation: KotlinJvmAndroidCompilation,
+        kspTaskProvider: TaskProvider<KspTask>,
+        javaOutputDir: File,
+        classOutputDir: File,
+    ) {
+        val kspJavaOutput = project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
+        val kspClassOutput = project.fileTree(classOutputDir).builtBy(kspTaskProvider)
+        kspJavaOutput.include("**/*.java")
+        kspClassOutput.include("**/*.class")
+        kotlinCompilation.androidVariant.registerExternalAptJavaOutput(kspJavaOutput)
+        kotlinCompilation.androidVariant.registerPreJavacGeneratedBytecode(kspClassOutput)
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -24,7 +24,6 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
-import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.SourceSet
@@ -155,7 +154,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 ?: return project.provider { emptyList() }
         val javaCompile = findJavaTaskForKotlinCompilation(kotlinCompilation)?.get()
         val kspExtension = project.extensions.getByType(KspExtension::class.java)
-
         val kspConfigurations = LinkedHashSet<Configuration>()
         kotlinCompilation.allKotlinSourceSets.forEach {
             it.kspConfiguration(project)?.let {
@@ -233,6 +231,15 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 resourcesTask.dependsOn(kspTaskProvider)
                 resourcesTask.from(resourceOutputDir)
             }
+        }
+        if (kotlinCompilation is KotlinJvmAndroidCompilation) {
+            androidIntegration.registerGeneratedJavaSources(
+                project = project,
+                kotlinCompilation = kotlinCompilation,
+                kspTaskProvider = kspTaskProvider,
+                javaOutputDir = javaOutputDir,
+                classOutputDir = classOutputDir,
+            )
         }
 
         return project.provider { emptyList() }


### PR DESCRIPTION
This PR adds code to register generated java sources with AGP so that
the IDE can discover them (useful when developer needs to debug
generated code or their code needs to access them).

I had to update AGP dependency to the plugin (instead of the API)
because the plugin does not yet provide the api to register generated
resource folders.

For some reason, the generated byte code sources gets overridden by the
kotlin path, hence, I couldn't assert them in tests.

Test: SourceSetConfigurationTest.registerJavaSourcesToAndroid