### PR TITLE
Check KSP and kotlin-gradle-plugin versions

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/VersionCheckIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/VersionCheckIT.kt
@@ -1,0 +1,22 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.*
+
+class VersionCheckIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground")
+
+    @Test
+    fun testVersion() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val result = gradleRunner.withArguments("-Dkotlin.compiler.execution.strategy=in-process", "-PkotlinVersion=1.4.20", "clean", "build").buildAndFail()
+        Assert.assertTrue(result.output.contains("Please pick the same version of ksp and kotlin plugins."))
+    }
+}

--- a/integration-tests/src/test/resources/playground/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+


### PR DESCRIPTION
Each KSP release depends on a specific Kotlin compiler version.
If their versions don't match, there might be runtime errors.