### PR TITLE
Incremental processing: support getSealedSubclasses from multiple files

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -56,6 +56,7 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
 
     override fun getSealedSubclasses(): Sequence<KSClassDeclaration> {
         return if (Modifier.SEALED in modifiers) {
+            ResolverImpl.instance.incrementalContext.recordGetSealedSubclasses(this)
             descriptor.sealedSubclassesSequence()
         } else {
             emptySequence()

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
@@ -1,0 +1,56 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class GetSealedSubclassesIncIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("sealed-subclasses", "test-processor")
+
+    @Test
+    fun testGetSealedSubclassesInc() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val expected2 = listOf(
+            "w: [ksp] Processing Impl1.kt",
+            "w: [ksp] Impl1 : []",
+            "w: [ksp] Processing Impl2.kt",
+            "w: [ksp] Impl2 : []",
+            "w: [ksp] Processing Sealed.kt",
+            "w: [ksp] Sealed : [Impl1, Impl2]",
+        )
+
+        val expected3 = listOf(
+            "w: [ksp] Processing Impl1.kt",
+            "w: [ksp] Impl1 : []",
+            "w: [ksp] Processing Impl2.kt",
+            "w: [ksp] Impl2 : []",
+            "w: [ksp] Processing Impl3.kt",
+            "w: [ksp] Impl3 : []",
+            "w: [ksp] Processing Sealed.kt",
+            "w: [ksp] Sealed : [Impl1, Impl2, Impl3]",
+        )
+
+        gradleRunner.withArguments("assemble").build().let { result ->
+            val outputs = result.output.split("\n").filter { it.startsWith("w: [ksp]")}
+            Assert.assertEquals(expected2, outputs)
+        }
+
+        File(project.root, "workload/src/main/kotlin/com/example/Impl3.kt").appendText("package com.example\n\n")
+        File(project.root, "workload/src/main/kotlin/com/example/Impl3.kt").appendText("class Impl3 : Sealed()\n")
+        gradleRunner.withArguments("assemble").build().let { result ->
+            val outputs = result.output.split("\n").filter { it.startsWith("w: [ksp]")}
+            Assert.assertEquals(expected3, outputs)
+        }
+
+        File(project.root, "workload/src/main/kotlin/com/example/Impl3.kt").delete()
+        gradleRunner.withArguments("assemble").build().let { result ->
+            val outputs = result.output.split("\n").filter { it.startsWith("w: [ksp]")}
+            Assert.assertEquals(expected2, outputs)
+        }
+    }
+}

--- a/integration-tests/src/test/resources/refs-gen/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/refs-gen/test-processor/src/main/kotlin/TestProcessor.kt
@@ -3,19 +3,10 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
 import java.io.OutputStreamWriter
 
-
-class TestProcessor : SymbolProcessor {
-    lateinit var codeGenerator: CodeGenerator
-    lateinit var logger: KSPLogger
-
-    override fun finish() {
-    }
-
-    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
-        this.codeGenerator = codeGenerator
-        this.logger = logger
-    }
-
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
     // FIXME: use getSymbolsWithAnnotation after it is fixed.
     var rounds = 0
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -45,5 +36,16 @@ class TestProcessor : SymbolProcessor {
         }
 
         return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger
+    ): SymbolProcessor {
+        return TestProcessor(codeGenerator, logger)
     }
 }

--- a/integration-tests/src/test/resources/sealed-subclasses/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/sealed-subclasses/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,32 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+
+
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getNewFiles().forEach { f ->
+            logger.warn("Processing ${f.fileName}")
+            f.declarations.forEach {
+                if (it is KSClassDeclaration) {
+                    val subs = it.getSealedSubclasses().map { it.simpleName.asString() }.toList()
+                    logger.warn("${it.simpleName.asString()} : $subs")
+                }
+            }
+        }
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger
+    ): SymbolProcessor {
+        return TestProcessor(codeGenerator, logger)
+    }
+}

--- a/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Impl1.kt
+++ b/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Impl1.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class Impl1 : Sealed()

--- a/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Impl2.kt
+++ b/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Impl2.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class Impl2 : Sealed()

--- a/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Sealed.kt
+++ b/integration-tests/src/test/resources/sealed-subclasses/workload/src/main/kotlin/com/example/Sealed.kt
@@ -1,0 +1,3 @@
+package com.example
+
+sealed class Sealed

--- a/integration-tests/src/test/resources/srcs-gen/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/srcs-gen/test-processor/src/main/kotlin/TestProcessor.kt
@@ -2,19 +2,10 @@ import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import java.io.OutputStreamWriter
 
-
-class TestProcessor : SymbolProcessor {
-    lateinit var codeGenerator: CodeGenerator
-    lateinit var logger: KSPLogger
-
-    override fun finish() {
-    }
-
-    override fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
-        this.codeGenerator = codeGenerator
-        this.logger = logger
-    }
-
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
     // FIXME: use getSymbolsWithAnnotation after it is fixed.
     var rounds = 0
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -51,5 +42,16 @@ class TestProcessor : SymbolProcessor {
         }
 
         return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger
+    ): SymbolProcessor {
+        return TestProcessor(codeGenerator, logger)
     }
 }

--- a/integration-tests/src/test/resources/test-processor/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
+++ b/integration-tests/src/test/resources/test-processor/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessor
@@ -1,1 +1,0 @@
-TestProcessor

--- a/integration-tests/src/test/resources/test-processor/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/test-processor/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider


### PR DESCRIPTION
`sealedMap` is introduced to track sealed interfaces and classes. It is a map from file to FQNs.

Unfortunately, There isn't a simple way to associate symbols with their supertypes without resolution, because of typealias. Therefore, all sealed classes / interfaces on which getSealedSubclasses is called are invalidated.

Fixes #323 