### PR TITLE
Incremental: support finer-grained classpath changes

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/DualLookupTracker.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/DualLookupTracker.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp
+
+import org.jetbrains.kotlin.incremental.LookupTrackerImpl
+import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.incremental.components.Position
+import org.jetbrains.kotlin.incremental.components.ScopeKind
+
+internal class DualLookupTracker : LookupTracker {
+    val symbolTracker = LookupTrackerImpl(LookupTracker.DO_NOTHING)
+    val classTracker = LookupTrackerImpl(LookupTracker.DO_NOTHING)
+
+    override val requiresPosition: Boolean
+        get() = symbolTracker.requiresPosition || classTracker.requiresPosition
+
+    override fun record(filePath: String, position: Position, scopeFqName: String, scopeKind: ScopeKind, name: String) {
+        symbolTracker.record(filePath, position, scopeFqName, scopeKind, name)
+        if (scopeKind == ScopeKind.CLASSIFIER) {
+            val className = scopeFqName.substringAfterLast('.')
+            val outerScope = scopeFqName.substringBeforeLast('.', "<anonymous>")
+            // DO NOT USE: ScopeKind is meaningless
+            classTracker.record(filePath, position, outerScope, scopeKind, className)
+        }
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -186,7 +186,7 @@ class IncrementalContext(
 
     private val baseDir = options.projectBaseDir
 
-    private val logsDir = File(baseDir, "build").apply { mkdir() }
+    private val logsDir = File(options.cachesDir, "logs").apply { mkdirs() }
     private val buildTime = Date().time
 
     private val modified = options.knownModified.map{ it.relativeTo(baseDir) }.toSet()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -557,8 +557,9 @@ class IncrementalContext(
         val name = fqn.substringAfterLast('.')
         val scope = fqn.substringBeforeLast('.', "<anonymous>")
 
+        // Java types are classes. Therefore lookups only happen in packages.
         fun record(scope: String, name: String) =
-            lookupTracker.record(path, Position.NO_POSITION, scope, ScopeKind.CLASSIFIER, name)
+            lookupTracker.record(path, Position.NO_POSITION, scope, ScopeKind.PACKAGE, name)
 
         record(scope, name)
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -205,7 +205,7 @@ enum class KspCliOption(
     CHANGED_CLASSES_OPTION(
     "changedClasses",
     "<changedClasses>",
-    "dirty classes in classpath",
+    "canonical / dot-separated names of dirty classes in classpath",
     false,
     false
     );

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -34,9 +34,6 @@ import com.intellij.psi.PsiTreeChangeListener
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.resolve.extensions.AnalysisHandlerExtension
 import java.io.File
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import org.jetbrains.kotlin.incremental.LookupTrackerImpl
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 
 private val KSP_OPTIONS = CompilerConfigurationKey.create<KspOptions.Builder>("Ksp options")
 
@@ -94,7 +91,7 @@ class KotlinSymbolProcessingComponentRegistrar : ComponentRegistrar {
         if (options.processingClasspath.isNotEmpty()) {
             val kotlinSymbolProcessingHandlerExtension = KotlinSymbolProcessingExtension(options, logger)
             AnalysisHandlerExtension.registerExtension(project, kotlinSymbolProcessingHandlerExtension)
-            configuration.put(CommonConfigurationKeys.LOOKUP_TRACKER, LookupTrackerImpl(LookupTracker.DO_NOTHING))
+            configuration.put(CommonConfigurationKeys.LOOKUP_TRACKER, DualLookupTracker())
 
             // Dummy extension point; Required by dropPsiCaches().
             CoreApplicationEnvironment.registerExtensionPoint(project.extensionArea, PsiTreeChangeListener.EP.name, PsiTreeChangeAdapter::class.java)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -73,6 +73,7 @@ class KotlinSymbolProcessingCommandLineProcessor : CommandLineProcessor {
         KspCliOption.KNOWN_REMOVED_OPTION -> knownRemoved.addAll(value.split(File.pathSeparator).map { File(it) } )
         KspCliOption.INCREMENTAL_OPTION -> incremental = value.toBoolean()
         KspCliOption.INCREMENTAL_LOG_OPTION -> incrementalLog = value.toBoolean()
+        KspCliOption.CHANGED_CLASSES_OPTION -> changedClasses.addAll(value.split(':'))
     }
 }
 
@@ -202,6 +203,14 @@ enum class KspCliOption(
     "log dirty files",
     false,
     false
+    ),
+
+    CHANGED_CLASSES_OPTION(
+    "changedClasses",
+    "<changedClasses>",
+    "dirty classes in classpath",
+    false,
+    false
     );
 }
 
@@ -227,6 +236,7 @@ class KspOptions(
     val kspOutputDir: File,
     val incremental: Boolean,
     val incrementalLog: Boolean,
+    val changedClasses: List<String>,
 ) {
     class Builder {
         var projectBaseDir: File? = null
@@ -250,6 +260,7 @@ class KspOptions(
         var kspOutputDir: File? = null
         var incremental: Boolean = false
         var incrementalLog: Boolean = false
+        var changedClasses: MutableList<String> = mutableListOf()
 
         fun build(): KspOptions {
             return KspOptions(
@@ -259,7 +270,7 @@ class KspOptions(
                 kotlinOutputDir!!,
                 resourceOutputDir!!,
                 processingClasspath, processors, processingOptions,
-                knownModified, knownRemoved, cachesDir!!, kspOutputDir!!, incremental, incrementalLog
+                knownModified, knownRemoved, cachesDir!!, kspOutputDir!!, incremental, incrementalLog, changedClasses
             )
         }
     }

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKotlinKSPTest.kt
@@ -18,6 +18,7 @@
 
 package com.google.devtools.ksp.test
 
+import com.google.devtools.ksp.DualLookupTracker
 import com.google.devtools.ksp.KotlinSymbolProcessingExtension
 import com.google.devtools.ksp.KspOptions
 import com.google.devtools.ksp.processing.impl.MessageCollectorBasedKSPLogger
@@ -31,8 +32,6 @@ import org.jetbrains.kotlin.codegen.ClassBuilderFactories
 import org.jetbrains.kotlin.codegen.CodegenTestCase
 import org.jetbrains.kotlin.codegen.GenerationUtils
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.incremental.LookupTrackerImpl
-import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.test.*
 import org.jetbrains.kotlin.test.util.KtTestUtil
@@ -117,7 +116,7 @@ abstract class AbstractKotlinKSPTest : KotlinBaseTest<AbstractKotlinKSPTest.KspT
             emptyList()
         )
         configuration.put(CommonConfigurationKeys.MODULE_NAME, module.name)
-        configuration.put(CommonConfigurationKeys.LOOKUP_TRACKER, LookupTrackerImpl(LookupTracker.DO_NOTHING))
+        configuration.put(CommonConfigurationKeys.LOOKUP_TRACKER, DualLookupTracker())
 
         val environment = KotlinCoreEnvironment.createForTests(
             testRootDisposable, configuration, EnvironmentConfigFiles.JVM_CONFIG_FILES

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -16,7 +16,8 @@ words, a processor needs to associate an output with the sources of the correspo
 * `Resolver.getDeclarationsFromPackage`
 
 Currently, only changes in Kotlin and Java sources are tracked. Changes to the classpath, namely to other modules
-or libraries, trigger a full re-processing of all sources.
+or libraries, trigger a full re-processing of all sources by default. To track changes in classpath, set the Gradle property
+`ksp.incremental.intermodule=true` for an experimental implementation on JVM.
 
 Incremental processing is currently enabled by default. To disable it, set the Gradle property
 `ksp.incremental=false`. To enable logs that dump the dirty set according to dependencies and

--- a/docs/incremental.md
+++ b/docs/incremental.md
@@ -120,12 +120,12 @@ Note that both of them are transitive and the second forms equivalence classes.
 To report a bug, please set Gradle properties `ksp.incremental=true` and `ksp.incremental.log=true`,
 and perform a clean build. This build produces two log files:
 
-* `build/kspDirtySet.log`
-* `build/kspSourceToOutputs.log`
+* `build/kspCaches/<source set>/logs/kspDirtySet.log`
+* `build/kspCaches/<source set>/logs/kspSourceToOutputs.log`
 
 You can then run successive incremental builds, which will generate two additional log files:
 
-* `build/kspDirtySetByDeps.log`
-* `build/kspDirtySetByOutputs.log`
+* `build/kspCaches/<source set>/logs/kspDirtySetByDeps.log`
+* `build/kspCaches/<source set>/logs/kspDirtySetByOutputs.log`
 
 These logs contain file names of sources and outputs, plus the timestamps of the builds.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -26,6 +26,7 @@ import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
@@ -35,6 +36,7 @@ import org.gradle.api.tasks.CompileClasspath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.LocalState
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
@@ -52,6 +54,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinSingleTargetExtension
 import org.jetbrains.kotlin.gradle.dsl.fillDefaultValues
 import org.jetbrains.kotlin.gradle.internal.CompilerArgumentsContributor
 import org.jetbrains.kotlin.gradle.internal.compilerArgumentsConfigurationFlags
+import org.jetbrains.kotlin.gradle.internal.kapt.incremental.KaptClasspathChanges
 import org.jetbrains.kotlin.gradle.plugin.*
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmCompilation
@@ -64,6 +67,8 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompileCommon
 import org.jetbrains.kotlin.gradle.tasks.SourceRoots
 import org.jetbrains.kotlin.incremental.ChangedFiles
 import org.jetbrains.kotlin.incremental.destinationAsFile
+import org.jetbrains.kotlin.incremental.isJavaFile
+import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.io.File
 import java.util.*
@@ -263,6 +268,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             kspTask.blockOtherCompilerPlugins = kspExtension.blockOtherCompilerPlugins
             kspTask.pluginConfigurationName = kotlinCompilation.pluginConfigurationName
             kspTask.apOptions.value(kspExtension.arguments).disallowChanges()
+            kspTask.kspCacheDir.fileValue(getKspCachesDir(project, sourceSetName)).disallowChanges()
 
             // depends on the processor; if the processor changes, it needs to be reprocessed.
             val processorClasspath = project.configurations.maybeCreate("${kspTaskName}ProcessorClasspath")
@@ -348,6 +354,12 @@ interface KspTask : Task {
     @get:InputFiles
     val processorClasspath: ConfigurableFileCollection
 
+    /**
+     * Output directory that contains caches necessary to support incremental annotation processing.
+     */
+    @get:LocalState
+    val kspCacheDir: DirectoryProperty
+
     fun configureCompilation(kotlinCompilation: KotlinCompilationData<*>, kotlinCompile: AbstractKotlinCompile<*>)
 }
 
@@ -399,7 +411,11 @@ abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
         sourceRoots: SourceRoots,
         changedFiles: ChangedFiles
     ) {
-        args.addChangedFiles(changedFiles)
+        if (changedFiles.hasNonSourceChange()) {
+            clearIncCache()
+        } else {
+            args.addChangedFiles(changedFiles)
+        }
         super.callCompilerAsync(args, sourceRoots, changedFiles)
     }
 }
@@ -456,7 +472,11 @@ abstract class KspTaskJS @Inject constructor(
         sourceRoots: SourceRoots,
         changedFiles: ChangedFiles
     ) {
-        args.addChangedFiles(changedFiles)
+        if (changedFiles.hasNonSourceChange()) {
+            clearIncCache()
+        } else {
+            args.addChangedFiles(changedFiles)
+        }
         super.callCompilerAsync(args, sourceRoots, changedFiles)
     }
 }
@@ -509,8 +529,34 @@ abstract class KspTaskMetadata : KotlinCompileCommon(KotlinMultiplatformCommonOp
         sourceRoots: SourceRoots,
         changedFiles: ChangedFiles
     ) {
-        args.addChangedFiles(changedFiles)
+        if (changedFiles.hasNonSourceChange()) {
+            clearIncCache()
+        } else {
+            args.addChangedFiles(changedFiles)
+        }
         super.callCompilerAsync(args, sourceRoots, changedFiles)
+    }
+}
+
+// This forces rebuild.
+private fun KspTask.clearIncCache() {
+    kspCacheDir.get().asFile.deleteRecursively()
+}
+
+private fun ChangedFiles.hasNonSourceChange(): Boolean {
+    if (this !is ChangedFiles.Known)
+        return true
+
+    return !(this.modified + this.removed).all {
+        it.isKotlinFile(listOf("kt")) || it.isJavaFile()
+    }
+}
+
+fun CommonCompilerArguments.addChangedClasses(changed: KaptClasspathChanges) {
+    if (changed is KaptClasspathChanges.Known) {
+        changed.names.ifNotEmpty {
+            addPluginOptions(listOf(SubpluginOption("changedClasses", joinToString(":"))))
+        }
     }
 }
 
@@ -522,8 +568,12 @@ fun CommonCompilerArguments.addPluginOptions(options: List<SubpluginOption>) {
 fun CommonCompilerArguments.addChangedFiles(changedFiles: ChangedFiles) {
     if (changedFiles is ChangedFiles.Known) {
         val options = mutableListOf<SubpluginOption>()
-        changedFiles.modified.ifNotEmpty { options += SubpluginOption("knownModified", map { it.path }.joinToString(File.pathSeparator)) }
-        changedFiles.removed.ifNotEmpty { options += SubpluginOption("knownRemoved", map { it.path }.joinToString(File.pathSeparator)) }
+        changedFiles.modified.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+            options += SubpluginOption("knownModified", map { it.path }.joinToString(File.pathSeparator))
+        }
+        changedFiles.removed.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+            options += SubpluginOption("knownRemoved", map { it.path }.joinToString(File.pathSeparator))
+        }
         options.ifNotEmpty { addPluginOptions(this) }
     }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
@@ -1,0 +1,65 @@
+package com.google.devtools.ksp.test
+
+import Artifact
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class IncrementalCPIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("incremental-classpath")
+
+    val src2Dirty = listOf(
+        "l1/src/main/kotlin/p1/L1.kt" to setOf(
+            "w: [ksp] p1/K1.kt",
+        ),
+        "l2/src/main/kotlin/p1/L2.kt" to setOf(
+            "w: [ksp] p1/K1.kt",
+            "w: [ksp] p1/K2.kt",
+        ),
+        "l3/src/main/kotlin/p1/L3.kt" to setOf(
+            "w: [ksp] p1/K3.kt",
+        ),
+    )
+
+    @Test
+    fun testCPChanges() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        src2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).appendText("\n\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                // Trivial changes should not result in re-processing.
+                Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
+            }
+        }
+
+        var i = 100
+        src2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).appendText("\n{ val v$i = ${i++} }\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.split("\n").filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(expectedDirties, dirties)
+            }
+        }
+
+        src2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).appendText("\n\nclass C${i++}\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.split("\n").filter { it.startsWith("w: [ksp]") }.toSet()
+                // Non-signature changes should not affect anything.
+                Assert.assertEquals(emptySet<String>(), dirties)
+            }
+        }
+    }
+}

--- a/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/gradle.properties
+++ b/integration-tests/src/test/resources/incremental-classpath/gradle.properties
@@ -1,0 +1,3 @@
+ksp.incremental=true
+ksp.incremental.log=true
+ksp.incremental.intermodule=true

--- a/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
@@ -1,0 +1,20 @@
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":l2"))
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/L1.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/L1.kt
@@ -1,0 +1,3 @@
+package p1
+
+open class L1 : L2()

--- a/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
@@ -1,0 +1,19 @@
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/l2/src/main/kotlin/p1/L2.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/l2/src/main/kotlin/p1/L2.kt
@@ -1,0 +1,3 @@
+package p1
+
+open class L2

--- a/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
@@ -1,0 +1,19 @@
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/l3/src/main/kotlin/p1/L3.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/l3/src/main/kotlin/p1/L3.kt
@@ -1,0 +1,3 @@
+package p1
+
+open class L3

--- a/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
@@ -1,0 +1,23 @@
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}
+
+rootProject.name = "incremental-test"
+
+include(":workload")
+include(":validator")
+include(":l1")
+include(":l2")
+include(":l3")

--- a/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
@@ -1,0 +1,26 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
@@ -1,0 +1,55 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import com.google.devtools.ksp.visitor.KSDefaultVisitor
+import java.io.File
+import java.io.OutputStream
+import java.io.OutputStreamWriter
+
+
+class Validator : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+    var processed = false
+
+    fun init(options: Map<String, String>, kotlinVersion: KotlinVersion, codeGenerator: CodeGenerator, logger: KSPLogger) {
+        this.codeGenerator = codeGenerator
+        this.logger = logger
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if(processed) {
+            return emptyList()
+        }
+        val validator = object : KSDefaultVisitor<OutputStreamWriter, Unit>() {
+            override fun defaultHandler(node: KSNode, data: OutputStreamWriter) = Unit
+
+            override fun visitDeclaration(declaration: KSDeclaration, data: OutputStreamWriter) {
+                data.write(declaration.qualifiedName?.asString() ?: declaration.simpleName.asString())
+                declaration.validate()
+            }
+        }
+
+        val files = resolver.getAllFiles()
+        files.forEach { file ->
+            logger.warn("${file.packageName.asString()}/${file.fileName}")
+            val output = OutputStreamWriter(codeGenerator.createNewFile(Dependencies(false, file), file.packageName.asString(), file.fileName, "log"))
+            file.declarations.forEach {
+                it.accept(validator, output)
+            }
+            output.close()
+        }
+        processed = true
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        env: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return Validator().apply {
+            init(env.options, env.kotlinVersion, env.codeGenerator, env.logger)
+        }
+    }
+}

--- a/integration-tests/src/test/resources/incremental-classpath/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider

--- a/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
@@ -1,0 +1,26 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    google()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":validator"))
+    implementation(project(":l1"))
+    implementation(project(":l2"))
+    implementation(project(":l3"))
+    testImplementation("junit:junit:4.12")
+    ksp(project(":validator"))
+}
+

--- a/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K1.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K1.kt
@@ -1,0 +1,5 @@
+package p1
+
+open class K1 {
+    val v = L1()
+}

--- a/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K2.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K2.kt
@@ -1,0 +1,5 @@
+package p1
+
+open class K2 {
+    val v = L2()
+}

--- a/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K3.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/src/main/kotlin/p1/K3.kt
@@ -1,0 +1,5 @@
+package p1
+
+open class K3 {
+    val v = L3()
+}


### PR DESCRIPTION
This PR uses KAPT's `KaptTask.findClasspathChanges` to find classpath changes and invalidate source files accordingly.

Note that lookups are tracked at symbol level (e.g., class names, function names, etc) in the compiler. Also, `KaptTask.findClasspathChanges` finds changed classes rather than symbols. Therefore `DualLookupTracker` is introduced to emulate source-to-declarations-of-a-class lookups.