### PR TITLE
Update implementation of blockOtherCompilerPlugins

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -330,7 +330,8 @@ abstract class KspTask : KspTaskJ() {
         // Start with / copy from kotlinCompile.
         kotlinCompile.setupCompilerArgs(args, defaultsOnly, ignoreClasspathResolutionErrors)
         if (blockOtherCompilerPlugins) {
-            val cfg = project.configurations.getByName(PLUGIN_CLASSPATH_CONFIGURATION_NAME)
+            // FIXME: ask upstream to provide an API to make this not implementation-dependent.
+            val cfg = project.configurations.getByName((pluginClasspath as Configuration).name)
             val dep = cfg.dependencies.single { it.name == KspGradleSubplugin.KSP_ARTIFACT_NAME }
             args.pluginClasspaths = cfg.files(dep).map { it.canonicalPath }.toTypedArray()
             args.pluginOptions = arrayOf()


### PR DESCRIPTION
Previously, kotlin-gradle-plugin names compiler plugin configuration
after PLUGIN_CLASSPATH_CONFIGURATION_NAME, now it is postfixed by target
and source set names.