### PR TITLE
Fixed Maven repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,9 +20,8 @@ subprojects {
     repositories {
         mavenCentral()
         google()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        jcenter()
+        maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
     tasks.withType<Jar>().configureEach {
         manifest.attributes.apply {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -130,6 +130,6 @@ repositories {
     flatDir {
         dirs("${project.rootDir}/third_party/prebuilt/repo/")
     }
-    maven("https://dl.bintray.com/kotlin/kotlin-eap")
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://www.jetbrains.com/intellij-repository/snapshots")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,8 +1,8 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
     val kotlinBaseVersion: String by settings
     resolutionStrategy {


### PR DESCRIPTION
This PR updates the repositories list to be able to resolve snapshot versions of Kotlin and Idea dependencies.

I recently cloned this repo to address an issue and noted that Kotlin's Bintray repository was down and the JetBrains's Snapshots one missing.