### PR TITLE
Support K/JS and K/Metadata

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -46,7 +46,7 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.BindingTrace
-import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -32,7 +32,7 @@ import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.psi.PsiTreeChangeAdapter
 import com.intellij.psi.PsiTreeChangeListener
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension
 import java.io.File
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.incremental.LookupTrackerImpl

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -81,6 +81,9 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     private val javaSerializableType = ResolverImpl.instance.javaSerializableType
 
     override val superTypes: Sequence<KSTypeReference> by lazy {
+        if (javaSerializableType == null)
+            return@lazy emptySequence()
+
         descriptor.defaultType.constructor.supertypes.asSequence().map {
             KSTypeReferenceDescriptorImpl.getCached(
                 if (it === mockSerializableType) javaSerializableType else it,

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -79,7 +79,7 @@ class AndroidPluginIntegration(
     fun registerGeneratedJavaSources(
         project: Project,
         kotlinCompilation: KotlinJvmAndroidCompilation,
-        kspTaskProvider: TaskProvider<KspTask>,
+        kspTaskProvider: TaskProvider<KspTaskJvm>,
         javaOutputDir: File,
         classOutputDir: File,
         resourcesOutputDir: FileCollection,

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -225,7 +225,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             return project.provider { emptyList() }
         }
 
-        val sourceSetName = kotlinCompilation.compilationName
+        val sourceSetName = kotlinCompilation.defaultSourceSetName
         val classOutputDir = getKspClassOutputDir(project, sourceSetName)
         val javaOutputDir = getKspJavaOutputDir(project, sourceSetName)
         val kotlinOutputDir = getKspKotlinOutputDir(project, sourceSetName)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -1,0 +1,56 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.*
+
+class KMPImplementedIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("kmp")
+
+    private fun verify(jarName: String, contents: List<String>) {
+        val artifact = File(project.root, jarName)
+        Assert.assertTrue(artifact.exists())
+
+        JarFile(artifact).use { jarFile ->
+            contents.forEach {
+                Assert.assertTrue(jarFile.getEntry(it).size > 0)
+            }
+        }
+    }
+
+    @Test
+    fun testAll() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val resultCleanBuild = gradleRunner.withArguments("clean", "build").build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
+
+        verify(
+            "workload/build/libs/workload-jvm-1.0-SNAPSHOT.jar",
+            listOf(
+                "com/example/Foo.class"
+            )
+        )
+
+        verify(
+            "workload/build/libs/workload-js-1.0-SNAPSHOT.jar",
+            listOf(
+                "playground-workload.js"
+            )
+        )
+
+        verify(
+            "workload/build/libs/workload-metadata-1.0-SNAPSHOT.jar",
+            listOf(
+                "com/example/Foo.kotlin_metadata"
+            )
+        )
+    }
+}

--- a/integration-tests/src/test/resources/kmp/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+    kotlin("multiplatform") apply false
+}
+
+val testRepo: String by project
+subprojects {
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        google()
+    }
+}
+

--- a/integration-tests/src/test/resources/kmp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("multiplatform") version kotlinVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+    }
+}
+
+rootProject.name = "playground"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/kmp/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/test-processor/build.gradle.kts
@@ -1,0 +1,22 @@
+val kspVersion: String by project
+
+plugins {
+    kotlin("multiplatform")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm()
+    sourceSets {
+        val jvmMain by getting {
+            dependencies {
+                implementation("com.squareup:javapoet:1.12.1")
+                implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+            }
+            kotlin.srcDir("src/main/kotlin")
+            resources.srcDir("src/main/resources")
+        }
+    }
+}

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,55 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+import java.io.OutputStreamWriter
+
+
+class TestProcessor(val codeGenerator: CodeGenerator, val logger: KSPLogger) : SymbolProcessor {
+    var invoked = false
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val allFiles = resolver.getAllFiles().map { it.fileName }
+        logger.warn(allFiles.toList().toString())
+        if (invoked) {
+            return emptyList()
+        }
+        invoked = true
+
+        codeGenerator.createNewFile(Dependencies(false), "", "Foo", "kt").use { output ->
+            OutputStreamWriter(output).use { writer ->
+                writer.write("package com.example\n\n")
+                writer.write("class Foo {\n")
+
+                val visitor = ClassVisitor()
+                resolver.getAllFiles().forEach {
+                    it.accept(visitor, writer)
+                }
+
+                writer.write("}\n")
+            }
+
+        }
+        return emptyList()
+    }
+}
+
+class ClassVisitor : KSTopDownVisitor<OutputStreamWriter, Unit>() {
+    override fun defaultHandler(node: KSNode, data: OutputStreamWriter) {
+    }
+
+    override fun visitClassDeclaration(
+        classDeclaration: KSClassDeclaration,
+        data: OutputStreamWriter
+    ) {
+        super.visitClassDeclaration(classDeclaration, data)
+        val symbolName = classDeclaration.simpleName.asString().toLowerCase()
+        data.write("    val $symbolName = true\n")
+    }
+
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(env: SymbolProcessorEnvironment): SymbolProcessor {
+        return TestProcessor(env.codeGenerator, env.logger)
+    }
+}

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider

--- a/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.google.devtools.ksp")
+}
+
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm {
+        withJava()
+    }
+    js() {
+        browser()
+        nodejs()
+    }
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                configurations.get("ksp").dependencies.add(project(":test-processor"))
+            }
+            kotlin.srcDir("src/main/kotlin")
+        }
+    }
+}

--- a/integration-tests/src/test/resources/kmp/workload/src/main/kotlin/com/example/Bar.kt
+++ b/integration-tests/src/test/resources/kmp/workload/src/main/kotlin/com/example/Bar.kt
@@ -1,0 +1,5 @@
+package com.example
+
+class Bar {
+    val baz = Foo().baz
+}

--- a/integration-tests/src/test/resources/kmp/workload/src/main/kotlin/com/example/Baz.kt
+++ b/integration-tests/src/test/resources/kmp/workload/src/main/kotlin/com/example/Baz.kt
@@ -1,0 +1,5 @@
+package com.example
+
+class Baz {
+    val bar = Foo().bar
+}


### PR DESCRIPTION
Currently, only a single `ksp()` configuration is supported in KMP, because the targets are added in configuration. Configurations like `kspJsMain` doesn't seem to be possible unless we built them unconditionally from presets. Unsupported targets are skipped by the else case in `val kspTaskClass = when (kotlinCompileTask) { ... }` around KspSubplugin.kt:246.

Also changed the path of KSP's output so as to accommodate different targets.