### PR TITLE
Introduce mapJavaToKotlin and mapKotlinToJava to Resolver

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -51,6 +51,15 @@ interface Resolver {
     /**
      * Find a class in the compilation classpath for the given name.
      *
+     * This returns the exact platform class when given a platform name. Note that java.lang.String isn't compatible
+     * with kotlin.String in the type system. Therefore, processors need to use mapJavaNameToKotlin() and mapKotlinNameToJava()
+     * explicitly to find the corresponding class names before calling getClassDeclarationByName if type checking
+     * is needed for the classes loaded by this.
+     *
+     * This behavior is limited to getClassDeclarationByName; When processors get a class or type from a Java source
+     * file, the conversion is done automatically. E.g., a java.lang.String in a Java source file is loaded as
+     * kotlin.String in KSP.
+     *
      * @param name fully qualified name of the class to be loaded; using '.' as separator.
      * @return a KSClassDeclaration, or null if not found.
      */
@@ -212,4 +221,35 @@ interface Resolver {
      */
     @KspExperimental
     fun getDeclarationsFromPackage(packageName: String): Sequence<KSDeclaration>
+
+    /**
+     * Returns the corresponding Kotlin class with the given Java class.
+     *
+     * E.g.
+     * java.lang.String -> kotlin.String
+     * java.lang.Integer -> kotlin.Int
+     * java.util.List -> kotlin.List
+     * java.util.Map.Entry -> kotlin.Map.Entry
+     * java.lang.Void -> null
+     *
+     * @param javaName a Java class name
+     * @return corresponding Kotlin class name or null
+     */
+    @KspExperimental
+    fun mapJavaNameToKotlin(javaName: KSName): KSName?
+
+    /**
+     * Returns the corresponding Java class with the given Kotlin class.
+     *
+     * E.g.
+     * kotlin.Throwable -> java.lang.Throwable
+     * kotlin.Int -> java.lang.Integer
+     * kotlin.Nothing -> java.lang.Void
+     * kotlin.IntArray -> null
+     *
+     * @param kotlinName a Java class name
+     * @return corresponding Java class name or null
+     */
+    @KspExperimental
+    fun mapKotlinNameToJava(kotlinName: KSName): KSName?
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -276,3 +276,23 @@ val KSType.outerType: KSType?
 
 val KSType.innerArguments: List<KSTypeArgument>
     get() = arguments.subList(0, declaration.typeParameters.size)
+
+@KspExperimental
+fun Resolver.getKotlinClassByName(name: KSName): KSClassDeclaration? {
+    val kotlinName = mapJavaNameToKotlin(name) ?: name
+    return getClassDeclarationByName(kotlinName)
+}
+
+@KspExperimental
+fun Resolver.getKotlinClassByName(name: String): KSClassDeclaration? =
+    getKotlinClassByName(getKSNameFromString(name))
+
+@KspExperimental
+fun Resolver.getJavaClassByName(name: KSName): KSClassDeclaration? {
+    val javaName = mapKotlinNameToJava(name) ?: name
+    return getClassDeclarationByName(javaName)
+}
+
+@KspExperimental
+fun Resolver.getJavaClassByName(name: String): KSClassDeclaration? =
+    getJavaClassByName(getKSNameFromString(name))

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -33,6 +33,7 @@ import com.google.devtools.ksp.symbol.impl.synthetic.*
 import com.intellij.openapi.project.Project
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.codegen.ClassBuilderMode
 import org.jetbrains.kotlin.codegen.OwnerKind
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
@@ -51,7 +52,9 @@ import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaTypeParameterDesc
 import org.jetbrains.kotlin.load.java.lazy.types.JavaTypeResolver
 import org.jetbrains.kotlin.load.java.lazy.types.toAttributes
 import org.jetbrains.kotlin.load.java.structure.impl.*
+import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.*
@@ -772,6 +775,15 @@ class ResolverImpl(
 
     internal val javaSerializableType = module.resolveClassByFqName(FqName("java.io.Serializable"), NoLookupLocation.WHEN_FIND_BY_FQNAME)!!.defaultType
 
+    private fun ClassId.toKSName() = KSNameImpl.getCached(asSingleFqName().toString())
+
+    @KspExperimental
+    override fun mapJavaNameToKotlin(javaName: KSName): KSName? =
+        JavaToKotlinClassMap.mapJavaToKotlin(FqName(javaName.asString()))?.toKSName()
+
+    @KspExperimental
+    override fun mapKotlinNameToJava(kotlinName: KSName): KSName? =
+        JavaToKotlinClassMap.mapKotlinToJava(FqNameUnsafe(kotlinName.asString()))?.toKSName()
 }
 
 open class BaseVisitor : KSVisitorVoid() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
@@ -19,8 +19,11 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getJavaClassByName
+import com.google.devtools.ksp.getKotlinClassByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.getClassDeclarationByName
 
 @KspExperimental
 open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
@@ -57,6 +60,12 @@ open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
             )?.asString()
             results.add("$it -> $j")
         }
+
+        if (resolver.getClassDeclarationByName("java.lang.String") != resolver.getJavaClassByName("kotlin.String"))
+            results.add("Error: getJavaClassByName")
+
+        if (resolver.getClassDeclarationByName("kotlin.String") != resolver.getKotlinClassByName("java.lang.String"))
+            results.add("Error: getKotlinClassByName")
 
         return emptyList()
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+
+@KspExperimental
+open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val typeCollector = TypeCollectorNoAccessor()
+    val types = mutableSetOf<KSType>()
+
+    val javaClasses = listOf(
+        "java.lang.String",
+        "java.lang.Integer",
+        "java.util.List",
+        "java.util.Map.Entry",
+        "java.lang.Void",
+    )
+
+    val kotlinClasses = listOf(
+        "kotlin.Throwable",
+        "kotlin.Int",
+        "kotlin.Nothing",
+        "kotlin.IntArray",
+    )
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        javaClasses.forEach {
+            val k = resolver.mapJavaNameToKotlin(
+                resolver.getKSNameFromString(it)
+            )?.asString()
+            results.add("$it -> $k")
+        }
+
+        kotlinClasses.forEach {
+            val j = resolver.mapKotlinNameToJava(
+                resolver.getKSNameFromString(it)
+            )?.asString()
+            results.add("$it -> $j")
+        }
+
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+}

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -182,6 +182,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/javaModifiers.kt");
     }
 
+    @TestMetadata("javaToKotlinMapper.kt")
+    public void testJavaToKotlinMapper() throws Exception {
+        runTest("testData/api/javaToKotlinMapper.kt");
+    }
+
     @TestMetadata("javaTypes.kt")
     public void testJavaTypes() throws Exception {
         runTest("testData/api/javaTypes.kt");

--- a/compiler-plugin/testData/api/javaToKotlinMapper.kt
+++ b/compiler-plugin/testData/api/javaToKotlinMapper.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: JavaToKotlinMapProcessor
+// EXPECTED:
+// java.lang.String -> kotlin.String
+// java.lang.Integer -> kotlin.Int
+// java.util.List -> kotlin.collections.List
+// java.util.Map.Entry -> kotlin.collections.Map.Entry
+// java.lang.Void -> null
+// kotlin.Throwable -> java.lang.Throwable
+// kotlin.Int -> java.lang.Integer
+// kotlin.Nothing -> java.lang.Void
+// kotlin.IntArray -> null
+// END
+
+val unused = Unit


### PR DESCRIPTION
They map Java classes to Kotlin classes and vice versa. For example,
    java.lang.String <-> kotlin.String
    java.lang.Integer <-> kotlin.Int

See https://kotlinlang.org/docs/java-interop.html#mapped-types for
details.

Also introduced two extension functions that loads Java/Kotlin as Kotlin/Java classes when applicable.

Fixes #126 