### PR TITLE
KspTaskJS: call inherited Configurator.configure

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -353,7 +353,7 @@ interface KspTask : Task {
 
 abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
     override fun configureCompilation(kotlinCompilation: KotlinCompilationData<*>, kotlinCompile: AbstractKotlinCompile<*>) {
-        AbstractKotlinCompile.Configurator<KspTaskJvm>(kotlinCompilation).configure(this)
+        Configurator<KspTaskJvm>(kotlinCompilation).configure(this)
         kotlinCompile as KotlinCompile
         val providerFactory = kotlinCompile.project.providers
         compileKotlinArgumentsContributor.set(
@@ -409,7 +409,7 @@ abstract class KspTaskJS @Inject constructor(
     objectFactory: ObjectFactory
 ) : Kotlin2JsCompile(KotlinJsOptionsImpl(), objectFactory), KspTask {
     override fun configureCompilation(kotlinCompilation: KotlinCompilationData<*>, kotlinCompile: AbstractKotlinCompile<*>) {
-        AbstractKotlinCompile.Configurator<KspTaskJS>(kotlinCompilation).configure(this)
+        Configurator<KspTaskJS>(kotlinCompilation).configure(this)
         kotlinCompile as Kotlin2JsCompile
         val providerFactory = kotlinCompile.project.providers
         compileKotlinArgumentsContributor.set(
@@ -462,7 +462,7 @@ abstract class KspTaskJS @Inject constructor(
 
 abstract class KspTaskMetadata : KotlinCompileCommon(KotlinMultiplatformCommonOptionsImpl()), KspTask {
     override fun configureCompilation(kotlinCompilation: KotlinCompilationData<*>, kotlinCompile: AbstractKotlinCompile<*>) {
-        AbstractKotlinCompile.Configurator<KspTaskMetadata>(kotlinCompilation).configure(this)
+        Configurator<KspTaskMetadata>(kotlinCompilation).configure(this)
         kotlinCompile as KotlinCompileCommon
         val providerFactory = kotlinCompile.project.providers
         compileKotlinArgumentsContributor.set(


### PR DESCRIPTION
instead of AbstractKotlinCompile.Configurator.configure, which misses JS
specific configurations.