### PR TITLE
add integration test for onError

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnErrorIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnErrorIT.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class OnErrorIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("on-error")
+
+    @Test
+    fun testOnError() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").buildAndFail().let { result ->
+            val errors = result.output.split("\n").filter { it.startsWith("e: [ksp]") }
+            Assert.assertEquals("e: [ksp] Error processor: errored at 2", errors.first())
+            Assert.assertEquals("e: [ksp] NormalProcessor called error on 2", errors.last())
+        }
+    }
+}

--- a/integration-tests/src/test/resources/on-error/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+

--- a/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
@@ -1,0 +1,24 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}
+

--- a/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/ErrorProcessor.kt
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/ErrorProcessor.kt
@@ -1,0 +1,38 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.File
+import java.io.OutputStream
+import kotlin.math.round
+
+
+class ErrorProcessor : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+    lateinit var file: OutputStream
+    var rounds = 0
+
+
+    override fun finish() {
+    }
+
+    override fun onError() {
+    }
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.logger = logger
+        this.codeGenerator = codeGenerator
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        rounds++
+        if (rounds == 2) {
+            logger.error("Error processor: errored at ${rounds}")
+        } else {
+            codeGenerator.createNewFile(Dependencies.ALL_FILES, "test", "error", "log")
+        }
+        return emptyList()
+    }
+}
+
+

--- a/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/NormalProcessor.kt
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/NormalProcessor.kt
@@ -1,0 +1,32 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+
+
+class NormalProcessor : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+    var rounds = 0
+
+
+    override fun finish() {
+    }
+
+    override fun onError() {
+        logger.error("NormalProcessor called error on $rounds")
+    }
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.logger = logger
+        this.codeGenerator = codeGenerator
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        rounds++
+        if (rounds == 1) {
+            codeGenerator.createNewFile(Dependencies.ALL_FILES, "test", "normal", "log")
+        }
+        return emptyList()
+    }
+}
+
+

--- a/integration-tests/src/test/resources/on-error/on-error-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
@@ -1,0 +1,2 @@
+ErrorProcessor
+NormalProcessor

--- a/integration-tests/src/test/resources/on-error/settings.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = "on-error"
+
+include(":workload")
+include(":on-error-processor")

--- a/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
@@ -1,0 +1,20 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    ksp(project(":on-error-processor"))
+}
+

--- a/integration-tests/src/test/resources/on-error/workload/src/main/java/com/example/A.kt
+++ b/integration-tests/src/test/resources/on-error/workload/src/main/java/com/example/A.kt
@@ -1,0 +1,7 @@
+package com.example
+
+
+fun main() {
+    print("hello world")
+}
+


### PR DESCRIPTION
I tried to test the `onError` behavior with logger.warn but it seems warnings are shadowed in case of errors.. Probably need another fix to make it work properly.