### PR TITLE
Implement getSealedSubclasses API on KSClassDeclaration

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
@@ -46,6 +46,12 @@ interface KSClassDeclaration : KSDeclaration, KSDeclarationContainer {
     val isCompanionObject: Boolean
 
     /**
+     * @return a sequence of sealed subclasses of this class, if any.
+     * Calling [getSealedSubclasses] requires type resolution therefore is expensive and should be avoided if possible.
+     */
+    fun getSealedSubclasses(): Sequence<KSClassDeclaration>
+
+    /**
      * Get all member functions of a class declaration, including declared and inherited.
      * @return List of function declarations from the class members.
      * Calling [getAllFunctions] requires type resolution therefore is expensive and should be avoided if possible.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSFunctionDeclarationImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationParameterImpl
@@ -62,6 +63,10 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
 
     override val isCompanionObject by lazy {
         descriptor.isCompanionObject
+    }
+
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> {
+        return descriptor.sealedSubclassesSequence()
     }
 
     override fun getAllFunctions(): List<KSFunctionDeclaration> = descriptor.getAllFunctions()
@@ -166,4 +171,11 @@ internal fun ClassDescriptor.getAllProperties(): List<KSPropertyDeclaration> {
                     else -> KSPropertyDeclarationDescriptorImpl.getCached(it as PropertyDescriptor)
                 }
             }
+}
+
+internal fun ClassDescriptor.sealedSubclassesSequence(): Sequence<KSClassDeclaration> {
+    // TODO record incremental subclass lookups in Kotlin 1.5.x?
+    return sealedSubclasses
+        .asSequence()
+        .map { KSClassDeclarationDescriptorImpl.getCached(it) }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -60,6 +60,8 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
 
     override val isCompanionObject = false
 
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> = emptySequence()
+
     private val descriptor: ClassDescriptor? by lazy {
         ResolverImpl.instance.resolveJavaDeclaration(psi) as ClassDescriptor
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -79,6 +79,9 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) : KSClas
         ResolverImpl.moduleClassResolver.resolveClass(JavaClassImpl(psi))
     }
 
+    // TODO in 1.5 + jvmTarget 15, will we return Java permitted types?
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> = emptySequence()
+
     override fun getAllFunctions(): List<KSFunctionDeclaration> =
             descriptor?.getAllFunctions() ?: emptyList()
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -27,9 +27,11 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
 import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
+import com.google.devtools.ksp.symbol.impl.binary.sealedSubclassesSequence
 import com.google.devtools.ksp.symbol.impl.synthetic.KSConstructorSyntheticImpl
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
@@ -50,6 +52,10 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
 
     override val isCompanionObject by lazy {
         (ktClassOrObject is KtObjectDeclaration) && (ktClassOrObject.isCompanion())
+    }
+
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> {
+        return descriptor.sealedSubclassesSequence()
     }
 
     override fun getAllFunctions(): List<KSFunctionDeclaration> = descriptor.getAllFunctions()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
@@ -57,6 +57,8 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
 
     override val typeParameters: List<KSTypeParameter> = emptyList()
 
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> = emptySequence()
+
     override fun asStarProjectedType(): KSType {
         return ResolverImpl.instance.builtIns.nothingType
     }


### PR DESCRIPTION
Resolves #218

Starting early for review. Next steps:
* Do we need to add in incremental tracking now or wait till Kotlin 1.5?
* Do we expose the same for Java 15 "permitted subtypes" if JVM target is set to 15+ and 1.5 language version is set?
* Tests!