### PR TITLE
Make finish() have a default implementation

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessor.kt
@@ -44,7 +44,7 @@ interface SymbolProcessor {
     /**
      * Called by Kotlin Symbol Processing to finalize the processing of a compilation.
      */
-    fun finish()
+    fun finish() {}
 
     /**
      * Called by Kotlin Symbol Processing to handle errors after a round of processing.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
@@ -27,8 +27,5 @@ abstract class AbstractTestProcessor : SymbolProcessor {
     override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
     }
 
-    override fun finish() {
-    }
-
     abstract fun toResult(): List<String>
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/processor/TestSymbolProcessor.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/processor/TestSymbolProcessor.kt
@@ -40,7 +40,4 @@ abstract class TestSymbolProcessor : SymbolProcessor {
         this.codeGenerator = codeGenerator
         this.logger = logger
     }
-
-    override fun finish() {
-    }
 }

--- a/integration-tests/src/test/resources/incremental/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental/validator/src/main/kotlin/Validator.kt
@@ -21,8 +21,6 @@ class Validator : SymbolProcessor {
         this.logger = logger
     }
 
-    override fun finish() = Unit
-
     override fun process(resolver: Resolver): List<KSAnnotated> {
         if(processed) {
             return emptyList()

--- a/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/ErrorProcessor.kt
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/ErrorProcessor.kt
@@ -12,13 +12,6 @@ class ErrorProcessor : SymbolProcessor {
     lateinit var file: OutputStream
     var rounds = 0
 
-
-    override fun finish() {
-    }
-
-    override fun onError() {
-    }
-
     override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
         this.logger = logger
         this.codeGenerator = codeGenerator

--- a/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/NormalProcessor.kt
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/src/main/kotlin/NormalProcessor.kt
@@ -8,9 +8,6 @@ class NormalProcessor : SymbolProcessor {
     var rounds = 0
 
 
-    override fun finish() {
-    }
-
     override fun onError() {
         logger.error("NormalProcessor called error on $rounds")
     }

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -20,8 +20,6 @@ class TestProcessor : SymbolProcessor {
         this.logger = logger
     }
 
-    override fun finish() = Unit
-
     override fun process(resolver: Resolver): List<KSAnnotated> {
         if(processed) {
             return emptyList()

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BuilderProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BuilderProcessor.kt
@@ -11,10 +11,6 @@ class BuilderProcessor : SymbolProcessor {
     lateinit var codeGenerator: CodeGenerator
     lateinit var logger: KSPLogger
 
-    override fun finish() {
-
-    }
-
     override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
         this.codeGenerator = codeGenerator
         this.logger = logger

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
@@ -14,9 +14,6 @@ class TestProcessor : SymbolProcessor {
         file.appendText("$indent$s\n")
     }
 
-    override fun finish() {
-    }
-
     override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
         this.codeGenerator = codeGenerator
         file = codeGenerator.createNewFile(Dependencies(false), "", "TestProcessor", "log")


### PR DESCRIPTION
Per chat in the kotlin-lang channel, this function often doesn't need implementing in processors and saves users a bit of boilerplate.