### PR TITLE
fix type arguments for inner classes

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/NestedClassTypeProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/NestedClassTypeProcessor.kt
@@ -1,0 +1,26 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
+
+class NestedClassTypeProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val c = resolver.getClassDeclarationByName("C")!!
+        c.declarations.filterIsInstance<KSPropertyDeclaration>()
+                .forEach{
+                    result.add(it.simpleName.asString())
+                    result.add(it.type.resolve().arguments.map { it.type?.annotations?.joinToString(separator = ",") { it.toString() } }.joinToString())
+                    result.add(it.type.resolve().arguments.joinToString(separator = ",") { it.toString() })
+                }
+        return emptyList()
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -20,12 +20,13 @@ package com.google.devtools.ksp.symbol.impl.binary
 
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.kotlin.IdKey
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 import org.jetbrains.kotlin.types.TypeProjection
 
 class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProjection) : KSTypeArgumentImpl() {
-    companion object : KSObjectCache<TypeProjection, KSTypeArgumentDescriptorImpl>() {
-        fun getCached(descriptor: TypeProjection) = cache.getOrPut(descriptor) { KSTypeArgumentDescriptorImpl(descriptor) }
+    companion object : KSObjectCache<IdKey<TypeProjection>, KSTypeArgumentDescriptorImpl>() {
+        fun getCached(descriptor: TypeProjection) = cache.getOrPut(IdKey(descriptor)) { KSTypeArgumentDescriptorImpl(descriptor) }
     }
 
     override val origin = Origin.CLASS

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -48,5 +48,7 @@ class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProje
         }
     }
 
-    override val annotations: List<KSAnnotation> = emptyList()
+    override val annotations: List<KSAnnotation> by lazy {
+        descriptor.type.annotations.map { KSAnnotationDescriptorImpl.getCached(it) }
+    }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -25,12 +25,13 @@ import org.jetbrains.kotlin.descriptors.TypeParameterDescriptor
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.google.devtools.ksp.symbol.impl.kotlin.IdKey
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import org.jetbrains.kotlin.types.*
 
 class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinType) : KSTypeReference {
-    companion object : KSObjectCache<KotlinType, KSTypeReferenceDescriptorImpl>() {
-        fun getCached(kotlinType: KotlinType) = cache.getOrPut(kotlinType) { KSTypeReferenceDescriptorImpl(kotlinType) }
+    companion object : KSObjectCache<IdKey<KotlinType>, KSTypeReferenceDescriptorImpl>() {
+        fun getCached(kotlinType: KotlinType) = cache.getOrPut(IdKey(kotlinType)) { KSTypeReferenceDescriptorImpl(kotlinType) }
     }
 
     override val origin = Origin.CLASS

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeArgumentJavaImpl.kt
@@ -51,7 +51,7 @@ class KSTypeArgumentJavaImpl private constructor(val psi: PsiType) : KSTypeArgum
             when {
                 psi.isExtends -> Variance.COVARIANT
                 psi.isSuper -> Variance.CONTRAVARIANT
-                psi.bound == null -> Variance.COVARIANT
+                psi.bound == null -> Variance.STAR
                 else -> Variance.INVARIANT
             }
         } else {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -55,11 +55,8 @@ class KSTypeImpl private constructor(
         }
     }
 
-    /**
-     * Even though that [KSTypeArgumentDescriptorImpl] is no heavier than [ksTypeArguments], the former doesn't carry [KSAnnotation].
-     */
     override val arguments: List<KSTypeArgument> by lazy {
-        ksTypeArguments ?: kotlinType.arguments.map { KSTypeArgumentDescriptorImpl.getCached(it) }
+        kotlinType.arguments.map { KSTypeArgumentDescriptorImpl.getCached(it) }
     }
 
     override fun isAssignableFrom(that: KSType): Boolean {

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -187,6 +187,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/multipleModules.kt");
     }
 
+    @TestMetadata(("nestedClassType.kt"))
+    public void testNestedClassType() throws Exception {
+        runTest("testData/api/nestedClassType.kt");
+    }
+
     @TestMetadata(("overridee.kt"))
     public void testOverridee() throws Exception {
         runTest("testData/api/overridee.kt");

--- a/compiler-plugin/testData/api/nestedClassType.kt
+++ b/compiler-plugin/testData/api/nestedClassType.kt
@@ -1,17 +1,24 @@
 // TEST PROCESSOR: NestedClassTypeProcessor
 // EXPECTED:
+// foo
+// @TypeAnno1
+// COVARIANT String
 // bar
-// , @TypeAnno
-// CONTRAVARIANT Int,COVARIANT String
+// , @TypeAnno2
+// CONTRAVARIANT Int,INVARIANT String
 // END
 // FILE: a.kt
-annotation class TypeAnno
+annotation class TypeAnno1
+annotation class TypeAnno2
 
 class Outer<T> {
     inner class InnerGeneric<P>
     inner class Inner
 }
 
+class G<T>
+
 class C {
-    val bar: Outer<out @TypeAnno String>.InnerGeneric<in Int>
+    val foo: Outer<out @TypeAnno1 String>.Inner
+    val bar: Outer<@TypeAnno2 String>.InnerGeneric<in Int>
 }

--- a/compiler-plugin/testData/api/nestedClassType.kt
+++ b/compiler-plugin/testData/api/nestedClassType.kt
@@ -1,0 +1,17 @@
+// TEST PROCESSOR: NestedClassTypeProcessor
+// EXPECTED:
+// bar
+// , @TypeAnno
+// CONTRAVARIANT Int,COVARIANT String
+// END
+// FILE: a.kt
+annotation class TypeAnno
+
+class Outer<T> {
+    inner class InnerGeneric<P>
+    inner class Inner
+}
+
+class C {
+    val bar: Outer<out @TypeAnno String>.InnerGeneric<in Int>
+}

--- a/compiler-plugin/testData/api/resolveJavaType.kt
+++ b/compiler-plugin/testData/api/resolveJavaType.kt
@@ -22,7 +22,7 @@
 // C<*kotlin.Any?>
 // kotlin.Int
 // kotlin.String?
-// kotlin.collections.MutableSet<out kotlin.Any?>?
+// kotlin.collections.MutableSet<*kotlin.Any?>?
 // kotlin.Unit
 // kotlin.IntArray?
 // C.T?


### PR DESCRIPTION
Basically just use descriptors to get type arguments from parent class(es).

Also found a bug in `KSTypeArgumentJavaImpl` for `<?>` where the original implementation does not align with compiler behavior. Although with this change, source based `KSTypeArgument` implementations looks to be obsolete as we use descriptors for everything now, probably better to remove all these implementations.