### PR TITLE
Added `containingFile` member to `KSValueParameter` interface

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueParameter.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueParameter.kt
@@ -33,6 +33,11 @@ interface KSValueParameter : KSAnnotated {
     val type: KSTypeReference
 
     /**
+     * The containing source file of this declaration, can be null if symbol does not come from a source file, i.e. from a class file.
+     */
+    val containingFile: KSFile?
+
+    /**
      * True if it is a vararg.
      */
     val isVararg: Boolean

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
@@ -41,6 +41,8 @@ class KSValueParameterDescriptorImpl private constructor(val descriptor: ValuePa
         descriptor.annotations.asSequence().map { KSAnnotationDescriptorImpl.getCached(it) }
     }
 
+    override val containingFile: KSFile? = null
+
     override val isCrossInline: Boolean = descriptor.isCrossinline
 
     override val isNoInline: Boolean = descriptor.isNoinline

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
@@ -23,8 +23,10 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import com.intellij.psi.PsiJavaFile
 
 class KSValueParameterJavaImpl private constructor(val psi: PsiParameter) : KSValueParameter {
+
     companion object : KSObjectCache<PsiParameter, KSValueParameterJavaImpl>() {
         fun getCached(psi: PsiParameter) = cache.getOrPut(psi) { KSValueParameterJavaImpl(psi) }
     }
@@ -59,6 +61,10 @@ class KSValueParameterJavaImpl private constructor(val psi: PsiParameter) : KSVa
 
     override val type: KSTypeReference by lazy {
         KSTypeReferenceJavaImpl.getCached(psi.type)
+    }
+
+    override val containingFile: KSFile? by lazy {
+        KSFileJavaImpl.getCached(psi.containingFile as PsiJavaFile)
     }
 
     override val hasDefault: Boolean = false

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -30,6 +30,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 
 class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : KSValueParameter {
+
     companion object : KSObjectCache<KtParameter, KSValueParameterImpl>() {
         fun getCached(ktParameter: KtParameter) = cache.getOrPut(ktParameter) { KSValueParameterImpl(ktParameter) }
     }
@@ -64,6 +65,10 @@ class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : K
 
     override val type: KSTypeReference by lazy {
         ktParameter.typeReference?.let { KSTypeReferenceImpl.getCached(it) } ?: findPropertyForAccessor()?.type ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType)
+    }
+
+    override val containingFile: KSFile? by lazy {
+        KSFileImpl.getCached(ktParameter.containingKtFile)
     }
 
     override val hasDefault: Boolean = ktParameter.hasDefaultValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSValueParameterSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSValueParameterSyntheticImpl.kt
@@ -44,6 +44,8 @@ class KSValueParameterSyntheticImpl(val owner: KSAnnotated?, resolve: () -> Valu
         descriptor.annotations.asSequence().map { KSAnnotationDescriptorImpl.getCached(it) }.plus(this.findAnnotationFromUseSiteTarget())
     }
 
+    override val containingFile: KSFile? = null
+
     override val origin: Origin = Origin.SYNTHETIC
 
     override val location: Location = NonExistLocation


### PR DESCRIPTION
This PR addresses https://github.com/google/ksp/issues/503 by adding `containingFile` to `KSValueParameter` interface signature.

To avoid repeating code, I took the opportunity to do a small refactor by introducing the `KSFileSymbol` (any better name?) interface and making `KSDeclaration` and `KSValueParameter` implement it.

I didn't add a test for this, but I'd be willing to. I'd to have an early validation of the approach first.