### PR TITLE
Add generated files to symbolsMap in subsequent builds

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -462,12 +462,12 @@ class IncrementalContext(
         // Update symbolsMap
         if (!rebuild) {
             // Update symbol caches from modified files.
-            options.knownModified.forEach {
+            updatedSymbols.keySet().forEach {
                 symbolsMap.set(it, updatedSymbols[it].toSet())
             }
 
             // Remove symbol caches from removed files.
-            options.knownRemoved.forEach {
+            removed.forEach {
                 symbolsMap.remove(it)
             }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSrcsIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSrcsIncIT.kt
@@ -23,12 +23,12 @@ class GeneratedSrcsIncIT {
 
         gradleRunner.withArguments("assemble").build().let { result ->
             val outputs = result.output.split("\n").filter { it.startsWith("w: [ksp]")}
-            Assert.assertEquals(outputs, expected)
+            Assert.assertEquals(expected, outputs)
         }
         File(project.root, "workload/src/main/kotlin/com/example/Baz.kt").appendText("\n\n")
         gradleRunner.withArguments("assemble").build().let { result ->
             val outputs = result.output.split("\n").filter { it.startsWith("w: [ksp]")}
-            Assert.assertEquals(outputs, expected)
+            Assert.assertEquals(expected, outputs)
         }
     }
 }

--- a/integration-tests/src/test/resources/refs-gen/workload/src/main/kotlin/com/example/Baz.kt
+++ b/integration-tests/src/test/resources/refs-gen/workload/src/main/kotlin/com/example/Baz.kt
@@ -1,3 +1,5 @@
 package com.example
 
 open class Baz
+
+val l: List<Int> = TODO()


### PR DESCRIPTION
and use relative paths.