### PR TITLE
Add syntax highlighting to docs

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -18,7 +18,7 @@ fun KSDeclaration.isLocal(): Boolean {
 
 Find the actual class or interface declaration that the alias points to recursively:
 
-```
+```kotlin
 fun KSTypeAlias.findActualType(): KSClassDeclaration {
     val resolvedType = this.type.resolve().declaration
     return if (resolvedType is KSTypeAlias) {

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -53,7 +53,7 @@ where `A` extends `B`. The processor got `A` by `Resolver.getSymbolsWithAnnotati
 `B` by `KSClassDeclaration.superTypes` from `A`. Because the inclusion of `B` is due to `A`,
 `B.kt` doesn't need to be specified in `dependencies` for `outputForA`. You can still specify `B.kt` in this case, but it is unnecessary.
 
-```
+```kotlin
 // A.kt
 @Interesting
 class A : B()

--- a/docs/multi-round.md
+++ b/docs/multi-round.md
@@ -9,7 +9,7 @@ To use multiple round processing, the `SymbolProcessor.process()` function needs
 
 The following sample code shows how to defer invalid symbols by using a validation check:
 
-```
+```kotlin
 override fun process(resolver: Resolver): List<KSAnnotated> {
     val symbols = resolver.getSymbolsWithAnnotation("com.example.annotation.Builder")
     val ret = symbols.filter { !it.validate() }


### PR DESCRIPTION
Fix missing syntax highlighting for Kotlin code in docs.