### PR TITLE
Add a reminder on the implication of certain changes

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -76,6 +76,11 @@ class KotlinSymbolProcessingCommandLineProcessor : CommandLineProcessor {
     }
 }
 
+// Changes here may break some third party libraries like Kotlin Compile Testing, where the compiler is invoked in
+// another way. Do our best to notify them when changing this.
+//
+// Third party libraries:
+//   https://github.com/tschuchortdev/kotlin-compile-testing
 class KotlinSymbolProcessingComponentRegistrar : ComponentRegistrar {
     override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
         val contentRoots = configuration[CLIConfigurationKeys.CONTENT_ROOTS] ?: emptyList()


### PR DESCRIPTION
Some third party projects invokes KSP in a different way.
Changes in KotlinSymbolProcessingPlugin may break them accidentally.
Do our best to notify them.