### PR TITLE
Don't check for JVM Static annotation

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -18,8 +18,6 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
-import com.google.devtools.ksp.findActualType
-import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
@@ -46,27 +44,10 @@ abstract class KSDeclarationImpl(ktDeclaration: KtDeclaration) : KSDeclaration {
     }
 
     override val modifiers: Set<Modifier> by lazy {
-        val modifiers = ktDeclaration.toKSModifiers()
-        val hasJvmStatic = when(ktDeclaration) {
-            is KtFunction, is KtProperty, is KtPropertyAccessor -> {
-                annotations.any {
-                    val declaration = it.annotationType.resolve().declaration.let { decl ->
-                        if (decl is KSTypeAlias) {
-                            decl.findActualType()
-                        } else {
-                            decl
-                        }
-                    }
-                    declaration.qualifiedName?.asString() == JvmStatic::class.java.canonicalName
-                }
-            }
-            else -> false
-        }
-        if (hasJvmStatic) {
-            modifiers + Modifier.JAVA_STATIC
-        } else {
-            modifiers
-        }
+        // we do not check for JVM_STATIC here intentionally as it actually means static in parent class,
+        // not in this class.
+        // see: https://github.com/google/ksp/issues/378
+        ktDeclaration.toKSModifiers()
     }
     override val containingFile: KSFile? by lazy {
         KSFileImpl.getCached(ktDeclaration.containingKtFile)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -132,7 +132,9 @@ fun MemberDescriptor.toKSModifiers(): Set<Modifier> {
     if (this.isExternal) {
         modifiers.add(Modifier.EXTERNAL)
     }
-    val isStatic = this.hasJvmStaticAnnotation() || (this.containingDeclaration as? ClassDescriptor)?.let { containingClass ->
+    // we are not checking for JVM_STATIC annotation here intentionally
+    // see: https://github.com/google/ksp/issues/378
+    val isStatic = (this.containingDeclaration as? ClassDescriptor)?.let { containingClass ->
         containingClass.staticScope.getContributedDescriptors(
             nameFilter = {
                 it == this.name

--- a/compiler-plugin/testData/api/javaModifiers.kt
+++ b/compiler-plugin/testData/api/javaModifiers.kt
@@ -52,10 +52,10 @@
 // Companion.companionField:
 // Companion.privateCompanionMethod: PRIVATE
 // Companion.privateCompanionField: PRIVATE
-// Companion.jvmStaticCompanionMethod: JAVA_STATIC
-// Companion.jvmStaticCompanionField: JAVA_STATIC
-// Companion.customJvmStaticCompanionMethod: JAVA_STATIC
-// Companion.customJvmStaticCompanionField: JAVA_STATIC
+// Companion.jvmStaticCompanionMethod:
+// Companion.jvmStaticCompanionField:
+// Companion.customJvmStaticCompanionMethod:
+// Companion.customJvmStaticCompanionField:
 // Companion.<init>: FINAL PUBLIC
 // OuterKotlinClass.<init>: FINAL PUBLIC
 // DependencyOuterJavaClass: OPEN PUBLIC
@@ -75,12 +75,12 @@
 // DependencyOuterKotlinClass: OPEN PUBLIC
 // DependencyOuterKotlinClass.Companion: FINAL PUBLIC
 // Companion.companionField: FINAL PUBLIC
-// Companion.customJvmStaticCompanionField: JAVA_STATIC FINAL PUBLIC
-// Companion.jvmStaticCompanionField: JAVA_STATIC FINAL PUBLIC
+// Companion.customJvmStaticCompanionField: FINAL PUBLIC
+// Companion.jvmStaticCompanionField: FINAL PUBLIC
 // Companion.privateCompanionField: FINAL PUBLIC
 // Companion.companionMethod: FINAL PUBLIC
-// Companion.customJvmStaticCompanionMethod: JAVA_STATIC FINAL PUBLIC
-// Companion.jvmStaticCompanionMethod: JAVA_STATIC FINAL PUBLIC
+// Companion.customJvmStaticCompanionMethod: FINAL PUBLIC
+// Companion.jvmStaticCompanionMethod: FINAL PUBLIC
 // Companion.privateCompanionMethod: FINAL PRIVATE
 // Companion.<init>: FINAL PRIVATE
 // DependencyOuterKotlinClass.DependencyInnerKotlinClass: FINAL PUBLIC INNER


### PR DESCRIPTION
In the previous JVM_STATIC fixes PR, we added checks for JvmStatic
annotation which created misleading results as if the JvmStatic
annotated method is static in the companion, not the containing class.

This PR removes that case and updates the test to ensure we don't
dispatch JVM_STATIC from companions. We'll still dispatch it for
compiled java classes.

Fixes: #378
Test: javaModifiers.kt