### PR TITLE
Add API to check if a property has a backing field

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -53,6 +53,13 @@ interface KSPropertyDeclaration : KSDeclaration {
     val isMutable: Boolean
 
     /**
+     * True if this property has a backing field
+     *
+     * https://kotlinlang.org/docs/properties.html#backing-fields
+     */
+    val hasBackingField: Boolean
+
+    /**
      * Indicates whether this is a delegated property.
      */
     fun isDelegated(): Boolean

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -53,7 +53,10 @@ interface KSPropertyDeclaration : KSDeclaration {
     val isMutable: Boolean
 
     /**
-     * True if this property has a backing field
+     * True if this property has a backing field.
+     *
+     * Note that, this is specific to the current property and does not check for properties that are overridden by this
+     * property.
      *
      * https://kotlinlang.org/docs/properties.html#backing-fields
      */

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+@Suppress("unused") // used in tests
+@OptIn(KspExperimental::class)
+open class BackingFieldProcessor : AbstractTestProcessor() {
+    lateinit var results: List<String>
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        results = listOf("lib", "main").flatMap { pkg ->
+            resolver.getDeclarationsFromPackage(pkg)
+                .flatMap { declaration ->
+                    val properties = mutableListOf<KSPropertyDeclaration>()
+                    declaration.accept(AllMembersVisitor(), properties)
+                    properties
+                }.map {
+                    "${it.qualifiedName?.asString()}: ${it.hasBackingField}"
+                }.sorted()
+        }
+        return emptyList()
+    }
+
+    private class AllMembersVisitor : KSTopDownVisitor<MutableList<KSPropertyDeclaration>, Unit>() {
+        override fun defaultHandler(node: KSNode, data: MutableList<KSPropertyDeclaration>) {
+        }
+
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: MutableList<KSPropertyDeclaration>) {
+            data.add(property)
+            super.visitPropertyDeclaration(property, data)
+        }
+
+
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
@@ -52,8 +52,6 @@ open class BackingFieldProcessor : AbstractTestProcessor() {
             data.add(property)
             super.visitPropertyDeclaration(property, data)
         }
-
-
     }
 
     override fun toResult(): List<String> {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -22,8 +22,6 @@ import org.jetbrains.kotlin.descriptors.*
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.hasBackingField
 
 class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: PropertyDescriptor) : KSPropertyDeclaration,
     KSDeclarationDescriptorImpl(descriptor),
@@ -83,12 +81,9 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
 
-    override val hasBackingField: Boolean
-        get() {
-            // TODO figure out how to do this. existing hasBackingField does not seem to work as I assumed
-            //  see links in `hasBackingFieldFixed` for more details
-            return descriptor.hasBackingFieldFixed()
-        }
+    override val hasBackingField: Boolean by lazy {
+        descriptor.hasBackingFieldWithBinaryClassSupport()
+    }
 
     override fun findOverridee(): KSPropertyDeclaration? {
         val propertyDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(this)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -22,6 +22,8 @@ import org.jetbrains.kotlin.descriptors.*
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.hasBackingField
 
 class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: PropertyDescriptor) : KSPropertyDeclaration,
     KSDeclarationDescriptorImpl(descriptor),
@@ -80,6 +82,13 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     override val type: KSTypeReference by lazy {
         KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin)
     }
+
+    override val hasBackingField: Boolean
+        get() {
+            // TODO figure out how to do this. existing hasBackingField does not seem to work as I assumed
+            //  see links in `hasBackingFieldFixed` for more details
+            return descriptor.hasBackingFieldFixed()
+        }
 
     override fun findOverridee(): KSPropertyDeclaration? {
         val propertyDescriptor = ResolverImpl.instance.resolvePropertyDeclaration(this)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -40,6 +40,9 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) : KSP
 
     override val isMutable: Boolean = true
 
+    override val hasBackingField: Boolean
+        get() = true
+
     override val annotations: Sequence<KSAnnotation> by lazy {
         psi.annotations.asSequence().map { KSAnnotationJavaImpl.getCached(it) }.memoized()
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -30,6 +30,8 @@ import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.hasBackingField
 
 class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) : KSPropertyDeclaration, KSDeclarationImpl(ktProperty),
     KSExpectActual by KSExpectActualImpl(ktProperty) {
@@ -56,6 +58,9 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
     override val isMutable: Boolean by lazy {
         ktProperty.isVar
     }
+
+    override val hasBackingField: Boolean
+        get() = propertyDescriptor?.hasBackingFieldFixed() ?: true
 
     override val getter: KSPropertyGetter? by lazy {
         ktProperty.getter?.let {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -60,7 +60,7 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
     }
 
     override val hasBackingField: Boolean
-        get() = propertyDescriptor?.hasBackingFieldFixed() ?: true
+        get() = ktProperty.initializer != null
 
     override val getter: KSPropertyGetter? by lazy {
         ktProperty.getter?.let {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -41,6 +41,9 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
         ktParameter.findParentDeclaration()!!.parentDeclaration
     }
 
+    override val hasBackingField: Boolean
+        get() = true
+
     override val extensionReceiver: KSTypeReference? = null
 
     override val isMutable: Boolean by lazy {

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -72,6 +72,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/asMemberOf.kt");
     }
 
+    @TestMetadata("backingFields.kt")
+    public void testBackingFields() throws Exception {
+        runTest("testData/api/backingFields.kt");
+    }
+
     @TestMetadata("builtInTypes.kt")
     public void testBuiltInTypes() throws Exception {
         runTest("testData/api/builtInTypes.kt");

--- a/compiler-plugin/testData/api/backingFields.kt
+++ b/compiler-plugin/testData/api/backingFields.kt
@@ -18,10 +18,24 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: BackingFieldProcessor
 // EXPECTED:
+// lib.BaseClass.abstractProp_willBeBacked: false
+// lib.BaseClass.abstractProp_wontBeBacked: false
+// lib.BaseClass.notOverriddenAbstractProp: true
+// lib.BaseClass.overriddenBaseProp_willBeBacked: true
+// lib.BaseClass.overriddenBaseProp_wontBeBacked: true
+// lib.ChildClass.abstractProp_willBeBacked: true
+// lib.ChildClass.abstractProp_wontBeBacked: false
+// lib.ChildClass.interfaceProp_willBeBacked: true
+// lib.ChildClass.interfaceProp_wontBeBacked: false
+// lib.ChildClass.overriddenBaseProp_willBeBacked: true
+// lib.ChildClass.overriddenBaseProp_wontBeBacked: false
 // lib.DataClass.value_Param: true
 // lib.DataClass.variable_Param: true
 // lib.JavaClass.javaField: true
 // lib.JavaClass.javaFieldWithAccessors: true
+// lib.MyInterface.interfaceProp_willBeBacked: false
+// lib.MyInterface.interfaceProp_wontBeBacked: false
+// lib.NormalClass.jvmField_withBacking: true
 // lib.NormalClass.value: true
 // lib.NormalClass.value_Param: true
 // lib.NormalClass.value_noBacking: false
@@ -36,10 +50,23 @@
 // lib.variable: true
 // lib.variable_noBacking: false
 // lib.variable_withBacking: true
+// main.BaseClass.abstractProp_willBeBacked: false
+// main.BaseClass.abstractProp_wontBeBacked: false
+// main.BaseClass.notOverriddenAbstractProp: true
+// main.BaseClass.overriddenBaseProp_willBeBacked: true
+// main.BaseClass.overriddenBaseProp_wontBeBacked: true
+// main.ChildClass.abstractProp_willBeBacked: true
+// main.ChildClass.abstractProp_wontBeBacked: false
+// main.ChildClass.interfaceProp_willBeBacked: true
+// main.ChildClass.interfaceProp_wontBeBacked: false
+// main.ChildClass.overriddenBaseProp_willBeBacked: true
+// main.ChildClass.overriddenBaseProp_wontBeBacked: false
 // main.DataClass.value_Param: true
 // main.DataClass.variable_Param: true
 // main.JavaClass.javaField: true
 // main.JavaClass.javaFieldWithAccessors: true
+// main.MyInterface.interfaceProp_willBeBacked: false
+// main.MyInterface.interfaceProp_wontBeBacked: false
 // main.NormalClass.value: true
 // main.NormalClass.value_Param: true
 // main.NormalClass.value_noBacking: false
@@ -59,6 +86,7 @@
 // MODULE: lib
 // FILE: lib.kt
 package lib
+
 val value: String = ""
 var variable: String = ""
 val value_noBacking: String
@@ -70,6 +98,7 @@ val value_withBacking: String = ""
     get() = field
 var variable_withBacking: String? = null
     get() = field
+
 data class DataClass(
     val value_Param: String,
     var variable_Param: String
@@ -91,6 +120,32 @@ class NormalClass(
         get() = field
     var variable_withBacking: String? = null
         get() = field
+    val jvmField_withBacking: String = ""
+}
+
+abstract class BaseClass {
+    open val overriddenBaseProp_willBeBacked: String = ""
+    open val overriddenBaseProp_wontBeBacked: String = ""
+    open val notOverriddenAbstractProp: String = ""
+    abstract val abstractProp_willBeBacked: String
+    abstract val abstractProp_wontBeBacked: String
+}
+
+interface MyInterface {
+    val interfaceProp_willBeBacked: String
+    val interfaceProp_wontBeBacked: String
+}
+
+class ChildClass: BaseClass(), MyInterface {
+    override val overriddenBaseProp_willBeBacked: String = ""
+    override val overriddenBaseProp_wontBeBacked: String
+        get() = ""
+    override val abstractProp_willBeBacked: String = ""
+    override val abstractProp_wontBeBacked: String
+        get() = ""
+    override val interfaceProp_willBeBacked: String = ""
+    override val interfaceProp_wontBeBacked: String
+        get() = ""
 }
 
 // FILE: lib/JavaClass.java
@@ -99,11 +154,15 @@ public class JavaClass {
     private String javaField;
     private String javaFieldWithAccessors;
 
-    public String getJavaFieldWithAccessors() { return ""; }
-    public void setJavaFieldWithAccessors(String value) { }
+    public String getJavaFieldWithAccessors()
+    { return ""; }
+    public void setJavaFieldWithAccessors(String value )
+    {}
 
-    public String getJavaAccessorWithoutField() { return ""; }
-    public void setJavaAccessorWithoutField(String value) { }
+    public String getJavaAccessorWithoutField()
+    { return ""; }
+    public void setJavaAccessorWithoutField(String value )
+    {}
 }
 
 // MODULE: main(lib)
@@ -125,6 +184,7 @@ data class DataClass(
     val value_Param: String,
     var variable_Param: String
 )
+
 class NormalClass(
     val value_Param: String,
     var variable_Param: String,
@@ -142,15 +202,45 @@ class NormalClass(
     var variable_withBacking: String? = null
         get() = field
 }
+
+abstract class BaseClass {
+    open val overriddenBaseProp_willBeBacked: String = ""
+    open val overriddenBaseProp_wontBeBacked: String = ""
+    open val notOverriddenAbstractProp: String = ""
+    abstract val abstractProp_willBeBacked: String
+    abstract val abstractProp_wontBeBacked: String
+}
+
+interface MyInterface {
+    val interfaceProp_willBeBacked: String
+    val interfaceProp_wontBeBacked: String
+}
+
+class ChildClass: BaseClass(), MyInterface {
+    override val overriddenBaseProp_willBeBacked: String = ""
+    override val overriddenBaseProp_wontBeBacked: String
+        get() = ""
+    override val abstractProp_willBeBacked: String = ""
+    override val abstractProp_wontBeBacked: String
+        get() = ""
+    override val interfaceProp_willBeBacked: String = ""
+    override val interfaceProp_wontBeBacked: String
+        get() = ""
+}
+
 // FILE: main/JavaClass.java
 package main;
 public class JavaClass {
     private String javaField;
     private String javaFieldWithAccessors;
 
-    public String getJavaFieldWithAccessors() { return ""; }
-    public void setJavaFieldWithAccessors(String value) { }
+    public String getJavaFieldWithAccessors()
+    { return ""; }
+    public void setJavaFieldWithAccessors(String value )
+    {}
 
-    public String getJavaAccessorWithoutField() { return ""; }
-    public void setJavaAccessorWithoutField(String value) { }
+    public String getJavaAccessorWithoutField()
+    { return ""; }
+    public void setJavaAccessorWithoutField(String value )
+    {}
 }

--- a/compiler-plugin/testData/api/backingFields.kt
+++ b/compiler-plugin/testData/api/backingFields.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: BackingFieldProcessor
+// EXPECTED:
+// lib.DataClass.value_Param: true
+// lib.DataClass.variable_Param: true
+// lib.JavaClass.javaField: true
+// lib.JavaClass.javaFieldWithAccessors: true
+// lib.NormalClass.value: true
+// lib.NormalClass.value_Param: true
+// lib.NormalClass.value_noBacking: false
+// lib.NormalClass.value_withBacking: true
+// lib.NormalClass.variable: true
+// lib.NormalClass.variable_Param: true
+// lib.NormalClass.variable_noBacking: false
+// lib.NormalClass.variable_withBacking: true
+// lib.value: true
+// lib.value_noBacking: false
+// lib.value_withBacking: true
+// lib.variable: true
+// lib.variable_noBacking: false
+// lib.variable_withBacking: true
+// main.DataClass.value_Param: true
+// main.DataClass.variable_Param: true
+// main.JavaClass.javaField: true
+// main.JavaClass.javaFieldWithAccessors: true
+// main.NormalClass.value: true
+// main.NormalClass.value_Param: true
+// main.NormalClass.value_noBacking: false
+// main.NormalClass.value_withBacking: true
+// main.NormalClass.variable: true
+// main.NormalClass.variable_Param: true
+// main.NormalClass.variable_noBacking: false
+// main.NormalClass.variable_withBacking: true
+// main.value: true
+// main.value_noBacking: false
+// main.value_withBacking: true
+// main.variable: true
+// main.variable_noBacking: false
+// main.variable_withBacking: true
+// END
+
+// MODULE: lib
+// FILE: lib.kt
+package lib
+val value: String = ""
+var variable: String = ""
+val value_noBacking: String
+    get() = "aa"
+var variable_noBacking: String
+    get() = "aa"
+    set(value) {}
+val value_withBacking: String = ""
+    get() = field
+var variable_withBacking: String? = null
+    get() = field
+data class DataClass(
+    val value_Param: String,
+    var variable_Param: String
+)
+
+class NormalClass(
+    val value_Param: String,
+    var variable_Param: String,
+    normalParam: String
+) {
+    val value: String = ""
+    var variable: String = ""
+    val value_noBacking: String
+        get() = "aa"
+    var variable_noBacking: String
+        get() = "aa"
+        set(value) {}
+    val value_withBacking: String = ""
+        get() = field
+    var variable_withBacking: String? = null
+        get() = field
+}
+
+// FILE: lib/JavaClass.java
+package lib;
+public class JavaClass {
+    private String javaField;
+    private String javaFieldWithAccessors;
+
+    public String getJavaFieldWithAccessors() { return ""; }
+    public void setJavaFieldWithAccessors(String value) { }
+
+    public String getJavaAccessorWithoutField() { return ""; }
+    public void setJavaAccessorWithoutField(String value) { }
+}
+
+// MODULE: main(lib)
+// FILE: main.kt
+package main
+val value: String = ""
+var variable: String = ""
+val value_noBacking: String
+    get() = "aa"
+var variable_noBacking: String
+    get() = "aa"
+    set(value) {}
+val value_withBacking: String = ""
+    get() = field
+var variable_withBacking: String? = null
+    get() = field
+
+data class DataClass(
+    val value_Param: String,
+    var variable_Param: String
+)
+class NormalClass(
+    val value_Param: String,
+    var variable_Param: String,
+    normalParam: String
+) {
+    val value: String = ""
+    var variable: String = ""
+    val value_noBacking: String
+        get() = "aa"
+    var variable_noBacking: String
+        get() = "aa"
+        set(value) {}
+    val value_withBacking: String = ""
+        get() = field
+    var variable_withBacking: String? = null
+        get() = field
+}
+// FILE: main/JavaClass.java
+package main;
+public class JavaClass {
+    private String javaField;
+    private String javaFieldWithAccessors;
+
+    public String getJavaFieldWithAccessors() { return ""; }
+    public void setJavaFieldWithAccessors(String value) { }
+
+    public String getJavaAccessorWithoutField() { return ""; }
+    public void setJavaAccessorWithoutField(String value) { }
+}


### PR DESCRIPTION
Unfortunately, the compiler API does not cover deserialized descriptors fully so I've implemented a custom binary class visitor to check that (provided by  @ting-yuan )