### PR TITLE
Adjust heap size for AndroidIT

### DIFF
--- a/integration-tests/src/test/resources/playground-android/gradle.properties
+++ b/integration-tests/src/test/resources/playground-android/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2048M


### PR DESCRIPTION
So as to fix recent OOMEs in `:workload:lint` in `AndroidIT` in CI:
https://github.com/google/ksp/actions/runs/941534021
https://github.com/google/ksp/actions/runs/949022386
https://github.com/google/ksp/actions/runs/962579576