### PR TITLE
Make KSP arguments public

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -22,6 +22,8 @@ import org.gradle.api.GradleException
 open class KspExtension {
     internal val apOptions = mutableMapOf<String, String>()
 
+    open val arguments: Map<String, String> get() = apOptions.toMap()
+
     open fun arg(k: String, v: String) {
         if ('=' in k) {
             throw GradleException("'=' is not allowed in custom option's name.")


### PR DESCRIPTION
Right now, `apOptions` are internal to the KSP Gradle plugin. Reading these options is useful for other Gradle plugins that might want to interact with KSP and options passed to it. For example the [prefiller plugin](https://github.com/simonschiller/prefiller) I'm maintaining needs access to some arguments passed to Room.

 Both [KAPT](https://github.com/JetBrains/kotlin/blob/617d99faac5ba0b9cb5dc1957b10b01153b94c4f/libraries/tools/kotlin-gradle-plugin/src/main/kotlin/org/jetbrains/kotlin/gradle/plugin/KaptExtension.kt#L104-L108) and [Java APT](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-master-dev:build-system/gradle-core/src/main/java/com/android/build/gradle/api/AnnotationProcessorOptions.java;l=36-42;drc=b9f365bba6605d0adf19f88a311e808906f31e1c) also allow easy public access to their arguments.