### PR TITLE
Integrate ktlint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.{kt,kts}]
+indent_size=4
+insert_final_newline=true
+max_line_length=120
+disabled_rules=no-wildcard-imports

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,19 +1,21 @@
+import com.google.devtools.ksp.configureKtlint
+import com.google.devtools.ksp.configureKtlintApplyToIdea
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
-
-plugins {
-    kotlin("jvm") version "1.4.30" apply false
-}
 
 if (!extra.has("kspVersion")) {
     val kotlinBaseVersion: String by project
     val today = LocalDateTime.now().format(DateTimeFormatter.BASIC_ISO_DATE)
     extra.set("kspVersion", "$kotlinBaseVersion-dev-experimental-$today")
 }
-
+repositories {
+    mavenCentral()
+}
+project.configureKtlintApplyToIdea()
 subprojects {
     group = "com.google.devtools.ksp"
     version = rootProject.extra.get("kspVersion") as String
+    this.configureKtlint()
     repositories {
         mavenCentral()
         google()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,9 @@
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    jcenter()
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,17 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+    val kotlinBaseVersion: String = java.util.Properties().also { props ->
+        settingsDir.parentFile.resolve("gradle.properties").inputStream().use {
+            props.load(it)
+        }
+    }["kotlinBaseVersion"] as String
+    resolutionStrategy {
+        eachPlugin {
+            if ( requested.id.id == "org.jetbrains.kotlin.jvm" ) {
+                useModule( "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion" )
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/google/devtools/ksp/Ktlint.kt
+++ b/buildSrc/src/main/kotlin/com/google/devtools/ksp/Ktlint.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.devtools.ksp
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.JavaExec
+
+// This file is mostly ported from AndroidX with minor modifications.
+// https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:buildSrc/src/main/kotlin/androidx/build/Ktlint.kt
+
+/**
+ * Adds a ktlintApplyToIdea task that updates the local .idea files to match the ktlint style.
+ */
+fun Project.configureKtlintApplyToIdea() {
+    if (this.rootProject !== this) {
+        throw IllegalArgumentException("Can only use root project for applyToIdea task")
+    }
+    tasks.register("ktlintApplyToIdea", JavaExec::class.java) { task ->
+        task.description = "Apply ktlint style to idea"
+        task.group = "Tooling"
+        task.classpath = getKtlintConfiguration()
+        task.main = "com.pinterest.ktlint.Main"
+        task.args = listOf(
+            "applyToIDEAProject",
+            "-y"
+        )
+    }
+}
+
+/**
+ * Configures a "ktlint" task for the project to check formatting and `ktlintFormat` task
+ * to fix formatting.
+ */
+fun Project.configureKtlint() {
+    val lintProvider = tasks.register("ktlint", JavaExec::class.java) { task ->
+        task.configureCommonKtlintParams(this@configureKtlint)
+        task.description = "Check Kotlin code style."
+        task.group = "Verification"
+    }
+
+    afterEvaluate {
+        // check task is not available yet, which is why we use afterEvaluate
+        project.tasks.named("check").configure { checkTask ->
+            checkTask.dependsOn(lintProvider)
+        }
+    }
+
+    tasks.register("ktlintFormat", JavaExec::class.java) { task ->
+        task.configureCommonKtlintParams(this@configureKtlint)
+        task.description = "Fix Kotlin code style deviations."
+        task.group = "formatting"
+        task.args = listOf("-F") + task.args!!
+    }
+}
+
+/**
+ * Configures common ktlint parameters for ktlint tasks
+ */
+private fun JavaExec.configureCommonKtlintParams(
+    project: Project
+) {
+    val ktlintInputFiles = project.fileTree(project.projectDir).also {
+        it.include("**/*.kt")
+        it.include("**/*.kts")
+        it.exclude("**/testData/**")
+    }
+    val outputFile = project.buildDir.resolve("reports/ktlint/ktlint-checkstyle-report.xml")
+    inputs.files(ktlintInputFiles)
+    classpath = project.getKtlintConfiguration()
+    main = "com.pinterest.ktlint.Main"
+    outputs.file(outputFile)
+    args = listOf(
+        "--reporter=plain",
+        "--reporter=checkstyle,output=$outputFile",
+    ) + ktlintInputFiles.files.map { it.absolutePath }
+}
+
+private fun Project.getKtlintConfiguration(): Configuration {
+    return configurations.findByName("ktlint") ?: configurations.create("ktlint") {
+        val dependency = dependencies.create("com.pinterest:ktlint:0.40.0")
+        it.dependencies.add(dependency)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,14 @@ pluginManagement {
         gradlePluginPortal()
         maven("https://dl.bintray.com/kotlin/kotlin-eap")
     }
+    val kotlinBaseVersion: String by settings
+    resolutionStrategy {
+        eachPlugin {
+            if ( requested.id.id == "org.jetbrains.kotlin.jvm" ) {
+                useModule( "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion" )
+            }
+        }
+    }
 }
 
 include("api")


### PR DESCRIPTION
It is a fork of what androidX does with minor modifications.

There are 3 new tasks:

rootProject:ktlintApplyToIdea -> Applied ktlint configuration to the
current .idea project folder

<subproject>:ktlint -> Runs ktlint checks
<subproject>:ktlintFormat -> Fixes formatting for the project. Note that
this may not be able to handle all violations.

I've not modified the CI files to run this since it fails right now. One
of the core maintaners should run the format tasks to come to a clean
slate then we can add it to CI. I've not added a baseline file since
they are very brittle.