### PR TITLE
Remove kotlinOptions.jvmTarget specification

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,7 +3,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 description = "Kotlin Symbol Processing API"
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
 }
 

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -11,7 +11,6 @@ val compilerTestEnabled: String by project
 val libsForTesting by configurations.creating
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -8,7 +8,6 @@ val googleTruthVersion: String by project
 val agpBaseVersion: String by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = "1.8"
     kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
 }
 


### PR DESCRIPTION
Kotlin 1.5 now targets JVM 1.8 [by defaut](https://kotlinlang.org/docs/whatsnew15.html#new-default-jvm-target-1-8), so there's no need to specify it again explicitly.