### PR TITLE
Add support for getting owner class binary name for members

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -223,6 +223,38 @@ interface Resolver {
     fun getJvmName(accessor: KSPropertyAccessor): String?
 
     /**
+     * Returns the [binary class name](https://asm.ow2.io/javadoc/org/objectweb/asm/Type.html#getClassName()) of the
+     * owner class in JVM for the given [KSPropertyDeclaration].
+     *
+     * For properties declared in classes / interfaces; this value is the binary class name of the declaring class.
+     *
+     * For top level properties, this is the binary class name of the synthetic class that is generated for the Kotlin
+     * file.
+     * see: https://kotlinlang.org/docs/java-to-kotlin-interop.html#package-level-functions
+     *
+     * Note that, for properties declared in companion objects, the returned owner class will be the Companion class.
+     * see: https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-methods
+     */
+    @KspExperimental
+    fun getOwnerJvmClassName(declaration: KSPropertyDeclaration): String?
+
+    /**
+     * Returns the [binary class name](https://asm.ow2.io/javadoc/org/objectweb/asm/Type.html#getClassName()) of the
+     * owner class in JVM for the given [KSFunctionDeclaration].
+     *
+     * For functions declared in classes / interfaces; this value is the binary class name of the declaring class.
+     *
+     * For top level functions, this is the binary class name of the synthetic class that is generated for the Kotlin
+     * file.
+     * see: https://kotlinlang.org/docs/java-to-kotlin-interop.html#package-level-functions
+     *
+     * Note that, for functions declared in companion objects, the returned owner class will be the Companion class.
+     * see: https://kotlinlang.org/docs/java-to-kotlin-interop.html#static-methods
+     */
+    @KspExperimental
+    fun getOwnerJvmClassName(declaration: KSFunctionDeclaration): String?
+
+    /**
      * Returns checked exceptions declared in a function's header.
      * @return A sequence of [KSType] declared in `throws` statement for a Java method or in @Throws annotation for a Kotlin function.
      * Checked exceptions from class files are not supported yet, an empty sequence will be returned instead.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -26,7 +26,6 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.binary.*
-import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.*
 import com.google.devtools.ksp.symbol.impl.kotlin.*
@@ -41,7 +40,6 @@ import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.get
 import org.jetbrains.kotlin.descriptors.*
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationDescriptor
-import org.jetbrains.kotlin.descriptors.impl.ModuleDescriptorImpl
 import org.jetbrains.kotlin.incremental.components.NoLookupLocation
 import org.jetbrains.kotlin.load.java.components.TypeUsage
 import org.jetbrains.kotlin.load.java.descriptors.JavaForKotlinOverridePropertyDescriptor
@@ -602,6 +600,26 @@ class ResolverImpl(
         return descriptor?.let {
             // KotlinTypeMapper.mapSignature always uses OwnerKind.IMPLEMENTATION
             typeMapper.mapFunctionName(descriptor, OwnerKind.IMPLEMENTATION)
+        }
+    }
+
+    @KspExperimental
+    override fun getOwnerJvmClassName(declaration: KSPropertyDeclaration): String? {
+        val descriptor = resolvePropertyDeclaration(declaration) ?: return null
+        return getJvmOwnerQualifiedName(descriptor)
+    }
+
+    @KspExperimental
+    override fun getOwnerJvmClassName(declaration: KSFunctionDeclaration): String? {
+        val descriptor = resolveFunctionDeclaration(declaration) ?: return null
+        return getJvmOwnerQualifiedName(descriptor)
+    }
+
+    private fun getJvmOwnerQualifiedName(descriptor: DeclarationDescriptor): String? {
+        return try {
+            typeMapper.mapImplementationOwner(descriptor).className
+        } catch (unsupported: UnsupportedOperationException) {
+            null
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TopLevelMemberProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/TopLevelMemberProcessor.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+@OptIn(KspExperimental::class)
+open class TopLevelMemberProcessor : AbstractTestProcessor() {
+    lateinit var results: List<String>
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        results = listOf("lib", "main").flatMap { pkg ->
+            resolver.getDeclarationsFromPackage(pkg)
+                .flatMap { declaration ->
+                    val declarations = mutableListOf<KSDeclaration>()
+                    declaration.accept(AllMembersVisitor(), declarations)
+                    declarations
+                }.map {
+                    "$pkg : ${it.simpleName.asString()} -> ${resolver.getSyntheticJvmClass(it)}"
+                }.sorted()
+        }
+        return emptyList()
+    }
+
+    private fun Resolver.getSyntheticJvmClass(
+        declaration: KSDeclaration
+    ) = when (declaration) {
+        is KSPropertyDeclaration -> this.getOwnerJvmClassName(declaration)
+        is KSFunctionDeclaration -> this.getOwnerJvmClassName(declaration)
+        else -> error("unexpected declaration $declaration")
+    }
+
+    private class AllMembersVisitor : KSTopDownVisitor<MutableList<KSDeclaration>, Unit>() {
+        override fun defaultHandler(node: KSNode, data: MutableList<KSDeclaration>) {
+        }
+
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: MutableList<KSDeclaration>) {
+            data.add(property)
+            super.visitPropertyDeclaration(property, data)
+        }
+
+        override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: MutableList<KSDeclaration>) {
+            data.add(function)
+            super.visitFunctionDeclaration(function, data)
+        }
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+}

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -267,6 +267,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/throwList.kt");
     }
 
+    @TestMetadata("topLevelMembers.kt")
+    public void testTopLevelMembers() throws Exception {
+        runTest("testData/api/topLevelMembers.kt");
+    }
+
     @TestMetadata("typeAlias.kt")
     public void testTypeAlias() throws Exception {
         runTest("testData/api/typeAlias.kt");

--- a/compiler-plugin/testData/api/topLevelMembers.kt
+++ b/compiler-plugin/testData/api/topLevelMembers.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: TopLevelMemberProcessor
+// EXPECTED:
+// lib : <init> -> lib.LibJavaClass
+// lib : <init> -> lib.RealLibClass
+// lib : <init> -> lib.RealLibClass$Companion
+// lib : functionInLib -> lib.LibKt
+// lib : functionInLibCompanion -> lib.RealLibClass$Companion
+// lib : functionInLibJvmName -> lib.LibCustomClassName
+// lib : functionInLibRealClass -> lib.RealLibClass
+// lib : javaFieldInLib -> lib.LibJavaClass
+// lib : javaMethodInLib -> lib.LibJavaClass
+// lib : jvmStaticFunctionInLibCompanion -> lib.RealLibClass$Companion
+// lib : jvmStaticValueInLibCompanion -> lib.RealLibClass$Companion
+// lib : jvmStaticVariableInLibCompanion -> lib.RealLibClass$Companion
+// lib : valueInLib -> lib.LibKt
+// lib : valueInLibCompanion -> lib.RealLibClass$Companion
+// lib : valueInLibJvmName -> lib.LibCustomClassName
+// lib : valueInLibRealClass -> lib.RealLibClass
+// lib : variableInLib -> lib.LibKt
+// lib : variableInLibCompanion -> lib.RealLibClass$Companion
+// lib : variableInLibJvmName -> lib.LibCustomClassName
+// lib : variableInLibRealClass -> lib.RealLibClass
+// main : <init> -> main.MainJavaClass
+// main : <init> -> main.RealMainClass
+// main : <init> -> main.RealMainClass$Companion
+// main : functionInMain -> main.MainKt
+// main : functionInMainCompanion -> main.RealMainClass$Companion
+// main : functionInMainJvmName -> main.MainCustomClassName
+// main : functionInMainRealClass -> main.RealMainClass
+// main : javaFieldInMain -> main.MainJavaClass
+// main : javaMethodInMain -> main.MainJavaClass
+// main : jvmStaticFunctionInMainCompanion -> main.RealMainClass$Companion
+// main : jvmStaticValueInMainCompanion -> main.RealMainClass$Companion
+// main : jvmStaticVariableInMainCompanion -> main.RealMainClass$Companion
+// main : valueInMain -> main.MainKt
+// main : valueInMainCompanion -> main.RealMainClass$Companion
+// main : valueInMainJvmName -> main.MainCustomClassName
+// main : valueInMainRealClass -> main.RealMainClass
+// main : variableInMain -> main.MainKt
+// main : variableInMainCompanion -> main.RealMainClass$Companion
+// main : variableInMainJvmName -> main.MainCustomClassName
+// main : variableInMainRealClass -> main.RealMainClass
+// END
+
+// MODULE: lib
+// FILE: lib.kt
+package lib
+fun functionInLib() {}
+val valueInLib: String = ""
+var variableInLib: String = ""
+class RealLibClass {
+    fun functionInLibRealClass() {}
+    val valueInLibRealClass: String = ""
+    var variableInLibRealClass: String = ""
+
+    companion object {
+        fun functionInLibCompanion() {}
+        val valueInLibCompanion: String = ""
+        var variableInLibCompanion: String = ""
+        @JvmStatic
+        fun jvmStaticFunctionInLibCompanion() {}
+        @JvmStatic
+        val jvmStaticValueInLibCompanion: String = ""
+        @JvmStatic
+        var jvmStaticVariableInLibCompanion: String = ""
+    }
+}
+// FILE: customName.kt
+@file:JvmName("LibCustomClassName")
+package lib
+fun functionInLibJvmName() {}
+val valueInLibJvmName: String = ""
+var variableInLibJvmName: String = ""
+
+// FILE: lib/LibJavaClass.java
+package lib;
+public class LibJavaClass {
+    public LibJavaClass() {}
+    private String javaFieldInLib;
+    private void javaMethodInLib() {
+    }
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+fun functionInMain() {}
+val valueInMain: String = ""
+var variableInMain: String = ""
+class RealMainClass {
+    fun functionInMainRealClass() {}
+    val valueInMainRealClass: String = ""
+    var variableInMainRealClass: String = ""
+
+    companion object {
+        fun functionInMainCompanion() {}
+        val valueInMainCompanion: String = ""
+        var variableInMainCompanion: String = ""
+        @JvmStatic
+        fun jvmStaticFunctionInMainCompanion() {}
+        @JvmStatic
+        val jvmStaticValueInMainCompanion: String = ""
+        @JvmStatic
+        var jvmStaticVariableInMainCompanion: String = ""
+    }
+}
+// FILE: customName.kt
+@file:JvmName("MainCustomClassName")
+package main
+fun functionInMainJvmName() {}
+val valueInMainJvmName: String = ""
+var variableInMainJvmName: String = ""
+// FILE: main/MainJavaClass.java
+package main;
+public class MainJavaClass {
+    public MainJavaClass() {}
+    private String javaFieldInMain;
+    private void javaMethodInMain() {
+    }
+}


### PR DESCRIPTION
This PR adds a new Resolver API to get the binary class name for the
owner of a function / property declaration.
(resolver.getOwnerJvmClassName)

For top level functions/properties; this value is necessary to be able
to generate Java code.
An alternative solution would be to synthesize KSClassDeclaration for
these top level members but that carries over JVM limitations to KSP
which is not great in the long term. This solution instead provides an
API to unblock Java code generating KSP Processors without taking much of
technical debt for KMP.

Fixes: #396
Test: topLevelMembers.kt