### PR TITLE
More tests for AGP support

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,5 +1,6 @@
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
+val agpBaseVersion: String by project
 
 plugins {
     kotlin("jvm")
@@ -13,6 +14,7 @@ dependencies {
 tasks.named<Test>("test") {
     systemProperty("kotlinVersion", kotlinBaseVersion)
     systemProperty("kspVersion", version)
+    systemProperty("agpVersion", agpBaseVersion)
     systemProperty("testRepo", File(rootProject.buildDir, "repos/test").absolutePath)
     dependsOn(":api:publishAllPublicationsToTestRepository")
     dependsOn(":gradle-plugin:publishAllPublicationsToTestRepository")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.*
+
+class AndroidIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-android")
+
+    @Test
+    fun testPlaygroundAndroid() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "build", "--info", "--stacktrace").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
+        }
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -13,10 +13,12 @@ class TemporaryTestProject(projectName: String) : TemporaryFolder() {
 
         val kotlinVersion = System.getProperty("kotlinVersion")
         val kspVersion = System.getProperty("kspVersion")
+        val agpVersion = System.getProperty("agpVersion")
         val testRepo = System.getProperty("testRepo")
         val gradleProperties = File(root, "gradle.properties")
         gradleProperties.appendText("\nkotlinVersion=$kotlinVersion")
         gradleProperties.appendText("\nkspVersion=$kspVersion")
+        gradleProperties.appendText("\nagpVersion=$agpVersion")
         gradleProperties.appendText("\ntestRepo=$testRepo")
     }
 

--- a/integration-tests/src/test/resources/playground-android/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/build.gradle.kts
@@ -1,0 +1,20 @@
+buildscript {
+    val testRepo: String by project
+
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        jcenter()
+        google()
+    }
+}
+
+allprojects {
+    val testRepo: String by project
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        jcenter()
+        google()
+    }
+}

--- a/integration-tests/src/test/resources/playground-android/gradle.properties
+++ b/integration-tests/src/test/resources/playground-android/gradle.properties
@@ -1,0 +1,3 @@
+kotlinVersion=1.4.30
+kspVersion=1.4.30-1.0.0-alpha02
+agpVersion=4.2.0-beta04

--- a/integration-tests/src/test/resources/playground-android/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/settings.gradle.kts
@@ -1,0 +1,24 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    val agpVersion: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("jvm") version kotlinVersion apply false
+        kotlin("android") version kotlinVersion apply false
+        id("com.android.application") version agpVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+        jcenter()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "playground"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
@@ -1,0 +1,26 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.squareup:javapoet:1.12.1")
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}
+

--- a/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/Builder.kt
+++ b/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/Builder.kt
@@ -1,0 +1,4 @@
+package com.example.annotation
+
+annotation class Builder {
+}

--- a/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/BuilderProcessor.kt
+++ b/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/BuilderProcessor.kt
@@ -1,0 +1,76 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.File
+import java.io.OutputStream
+
+fun OutputStream.appendText(str: String) {
+    this.write(str.toByteArray())
+}
+class BuilderProcessor : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.codeGenerator = codeGenerator
+        this.logger = logger
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val symbols = resolver.getSymbolsWithAnnotation("com.example.annotation.Builder")
+        val ret = symbols.filter { !it.validate() }
+        symbols
+            .filter { it is KSClassDeclaration && it.validate() }
+            .map { it.accept(BuilderVisitor(), Unit) }
+        return ret
+    }
+
+    inner class BuilderVisitor : KSVisitorVoid() {
+        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
+            classDeclaration.primaryConstructor!!.accept(this, data)
+        }
+
+        override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
+            val parent = function.parentDeclaration as KSClassDeclaration
+            val packageName = parent.containingFile!!.packageName.asString()
+            val className = "${parent.simpleName.asString()}Builder"
+            val file = codeGenerator.createNewFile(Dependencies(true, function.containingFile!!), packageName , className)
+            file.appendText("package $packageName\n\n")
+            file.appendText("import HELLO\n\n")
+            file.appendText("class $className{\n")
+            function.parameters.forEach {
+                val name = it.name!!.asString()
+                val typeName = StringBuilder(it.type.resolve().declaration.qualifiedName?.asString() ?: "<ERROR>")
+                val typeArgs = it.type.element!!.typeArguments
+                if (it.type.element!!.typeArguments.isNotEmpty()) {
+                    typeName.append("<")
+                    typeName.append(
+                            typeArgs.map {
+                                val type = it.type?.resolve()
+                                "${it.variance.label} ${type?.declaration?.qualifiedName?.asString() ?: "ERROR"}" +
+                                        if (type?.nullability == Nullability.NULLABLE) "?" else ""
+                            }.joinToString(", ")
+                    )
+                    typeName.append(">")
+                }
+                file.appendText("    private var $name: $typeName? = null\n")
+                file.appendText("    internal fun with${name.capitalize()}($name: $typeName): $className {\n")
+                file.appendText("        this.$name = $name\n")
+                file.appendText("        return this\n")
+                file.appendText("    }\n\n")
+            }
+            file.appendText("    internal fun build(): ${parent.qualifiedName!!.asString()} {\n")
+            file.appendText("        return ${parent.qualifiedName!!.asString()}(")
+            file.appendText(
+                function.parameters.map {
+                    "${it.name!!.asString()}!!"
+                }.joinToString(", ")
+            )
+            file.appendText(")\n")
+            file.appendText("    }\n")
+            file.appendText("}\n")
+            file.close()
+        }
+    }
+
+}

--- a/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground-android/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,260 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.File
+import java.io.OutputStream
+
+
+class TestProcessor : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var file: OutputStream
+    var invoked = false
+
+    fun emit(s: String, indent: String) {
+        file.appendText("$indent$s\n")
+    }
+
+    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.codeGenerator = codeGenerator
+        file = codeGenerator.createNewFile(Dependencies(false), "", "TestProcessor", "log")
+        emit("TestProcessor: init($options)", "")
+
+        val javaFile = codeGenerator.createNewFile(Dependencies(false), "", "Generated", "java")
+        javaFile.appendText("class Generated {}")
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (invoked) {
+            return emptyList()
+        }
+        val fileKt = codeGenerator.createNewFile(Dependencies(false), "", "HELLO", "java")
+        fileKt.appendText("public class HELLO{\n")
+        fileKt.appendText("public int foo() { return 1234; }\n")
+        fileKt.appendText("}")
+
+        val files = resolver.getAllFiles()
+        emit("TestProcessor: process()", "")
+        val visitor = TestVisitor()
+        for (file in files) {
+            emit("TestProcessor: processing ${file.fileName}", "")
+            file.accept(visitor, "")
+        }
+        invoked = true
+        return emptyList()
+    }
+
+    inner class TestVisitor : KSVisitor<String, Unit> {
+
+        override fun visitReferenceElement(element: KSReferenceElement, data: String) {
+        }
+
+        override fun visitModifierListOwner(modifierListOwner: KSModifierListOwner, data: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun visitNode(node: KSNode, data: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: String) {
+            TODO("Not yet implemented")
+        }
+
+        override fun visitDynamicReference(reference: KSDynamicReference, data: String) {
+            TODO("Not yet implemented")
+        }
+        val visited = HashSet<Any>()
+
+        private fun checkVisited(symbol: Any): Boolean {
+            return if (visited.contains(symbol)) {
+                true
+            } else {
+                visited.add(symbol)
+                false
+            }
+        }
+
+        private fun invokeCommonDeclarationApis(declaration: KSDeclaration, indent: String) {
+            emit(
+              "${declaration.modifiers.joinToString(" ")} ${declaration.simpleName.asString()}", indent
+            )
+            declaration.annotations.map { it.accept(this, "$indent  ") }
+            if (declaration.parentDeclaration != null)
+                emit("  enclosing: ${declaration.parentDeclaration!!.qualifiedName?.asString()}", indent)
+            declaration.containingFile?.let { emit("${it.packageName.asString()}.${it.fileName}", indent) }
+            declaration.typeParameters.map { it.accept(this, "$indent  ") }
+        }
+
+        override fun visitFile(file: KSFile, data: String) {
+//            if (!file.packageName.asString().startsWith("eu.kanade.tachiyomi.data")) {
+//                return
+//            }
+            if (checkVisited(file)) return
+            file.annotations.map{ it.accept(this, "$data  ") }
+            emit(file.packageName.asString(), data)
+            for (declaration in file.declarations) {
+                declaration.accept(this, data)
+            }
+        }
+
+        override fun visitAnnotation(annotation: KSAnnotation, data: String) {
+            if (checkVisited(annotation)) return
+            emit("annotation", data)
+            annotation.annotationType.accept(this, "$data  ")
+            annotation.arguments.map { it.accept(this, "$data  ") }
+        }
+
+        override fun visitCallableReference(reference: KSCallableReference, data: String) {
+            if (checkVisited(reference)) return
+            emit("element: ", data)
+            reference.functionParameters.map { it.accept(this, "$data  ") }
+            reference.receiverType?.accept(this, "$data receiver")
+            reference.returnType.accept(this, "$data  ")
+        }
+
+        override fun visitPropertyGetter(getter: KSPropertyGetter, data: String) {
+            if (checkVisited(getter)) return
+            emit("propertyGetter: ", data)
+            getter.annotations.map { it.accept(this, "$data  ") }
+            emit(getter.modifiers.joinToString(" "), data)
+            getter.returnType?.accept(this, "$data  ")
+        }
+
+        override fun visitPropertySetter(setter: KSPropertySetter, data: String) {
+            if (checkVisited(setter)) return
+            emit("propertySetter: ", data)
+            setter.annotations.map { it.accept(this, "$data  ") }
+            emit(setter.modifiers.joinToString(" "), data)
+//            setter.parameter.accept(this, "$data  ")
+        }
+
+        override fun visitTypeArgument(typeArgument: KSTypeArgument, data: String) {
+            if (checkVisited(typeArgument)) return
+            typeArgument.annotations.map{ it.accept(this, "$data  ") }
+            emit(
+              when (typeArgument.variance) {
+                  Variance.STAR -> "*"
+                  Variance.COVARIANT -> "out"
+                  Variance.CONTRAVARIANT -> "in"
+                  else -> ""
+              }, data
+            )
+            typeArgument.type?.accept(this, "$data  ")
+        }
+
+        override fun visitTypeParameter(typeParameter: KSTypeParameter, data: String) {
+            if (checkVisited(typeParameter)) return
+            typeParameter.annotations.map{ it.accept(this, "$data  ") }
+            if (typeParameter.isReified) {
+                emit("reified ", data)
+            }
+            emit(
+              when (typeParameter.variance) {
+                  Variance.COVARIANT -> "out "
+                  Variance.CONTRAVARIANT -> "in "
+                  else -> ""
+              } + typeParameter.name.asString(), data
+            )
+            if (typeParameter.bounds.isNotEmpty()) {
+                typeParameter.bounds.map { it.accept(this, "$data  ") }
+            }
+        }
+
+        override fun visitValueParameter(valueParameter: KSValueParameter, data: String) {
+            if (checkVisited(valueParameter)) return
+            valueParameter.annotations.map { it.accept(this, "$data  ") }
+            if (valueParameter.isVararg) {
+                emit("vararg", "$data  ")
+            }
+            if (valueParameter.isNoInline) {
+                emit("noinline", "$data  ")
+            }
+            if (valueParameter.isCrossInline) {
+                emit("crossinline ", "$data  ")
+            }
+            emit(valueParameter.name?.asString() ?: "_", "$data  ")
+            valueParameter.type.accept(this, "$data  ")
+        }
+
+        override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: String) {
+            if (checkVisited(function)) return
+            invokeCommonDeclarationApis(function, data)
+            for (declaration in function.declarations) {
+                declaration.accept(this, "$data  ")
+            }
+            function.parameters.map { it.accept(this, "$data  ") }
+            function.typeParameters.map { it.accept(this, "$data  ") }
+            function.extensionReceiver?.accept(this, "$data extension:")
+            emit("returnType:", data)
+            function.returnType?.accept(this, "$data  ")
+        }
+
+        override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: String) {
+            if (checkVisited(classDeclaration)) return
+            invokeCommonDeclarationApis(classDeclaration, data)
+            emit(classDeclaration.classKind.type, data)
+            for (declaration in classDeclaration.declarations) {
+                declaration.accept(this, "$data ")
+            }
+            classDeclaration.superTypes.map { it.accept(this, "$data  ") }
+            classDeclaration.primaryConstructor?.accept(this, "$data  ")
+        }
+
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: String) {
+            if (checkVisited(property)) return
+            invokeCommonDeclarationApis(property, data)
+            property.type.accept(this, "$data  ")
+            property.extensionReceiver?.accept(this, "$data extension:")
+            property.setter?.accept(this, "$data  ")
+            property.getter?.accept(this, "$data  ")
+        }
+
+        override fun visitTypeReference(typeReference: KSTypeReference, data: String) {
+            if (checkVisited(typeReference)) return
+            typeReference.annotations.map{ it.accept(this, "$data  ") }
+            val type = typeReference.resolve()
+            type.let {
+                emit("resolved to: ${it.declaration.qualifiedName?.asString()}", data)
+            }
+            //resolved.accept(this, "$data  ")
+            // TODO: KSTypeReferenceJavaImpl hasn't completed yet.
+            try {
+                typeReference.element?.accept(this, "$data  ")
+            } catch (e: IllegalStateException) {
+                emit("TestProcessor: exception: $e", data)
+            }
+        }
+
+        override fun visitAnnotated(annotated: KSAnnotated, data: String) {
+        }
+
+        override fun visitDeclaration(declaration: KSDeclaration, data: String) {
+        }
+
+        override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: String) {
+        }
+
+        override fun visitParenthesizedReference(reference: KSParenthesizedReference, data: String) {
+        }
+
+        override fun visitClassifierReference(reference: KSClassifierReference, data: String) {
+            if (checkVisited(reference)) return
+            if (reference.typeArguments.isNotEmpty()) {
+                reference.typeArguments.map { it.accept(this, "$data  ") }
+            }
+        }
+
+        override fun visitTypeAlias(typeAlias: KSTypeAlias, data: String) {
+        }
+
+        override fun visitValueArgument(valueArgument: KSValueArgument, data: String) {
+            if (checkVisited(valueArgument)) return
+            val name = valueArgument.name?.asString() ?: "<no name>"
+            emit("$name: ${valueArgument.value}", data)
+            valueArgument.annotations.map { it.accept(this, "$data  ") }
+        }
+    }
+
+}
+
+

--- a/integration-tests/src/test/resources/playground-android/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
+++ b/integration-tests/src/test/resources/playground-android/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
@@ -1,0 +1,2 @@
+TestProcessor
+BuilderProcessor

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -1,0 +1,39 @@
+val testRepo: String by project
+
+plugins {
+    // DO NOT CHANGE THE ORDER.
+    id("com.google.devtools.ksp")
+    id("com.android.application")
+    kotlin("android")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    google()
+    jcenter()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":test-processor"))
+    ksp(project(":test-processor"))
+}
+ 
+android {
+    compileSdkVersion(30)
+    defaultConfig {
+        applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
+        minSdkVersion(30)
+        targetSdkVersion(30)
+        versionCode = 1
+        versionName = "1.0"
+    }
+}
+
+ksp {
+    arg("option1", "value1")
+    arg("option2", "value2")
+}

--- a/integration-tests/src/test/resources/playground-android/workload/src/main/AndroidManifest.xml
+++ b/integration-tests/src/test/resources/playground-android/workload/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.myapplication">
+</manifest>

--- a/integration-tests/src/test/resources/playground-android/workload/src/main/java/com/example/A.kt
+++ b/integration-tests/src/test/resources/playground-android/workload/src/main/java/com/example/A.kt
@@ -1,0 +1,18 @@
+package com.example
+
+import HELLO
+
+fun main() {
+    val hello = HELLO()
+    println(hello.foo())
+
+    val builder = AClassBuilder()
+    builder
+        .withA(1)
+        .withB("foo")
+        .withC(2.3)
+    val aClass : AClass = builder.build()
+    println(aClass.foo())
+}
+
+

--- a/integration-tests/src/test/resources/playground-android/workload/src/main/java/com/example/AClass.kt
+++ b/integration-tests/src/test/resources/playground-android/workload/src/main/java/com/example/AClass.kt
@@ -1,0 +1,10 @@
+package com.example
+
+import com.example.annotation.Builder
+import HELLO
+
+@Builder
+class AClass(private val a: Int, val b: String, val c: Double, val d: HELLO) {
+    val p = "$a, $b, $c"
+    fun foo() = p
+}


### PR DESCRIPTION
In `workload/build.gradle.kts`, the order of plugins is critical. The test would fail with the following message without #318.

```
Extension of type 'CommonExtension' does not exist. Currently registered extension types: [ExtraPropertiesExtension, KspExtension]
```