### PR TITLE
add a workaround for unsupported type substitution for property accessors

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -754,6 +754,11 @@ class ResolverImpl(
                 )
             }
             val typeSubstitutor = containing.kotlinType.createTypeSubstitutor()
+            if (declaration is PropertyAccessorDescriptor) {
+                val substitutedProperty = (declaration.correspondingProperty).substitute(typeSubstitutor)
+                // TODO: Fix in upstream for property accessors: https://github.com/JetBrains/kotlin/blob/master/core/descriptors/src/org/jetbrains/kotlin/descriptors/impl/PropertyAccessorDescriptorImpl.java#L122
+                return KSFunctionImpl((substitutedProperty as PropertyDescriptor).accessors.single { it.name == declaration.name })
+            }
             val substituted = declaration.substitute(typeSubstitutor)
             return KSFunctionImpl(substituted)
         }

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -85,6 +85,13 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
                 }
             }
         }
+        val javaImpl = resolver.getClassDeclarationByName("JavaImpl")!!
+        val getX = javaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getX" }
+        val getY = javaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "getY" }
+        val setY = javaImpl.getDeclaredFunctions().first { it.simpleName.asString() == "setY" }
+        results.add(getX.asMemberOf(javaImpl.asStarProjectedType()).toSignature())
+        results.add(getY.asMemberOf(javaImpl.asStarProjectedType()).toSignature())
+        results.add(setY.asMemberOf(javaImpl.asStarProjectedType()).toSignature())
         return emptyList()
     }
 

--- a/compiler-plugin/testData/api/asMemberOf.kt
+++ b/compiler-plugin/testData/api/asMemberOf.kt
@@ -85,6 +85,9 @@
 // errorType: (<Error>?) -> <Error>?
 // expected comparison failures
 // <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.String?
+// () -> kotlin.Int!!
+// () -> kotlin.Int!!
+// (kotlin.Int!!) -> kotlin.Unit!!
 // END
 // FILE: Input.kt
 open class Base<BaseTypeArg1, BaseTypeArg2> {
@@ -125,6 +128,11 @@ fun <T>fileLevelFunction():Unit = TODO()
 val fileLevelProperty:Int = 3
 val errorType: NonExistingType
 
+interface KotlinInterface {
+    val x:Int
+    var y:Int
+}
+
 // FILE: JavaInput.java
 class JavaBase<BaseTypeArg1, BaseTypeArg2> {
     int intType;
@@ -142,4 +150,15 @@ class JavaBase<BaseTypeArg1, BaseTypeArg2> {
 }
 
 class JavaChild1 extends JavaBase<String, Integer> {
+}
+
+class JavaImpl implements KotlinInterface {
+    public int getX() {
+        return 1;
+    }
+    public int getY() {
+        return 1;
+    }
+    public void setY(int value) {
+    }
 }


### PR DESCRIPTION
fixes #462 
Current fix relies on the underlying naming convention for `JavaPropertyAccessor` from Kotlin compiler, which might change and break logic. Ultimate change should happen in upstream to fill out the `TODO` for `PropertyAccessorDescriptorImpl`