### PR TITLE
Build & upload artifact on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+# Workflow to build release artifacts
+
+name: release artifacts
+
+on:
+  release:
+    types: [ created ]
+
+jobs:
+  build-and-test:
+    strategy:
+      fail-fast: false
+
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Setup Java 8
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '8'
+        java-package: jdk
+        architecture: x64
+    - name: set JDK 6,7,8 environment variables for kotlin compiler
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      run: echo ::set-env name=JDK_16::$(echo $JAVA_HOME) && echo ::set-env name=JDK_17::$(echo $JAVA_HOME) && echo ::set-env name=JDK_18::$(echo $JAVA_HOME)
+    - name: Setup Java 9
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '9'
+        java-package: jdk
+        architecture: x64
+    - name: set JDK_9 environment variable for kotlin compiler
+      env:
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
+      run: echo ::set-env name=JDK_9::$(echo $JAVA_HOME)
+    - name: Setup Java 11
+      uses: actions/setup-java@v1.4.3
+      with:
+        java-version: '11'
+        java-package: jdk
+        architecture: x64
+
+    # Checkout
+    - uses: actions/checkout@v2
+
+    # Build cache
+    - name: Cache Gradle Cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle.properties') }}
+        # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+    - name: Cache gradle wrapper
+      uses: actions/cache@v2
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+    # Build KSP artifacts
+    - name: build
+      run: |
+        REF=${{ github.ref }} # refs/tags/$KSP_VERSION
+        ./gradlew --info -PkspVersion=${REF:10} -PoutRepo=$(pwd)/build/repos/release publishAllPublicationsToMavenRepository
+    - name: pack
+      run: cd build/repos/release/ && zip -r ../../artifacts.zip .
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./build/artifacts.zip
+        asset_name: artifacts.zip
+        asset_content_type: application/zip


### PR DESCRIPTION
It sets `kspVersion` by the tag name associated in a release.

There are 2 differences to main.yml:
1. events
2. actions after # Build KSP artifacts