### PR TITLE
Always include the main `ksp` configuration

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -99,6 +99,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
 
     override fun apply(project: Project) {
         project.extensions.create("ksp", KspExtension::class.java)
+        // Always include the main `ksp` configuration.
+        // TODO: multiplatform
+        project.configurations.create(KSP_MAIN_CONFIGURATION_NAME)
         project.plugins.withType(KotlinPluginWrapper::class.java) {
             // kotlin extension has the compilation target that we need to look for to create configurations
             decorateKotlinExtension(project)
@@ -161,6 +164,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             it.kspConfiguration(project)?.let {
                 kspConfigurations.add(it)
             }
+        }
+        // Always include the main `ksp` configuration.
+        // TODO: multiplatform
+        project.configurations.findByName(KSP_MAIN_CONFIGURATION_NAME)?.let {
+            kspConfigurations.add(it)
         }
         val nonEmptyKspConfigurations = kspConfigurations.filter { it.dependencies.isNotEmpty() }
         if (nonEmptyKspConfigurations.isEmpty()) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
@@ -1,0 +1,33 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.*
+
+class MultiplatformIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-mpp", "playground")
+
+    @Test
+    fun testJVM() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val resultCleanBuild = gradleRunner.withArguments("clean", "build").build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
+
+        val artifact = File(project.root, "workload/build/libs/workload-jvm-1.0-SNAPSHOT.jar")
+        Assert.assertTrue(artifact.exists())
+
+        JarFile(artifact).use { jarFile ->
+            Assert.assertTrue(jarFile.getEntry("TestProcessor.log").size > 0)
+            Assert.assertTrue(jarFile.getEntry("HELLO.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
+        }
+    }
+}

--- a/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    kotlin("multiplatform") apply false
+}
+
+val testRepo: String by project
+subprojects {
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        google()
+    }
+}
+

--- a/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("multiplatform") version kotlinVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = "playground"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/playground-mpp/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/test-processor/build.gradle.kts
@@ -1,0 +1,22 @@
+val kspVersion: String by project
+
+plugins {
+    kotlin("multiplatform")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm()
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation("com.squareup:javapoet:1.12.1")
+                implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+            }
+            kotlin.srcDir("src/main/kotlin")
+            resources.srcDir("src/main/resources")
+        }
+    }
+}

--- a/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.google.devtools.ksp")
+}
+
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm {
+        withJava()
+    }
+    sourceSets {
+        val commonMain by getting
+        val jvmMain by getting {
+            dependencies {
+                implementation(project(":test-processor"))
+                configurations.get("ksp").dependencies.add(project(":test-processor"))
+            }
+            kotlin.srcDir("src/main/java")
+        }
+    }
+}
+
+ksp {
+    arg("option1", "value1")
+    arg("option2", "value2")
+}


### PR DESCRIPTION
With MPP, `KotlinPluginWrapper` isn't always applied and the source set
`main` may not exist.