### PR TITLE
fix getDeclarationsFromPackage to exclude symbols found in module descriptor

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -134,7 +134,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(val options: KspOptions, 
         }
 
         // dirtyFiles cannot be reused because they are created in the old container.
-        val resolver = ResolverImpl(module, ksFiles.filterNot { it.filePath in cleanFilenames }, newFiles, deferredSymbols, bindingTrace, project, componentProvider, incrementalContext)
+        val resolver = ResolverImpl(module, ksFiles.filterNot { it.filePath in cleanFilenames }, newFiles, deferredSymbols, bindingTrace, project, componentProvider, incrementalContext, options)
 
         val providers = loadProviders()
         if (!initialized) {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/GetPackageProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/GetPackageProcessor.kt
@@ -15,7 +15,7 @@ class GetPackageProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         addPackage("lib1", resolver)
         addPackage("lib2", resolver)
-        addPackage("main", resolver)
+        addPackage("main.test", resolver)
         return emptyList()
     }
 

--- a/compiler-plugin/testData/api/getPackage.kt
+++ b/compiler-plugin/testData/api/getPackage.kt
@@ -26,10 +26,10 @@
 // symbols from package lib2
 // lib2.Foo KOTLIN_LIB
 // lib2.a KOTLIN_LIB
-// symbols from package main
-// main.KotlinMain KOTLIN
-// main.C JAVA
-// main.D JAVA
+// symbols from package main.test
+// main.test.KotlinMain KOTLIN
+// main.test.C JAVA
+// main.test.D JAVA
 // END
 
 // MODULE: lib1
@@ -66,17 +66,34 @@ class FooInSource
 
 val propInSource = 1
 // FILE: main.kt
-package main
+package main.test
 
 class KotlinMain
 
-// FILE: C.java
-package main;
+// FILE: main/test/C.java
+package main.test;
 
 public class C {
 
 }
 
 class D {
+
+}
+
+// FILE: wrongDir/K.java
+package main;
+
+public class K {
+
+}
+
+class KK {}
+
+
+// FILE: main/test/main/test/L.java
+package main.test;
+
+public class L {
 
 }


### PR DESCRIPTION
A follow up on #442 

Actually module descriptor is able to find symbols from Java source iff the said class is sitting in the file with name and path following Java convention, i.e. for a class `main.C`, it has to be in a file of path `/main/C.java`, therefore ignoring other classes in the same file, or any files not following path convention. With that, a distinct call is needed to filter redundant classes found.