### PR TITLE
Extract create args to SymbolProcessorEnvironment

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,7 @@ KSP expects an implementation of the `SymbolProcessorProvider` interface to inst
 
 ```kotlin
 interface SymbolProcessorProvider {
-    fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
-    ): SymbolProcessor
+    fun create(environment: SymbolProcessorEnvironment): SymbolProcessor
 }
 ```
 
@@ -148,7 +143,7 @@ class HelloFunctionFinderProcessor : SymbolProcessor() {
     ...
     
     class Provider : SymbolProcessorProvider {
-        override fun create(...): SymbolProcessor = ...
+        override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = ...
     }
 }
 ```

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironemnt.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironemnt.kt
@@ -1,0 +1,20 @@
+package com.google.devtools.ksp.processing
+
+class SymbolProcessorEnvironment(
+    /**
+     * passed from command line, Gradle, etc.
+     */
+    val options: Map<String, String>,
+    /**
+     * language version of compilation environment.
+     */
+    val kotlinVersion: KotlinVersion,
+    /**
+     * creates managed files.
+     */
+    val codeGenerator: CodeGenerator,
+    /**
+     * for logging to build output.
+     */
+    val logger: KSPLogger
+)

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorProvider.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorProvider.kt
@@ -3,19 +3,9 @@ package com.google.devtools.ksp.processing
 /**
  * [SymbolProcessorProvider] is the interface used by plugins to integrate into Kotlin Symbol Processing.
  */
-fun interface SymbolProcessorProvider {
+interface SymbolProcessorProvider {
     /**
-    * Called by Kotlin Symbol Processing to create the processor.
-    *
-    * @param options passed from command line, Gradle, etc.
-    * @param kotlinVersion language version of compilation environment.
-    * @param codeGenerator creates managed files.
-    * @param logger for logging to build output.
-    */
-    fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
-    ): SymbolProcessor
+     * Called by Kotlin Symbol Processing to create the processor.
+     */
+    fun create(environment: SymbolProcessorEnvironment): SymbolProcessor
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -1,6 +1,5 @@
 package com.google.devtools.ksp.visitor
 
-import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.symbol.*
 
 class KSValidateVisitor(private val predicate: (KSNode?, KSNode) -> Boolean) : KSDefaultVisitor<KSNode?, Boolean>() {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.processing.impl.CodeGeneratorImpl
 import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
@@ -149,7 +150,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(val options: KspOptions, 
             processors = providers.mapNotNull { provider ->
                 var processor: SymbolProcessor? = null
                 handleException {
-                    processor = provider.create(options.processingOptions, KotlinVersion.CURRENT, codeGenerator, logger)
+                    processor = provider.create(SymbolProcessorEnvironment(options.processingOptions, KotlinVersion.CURRENT, codeGenerator, logger))
                 }?.let { analysisResult -> return@doAnalysis analysisResult }
                 if (logger.hasError()) {
                     return@mapNotNull null

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/LegacySymbolProcessorAdapter.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/LegacySymbolProcessorAdapter.kt
@@ -1,19 +1,13 @@
 package com.google.devtools.ksp
 
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
 internal class LegacySymbolProcessorAdapter(
     private val symbolProcessor: SymbolProcessor
 ) : SymbolProcessorProvider {
-    override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
-    ): SymbolProcessor = symbolProcessor.apply {
-        init(options, kotlinVersion, codeGenerator, logger)
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = symbolProcessor.apply {
+        init(environment.options, environment.kotlinVersion, environment.codeGenerator, environment.logger)
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
@@ -18,18 +18,12 @@
 
 package com.google.devtools.ksp.processor
 
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
 abstract class AbstractTestProcessor : SymbolProcessor, SymbolProcessorProvider {
     abstract fun toResult(): List<String>
 
-    override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
-    ): SymbolProcessor = this
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = this
 }

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -143,7 +143,7 @@
 </details>
 
 ## Pass Options to Processors
-Processor options in `SymbolProcessorProvider.create(options: Map<String, String>, ...)` are specified in gradle build scripts:
+Processor options in `SymbolProcessorEnvironment.options` are specified in gradle build scripts:
 ```
   ksp {
     arg("option1", "value1")

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -59,7 +59,7 @@ class GradleCompilationTest {
             }
         }
 
-        class Provider : TestSymbolProcessorProvider({ _, _, _, logger -> ErrorReporting(logger) })
+        class Provider : TestSymbolProcessorProvider({ env -> ErrorReporting(env.logger) })
 
         testRule.addProvider(Provider::class)
         val failure = testRule.runner()
@@ -105,7 +105,7 @@ class GradleCompilationTest {
             }
         }
 
-        class Provider : TestSymbolProcessorProvider({ _, _, codeGenerator, _ -> MyProcessor(codeGenerator) })
+        class Provider : TestSymbolProcessorProvider({ env -> MyProcessor(env.codeGenerator) })
 
         testRule.addProvider(Provider::class)
 

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -268,7 +268,7 @@ class SourceSetConfigurationsTest {
             }
         }
 
-        class Provider : TestSymbolProcessorProvider({ _, _, codeGenerator, _ -> Processor(codeGenerator) })
+        class Provider : TestSymbolProcessorProvider({ env -> Processor(env.codeGenerator) })
 
         testRule.addProvider(Provider::class)
         if (useAndroidTest) {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/processor/TestSymbolProcessorProvider.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/processor/TestSymbolProcessorProvider.kt
@@ -16,23 +16,14 @@
  */
 package com.google.devtools.ksp.gradle.processor
 
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.KSPLogger
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
 abstract class TestSymbolProcessorProvider(
     private val builder: (
-        options: Map<String, String>,
-        version: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
+        environment: SymbolProcessorEnvironment
     ) -> SymbolProcessor
 ) : SymbolProcessorProvider {
-    override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
-    ): SymbolProcessor = builder(options, kotlinVersion, codeGenerator, logger)
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = builder(environment)
 }

--- a/integration-tests/src/test/resources/init-plus-provider/provider-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/init-plus-provider/provider-processor/src/main/kotlin/TestProcessor.kt
@@ -37,10 +37,7 @@ class TestProcessor(options: Map<String, String>, val codeGenerator: CodeGenerat
 
     class Provider : SymbolProcessorProvider {
         override fun create(
-            options: Map<String, String>,
-            kotlinVersion: KotlinVersion,
-            codeGenerator: CodeGenerator,
-            logger: KSPLogger
-        ): SymbolProcessor = TestProcessor(options, codeGenerator)
+            environment: SymbolProcessorEnvironment
+        ): SymbolProcessor = TestProcessor(environment.options, environment.codeGenerator)
     }
 }

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,8 +1,4 @@
-import com.google.devtools.ksp.processing.CodeGenerator
-import com.google.devtools.ksp.processing.Dependencies
-import com.google.devtools.ksp.processing.KSPLogger
-import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
 import com.google.devtools.ksp.visitor.KSDefaultVisitor
@@ -49,5 +45,3 @@ class TestProcessor : SymbolProcessor {
         return emptyList()
     }
 }
-
-

--- a/integration-tests/src/test/resources/refs-gen/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/refs-gen/test-processor/src/main/kotlin/TestProcessor.kt
@@ -41,11 +41,8 @@ class TestProcessor(
 
 class TestProcessorProvider : SymbolProcessorProvider {
     override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
+        environment: SymbolProcessorEnvironment
     ): SymbolProcessor {
-        return TestProcessor(codeGenerator, logger)
+        return TestProcessor(environment.codeGenerator, environment.logger)
     }
 }

--- a/integration-tests/src/test/resources/sealed-subclasses/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/sealed-subclasses/test-processor/src/main/kotlin/TestProcessor.kt
@@ -22,11 +22,8 @@ class TestProcessor(
 
 class TestProcessorProvider : SymbolProcessorProvider {
     override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
+        environment: SymbolProcessorEnvironment
     ): SymbolProcessor {
-        return TestProcessor(codeGenerator, logger)
+        return TestProcessor(environment.codeGenerator, environment.logger)
     }
 }

--- a/integration-tests/src/test/resources/srcs-gen/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/srcs-gen/test-processor/src/main/kotlin/TestProcessor.kt
@@ -47,11 +47,8 @@ class TestProcessor(
 
 class TestProcessorProvider : SymbolProcessorProvider {
     override fun create(
-        options: Map<String, String>,
-        kotlinVersion: KotlinVersion,
-        codeGenerator: CodeGenerator,
-        logger: KSPLogger
+        environment: SymbolProcessorEnvironment
     ): SymbolProcessor {
-        return TestProcessor(codeGenerator, logger)
+        return TestProcessor(environment.codeGenerator, environment.logger)
     }
 }


### PR DESCRIPTION
This allows future arguments to be added without forcing changes to downstream
processors. Naming is modeled after apt's ProcessingEnvironment.