### PR TITLE
Add support for KSAnnotated annotation methods 

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -17,6 +17,7 @@
 package com.google.devtools.ksp.symbol.impl
 
 import com.google.devtools.ksp.ExceptionMessage
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.MemoizedSequence
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
@@ -58,6 +59,11 @@ import org.jetbrains.kotlin.types.StarProjectionImpl
 import org.jetbrains.kotlin.types.TypeProjectionImpl
 import org.jetbrains.kotlin.types.replace
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+import java.lang.reflect.InvocationHandler
+import java.lang.reflect.Method
+import java.lang.reflect.Proxy
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KClass
 
 private val jvmModifierMap = mapOf(
     JvmModifier.PUBLIC to Modifier.PUBLIC,
@@ -176,7 +182,8 @@ fun MemberDescriptor.toKSModifiers(): Set<Modifier> {
         DescriptorVisibilities.PUBLIC -> modifiers.add(Modifier.PUBLIC)
         DescriptorVisibilities.PROTECTED,
         JavaDescriptorVisibilities.PROTECTED_AND_PACKAGE,
-        JavaDescriptorVisibilities.PROTECTED_STATIC_VISIBILITY -> modifiers.add(Modifier.PROTECTED)
+        JavaDescriptorVisibilities.PROTECTED_STATIC_VISIBILITY,
+        -> modifiers.add(Modifier.PROTECTED)
         DescriptorVisibilities.PRIVATE -> modifiers.add(Modifier.PRIVATE)
         DescriptorVisibilities.INTERNAL -> modifiers.add(Modifier.INTERNAL)
         // Since there is no modifier for package-private, use No modifier to tell if a symbol from binary is package private.
@@ -228,7 +235,9 @@ fun PsiElement.findParentAnnotated(): KSAnnotated? {
         is PsiJavaFile -> null
         is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(parent)
         is KtProperty -> KSPropertyDeclarationImpl.getCached(parent)
-        is KtPropertyAccessor -> if (parent.isGetter) { KSPropertyGetterImpl.getCached(parent) } else {
+        is KtPropertyAccessor -> if (parent.isGetter) {
+            KSPropertyGetterImpl.getCached(parent)
+        } else {
             KSPropertySetterImpl.getCached(parent)
         }
         is KtTypeAlias -> KSTypeAliasImpl.getCached(parent)
@@ -490,7 +499,7 @@ internal fun PropertyDescriptor.hasBackingFieldWithBinaryClassSupport(): Boolean
  */
 internal object BinaryFieldsCache : KSObjectCache<ClassId, Set<Name>>() {
     fun getCached(
-        kotlinJvmBinaryClass: KotlinJvmBinaryClass
+        kotlinJvmBinaryClass: KotlinJvmBinaryClass,
     ) = cache.getOrPut(kotlinJvmBinaryClass.classId) {
         val visitor = PropNamesVisitor()
         kotlinJvmBinaryClass.visitMembers(visitor, null)
@@ -533,3 +542,140 @@ private val PropertyDescriptor.declaresDefaultValue: Boolean
         is KtParameter -> declaration.defaultValue != null
         else -> false
     }
+
+@KspExperimental
+fun <T : Annotation> KSAnnotated.getAnnotationsByType(annotationKClass: KClass<T>): Sequence<T> {
+    return this.annotations.filter {
+        it.shortName.getShortName() == annotationKClass.simpleName && it.annotationType.resolve().declaration
+            .qualifiedName?.asString() == annotationKClass.qualifiedName
+    }.map { it.toAnnotation(annotationKClass.java) }
+}
+
+@KspExperimental
+fun <T : Annotation> KSAnnotated.isAnnotationPresent(annotationKClass: KClass<T>): Boolean =
+    getAnnotationsByType(annotationKClass).firstOrNull() != null
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : Annotation> KSAnnotation.toAnnotation(annotationClass: Class<T>): T {
+    return Proxy.newProxyInstance(
+        annotationClass.classLoader,
+        arrayOf(annotationClass),
+        createInvocationHandler(annotationClass)
+    ) as T
+}
+
+@Suppress("TooGenericExceptionCaught")
+private fun KSAnnotation.createInvocationHandler(clazz: Class<*>): InvocationHandler {
+    val cache = ConcurrentHashMap<Pair<Class<*>, Any>, Any>(arguments.size)
+    return InvocationHandler { proxy, method, _ ->
+        if (method.name == "toString" && arguments.none { it.name?.asString() == "toString" }) {
+            clazz.canonicalName +
+                arguments.map { argument: KSValueArgument ->
+                    // handles default values for enums otherwise returns null
+                    val methodName = argument.name?.asString()
+                    val value = proxy.javaClass.methods.find { m -> m.name == methodName }?.invoke(proxy)
+                    "$methodName=$value"
+                }.toList()
+        } else {
+            val argument = try {
+                arguments.first { it.name?.asString() == method.name }
+            } catch (e: NullPointerException) {
+                throw IllegalArgumentException("This is a bug using the default KClass for an annotation", e)
+            }
+            when (val result = argument.value ?: method.defaultValue) {
+                is Proxy -> result
+                is List<*> -> {
+                    val value = { result.asArray(method) }
+                    cache.getOrPut(Pair(method.returnType, result), value)
+                }
+                else -> {
+                    when {
+                        method.returnType.isEnum -> {
+                            val value = { result.asEnum(method.returnType) }
+                            cache.getOrPut(Pair(method.returnType, result), value)
+                        }
+                        method.returnType.isAnnotation -> {
+                            val value = { (result as KSAnnotation).asAnnotation(method.returnType) }
+                            cache.getOrPut(Pair(method.returnType, result), value)
+                        }
+                        method.returnType.name == "java.lang.Class" -> {
+                            val value = { (result as KSType).asClass() }
+                            cache.getOrPut(Pair(method.returnType, result), value)
+                        }
+                        method.returnType.name == "byte" -> {
+                            val value = { result.asByte() }
+                            cache.getOrPut(Pair(method.returnType, result), value)
+                        }
+                        method.returnType.name == "short" -> {
+                            val value = { result.asShort() }
+                            cache.getOrPut(Pair(method.returnType, result), value)
+                        }
+                        else -> result // original value
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun KSAnnotation.asAnnotation(
+    annotationInterface: Class<*>,
+): Any {
+    return Proxy.newProxyInstance(
+        this.javaClass.classLoader, arrayOf(annotationInterface),
+        this.createInvocationHandler(annotationInterface)
+    ) as Proxy
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun List<*>.asArray(method: Method) =
+    when (method.returnType.componentType.name) {
+        "boolean" -> (this as List<Boolean>).toBooleanArray()
+        "byte" -> (this as List<Byte>).toByteArray()
+        "short" -> (this as List<Short>).toShortArray()
+        "char" -> (this as List<Char>).toCharArray()
+        "double" -> (this as List<Double>).toDoubleArray()
+        "float" -> (this as List<Float>).toFloatArray()
+        "int" -> (this as List<Int>).toIntArray()
+        "long" -> (this as List<Long>).toLongArray()
+        "java.lang.Class" -> (this as List<KSType>).map {
+            Class.forName(it.declaration.qualifiedName!!.asString())
+        }.toTypedArray()
+        "java.lang.String" -> (this as List<String>).toTypedArray()
+        else -> { // arrays of enums or annotations
+            when {
+                method.returnType.componentType.isEnum -> {
+                    this.toArray(method) { result -> result.asEnum(method.returnType.componentType) }
+                }
+                method.returnType.componentType.isAnnotation -> {
+                    this.toArray(method) { result ->
+                        (result as KSAnnotation).asAnnotation(method.returnType.componentType)
+                    }
+                }
+                else -> throw IllegalStateException("Unable to process type ${method.returnType.componentType.name}")
+            }
+        }
+    }
+
+@Suppress("UNCHECKED_CAST")
+private fun List<*>.toArray(method: Method, valueProvider: (Any) -> Any): Array<Any?> {
+    val array: Array<Any?> = java.lang.reflect.Array.newInstance(
+        method.returnType.componentType,
+        this.size
+    ) as Array<Any?>
+    for (r in 0 until this.size) {
+        array[r] = this[r]?.let { valueProvider.invoke(it) }
+    }
+    return array
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> Any.asEnum(returnType: Class<T>): T =
+    returnType.getDeclaredMethod("valueOf", String::class.java).invoke(null, this.toString()) as T
+
+private fun Any.asByte(): Byte = if (this is Int) this.toByte() else this as Byte
+
+private fun Any.asShort(): Short = if (this is Int) this.toShort() else this as Short
+
+private fun KSType.asClass() = Class.forName(this.declaration.qualifiedName!!.asString())

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -37,6 +37,16 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
     }
 
+    @TestMetadata("annotatedUtil.kt")
+    public void testAnnotatedUtil() throws Exception {
+        runTest("testData/api/annotatedUtil.kt");
+    }
+
+    @TestMetadata("javaAnnotatedUtil.kt")
+    public void testJavaAnnotatedUtil() throws Exception {
+        runTest("testData/api/javaAnnotatedUtil.kt");
+    }
+
     @TestMetadata("allFunctions.kt")
     public void testAllFunctions() throws Exception {
         runTest("testData/api/allFunctions.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.impl.getAnnotationsByType
+import com.google.devtools.ksp.symbol.impl.isAnnotationPresent
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+import kotlin.reflect.KClass
+
+class AnnotatedUtilProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    private val annotationKClasses = listOf(
+        ParametersTestAnnotation::class,
+        ParameterArraysTestAnnotation::class,
+        ParametersTestWithNegativeDefaultsAnnotation::class,
+        OuterAnnotation::class
+    )
+    private val visitors = listOf(IsAnnotationPresentVisitor(), GetAnnotationsByTypeVisitor())
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("com.google.devtools.ksp.processor.Test", true).forEach {
+            results.add("Test: $it")
+            visitors.forEach { visitor -> it.accept(visitor, results) }
+        }
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    inner class IsAnnotationPresentVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+        @OptIn(KspExperimental::class)
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
+            annotationKClasses.forEach { clazz ->
+                if (annotated.isAnnotationPresent(clazz)) {
+                    data.add("IsPresent: $clazz")
+                }
+            }
+        }
+
+        override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+        }
+    }
+
+    inner class GetAnnotationsByTypeVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+        @OptIn(KspExperimental::class)
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
+            annotationKClasses.forEach { clazz ->
+                annotated.getAnnotationsByType(clazz).forEach { data.add("ByType: ${it.asString()}") }
+            }
+        }
+
+        override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+annotation class ParametersTestAnnotation(
+    val booleanValue: Boolean = false,
+    val byteValue: Byte = 2,
+    val shortValue: Short = 3,
+    val charValue: Char = 'b',
+    val doubleValue: Double = 4.0,
+    val floatValue: Float = 5.0f,
+    val intValue: Int = 6,
+    val longValue: Long = 7L,
+    val stringValue: String = "emptystring",
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    // https://github.com/google/ksp/issues/53
+    val kClassValue: KClass<*> = ParametersTestAnnotation::class,
+    val enumValue: TestEnum = TestEnum.NONE,
+)
+
+fun ParameterArraysTestAnnotation.asString(): String =
+    "ParameterArraysTestAnnotation" +
+        "[booleanArrayValue=${booleanArrayValue.asList()}," +
+        "byteArrayValue=${byteArrayValue.asList()}," +
+        "shortArrayValue=${shortArrayValue.asList()}," +
+        "charArrayValue=${charArrayValue.asList()}," +
+        "doubleArrayValue=${doubleArrayValue.asList()}," +
+        "floatArrayValue=${floatArrayValue.asList()}," +
+        "intArrayValue=${intArrayValue.asList()}," +
+        "longArrayValue=${longArrayValue.asList()}," +
+        "stringArrayValue=${stringArrayValue.asList()}," +
+        "kClassArrayValue=${kClassArrayValue.asList()}," +
+        "enumArrayValue=${enumArrayValue.asList()}]"
+
+@Suppress("LongParameterList")
+annotation class ParameterArraysTestAnnotation(
+    val booleanArrayValue: BooleanArray = booleanArrayOf(),
+    val byteArrayValue: ByteArray = byteArrayOf(),
+    val shortArrayValue: ShortArray = shortArrayOf(),
+    val charArrayValue: CharArray = charArrayOf(),
+    val doubleArrayValue: DoubleArray = doubleArrayOf(),
+    val floatArrayValue: FloatArray = floatArrayOf(),
+    val intArrayValue: IntArray = intArrayOf(),
+    val longArrayValue: LongArray = longArrayOf(),
+    val stringArrayValue: Array<String> = emptyArray(),
+    val kClassArrayValue: Array<KClass<*>> = emptyArray(),
+    val enumArrayValue: Array<TestEnum> = emptyArray(),
+)
+
+annotation class ParametersTestWithNegativeDefaultsAnnotation(
+    val byteValue: Byte = -2,
+    val shortValue: Short = -3,
+    val doubleValue: Double = -4.0,
+    val floatValue: Float = -5.0f,
+    val intValue: Int = -6,
+    val longValue: Long = -7L,
+)
+
+enum class TestEnum {
+    NONE, VALUE1, VALUE2
+}
+
+annotation class Test
+
+annotation class InnerAnnotation(val value: String = "default")
+
+annotation class OuterAnnotation(
+    val innerAnnotation: InnerAnnotation = InnerAnnotation(),
+)
+
+fun Annotation.asString(): String {
+    return when (this) {
+        is ParameterArraysTestAnnotation -> asString()
+        else -> toString()
+    }
+}

--- a/compiler-plugin/testData/api/annotatedUtil.kt
+++ b/compiler-plugin/testData/api/annotatedUtil.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotatedUtilProcessor
+// EXPECTED:
+// Test: OnlyTestAnnotation
+// Test: ParametersTestAnnotationWithValuesTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, shortValue=202, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// Test: ParametersTestAnnotationWithDefaultsTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// Test: ParametersTestWithNegativeDefaultsAnnotationTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
+// ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
+// Test: ParameterArraysTestAnnotationWithDefaultTest
+// IsPresent: class com.google.devtools.ksp.processor.ParameterArraysTestAnnotation
+// ByType: ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],shortArrayValue=[-1, 2, 3],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// Test: AnnotationWithinAnAnnotationTest
+// IsPresent: class com.google.devtools.ksp.processor.OuterAnnotation
+// ByType: com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// END
+// MODULE: annotations
+// FILE: com/google/devtools/ksp/processor/a.kt
+package com.google.devtools.ksp.processor
+
+import kotlin.reflect.KClass
+import java.lang.Throwable
+
+annotation class Test
+
+@Suppress("LongParameterList")
+annotation class ParametersTestAnnotation(
+    val booleanValue: Boolean = false,
+    val byteValue: Byte = 2,
+    val shortValue: Short = 3,
+    val charValue: Char = 'b',
+    val doubleValue: Double = 4.0,
+    val floatValue: Float = 5.0f,
+    val intValue: Int = 6,
+    val longValue: Long = 7L,
+    val stringValue: String = "emptystring",
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    val kClassValue: KClass<*> = ParametersTestAnnotation::class,
+    val enumValue: TestEnum = TestEnum.NONE,
+)
+
+@Suppress("LongParameterList")
+annotation class ParameterArraysTestAnnotation(
+    val booleanArrayValue: BooleanArray = booleanArrayOf(),
+    val byteArrayValue: ByteArray = byteArrayOf(),
+    val shortArrayValue: ShortArray = shortArrayOf(),
+    val charArrayValue: CharArray = charArrayOf(),
+    val doubleArrayValue: DoubleArray = doubleArrayOf(),
+    val floatArrayValue: FloatArray = floatArrayOf(),
+    val intArrayValue: IntArray = intArrayOf(),
+    val longArrayValue: LongArray = longArrayOf(),
+    val stringArrayValue: Array<String> = emptyArray(),
+    val kClassArrayValue: Array<KClass<*>> = emptyArray(),
+    val enumArrayValue: Array<TestEnum> = emptyArray(),
+)
+
+annotation class ParametersTestWithNegativeDefaultsAnnotation(
+    val byteValue: Byte = -2,
+    val shortValue: Short = -3,
+    val doubleValue: Double = -4.0,
+    val floatValue: Float = -5.0f,
+    val intValue: Int = -6,
+    val longValue: Long = -7L,
+)
+
+enum class TestEnum {
+    NONE, VALUE1, VALUE2
+}
+
+annotation class InnerAnnotation(val value: String = "default")
+
+annotation class OuterAnnotation(
+    val innerAnnotation : InnerAnnotation = InnerAnnotation()
+)
+
+/////////////////////////////////////////////////////////
+// Tests
+/////////////////////////////////////////////////////////
+
+@Test
+@Test
+class OnlyTestAnnotation
+
+@ParametersTestAnnotation(
+    booleanValue = true,
+    byteValue = 5,
+    shortValue = 202,
+    charValue = 'k',
+    doubleValue = 5.12,
+    floatValue = 123.3f,
+    intValue = 2,
+    longValue = 4L,
+    stringValue = "someValue",
+    java.lang.Throwable::class,
+    TestEnum.VALUE1,
+)
+@Test
+class ParametersTestAnnotationWithValuesTest
+
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
+@Test
+class ParametersTestAnnotationWithDefaultsTest
+
+@ParametersTestWithNegativeDefaultsAnnotation
+@ParametersTestWithNegativeDefaultsAnnotation
+@Test
+class ParametersTestWithNegativeDefaultsAnnotationTest
+
+@ParameterArraysTestAnnotation(
+    booleanArrayValue = booleanArrayOf(true, false),
+    byteArrayValue = byteArrayOf(-2, 4),
+    shortArrayValue = shortArrayOf(-1, 2, 3),
+    charArrayValue = charArrayOf('a', 'b', 'c'),
+    doubleArrayValue = doubleArrayOf(1.1, 2.2, 3.3),
+    floatArrayValue = floatArrayOf(1.0f, 2.0f, 3.3f),
+    intArrayValue = intArrayOf(1, 2, 4, 8, 16),
+    longArrayValue = longArrayOf(1L, 2L, 4L, 8L, 16, 32L),
+    stringArrayValue = arrayOf("first", "second", "third"),
+    kClassArrayValue = arrayOf(Throwable::class, ParametersTestAnnotation::class),
+    enumArrayValue = arrayOf(TestEnum.VALUE1, TestEnum.VALUE2, TestEnum.VALUE1, TestEnum.VALUE2),
+)
+@Test
+class ParameterArraysTestAnnotationWithDefaultTest
+
+@OuterAnnotation(innerAnnotation = InnerAnnotation("hello from the other side"))
+@Test
+class AnnotationWithinAnAnnotationTest

--- a/compiler-plugin/testData/api/javaAnnotatedUtil.kt
+++ b/compiler-plugin/testData/api/javaAnnotatedUtil.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotatedUtilProcessor
+// EXPECTED:
+// Test: OnlyTestAnnotation
+// Test: ParametersTestAnnotationWithValuesTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, shortValue=202, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// Test: ParametersTestAnnotationWithDefaultsTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// Test: ParametersTestWithNegativeDefaultsAnnotationTest
+// IsPresent: class com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation
+// ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
+// ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
+// Test: ParameterArraysTestAnnotationWithDefaultTest
+// IsPresent: class com.google.devtools.ksp.processor.ParameterArraysTestAnnotation
+// ByType: ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],shortArrayValue=[-1, 2, 3],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// Test: AnnotationWithinAnAnnotationTest
+// IsPresent: class com.google.devtools.ksp.processor.OuterAnnotation
+// ByType: com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// END
+// FILE: com/google/devtools/ksp/processor/A.java
+package com.google.devtools.ksp.processor;
+
+import kotlin.reflect.KClass
+
+public class A {}
+
+
+public @interface Test {}
+
+public @interface ParametersTestAnnotation {
+    Boolean booleanValue() default false;
+    Byte byteValue() default 2;
+    Short shortValue() default 3;
+    Char charValue() default 'b';
+    Double doubleValue() default 4.0;
+    Float floatValue() default 5.0f;
+    Int intValue() default 6;
+    Long longValue() default 7L;
+    String stringValue() default "emptystring";
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    Class<?> kClassValue() default ParametersTestAnnotation.class;
+    TestEnum enumValue() default TestEnum.NONE;
+}
+
+public @interface ParametersTestWithNegativeDefaultsAnnotation {
+    Byte byteValue() default -2;
+    Short shortValue() default -3;
+    Double doubleValue() default -4.0;
+    Float floatValue() default -5.0f;
+    Int intValue() default -6;
+    Long longValue() default -7L;
+}
+
+public @interface ParameterArraysTestAnnotation {
+    boolean[] booleanArrayValue();
+    byte[] byteArrayValue() default { };
+    short[] shortArrayValue() default { };
+    char[] charArrayValue() default { };
+    double[] doubleArrayValue() default { };
+    float[] floatArrayValue() default { };
+    int[] intArrayValue() default { };
+    long[] longArrayValue() default { };
+    string[] stringArrayValue() default { };
+    Class[] kClassArrayValue() default { };
+    TestEnum[] enumArrayValue() default { };
+}
+
+public enum TestEnum {
+    NONE, VALUE1, VALUE2;
+}
+
+public @interface InnerAnnotation {
+    String value() default "defaultValue";
+}
+
+public @interface OuterAnnotation {
+    InnerAnnotation innerAnnotation() default InnerAnnotation();
+}
+
+/////////////////////////////////////////////////////////
+// Tests
+/////////////////////////////////////////////////////////
+
+@Test
+@Test
+public class OnlyTestAnnotation {}
+
+@ParametersTestAnnotation(
+    booleanValue = true,
+    byteValue = 5,
+    shortValue = 202,
+    charValue = 'k',
+    doubleValue = 5.12,
+    floatValue = 123.3f,
+    intValue = 2,
+    longValue = 4L,
+    stringValue = "someValue",
+    kClassValue = java.lang.Throwable.class,
+    enumValue = TestEnum.VALUE1
+)
+@Test
+public class ParametersTestAnnotationWithValuesTest {}
+
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
+@Test
+public class ParametersTestAnnotationWithDefaultsTest {}
+
+@ParametersTestWithNegativeDefaultsAnnotation
+@ParametersTestWithNegativeDefaultsAnnotation
+@Test
+public class ParametersTestWithNegativeDefaultsAnnotationTest {}
+
+@ParameterArraysTestAnnotation(
+    booleanArrayValue = {true, false},
+    byteArrayValue = {-2, 4},
+    shortArrayValue = {-1, 2, 3},
+    charArrayValue = {'a', 'b', 'c'},
+    doubleArrayValue = {1.1, 2.2, 3.3},
+    floatArrayValue = {1.0f, 2.0f, 3.3f},
+    intArrayValue = {1, 2, 4, 8, 16},
+    longArrayValue = {1L, 2L, 4L, 8L, 16, 32L},
+    stringArrayValue = {"first", "second", "third"},
+    kClassArrayValue = {java.lang.Throwable.class, ParametersTestAnnotation.class},
+    enumArrayValue = {TestEnum.VALUE1, TestEnum.VALUE2, TestEnum.VALUE1, TestEnum.VALUE2}
+)
+@Test
+public class ParameterArraysTestAnnotationWithDefaultTest {}
+
+@OuterAnnotation(innerAnnotation = @InnerAnnotation(value = "hello from the other side"))
+@Test
+public class AnnotationWithinAnAnnotationTest {}
+
+// FILE: Annotations.kt


### PR DESCRIPTION
- mirror get annotation methods from Java
- Added support for the following extension functions 
   - KSAnnotated#isAnnotationPresent
   - KSAnnotated#getAnnotationsByType

