### PR TITLE
Introduce asMemberOf to KSPropertyDeclaration and KSFunctionDeclaration

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -116,64 +116,6 @@ interface Resolver {
     fun overrides(overrider: KSDeclaration, overridee: KSDeclaration): Boolean
 
     /**
-     * Returns the type of the [property] when it is viewed as member of the [containing] type.
-     *
-     * For instance, for the following input:
-     * ```
-     * class Base<T>(val x:T)
-     * val foo: Base<Int>
-     * val bar: Base<String>
-     * ```
-     * When `x` is viewed as member of `foo`, this method will return the [KSType] for `Int`
-     * whereas when `x` is viewed as member of `bar`, this method will return the [KSType]
-     * representing `String`.
-     *
-     * If the substitution fails (e.g. if [containing] is an error type, a [KSType] with [KSType.isError] `true` is
-     * returned.
-     *
-     * @param property The property whose type will be returned
-     * @param containing The type that contains [property]
-     * @throws IllegalArgumentException Throws [IllegalArgumentException] when [containing] does not contain
-     * [property] or if the [property] is not declared in a class, object or interface.
-     */
-    fun asMemberOf(
-        property: KSPropertyDeclaration,
-        containing: KSType
-    ): KSType
-
-    /**
-     * Returns the type of the [function] when it is viewed as member of the [containing] type.
-     *
-     * For instance, for the following input:
-     * ```
-     * interface Base<T> {
-     *   fun f(t:T?):T
-     * }
-     * val foo: Base<Int>
-     * val bar: Base<String>
-     * ```
-     * When `f()` is viewed as member of `foo`, this method will return a [KSFunction] where
-     * the [KSFunction.returnType] is `Int` and the parameter `t` is of type `Int?`.
-     * When `f()` is viewed as member of `bar`, this method will return a [KSFunction]
-     * where the [KSFunction.returnType] is `String` and the parameter `t` is of type `String?`.
-     *
-     * If the function has type parameters, they'll not be resolved and can be read from
-     * [KSFunction.typeParameters].
-     *
-     * If the substitution fails (e.g. if [containing] is an error type, a [KSFunction] with [KSFunction.isError] `true`
-     * is returned.
-     *
-     * @param function The function whose types will be resolved
-     * @param containing The type that contains [function].
-     * @throws IllegalArgumentException Throws [IllegalArgumentException] when [containing] does not contain [function]
-     * or if the [function] is not declared in a class, object or interface.
-     */
-    fun asMemberOf(
-        function: KSFunctionDeclaration,
-        containing: KSType
-    ): KSFunction
-
-    /**
      * Returns the jvm name of the given function.
      * This function might fail due to resolution error, in case of error, null is returned.
      * Resolution error could be caused by bad code that could not be resolved by compiler, or KSP bugs.

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -84,4 +84,9 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
      * Calling [findOverridee] is expensive and should be avoided if possible.
      */
     fun findOverridee(): KSFunctionDeclaration?
+
+    /**
+     * See Resolver.asMemberOf(function: KSFunctionDeclaration, containing: KSType).
+     */
+    fun asMemberOf(containing: KSType): KSFunction
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -86,7 +86,30 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
     fun findOverridee(): KSFunctionDeclaration?
 
     /**
-     * See Resolver.asMemberOf(function: KSFunctionDeclaration, containing: KSType).
+     * Returns the type of the [function] when it is viewed as member of the [containing] type.
+     *
+     * For instance, for the following input:
+     * ```
+     * interface Base<T> {
+     *   fun f(t:T?):T
+     * }
+     * val foo: Base<Int>
+     * val bar: Base<String>
+     * ```
+     * When `f()` is viewed as member of `foo`, this method will return a [KSFunction] where
+     * the [KSFunction.returnType] is `Int` and the parameter `t` is of type `Int?`.
+     * When `f()` is viewed as member of `bar`, this method will return a [KSFunction]
+     * where the [KSFunction.returnType] is `String` and the parameter `t` is of type `String?`.
+     *
+     * If the function has type parameters, they'll not be resolved and can be read from
+     * [KSFunction.typeParameters].
+     *
+     * If the substitution fails (e.g. if [containing] is an error type, a [KSFunction] with [KSFunction.isError] `true`
+     * is returned.
+     *
+     * @param containing The type that contains [function].
+     * @throws IllegalArgumentException Throws [IllegalArgumentException] when [containing] does not contain [function]
+     * or if the [function] is not declared in a class, object or interface.
      */
     fun asMemberOf(containing: KSType): KSFunction
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -87,7 +87,24 @@ interface KSPropertyDeclaration : KSDeclaration {
     fun findOverridee(): KSPropertyDeclaration?
 
     /**
-     * See Resolver.asMemberOf(property: KSPropertyDeclaration, containing: KSType).
+     * Returns the type of the [property] when it is viewed as member of the [containing] type.
+     *
+     * For instance, for the following input:
+     * ```
+     * class Base<T>(val x:T)
+     * val foo: Base<Int>
+     * val bar: Base<String>
+     * ```
+     * When `x` is viewed as member of `foo`, this method will return the [KSType] for `Int`
+     * whereas when `x` is viewed as member of `bar`, this method will return the [KSType]
+     * representing `String`.
+     *
+     * If the substitution fails (e.g. if [containing] is an error type, a [KSType] with [KSType.isError] `true` is
+     * returned.
+     *
+     * @param containing The type that contains [property]
+     * @throws IllegalArgumentException Throws [IllegalArgumentException] when [containing] does not contain
+     * [property] or if the [property] is not declared in a class, object or interface.
      */
     fun asMemberOf(containing: KSType): KSType
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -85,4 +85,9 @@ interface KSPropertyDeclaration : KSDeclaration {
      * Calling [findOverridee] is expensive and should be avoided if possible.
      */
     fun findOverridee(): KSPropertyDeclaration?
+
+    /**
+     * See Resolver.asMemberOf(property: KSPropertyDeclaration, containing: KSType).
+     */
+    fun asMemberOf(containing: KSType): KSType
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -95,6 +95,7 @@ class ResolverImpl(
      * Checking as member of is an expensive operation, hence we cache result values in this map.
      */
     private val functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>
+    private val propertyAsMemberOfCache: MutableMap<Pair<KSPropertyDeclaration, KSType>, KSType>
 
     private val typeMapper = KotlinTypeMapper(
         BindingContext.EMPTY, ClassBuilderMode.LIGHT_CLASSES,
@@ -132,6 +133,7 @@ class ResolverImpl(
 
         nameToKSMap = mutableMapOf()
         functionAsMemberOfCache = mutableMapOf()
+        propertyAsMemberOfCache = mutableMapOf()
 
         val visitor = object : KSVisitorVoid() {
             override fun visitFile(file: KSFile, data: Unit) {
@@ -659,6 +661,16 @@ class ResolverImpl(
     }
 
     override fun asMemberOf(
+        property: KSPropertyDeclaration,
+        containing: KSType
+    ): KSType {
+        val key = property to containing
+        return propertyAsMemberOfCache.getOrPut(key) {
+            computeAsMemberOf(property, containing)
+        }
+    }
+
+    private fun computeAsMemberOf(
         property: KSPropertyDeclaration,
         containing: KSType
     ): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -660,7 +660,7 @@ class ResolverImpl(
         return KSTypeArgumentLiteImpl.getCached(typeRef, variance)
     }
 
-    override fun asMemberOf(
+    internal fun asMemberOf(
         property: KSPropertyDeclaration,
         containing: KSType
     ): KSType {
@@ -696,7 +696,7 @@ class ResolverImpl(
         return KSErrorType
     }
 
-    override fun asMemberOf(
+    internal fun asMemberOf(
         function: KSFunctionDeclaration,
         containing: KSType
     ): KSFunction {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -65,7 +65,8 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         // make sure values are cached
         val first = resolver.asMemberOf(listGet, listOfStrings)
         val second = resolver.asMemberOf(listGet, listOfStrings)
-        if (first !== second) {
+        val third = listGet.asMemberOf(listOfStrings)
+        if (first !== second || second !== third) {
             results.add("cache error, repeated computation")
         }
 
@@ -125,7 +126,11 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         containing: KSType
     ): String {
         val result = kotlin.runCatching {
-            asMemberOf(function, containing)
+            asMemberOf(function, containing).also {
+                if (it !== function.asMemberOf(containing)) {
+                    results.add("Error: Resolver.asMemberOf(function, containing) !== function.asMemberOf(containing)")
+                }
+            }
         }
         return if (result.isSuccess) {
             val ksFunction = result.getOrThrow()
@@ -145,7 +150,11 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         containing: KSType
     ): String {
         val result = kotlin.runCatching {
-            asMemberOf(property, containing)
+            asMemberOf(property, containing).also {
+                if (it !== property.asMemberOf(containing)) {
+                    results.add("Error: Resolver.asMemberOf(property, containing) !== property.asMemberOf(containing)")
+                }
+            }
         }
         return if (result.isSuccess) {
             result.getOrThrow().toSignature()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -63,10 +63,9 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         results.add("errorType: " + resolver.asMemberOfSignature(listGet, errorType))
 
         // make sure values are cached
-        val first = resolver.asMemberOf(listGet, listOfStrings)
-        val second = resolver.asMemberOf(listGet, listOfStrings)
-        val third = listGet.asMemberOf(listOfStrings)
-        if (first !== second || second !== third) {
+        val first = listGet.asMemberOf(listOfStrings)
+        val second = listGet.asMemberOf(listOfStrings)
+        if (first !== second) {
             results.add("cache error, repeated computation")
         }
 
@@ -126,9 +125,9 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         containing: KSType
     ): String {
         val result = kotlin.runCatching {
-            asMemberOf(function, containing).also {
+            function.asMemberOf(containing).also {
                 if (it !== function.asMemberOf(containing)) {
-                    results.add("Error: Resolver.asMemberOf(function, containing) !== function.asMemberOf(containing)")
+                    results.add("cache error, repeated computation")
                 }
             }
         }
@@ -150,9 +149,9 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         containing: KSType
     ): String {
         val result = kotlin.runCatching {
-            asMemberOf(property, containing).also {
+            property.asMemberOf(containing).also {
                 if (it !== property.asMemberOf(containing)) {
-                    results.add("Error: Resolver.asMemberOf(property, containing) !== property.asMemberOf(containing)")
+                    results.add("cache error, repeated computation")
                 }
             }
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
@@ -48,7 +48,7 @@ class RecordJavaAsMemberOfProcessor : AbstractTestProcessor() {
             }
         }
 
-        resolver.asMemberOf(function!!, type!!)
+        function!!.asMemberOf(type!!)
 
         if (resolver is ResolverImpl) {
             val m = resolver.incrementalContext.dumpLookupRecords()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -102,4 +102,7 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitFunctionDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSFunction =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -97,4 +97,7 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSType =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -117,4 +117,7 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) : KS
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitFunctionDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSFunction =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
+import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiJavaFile
 import com.google.devtools.ksp.symbol.*
@@ -87,4 +88,6 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
         return visitor.visitPropertyDeclaration(this, data)
     }
 
+    override fun asMemberOf(containing: KSType): KSType =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -103,5 +103,8 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitFunctionDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSFunction =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -99,6 +99,9 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSType =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }
 
 internal fun KtAnnotated.filterUseSiteTargetAnnotations(): List<KtAnnotationEntry> {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -81,4 +81,7 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitPropertyDeclaration(this, data)
     }
+
+    override fun asMemberOf(containing: KSType): KSType =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
@@ -19,6 +19,7 @@
 package com.google.devtools.ksp.symbol.impl.synthetic
 
 import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
@@ -101,4 +102,7 @@ class KSConstructorSyntheticImpl(val ksClassDeclaration: KSClassDeclaration) : K
     override fun toString(): String {
         return "synthetic constructor for ${this.parentDeclaration}"
     }
+
+    override fun asMemberOf(containing: KSType): KSFunction =
+        ResolverImpl.instance.asMemberOf(this, containing)
 }


### PR DESCRIPTION
They are more convenient and object oriented.

fixes #208 