### PR TITLE
JVM: run processors even without Kotlin sources

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -506,6 +506,7 @@ abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
         }
         args.addPluginOptions(options)
         args.destinationAsFile = destination
+        args.allowNoSourceFiles = true
     }
 
     // Overrding an internal function is hacky.
@@ -530,6 +531,8 @@ abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
         args.addChangedFiles(changedFiles)
         super.callCompilerAsync(args, sourceRoots, changedFiles)
     }
+
+    override fun skipCondition(): Boolean = false
 }
 
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaOnlyIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaOnlyIT.kt
@@ -1,0 +1,31 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class JavaOnlyIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("java-only", "test-processor")
+
+    @Test
+    fun testJavaOnly() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        File(project.root, "workload/src/main/java/com/example/Foo.java").delete()
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.NO_SOURCE, result.task(":workload:kspKotlin")?.outcome)
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+    }
+}

--- a/integration-tests/src/test/resources/java-only/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/java-only/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,31 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.OutputStreamWriter
+
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
+    var rounds = 0
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (++rounds == 1) {
+            codeGenerator.createNewFile(Dependencies(false), "com.example", "Bar", "kt").use { output ->
+                OutputStreamWriter(output).use { writer ->
+                    writer.write("package com.example\n\n")
+                    writer.write("interface Bar\n")
+                }
+            }
+        }
+
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        environment: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return TestProcessor(environment.codeGenerator, environment.logger)
+    }
+}

--- a/integration-tests/src/test/resources/java-only/workload/src/main/java/com/example/Foo.java
+++ b/integration-tests/src/test/resources/java-only/workload/src/main/java/com/example/Foo.java
@@ -1,0 +1,4 @@
+package com.example;
+
+class Foo implements Bar {
+}


### PR DESCRIPTION
If there's no Java either, Gradle will skip the task. (NO-SOURCE)