### PR TITLE
Split Origin.CLASS into KOTLIN_LIB and JAVA_LIB

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/Origin.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/Origin.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.symbol
 
 enum class Origin {
     KOTLIN,
-    CLASS,
+    KOTLIN_LIB,
     JAVA,
+    JAVA_LIB,
     SYNTHETIC
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.*
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyAccessor
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class LibOriginsProcessor : AbstractTestProcessor() {
+    private val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    inner class MyCollector : KSTopDownVisitor<Unit, Unit>() {
+        override fun defaultHandler(node: KSNode, data: Unit) = Unit
+
+        override fun visitDeclaration(declaration: KSDeclaration, data: Unit) {
+            result.add("declaration: ${declaration.qualifiedName?.asString() ?: declaration.simpleName.asString()}: ${declaration.origin.name}")
+            super.visitDeclaration(declaration, data)
+        }
+
+        override fun visitAnnotation(annotation: KSAnnotation, data: Unit) {
+            result.add("annotation: ${annotation.shortName.asString()}: ${annotation.origin.name}")
+            super.visitAnnotation(annotation, data)
+        }
+
+        override fun visitTypeReference(typeReference: KSTypeReference, data: Unit) {
+            result.add("reference: $typeReference: ${typeReference.origin.name}")
+            super.visitTypeReference(typeReference, data)
+        }
+
+        override fun visitClassifierReference(reference: KSClassifierReference, data: Unit) {
+            result.add("classifier ref: $reference: ${reference.origin.name}")
+            super.visitClassifierReference(reference, data)
+        }
+
+        override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
+            result.add("value param: $valueParameter: ${valueParameter.origin.name}")
+            super.visitValueParameter(valueParameter, data)
+        }
+
+        override fun visitTypeArgument(typeArgument: KSTypeArgument, data: Unit) {
+            result.add("type arg: $typeArgument: ${typeArgument.origin.name}")
+            super.visitTypeArgument(typeArgument, data)
+        }
+
+        override fun visitPropertyAccessor(accessor: KSPropertyAccessor, data: Unit) {
+            result.add("property accessor: $accessor: ${accessor.origin.name}")
+            super.visitPropertyAccessor(accessor, data)
+        }
+    }
+
+    @KspExperimental
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val visitor = MyCollector()
+
+        // FIXME: workaround for https://github.com/google/ksp/issues/418
+        resolver.getDeclarationsFromPackage("foo.bar").forEach {
+            if (it.containingFile == null) {
+                it.accept(visitor, Unit)
+            }
+        }
+
+        resolver.getNewFiles().forEach {
+            it.accept(visitor, Unit)
+        }
+
+        result.sort()
+        return emptyList()
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
@@ -40,7 +40,7 @@ open class ReferenceElementProcessor: AbstractTestProcessor() {
         for (i in sortedReferences)
             results.add("KSClassifierReferenceImpl: Qualifier of ${i.element} is ${(i.element as KSClassifierReference).qualifier}")
 
-        val descriptorReferences = sortedReferences.map { KSTypeReferenceDescriptorImpl.getCached((it.resolve() as KSTypeImpl).kotlinType) }
+        val descriptorReferences = sortedReferences.map { KSTypeReferenceDescriptorImpl.getCached((it.resolve() as KSTypeImpl).kotlinType, Origin.SYNTHETIC) }
         for (i in descriptorReferences) {
             results.add("KSClassifierReferenceDescriptorImpl: Qualifier of ${i.element} is ${(i.element as KSClassifierReference).qualifier}")
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -32,6 +32,8 @@ import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSValueArgumentLiteImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
+import org.jetbrains.kotlin.load.java.components.JavaAnnotationDescriptor
+import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaAnnotationDescriptor
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
@@ -42,12 +44,17 @@ class KSAnnotationDescriptorImpl private constructor(val descriptor: AnnotationD
         fun getCached(descriptor: AnnotationDescriptor) = cache.getOrPut(descriptor) { KSAnnotationDescriptorImpl(descriptor) }
     }
 
-    override val origin = Origin.CLASS
+    override val origin =
+        when (descriptor) {
+            is JavaAnnotationDescriptor, is LazyJavaAnnotationDescriptor -> Origin.JAVA_LIB
+            else -> Origin.KOTLIN_LIB
+        }
+
 
     override val location: Location = NonExistLocation
 
     override val annotationType: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
     override val arguments: List<KSValueArgument> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -83,7 +83,8 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     override val superTypes: Sequence<KSTypeReference> by lazy {
         descriptor.defaultType.constructor.supertypes.asSequence().map {
             KSTypeReferenceDescriptorImpl.getCached(
-                if (it === mockSerializableType) javaSerializableType else it
+                if (it === mockSerializableType) javaSerializableType else it,
+                origin
             )
         }.memoized()
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
@@ -25,12 +25,17 @@ import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.memoized
+import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
+import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
-abstract class KSDeclarationDescriptorImpl(descriptor: DeclarationDescriptor) : KSDeclaration {
+abstract class KSDeclarationDescriptorImpl(private val descriptor: DeclarationDescriptor) : KSDeclaration {
 
-    override val origin = Origin.CLASS
+    override val origin by lazy {
+        descriptor.origin
+    }
 
     override val containingFile: KSFile? = null
 
@@ -66,3 +71,10 @@ abstract class KSDeclarationDescriptorImpl(descriptor: DeclarationDescriptor) : 
     }
 
 }
+
+val DeclarationDescriptor.origin: Origin
+    get() = if (parentsWithSelf.firstIsInstanceOrNull<JavaClassDescriptor>() != null) {
+        Origin.JAVA_LIB
+    } else {
+        Origin.KOTLIN_LIB
+    }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -56,7 +56,7 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
     override val extensionReceiver: KSTypeReference? by lazy {
         val extensionReceiver = descriptor.extensionReceiverParameter?.type
         if (extensionReceiver != null) {
-            KSTypeReferenceDescriptorImpl.getCached(extensionReceiver)
+            KSTypeReferenceDescriptorImpl.getCached(extensionReceiver, origin)
         } else {
             null
         }
@@ -95,7 +95,7 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
         if (returnType == null) {
             null
         } else {
-            KSTypeReferenceDescriptorImpl.getCached(returnType)
+            KSTypeReferenceDescriptorImpl.getCached(returnType, origin)
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyAccessorDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyAccessorDescriptorImpl.kt
@@ -24,15 +24,19 @@ import com.google.devtools.ksp.symbol.impl.memoized
 import com.google.devtools.ksp.symbol.impl.toFunctionKSModifiers
 import com.google.devtools.ksp.symbol.impl.toKSModifiers
 import com.google.devtools.ksp.symbol.impl.toKSPropertyDeclaration
+import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
+import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
 
 abstract class KSPropertyAccessorDescriptorImpl(val descriptor: PropertyAccessorDescriptor) : KSPropertyAccessor {
-    override val origin: Origin
-        get() = when(receiver.origin) {
+    override val origin: Origin by lazy {
+        when (receiver.origin) {
             // if receiver is kotlin source, that means we are a synthetic where developer
             // didn't declare an explicit accessor so we used the descriptor instead
             Origin.KOTLIN -> Origin.SYNTHETIC
-            else -> Origin.CLASS
+            else -> descriptor.origin
         }
+    }
 
     override val receiver: KSPropertyDeclaration by lazy {
         descriptor.correspondingProperty.toKSPropertyDeclaration()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -32,7 +32,7 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
 
     override val extensionReceiver: KSTypeReference? by lazy {
         if (descriptor.extensionReceiverParameter != null) {
-            KSTypeReferenceDescriptorImpl.getCached(descriptor.extensionReceiverParameter!!.type)
+            KSTypeReferenceDescriptorImpl.getCached(descriptor.extensionReceiverParameter!!.type, origin)
         } else {
             null
         }
@@ -78,7 +78,7 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
     override fun findOverridee(): KSPropertyDeclaration? {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyGetterDescriptorImpl.kt
@@ -30,7 +30,7 @@ class KSPropertyGetterDescriptorImpl private constructor(descriptor: PropertyGet
 
     override val returnType: KSTypeReference? by lazy {
         if (descriptor.returnType != null) {
-            KSTypeReferenceDescriptorImpl.getCached(descriptor.returnType!!)
+            KSTypeReferenceDescriptorImpl.getCached(descriptor.returnType!!, origin)
         } else {
             null
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeAliasDescriptorImpl.kt
@@ -30,7 +30,7 @@ class KSTypeAliasDescriptorImpl(descriptor: TypeAliasDescriptor) : KSTypeAlias,
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.underlyingType)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.underlyingType, origin)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -24,17 +24,15 @@ import com.google.devtools.ksp.symbol.impl.kotlin.IdKey
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 import org.jetbrains.kotlin.types.TypeProjection
 
-class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProjection) : KSTypeArgumentImpl() {
-    companion object : KSObjectCache<IdKey<TypeProjection>, KSTypeArgumentDescriptorImpl>() {
-        fun getCached(descriptor: TypeProjection) = cache.getOrPut(IdKey(descriptor)) { KSTypeArgumentDescriptorImpl(descriptor) }
+class KSTypeArgumentDescriptorImpl private constructor(val descriptor: TypeProjection, override val origin: Origin) : KSTypeArgumentImpl() {
+    companion object : KSObjectCache<IdKey<Pair<TypeProjection, Origin>>, KSTypeArgumentDescriptorImpl>() {
+        fun getCached(descriptor: TypeProjection, origin: Origin) = cache.getOrPut(IdKey(Pair(descriptor, origin))) { KSTypeArgumentDescriptorImpl(descriptor, origin) }
     }
-
-    override val origin = Origin.CLASS
 
     override val location: Location = NonExistLocation
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
     override val variance: Variance by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeParameterDescriptorImpl.kt
@@ -38,7 +38,7 @@ class KSTypeParameterDescriptorImpl private constructor(val descriptor: TypePara
     }
 
     override val bounds: Sequence<KSTypeReference> by lazy {
-        descriptor.upperBounds.asSequence().map { KSTypeReferenceDescriptorImpl.getCached(it) }
+        descriptor.upperBounds.asSequence().map { KSTypeReferenceDescriptorImpl.getCached(it, origin) }
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -30,17 +30,15 @@ import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import com.google.devtools.ksp.symbol.impl.memoized
 import org.jetbrains.kotlin.types.*
 
-class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinType) : KSTypeReference {
-    companion object : KSObjectCache<IdKey<KotlinType>, KSTypeReferenceDescriptorImpl>() {
-        fun getCached(kotlinType: KotlinType) = cache.getOrPut(IdKey(kotlinType)) { KSTypeReferenceDescriptorImpl(kotlinType) }
+class KSTypeReferenceDescriptorImpl private constructor(val kotlinType: KotlinType, override val origin: Origin) : KSTypeReference {
+    companion object : KSObjectCache<IdKey<Pair<KotlinType, Origin>>, KSTypeReferenceDescriptorImpl>() {
+        fun getCached(kotlinType: KotlinType, origin: Origin) = cache.getOrPut(IdKey(Pair(kotlinType, origin))) { KSTypeReferenceDescriptorImpl(kotlinType, origin) }
     }
-
-    override val origin = Origin.CLASS
 
     override val location: Location = NonExistLocation
 
     override val element: KSReferenceElement by lazy {
-        KSClassifierReferenceDescriptorImpl.getCached(kotlinType)
+        KSClassifierReferenceDescriptorImpl.getCached(kotlinType, origin)
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
@@ -24,13 +24,16 @@ import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import org.jetbrains.kotlin.resolve.calls.components.hasDefaultValue
 import org.jetbrains.kotlin.resolve.calls.components.isVararg
+import org.jetbrains.kotlin.resolve.descriptorUtil.parentsWithSelf
 
 class KSValueParameterDescriptorImpl private constructor(val descriptor: ValueParameterDescriptor) : KSValueParameter {
     companion object : KSObjectCache<ValueParameterDescriptor, KSValueParameterDescriptorImpl>() {
         fun getCached(descriptor: ValueParameterDescriptor) = cache.getOrPut(descriptor) { KSValueParameterDescriptorImpl(descriptor) }
     }
 
-    override val origin = Origin.CLASS
+    override val origin by lazy {
+        descriptor.origin
+    }
 
     override val location: Location = NonExistLocation
 
@@ -53,7 +56,7 @@ class KSValueParameterDescriptorImpl private constructor(val descriptor: ValuePa
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
     override val hasDefault: Boolean = descriptor.hasDefaultValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -54,7 +54,7 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
 
     override val arguments: List<KSValueArgument> by lazy {
         val annotationConstructor =
-            ((annotationType.resolve() as KSTypeImpl).kotlinType.constructor.declarationDescriptor as? ClassDescriptor)
+            ((annotationType.resolve() as? KSTypeImpl)?.kotlinType?.constructor?.declarationDescriptor as? ClassDescriptor)
                 ?.constructors?.single()
         val presentValueArguments = psi.parameterList.attributes
             .mapIndexed { index, it ->

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -76,20 +76,21 @@ class KSTypeReferenceJavaImpl private constructor(val psi: PsiType) : KSTypeRefe
         when (type) {
             is PsiClassType -> KSClassifierReferenceJavaImpl.getCached(type)
             is PsiWildcardType -> KSClassifierReferenceJavaImpl.getCached(type.extendsBound as PsiClassType)
-            is PsiPrimitiveType -> KSClassifierReferenceDescriptorImpl.getCached(type.toKotlinType())
+            is PsiPrimitiveType -> KSClassifierReferenceDescriptorImpl.getCached(type.toKotlinType(), origin)
             is PsiArrayType -> {
                 val componentType = ResolverImpl.instance.resolveJavaType(type.componentType)
                 if (type.componentType !is PsiPrimitiveType) {
                     KSClassifierReferenceDescriptorImpl.getCached(
-                        ResolverImpl.instance.module.builtIns.getArrayType(Variance.INVARIANT, componentType)
+                        ResolverImpl.instance.module.builtIns.getArrayType(Variance.INVARIANT, componentType),
+                        origin
                     )
                 } else {
                     KSClassifierReferenceDescriptorImpl.getCached(
-                        ResolverImpl.instance.module.builtIns.getPrimitiveArrayKotlinTypeByPrimitiveKotlinType(componentType)!!
+                        ResolverImpl.instance.module.builtIns.getPrimitiveArrayKotlinTypeByPrimitiveKotlinType(componentType)!!, origin
                     )
                 }
             }
-            null -> KSClassifierReferenceDescriptorImpl.getCached((ResolverImpl.instance.builtIns.anyType as KSTypeImpl).kotlinType.makeNullable())
+            null -> KSClassifierReferenceDescriptorImpl.getCached((ResolverImpl.instance.builtIns.anyType as KSTypeImpl).kotlinType.makeNullable(), origin)
             else -> throw IllegalStateException("Unexpected psi type for ${type.javaClass}, $ExceptionMessage")
         }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyGetterImpl.kt
@@ -40,7 +40,7 @@ class KSPropertyGetterImpl private constructor(ktPropertyGetter: KtPropertyAcces
             KSTypeReferenceImpl.getCached(property.typeReference!!)
         } else {
             val desc = ResolverImpl.instance.resolveDeclaration(property) as PropertyDescriptor
-            KSTypeReferenceDescriptorImpl.getCached(desc.returnType!!)
+            KSTypeReferenceDescriptorImpl.getCached(desc.returnType!!, origin)
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -59,8 +59,9 @@ class KSTypeImpl private constructor(
         }
     }
 
+    // TODO: fix calls to getKSTypeCached and use ksTypeArguments when available.
     override val arguments: List<KSTypeArgument> by lazy {
-        kotlinType.arguments.map { KSTypeArgumentDescriptorImpl.getCached(it) }
+        kotlinType.arguments.map { KSTypeArgumentDescriptorImpl.getCached(it, Origin.SYNTHETIC) }
     }
 
     override fun isAssignableFrom(that: KSType): Boolean {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSPropertyGetterSyntheticImpl.kt
@@ -40,7 +40,7 @@ class KSPropertyGetterSyntheticImpl(val ksPropertyDeclaration: KSPropertyDeclara
 
     override val returnType: KSTypeReference? by lazy {
         if (descriptor.returnType != null) {
-            KSTypeReferenceDescriptorImpl.getCached(descriptor.returnType!!)
+            KSTypeReferenceDescriptorImpl.getCached(descriptor.returnType!!, origin)
         } else {
             null
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSTypeReferenceSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSTypeReferenceSyntheticImpl.kt
@@ -25,4 +25,8 @@ class KSTypeReferenceSyntheticImpl(val ksType: KSType) : KSTypeReference {
     override fun resolve(): KSType {
         return ksType
     }
+
+    override fun toString(): String {
+        return ksType.toString()
+    }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSValueParameterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSValueParameterSyntheticImpl.kt
@@ -25,7 +25,7 @@ class KSValueParameterSyntheticImpl(val owner: KSAnnotated?, resolve: () -> Valu
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type)
+        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
     override val isVararg: Boolean = descriptor.isVararg

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -373,8 +373,8 @@ internal fun ModuleClassResolver.resolveContainingClass(psiMethod: PsiMethod): C
 }
 
 internal fun KSAnnotated.getInstanceForCurrentRound(): KSAnnotated? {
-    if (this.origin == Origin.CLASS) {
-        return null
+    when (origin) {
+        Origin.KOTLIN_LIB, Origin.JAVA_LIB -> return null
     }
     return when (this) {
         is KSClassDeclarationImpl -> KSClassDeclarationImpl.getCached(this.ktClassOrObject)

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -197,6 +197,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/javaTypes2.kt");
     }
 
+    @TestMetadata("libOrigins.kt")
+    public void testLibOrigins() throws Exception {
+        runTest("testData/api/libOrigins.kt");
+    }
+
     @TestMetadata("makeNullable.kt")
     public void testMakeNullable() throws Exception {
         runTest("testData/api/makeNullable.kt");

--- a/compiler-plugin/testData/api/crossModuleTypeAlias.kt
+++ b/compiler-plugin/testData/api/crossModuleTypeAlias.kt
@@ -2,8 +2,8 @@
 // TEST PROCESSOR: CrossModuleTypeAliasTestProcessor
 // EXPECTED:
 // A1(KOTLIN)
-// A2(CLASS)
-// M1(CLASS)
+// A2(KOTLIN_LIB)
+// M1(KOTLIN_LIB)
 // END
 
 // MODULE: module1

--- a/compiler-plugin/testData/api/getPackage.kt
+++ b/compiler-plugin/testData/api/getPackage.kt
@@ -20,12 +20,12 @@
 // symbols from package lib1
 // lib1.FooInSource KOTLIN
 // lib1.propInSource KOTLIN
-// lib1.Bar CLASS
-// lib1.Foo CLASS
-// lib1.funcFoo CLASS
+// lib1.Bar JAVA_LIB
+// lib1.Foo KOTLIN_LIB
+// lib1.funcFoo KOTLIN_LIB
 // symbols from package lib2
-// lib2.Foo CLASS
-// lib2.a CLASS
+// lib2.Foo KOTLIN_LIB
+// lib2.a KOTLIN_LIB
 // symbols from package main
 // main.KotlinMain KOTLIN
 // END

--- a/compiler-plugin/testData/api/libOrigins.kt
+++ b/compiler-plugin/testData/api/libOrigins.kt
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: LibOriginsProcessor
+// EXPECTED:
+// annotation: Anno1: KOTLIN_LIB
+// annotation: Anno2: JAVA_LIB
+// annotation: Anno3: KOTLIN
+// annotation: Anno4: JAVA
+// classifier ref: Anno1: KOTLIN_LIB
+// classifier ref: Anno1: KOTLIN_LIB
+// classifier ref: Anno2: JAVA_LIB
+// classifier ref: Anno2: KOTLIN_LIB
+// classifier ref: Anno3: KOTLIN
+// classifier ref: Anno3: KOTLIN_LIB
+// classifier ref: Anno4: KOTLIN_LIB
+// classifier ref: Annotation: KOTLIN_LIB
+// classifier ref: Annotation: KOTLIN_LIB
+// classifier ref: Annotation: KOTLIN_LIB
+// classifier ref: Annotation: KOTLIN_LIB
+// classifier ref: Any: JAVA_LIB
+// classifier ref: Any: JAVA_LIB
+// classifier ref: Any: JAVA_LIB
+// classifier ref: Any: KOTLIN_LIB
+// classifier ref: Any: KOTLIN_LIB
+// classifier ref: Any: KOTLIN_LIB
+// classifier ref: ArrayList<(T2..T2?)>: JAVA_LIB
+// classifier ref: Byte: JAVA_LIB
+// classifier ref: Byte: JAVA_LIB
+// classifier ref: Byte: JAVA_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: Int: KOTLIN_LIB
+// classifier ref: JavaLib: JAVA_LIB
+// classifier ref: JavaLib: JAVA_LIB
+// classifier ref: JavaLib: JAVA_LIB
+// classifier ref: JavaLib<T2>: JAVA_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass: KOTLIN_LIB
+// classifier ref: KotlinLibClass<T1>: KOTLIN_LIB
+// classifier ref: KotlinSrcClass: SYNTHETIC
+// classifier ref: List<Int>: KOTLIN_LIB
+// classifier ref: List<T1>: KOTLIN_LIB
+// classifier ref: List<T1>: KOTLIN_LIB
+// classifier ref: List<T1>: KOTLIN_LIB
+// classifier ref: List<T1>: KOTLIN_LIB
+// classifier ref: Long: JAVA
+// classifier ref: Long: JAVA
+// classifier ref: Long: JAVA
+// classifier ref: Object: JAVA
+// classifier ref: Set: KOTLIN
+// classifier ref: Set: KOTLIN
+// classifier ref: Set: KOTLIN
+// classifier ref: Set: KOTLIN
+// classifier ref: Set<T3>: SYNTHETIC
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: KOTLIN
+// classifier ref: Short: SYNTHETIC
+// classifier ref: Short: SYNTHETIC
+// classifier ref: Short: SYNTHETIC
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T1: KOTLIN_LIB
+// classifier ref: T2: JAVA_LIB
+// classifier ref: T2: JAVA_LIB
+// classifier ref: T2: JAVA_LIB
+// classifier ref: T3: KOTLIN
+// classifier ref: T3: KOTLIN
+// classifier ref: T3: KOTLIN
+// classifier ref: T3: KOTLIN
+// classifier ref: T3: SYNTHETIC
+// classifier ref: T4: JAVA
+// classifier ref: T4: JAVA
+// declaration: <init>: KOTLIN
+// declaration: T3: KOTLIN
+// declaration: foo.bar.Anno1.<init>: KOTLIN_LIB
+// declaration: foo.bar.Anno1: KOTLIN_LIB
+// declaration: foo.bar.Anno2.<init>: KOTLIN_LIB
+// declaration: foo.bar.Anno2: KOTLIN_LIB
+// declaration: foo.bar.Anno3.<init>: KOTLIN_LIB
+// declaration: foo.bar.Anno3: KOTLIN_LIB
+// declaration: foo.bar.Anno4.<init>: KOTLIN_LIB
+// declaration: foo.bar.Anno4: KOTLIN_LIB
+// declaration: foo.bar.JavaLib.<init>: JAVA_LIB
+// declaration: foo.bar.JavaLib.T2: JAVA_LIB
+// declaration: foo.bar.JavaLib.T2: JAVA_LIB
+// declaration: foo.bar.JavaLib.f1: JAVA_LIB
+// declaration: foo.bar.JavaLib.javaLibField: JAVA_LIB
+// declaration: foo.bar.JavaLib.javaLibFunction: JAVA_LIB
+// declaration: foo.bar.JavaLib: JAVA_LIB
+// declaration: foo.bar.JavaSrc.<init>: SYNTHETIC
+// declaration: foo.bar.JavaSrc.LinkedList: JAVA
+// declaration: foo.bar.JavaSrc.f2: JAVA
+// declaration: foo.bar.JavaSrc.javaSrcField: JAVA
+// declaration: foo.bar.JavaSrc.javaSrcFunction: JAVA
+// declaration: foo.bar.JavaSrc.p0: JAVA
+// declaration: foo.bar.JavaSrc: JAVA
+// declaration: foo.bar.KotlinLibClass.<init>: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.T1: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.T1: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.f1: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.f2: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.f3: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.p1: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.p2: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass.p3: KOTLIN_LIB
+// declaration: foo.bar.KotlinLibClass: KOTLIN_LIB
+// declaration: foo.bar.KotlinSrcClass.g1: KOTLIN
+// declaration: foo.bar.KotlinSrcClass.g2: KOTLIN
+// declaration: foo.bar.KotlinSrcClass.g3: KOTLIN
+// declaration: foo.bar.KotlinSrcClass.q1: KOTLIN
+// declaration: foo.bar.KotlinSrcClass.q2: KOTLIN
+// declaration: foo.bar.KotlinSrcClass.q3: KOTLIN
+// declaration: foo.bar.KotlinSrcClass: KOTLIN
+// declaration: foo.bar.kotlinLibFuntion: KOTLIN_LIB
+// declaration: foo.bar.kotlinLibProperty: KOTLIN_LIB
+// declaration: foo.bar.kotlinSrcFuntion: KOTLIN
+// declaration: foo.bar.kotlinSrcProperty: KOTLIN
+// property accessor: kotlinLibProperty.getter(): KOTLIN_LIB
+// property accessor: kotlinSrcProperty.getter(): SYNTHETIC
+// property accessor: p1.getter(): KOTLIN_LIB
+// property accessor: p2.getter(): KOTLIN_LIB
+// property accessor: p3.getter(): KOTLIN_LIB
+// property accessor: q1.getter(): SYNTHETIC
+// property accessor: q2.getter(): SYNTHETIC
+// property accessor: q3.getter(): SYNTHETIC
+// reference: Anno1: KOTLIN_LIB
+// reference: Anno1: KOTLIN_LIB
+// reference: Anno2: JAVA_LIB
+// reference: Anno2: KOTLIN_LIB
+// reference: Anno3: KOTLIN
+// reference: Anno3: KOTLIN_LIB
+// reference: Anno4: JAVA
+// reference: Anno4: KOTLIN_LIB
+// reference: Annotation: KOTLIN_LIB
+// reference: Annotation: KOTLIN_LIB
+// reference: Annotation: KOTLIN_LIB
+// reference: Annotation: KOTLIN_LIB
+// reference: Any: JAVA_LIB
+// reference: Any: JAVA_LIB
+// reference: Any: JAVA_LIB
+// reference: Any: KOTLIN_LIB
+// reference: Any: KOTLIN_LIB
+// reference: Any: KOTLIN_LIB
+// reference: ArrayList<(T2..T2?)>: JAVA_LIB
+// reference: Byte: JAVA_LIB
+// reference: Byte: JAVA_LIB
+// reference: Byte: JAVA_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: Int: KOTLIN_LIB
+// reference: JavaLib<T2>: JAVA_LIB
+// reference: JavaSrc: SYNTHETIC
+// reference: KotlinLibClass<T1>: KOTLIN_LIB
+// reference: KotlinSrcClass<T3>: KOTLIN
+// reference: List<Int>: KOTLIN_LIB
+// reference: List<T1>: KOTLIN_LIB
+// reference: List<T1>: KOTLIN_LIB
+// reference: List<T1>: KOTLIN_LIB
+// reference: List<T1>: KOTLIN_LIB
+// reference: Long: JAVA
+// reference: Long: JAVA
+// reference: Long: JAVA
+// reference: Object: JAVA
+// reference: Set: KOTLIN
+// reference: Set: KOTLIN
+// reference: Set: KOTLIN
+// reference: Set: KOTLIN
+// reference: Set<T3>: SYNTHETIC
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: KOTLIN
+// reference: Short: SYNTHETIC
+// reference: Short: SYNTHETIC
+// reference: Short: SYNTHETIC
+// reference: T1: KOTLIN_LIB
+// reference: T1: KOTLIN_LIB
+// reference: T1: KOTLIN_LIB
+// reference: T1: KOTLIN_LIB
+// reference: T1: KOTLIN_LIB
+// reference: T1: KOTLIN_LIB
+// reference: T2: JAVA_LIB
+// reference: T2: JAVA_LIB
+// reference: T2: JAVA_LIB
+// reference: T3: KOTLIN
+// reference: T3: KOTLIN
+// reference: T3: KOTLIN
+// reference: T3: KOTLIN
+// reference: T3: SYNTHETIC
+// reference: T4: JAVA
+// reference: T4: JAVA
+// type arg: INVARIANT Int: KOTLIN_LIB
+// type arg: INVARIANT Short: KOTLIN
+// type arg: INVARIANT T1: KOTLIN_LIB
+// type arg: INVARIANT T1: KOTLIN_LIB
+// type arg: INVARIANT T1: KOTLIN_LIB
+// type arg: INVARIANT T1: KOTLIN_LIB
+// type arg: INVARIANT T1: KOTLIN_LIB
+// type arg: INVARIANT T2: JAVA_LIB
+// type arg: INVARIANT T2: JAVA_LIB
+// type arg: INVARIANT T3: KOTLIN
+// type arg: INVARIANT T3: KOTLIN
+// type arg: INVARIANT T3: KOTLIN
+// type arg: INVARIANT T3: SYNTHETIC
+// value param: p0: JAVA_LIB
+// value param: p1: JAVA_LIB
+// value param: p1: KOTLIN_LIB
+// value param: p2: KOTLIN_LIB
+// value param: p4: KOTLIN_LIB
+// value param: p5: KOTLIN_LIB
+// value param: p6: KOTLIN_LIB
+// value param: q1: KOTLIN
+// value param: q2: KOTLIN
+// value param: q4: KOTLIN
+// value param: q5: KOTLIN
+// value param: q6: KOTLIN
+// END
+// MODULE: module1
+// FILE: KotlinLib.kt
+package foo.bar
+
+val kotlinLibProperty: Int = 0
+fun kotlinLibFuntion(): Int = 0
+
+annotation class Anno1
+annotation class Anno2
+annotation class Anno3
+annotation class Anno4
+
+@Anno1
+class KotlinLibClass<T1>(val p1: List<T1>, val p2: Int)  {
+    val p3: Int = 0
+    fun f1(p4: T1): Int = 0
+    fun f2(p5: List<T1>): Int = 0
+    fun f3(p6: List<Int>): Int = 0
+}
+
+// FILE: JavaLib.java
+package foo.bar;
+
+import java.util.ArrayList;
+
+@Anno2
+class JavaLib<T2> {
+    Byte javaLibField = 0;
+    Byte javaLibFunction() {
+        return 0;
+    }
+    Byte f1(T2 p0, ArrayList<T2> p1) {
+        return 0;
+    }
+}
+
+// MODULE: main(module1)
+// FILE: KotlinSrc.kt
+package foo.bar
+val kotlinSrcProperty: Short = 0
+fun kotlinSrcFuntion(): Short = 0
+
+@Anno3
+class KotlinSrcClass<T3>(val q1: Set<T3>, val q2: Short)  {
+    val q3: Short = 0
+    fun g1(q4: T3): Short = 0
+    fun g2(q5: Set<T3>): Short = 0
+    fun g3(q6: Set<Short>): Short = 0
+}
+
+// FILE: JavaSrc.java
+package foo.bar;
+
+import java.util.LinkedList;
+
+@Anno4
+class JavaSrc {
+    Long javaSrcField = 0;
+    Long javaSrcFunction() {
+        return 0;
+    }
+    Long f2<T4>(T4 p0, LinkedList<T4> p1) {
+        return 0;
+    }
+}
+

--- a/compiler-plugin/testData/api/multipleModules.kt
+++ b/compiler-plugin/testData/api/multipleModules.kt
@@ -2,11 +2,11 @@
 // TEST PROCESSOR: MultiModuleTestProcessor
 // EXPECTED:
 // ClassInMainModule[KOTLIN]
-// ClassInModule1[CLASS]
-// ClassInModule2[CLASS]
+// ClassInModule1[KOTLIN_LIB]
+// ClassInModule2[KOTLIN_LIB]
 // JavaClassInMainModule[JAVA]
-// JavaClassInModule1[CLASS]
-// JavaClassInModule2[CLASS]
+// JavaClassInModule1[JAVA_LIB]
+// JavaClassInModule2[JAVA_LIB]
 // TestTarget[KOTLIN]
 // END
 // MODULE: module1


### PR DESCRIPTION
For KSAnnotationDescriptor, check whether the underlying descripter is
JavaAnnotationDescriptor.

For KSDeclarationDescriptorImpl, KSPropertyAccessorDescriptorImpl and
KSValueParameterDescriptorImpl, check whether they are contained by
JavaClassDescriptor.

For KSTypeReferenceDescriptorImpl, KSClassifierReferenceDescriptorImpl
and KSTypeArgumentDescriptorImpl, specify the origin in their creation
appropriately. Most of time it is the same as where they are created.
The only exception is when it's created for type arguemnts from KotlinType.
In that case it is SYNTHETIC.
