### PR TITLE
Improvements on JAVA_STATIC modifier detection

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -93,6 +93,12 @@ class ResolverImpl(
     private val nameToKSMap: MutableMap<KSName, KSClassDeclaration>
 
     /**
+     * Cached class declaration for JvmStatic annotation as it is repeatedly used for modifier resolution
+     */
+    val jvmStaticClassDeclaration : KSClassDeclaration? by lazy {
+        getClassDeclarationByName(JvmStatic::class.java.canonicalName)
+    }
+    /**
      * Checking as member of is an expensive operation, hence we cache result values in this map.
      */
     private val functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -93,12 +93,6 @@ class ResolverImpl(
     private val nameToKSMap: MutableMap<KSName, KSClassDeclaration>
 
     /**
-     * Cached class declaration for JvmStatic annotation as it is repeatedly used for modifier resolution
-     */
-    val jvmStaticClassDeclaration : KSClassDeclaration? by lazy {
-        getClassDeclarationByName(JvmStatic::class.java.canonicalName)
-    }
-    /**
      * Checking as member of is an expensive operation, hence we cache result values in this map.
      */
     private val functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
@@ -38,8 +38,6 @@ class JavaModifierProcessor : AbstractTestProcessor() {
             .forEach {
                 it.superTypes.single().resolve().declaration.accept(ModifierVisitor(), Unit)
             }
-//        val symbol = resolver.getSymbolsWithAnnotation("Test").single() as KSClassDeclaration
-//        symbol.superTypes.single().resolve()!!.declaration.accept(ModifierVisitor(), Unit)
         return emptyList()
     }
 
@@ -68,7 +66,7 @@ class JavaModifierProcessor : AbstractTestProcessor() {
                 "${parent.simpleName.asString()}."
             } + simpleName.asString()
             val modifiersSignature = modifiers.map { it.toString() }.joinToString(" ")
-            return "$id: $modifiersSignature"
+            return "$id: $modifiersSignature".trim()
         }
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -57,7 +57,7 @@ abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
                             decl
                         }
                     }
-                    declaration == ResolverImpl.instance.jvmStaticClassDeclaration
+                    declaration.qualifiedName?.asString() == JvmStatic::class.java.canonicalName
                 }
             }
             else -> false

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -18,6 +18,8 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
@@ -44,7 +46,15 @@ abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
     }
 
     override val modifiers: Set<Modifier> by lazy {
-        ktDeclaration.toKSModifiers()
+        val modifiers = ktDeclaration.toKSModifiers()
+        val hasJvmStatic = annotations.any {
+            it.annotationType.resolve().declaration == ResolverImpl.instance.jvmStaticClassDeclaration
+        }
+        if (hasJvmStatic) {
+            modifiers + Modifier.JAVA_STATIC
+        } else {
+            modifiers
+        }
     }
     override val containingFile: KSFile? by lazy {
         KSFileImpl.getCached(ktDeclaration.containingKtFile)

--- a/compiler-plugin/testData/api/javaModifiers.kt
+++ b/compiler-plugin/testData/api/javaModifiers.kt
@@ -29,24 +29,56 @@
 // C.foo: ABSTRACT JAVA_STRICT
 // C.<init>: FINAL PUBLIC
 // OuterJavaClass: PUBLIC
+// OuterJavaClass.staticPublicField: PUBLIC JAVA_STATIC
+// OuterJavaClass.staticPackageProtectedField: JAVA_STATIC
+// OuterJavaClass.staticProtectedField: PROTECTED JAVA_STATIC
+// OuterJavaClass.staticPrivateField: PRIVATE JAVA_STATIC
 // OuterJavaClass.InnerJavaClass: PUBLIC
 // InnerJavaClass.<init>: FINAL PUBLIC
 // OuterJavaClass.NestedJavaClass: PUBLIC JAVA_STATIC
 // NestedJavaClass.<init>: FINAL PUBLIC
+// OuterJavaClass.staticPublicMethod: PUBLIC JAVA_STATIC
+// OuterJavaClass.staticPackageProtectedMethod: JAVA_STATIC
+// OuterJavaClass.staticProtectedMethod: PROTECTED JAVA_STATIC
+// OuterJavaClass.staticPrivateMethod: PRIVATE JAVA_STATIC
 // OuterJavaClass.<init>: FINAL PUBLIC
 // OuterKotlinClass: OPEN
 // OuterKotlinClass.InnerKotlinClass: INNER
 // InnerKotlinClass.<init>: FINAL PUBLIC
 // OuterKotlinClass.NestedKotlinClass: OPEN
 // NestedKotlinClass.<init>: FINAL PUBLIC
+// OuterKotlinClass.Companion:
+// Companion.companionMethod:
+// Companion.companionField:
+// Companion.privateCompanionMethod: PRIVATE
+// Companion.privateCompanionField: PRIVATE
+// Companion.jvmStaticCompanionMethod: JAVA_STATIC
+// Companion.jvmStaticCompanionField: JAVA_STATIC
+// Companion.<init>: FINAL PUBLIC
 // OuterKotlinClass.<init>: FINAL PUBLIC
 // DependencyOuterJavaClass: OPEN PUBLIC
 // DependencyOuterJavaClass.DependencyNestedJavaClass: OPEN PUBLIC
 // DependencyNestedJavaClass.<init>: FINAL PUBLIC
 // DependencyOuterJavaClass.DependencyInnerJavaClass: OPEN PUBLIC INNER
 // DependencyInnerJavaClass.<init>: FINAL PUBLIC
+// DependencyOuterJavaClass.staticPublicMethod: JAVA_STATIC PUBLIC
+// DependencyOuterJavaClass.staticPackageProtectedMethod: JAVA_STATIC
+// DependencyOuterJavaClass.staticProtectedMethod: JAVA_STATIC PROTECTED
+// DependencyOuterJavaClass.staticPrivateMethod: JAVA_STATIC PRIVATE
+// DependencyOuterJavaClass.staticPublicField: JAVA_STATIC FINAL PUBLIC
+// DependencyOuterJavaClass.staticPackageProtectedField: JAVA_STATIC FINAL
+// DependencyOuterJavaClass.staticProtectedField: JAVA_STATIC FINAL PROTECTED
+// DependencyOuterJavaClass.staticPrivateField: JAVA_STATIC FINAL PRIVATE
 // DependencyOuterJavaClass.<init>: FINAL PUBLIC
 // DependencyOuterKotlinClass: OPEN PUBLIC
+// DependencyOuterKotlinClass.Companion: FINAL PUBLIC
+// Companion.companionField: FINAL PUBLIC
+// Companion.jvmStaticCompanionField: JAVA_STATIC FINAL PUBLIC
+// Companion.privateCompanionField: FINAL PUBLIC
+// Companion.companionMethod: FINAL PUBLIC
+// Companion.jvmStaticCompanionMethod: JAVA_STATIC FINAL PUBLIC
+// Companion.privateCompanionMethod: FINAL PRIVATE
+// Companion.<init>: FINAL PRIVATE
 // DependencyOuterKotlinClass.DependencyInnerKotlinClass: FINAL PUBLIC INNER
 // DependencyInnerKotlinClass.<init>: FINAL PUBLIC
 // DependencyOuterKotlinClass.DependencyNestedKotlinClass: OPEN PUBLIC
@@ -58,11 +90,29 @@
 public class DependencyOuterJavaClass {
     public class DependencyInnerJavaClass {}
     public static class DependencyNestedJavaClass {}
+    public static void staticPublicMethod() {}
+    public static String staticPublicField;
+    static void staticPackageProtectedMethod() {}
+    static String staticPackageProtectedField;
+    protected static void staticProtectedMethod() {}
+    protected static String staticProtectedField;
+    private static void staticPrivateMethod() {}
+    private static String staticPrivateField;
 }
 // FILE: DependencyOuterKotlinClass.kt
 open class DependencyOuterKotlinClass {
     inner class DependencyInnerKotlinClass
     open class DependencyNestedKotlinClass
+    companion object {
+        fun companionMethod() {}
+        val companionField:String = ""
+        private fun privateCompanionMethod() {}
+        val privateCompanionField:String = ""
+        @JvmStatic
+        fun jvmStaticCompanionMethod() {}
+        @JvmStatic
+        val jvmStaticCompanionField:String = ""
+    }
 }
 // MODULE: main(module1)
 // FILE: a.kt
@@ -114,9 +164,27 @@ public abstract class C {
 public class OuterJavaClass {
     public class InnerJavaClass {}
     public static class NestedJavaClass {}
+    public static void staticPublicMethod() {}
+    public static String staticPublicField;
+    static void staticPackageProtectedMethod() {}
+    static String staticPackageProtectedField;
+    protected static void staticProtectedMethod() {}
+    protected static String staticProtectedField;
+    private static void staticPrivateMethod() {}
+    private static String staticPrivateField;
 }
 // FILE: OuterKotlinClass.kt
 open class OuterKotlinClass {
     inner class InnerKotlinClass
     open class NestedKotlinClass
+    companion object {
+        fun companionMethod() {}
+        val companionField:String = ""
+        private fun privateCompanionMethod() {}
+        private val privateCompanionField:String = ""
+        @JvmStatic
+        fun jvmStaticCompanionMethod() {}
+        @JvmStatic
+        val jvmStaticCompanionField:String = ""
+    }
 }

--- a/compiler-plugin/testData/api/javaModifiers.kt
+++ b/compiler-plugin/testData/api/javaModifiers.kt
@@ -54,6 +54,8 @@
 // Companion.privateCompanionField: PRIVATE
 // Companion.jvmStaticCompanionMethod: JAVA_STATIC
 // Companion.jvmStaticCompanionField: JAVA_STATIC
+// Companion.customJvmStaticCompanionMethod: JAVA_STATIC
+// Companion.customJvmStaticCompanionField: JAVA_STATIC
 // Companion.<init>: FINAL PUBLIC
 // OuterKotlinClass.<init>: FINAL PUBLIC
 // DependencyOuterJavaClass: OPEN PUBLIC
@@ -73,9 +75,11 @@
 // DependencyOuterKotlinClass: OPEN PUBLIC
 // DependencyOuterKotlinClass.Companion: FINAL PUBLIC
 // Companion.companionField: FINAL PUBLIC
+// Companion.customJvmStaticCompanionField: JAVA_STATIC FINAL PUBLIC
 // Companion.jvmStaticCompanionField: JAVA_STATIC FINAL PUBLIC
 // Companion.privateCompanionField: FINAL PUBLIC
 // Companion.companionMethod: FINAL PUBLIC
+// Companion.customJvmStaticCompanionMethod: JAVA_STATIC FINAL PUBLIC
 // Companion.jvmStaticCompanionMethod: JAVA_STATIC FINAL PUBLIC
 // Companion.privateCompanionMethod: FINAL PRIVATE
 // Companion.<init>: FINAL PRIVATE
@@ -100,6 +104,7 @@ public class DependencyOuterJavaClass {
     private static String staticPrivateField;
 }
 // FILE: DependencyOuterKotlinClass.kt
+typealias DependencyCustomJvmStatic=JvmStatic
 open class DependencyOuterKotlinClass {
     inner class DependencyInnerKotlinClass
     open class DependencyNestedKotlinClass
@@ -112,6 +117,10 @@ open class DependencyOuterKotlinClass {
         fun jvmStaticCompanionMethod() {}
         @JvmStatic
         val jvmStaticCompanionField:String = ""
+        @DependencyCustomJvmStatic
+        fun customJvmStaticCompanionMethod() {}
+        @DependencyCustomJvmStatic
+        val customJvmStaticCompanionField:String = ""
     }
 }
 // MODULE: main(module1)
@@ -174,6 +183,7 @@ public class OuterJavaClass {
     private static String staticPrivateField;
 }
 // FILE: OuterKotlinClass.kt
+typealias CustomJvmStatic=JvmStatic
 open class OuterKotlinClass {
     inner class InnerKotlinClass
     open class NestedKotlinClass
@@ -186,5 +196,9 @@ open class OuterKotlinClass {
         fun jvmStaticCompanionMethod() {}
         @JvmStatic
         val jvmStaticCompanionField:String = ""
+        @CustomJvmStatic
+        fun customJvmStaticCompanionMethod() {}
+        @CustomJvmStatic
+        val customJvmStaticCompanionField:String = ""
     }
 }


### PR DESCRIPTION
This PR improves how we detect JAVA_STATIC modifier in declarations.

For descriptors, it wasn't showing up at all as the Descriptor API does
not have an API to return it. This change checks the containing
declaration's static scope to decide.

To be more consistent, I've also added checks for JvmStatic for both
descriptor and declaration implementation. I cached the ClassDeclaration
in Resolver (not great but does the job).

Also fixed another issue where we could add OPEN modifier based on
modality without checking if it is private or not. Added that logic into
the Descriptor -> Modifiers converter.

Fixes: #231
Test: javaModifiers