### PR TITLE
Update sourceToOutputsMap before restoring outputs

### DIFF
--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -38,6 +38,12 @@ class TestProcessor : SymbolProcessor {
 
         resolver.getNewFiles().forEach { file ->
             logger.warn("${file.packageName.asString()}/${file.fileName}")
+            val outputBaseFN = file.fileName.replace(".kt", "Generated").replace(".java", "Generated")
+            codeGenerator.createNewFile(Dependencies(false, file), file.packageName.asString(), outputBaseFN, "kt").use { output ->
+                OutputStreamWriter(output).use { writer ->
+                    writer.write("private val unused = \"unused\"")
+                }
+            }
         }
         processed = true
         return emptyList()


### PR DESCRIPTION
Clean files should be calculated with the up-to-date sourceToOutputsMap.

Also add reprocessed sources and outputs in `kspSourceToOutputsMap.log`.

Fixes #327 