### PR TITLE
Add support for KSAnnotated annotation methods

### DIFF
--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -37,6 +37,16 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         KotlinTestUtils.runTest(this::doTest, this, testDataFilePath);
     }
 
+    @TestMetadata("annotatedUtil.kt")
+    public void testAnnotatedUtil() throws Exception {
+        runTest("testData/api/annotatedUtil.kt");
+    }
+
+    @TestMetadata("javaAnnotatedUtil.kt")
+    public void testJavaAnnotatedUtil() throws Exception {
+        runTest("testData/api/javaAnnotatedUtil.kt");
+    }
+
     @TestMetadata("allFunctions.kt")
     public void testAllFunctions() throws Exception {
         runTest("testData/api/allFunctions.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.impl.getAnnotation
+import com.google.devtools.ksp.symbol.impl.getAnnotations
+import com.google.devtools.ksp.symbol.impl.getAnnotationsByType
+import com.google.devtools.ksp.symbol.impl.isAnnotationPresent
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+import kotlin.reflect.KClass
+
+class AnnotatedUtilProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    private val annotationKClasses = listOf(ParametersTestAnnotation::class, ParameterArraysTestAnnotation::class, ParametersTestWithNegativeDefaultsAnnotation::class, OuterAnnotation::class)
+    private val visitors = listOf(GetAnnotationVisitor(), GetAnnotationsVisitor(), GetAnnotationsByTypeVisitor())
+
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("com.google.devtools.ksp.processor.Test", true).forEach {
+            results.add("Test: $it")
+            visitors.forEach { visitor -> it.accept(visitor, results) }
+        }
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    inner class GetAnnotationVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
+            annotationKClasses.forEach { kClass ->
+                if (annotated.isAnnotationPresent(kClass)) {
+                    annotated.getAnnotation(kClass)?.let { data.add(it.asString()) }
+                }
+            }
+        }
+
+        override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+        }
+    }
+
+    inner class GetAnnotationsVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
+            annotated.getAnnotations().forEach { data.add(it.asString()) }
+        }
+
+        override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+        }
+    }
+
+    inner class GetAnnotationsByTypeVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+        override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
+            annotationKClasses.forEach { kClass ->
+                annotated.getAnnotationsByType(kClass).forEach { data.add(it.asString()) }
+            }
+        }
+
+        override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+annotation class ParametersTestAnnotation(
+    val booleanValue: Boolean = false,
+    val byteValue: Byte = 2,
+    val charValue: Char = 'b',
+    val doubleValue: Double = 3.0,
+    val floatValue: Float = 4.0f,
+    val intValue: Int = 5,
+    val longValue: Long = 6L,
+    val stringValue: String = "emptystring",
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    // https://github.com/google/ksp/issues/53
+    val kClassValue: KClass<*> = ParametersTestAnnotation::class,
+    val enumValue: TestEnum = TestEnum.NONE,
+)
+
+fun ParameterArraysTestAnnotation.asString(): String =
+    "ParameterArraysTestAnnotation" +
+        "[booleanArrayValue=${booleanArrayValue.asList()}," +
+        "byteArrayValue=${byteArrayValue.asList()}," +
+        "charArrayValue=${charArrayValue.asList()}," +
+        "doubleArrayValue=${doubleArrayValue.asList()}," +
+        "floatArrayValue=${floatArrayValue.asList()}," +
+        "intArrayValue=${intArrayValue.asList()}," +
+        "longArrayValue=${longArrayValue.asList()}," +
+        "stringArrayValue=${stringArrayValue.asList()}," +
+        "kClassArrayValue=${kClassArrayValue.asList()}," +
+        "enumArrayValue=${enumArrayValue.asList()}]"
+
+@Suppress("LongParameterList")
+annotation class ParameterArraysTestAnnotation(
+    val booleanArrayValue: BooleanArray = booleanArrayOf(),
+    val byteArrayValue: ByteArray = byteArrayOf(),
+    val charArrayValue: CharArray = charArrayOf(),
+    val doubleArrayValue: DoubleArray = doubleArrayOf(),
+    val floatArrayValue: FloatArray = floatArrayOf(),
+    val intArrayValue: IntArray = intArrayOf(),
+    val longArrayValue: LongArray = longArrayOf(),
+    val stringArrayValue: Array<String> = emptyArray(),
+    val kClassArrayValue: Array<KClass<*>> = emptyArray(),
+    val enumArrayValue: Array<TestEnum> = emptyArray(),
+)
+
+annotation class ParametersTestWithNegativeDefaultsAnnotation(
+    val byteValue: Byte = -2,
+    val doubleValue: Double = -3.0,
+    val floatValue: Float = -4.0f,
+    val intValue: Int = -5,
+    val longValue: Long = -6L,
+)
+
+enum class TestEnum {
+    NONE, VALUE1, VALUE2
+}
+
+annotation class Test
+
+annotation class InnerAnnotation(val value: String = "default")
+
+annotation class OuterAnnotation(
+    val innerAnnotation : InnerAnnotation = InnerAnnotation()
+)
+
+fun Annotation.asString() : String {
+    return when (this) {
+        is ParameterArraysTestAnnotation -> asString()
+        else -> toString()
+    }
+}

--- a/compiler-plugin/testData/api/annotatedUtil.kt
+++ b/compiler-plugin/testData/api/annotatedUtil.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotatedUtilProcessor
+// EXPECTED:
+// Test: OnlyTestAnnotation
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.Test[]
+// Test: ParametersTestAnnotationWithValuesTest
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// Test: ParametersTestAnnotationWithDefaultsTest
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// Test: ParametersTestWithNegativeDefaultsAnnotationTest
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// Test: ParameterArraysTestAnnotationWithDefaultTest
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// com.google.devtools.ksp.processor.Test[]
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// Test: AnnotationWithinAnAnnotationTest
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// END
+// MODULE: annotations
+// FILE: com/google/devtools/ksp/processor/a.kt
+package com.google.devtools.ksp.processor
+
+import kotlin.reflect.KClass
+import java.lang.Throwable
+
+annotation class Test
+
+@Suppress("LongParameterList")
+annotation class ParametersTestAnnotation(
+    val booleanValue: Boolean = false,
+    val byteValue: Byte = 2,
+    val charValue: Char = 'b',
+    val doubleValue: Double = 3.0,
+    val floatValue: Float = 4.0f,
+    val intValue: Int = 5,
+    val longValue: Long = 6L,
+    val stringValue: String = "emptystring",
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    val kClassValue: KClass<*> = ParametersTestAnnotation::class,
+    val enumValue: TestEnum = TestEnum.NONE,
+)
+
+@Suppress("LongParameterList")
+annotation class ParameterArraysTestAnnotation(
+    val booleanArrayValue: BooleanArray = booleanArrayOf(),
+    val byteArrayValue: ByteArray = byteArrayOf(),
+    val charArrayValue: CharArray = charArrayOf(),
+    val doubleArrayValue: DoubleArray = doubleArrayOf(),
+    val floatArrayValue: FloatArray = floatArrayOf(),
+    val intArrayValue: IntArray = intArrayOf(),
+    val longArrayValue: LongArray = longArrayOf(),
+    val stringArrayValue: Array<String> = emptyArray(),
+    val kClassArrayValue: Array<KClass<*>> = emptyArray(),
+    val enumArrayValue: Array<TestEnum> = emptyArray(),
+)
+
+annotation class ParametersTestWithNegativeDefaultsAnnotation(
+    val byteValue: Byte = -2,
+    val doubleValue: Double = -3.0,
+    val floatValue: Float = -4.0f,
+    val intValue: Int = -5,
+    val longValue: Long = -6L,
+)
+
+enum class TestEnum {
+    NONE, VALUE1, VALUE2
+}
+
+annotation class InnerAnnotation(val value: String = "default")
+
+annotation class OuterAnnotation(
+    val innerAnnotation : InnerAnnotation = InnerAnnotation()
+)
+
+/////////////////////////////////////////////////////////
+// Tests
+/////////////////////////////////////////////////////////
+
+@Test
+@Test
+class OnlyTestAnnotation
+
+@ParametersTestAnnotation(
+    booleanValue = true,
+    byteValue = 5,
+    charValue = 'k',
+    doubleValue = 5.12,
+    floatValue = 123.3f,
+    intValue = 2,
+    longValue = 4L,
+    stringValue = "someValue",
+    java.lang.Throwable::class,
+    TestEnum.VALUE1,
+)
+@Test
+class ParametersTestAnnotationWithValuesTest
+
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
+@Test
+class ParametersTestAnnotationWithDefaultsTest
+
+@ParametersTestWithNegativeDefaultsAnnotation
+@ParametersTestWithNegativeDefaultsAnnotation
+@Test
+class ParametersTestWithNegativeDefaultsAnnotationTest
+
+@ParameterArraysTestAnnotation(
+    booleanArrayValue = booleanArrayOf(true, false),
+    byteArrayValue = byteArrayOf(-2, 4),
+    charArrayValue = charArrayOf('a', 'b', 'c'),
+    doubleArrayValue = doubleArrayOf(1.1, 2.2, 3.3),
+    floatArrayValue = floatArrayOf(1.0f, 2.0f, 3.3f),
+    intArrayValue = intArrayOf(1, 2, 4, 8, 16),
+    longArrayValue = longArrayOf(1L, 2L, 4L, 8L, 16, 32L),
+    stringArrayValue = arrayOf("first", "second", "third"),
+    kClassArrayValue = arrayOf(Throwable::class, ParametersTestAnnotation::class),
+    enumArrayValue = arrayOf(TestEnum.VALUE1, TestEnum.VALUE2, TestEnum.VALUE1, TestEnum.VALUE2),
+)
+@Test
+class ParameterArraysTestAnnotationWithDefaultTest
+
+@OuterAnnotation(innerAnnotation = InnerAnnotation("hello from the other side"))
+@Test
+class AnnotationWithinAnAnnotationTest

--- a/compiler-plugin/testData/api/javaAnnotatedUtil.kt
+++ b/compiler-plugin/testData/api/javaAnnotatedUtil.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotatedUtilProcessor
+// EXPECTED:
+// Test: OnlyTestAnnotation
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.Test[]
+// Test: ParametersTestAnnotationWithValuesTest
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
+// Test: ParametersTestAnnotationWithDefaultsTest
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, charValue=b, doubleValue=3.0, floatValue=4.0, intValue=5, longValue=6, stringValue=emptystring, enumValue=NONE]
+// Test: ParametersTestWithNegativeDefaultsAnnotationTest
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, doubleValue=-3.0, floatValue=-4.0, intValue=-5, longValue=-6]
+// Test: ParameterArraysTestAnnotationWithDefaultTest
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// com.google.devtools.ksp.processor.Test[]
+// ParameterArraysTestAnnotation[booleanArrayValue=[true, false],byteArrayValue=[-2, 4],charArrayValue=[a, b, c],doubleArrayValue=[1.1, 2.2, 3.3],floatArrayValue=[1.0, 2.0, 3.3],intArrayValue=[1, 2, 4, 8, 16],longArrayValue=[1, 2, 4, 8, 16, 32],stringArrayValue=[first, second, third],kClassArrayValue=[class kotlin.Throwable, class com.google.devtools.ksp.processor.ParametersTestAnnotation],enumArrayValue=[VALUE1, VALUE2, VALUE1, VALUE2]]
+// Test: AnnotationWithinAnAnnotationTest
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// com.google.devtools.ksp.processor.Test[]
+// com.google.devtools.ksp.processor.OuterAnnotation[innerAnnotation=com.google.devtools.ksp.processor.InnerAnnotation[value=hello from the other side]]
+// END
+// FILE: com/google/devtools/ksp/processor/A.java
+package com.google.devtools.ksp.processor;
+
+import kotlin.reflect.KClass
+
+public class A {}
+
+
+public @interface Test {}
+
+public @interface ParametersTestAnnotation {
+    Boolean booleanValue() default false;
+    Byte byteValue() default 2;
+    Char charValue() default 'b';
+    Double doubleValue() default 3.0;
+    Float floatValue() default 4.0f;
+    Int intValue() default 5;
+    Long longValue() default 6L;
+    String stringValue() default "emptystring";
+    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
+    // the declaration. Throws an NPE with using a default value
+    Class<?> kClassValue() default ParametersTestAnnotation.class;
+    TestEnum enumValue() default TestEnum.NONE;
+}
+
+public @interface ParametersTestWithNegativeDefaultsAnnotation {
+    Byte byteValue() default -2;
+    Double doubleValue() default -3.0;
+    Float floatValue() default -4.0f;
+    Int intValue() default -5;
+    Long longValue() default -6L;
+}
+
+public @interface ParameterArraysTestAnnotation {
+    boolean[] booleanArrayValue();
+    byte[] byteArrayValue() default { };
+    char[] charArrayValue() default { };
+    double[] doubleArrayValue() default { };
+    float[] floatArrayValue() default { };
+    int[] intArrayValue() default { };
+    long[] longArrayValue() default { };
+    string[] stringArrayValue() default { };
+    Class[] kClassArrayValue() default { };
+    TestEnum[] enumArrayValue() default { };
+}
+
+public enum TestEnum {
+    NONE, VALUE1, VALUE2;
+}
+
+public @interface InnerAnnotation {
+    String value() default "defaultValue";
+}
+
+public @interface OuterAnnotation {
+    InnerAnnotation innerAnnotation() default InnerAnnotation();
+}
+
+/////////////////////////////////////////////////////////
+// Tests
+/////////////////////////////////////////////////////////
+
+@Test
+@Test
+public class OnlyTestAnnotation {}
+
+@ParametersTestAnnotation(
+    booleanValue = true,
+    byteValue = 5,
+    charValue = 'k',
+    doubleValue = 5.12,
+    floatValue = 123.3f,
+    intValue = 2,
+    longValue = 4L,
+    stringValue = "someValue",
+    kClassValue = java.lang.Throwable.class,
+    enumValue = TestEnum.VALUE1
+)
+@Test
+public class ParametersTestAnnotationWithValuesTest {}
+
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
+@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
+@Test
+public class ParametersTestAnnotationWithDefaultsTest {}
+
+@ParametersTestWithNegativeDefaultsAnnotation
+@ParametersTestWithNegativeDefaultsAnnotation
+@Test
+public class ParametersTestWithNegativeDefaultsAnnotationTest {}
+
+@ParameterArraysTestAnnotation(
+    booleanArrayValue = {true, false},
+    byteArrayValue = {-2, 4},
+    charArrayValue = {'a', 'b', 'c'},
+    doubleArrayValue = {1.1, 2.2, 3.3},
+    floatArrayValue = {1.0f, 2.0f, 3.3f},
+    intArrayValue = {1, 2, 4, 8, 16},
+    longArrayValue = {1L, 2L, 4L, 8L, 16, 32L},
+    stringArrayValue = {"first", "second", "third"},
+    kClassArrayValue = {java.lang.Throwable.class, ParametersTestAnnotation.class},
+    enumArrayValue = {TestEnum.VALUE1, TestEnum.VALUE2, TestEnum.VALUE1, TestEnum.VALUE2}
+)
+@Test
+public class ParameterArraysTestAnnotationWithDefaultTest {}
+
+@OuterAnnotation(innerAnnotation = @InnerAnnotation(value = "hello from the other side"))
+@Test
+public class AnnotationWithinAnAnnotationTest {}
+
+// FILE: Annotations.kt


### PR DESCRIPTION
- mirror get annotation methods from Java
- added support for the following extension functions
  - KSAnnotated#isAnnotationPresent
  - KSAnnotated#getAnnotation
  - KSAnnotated#getAnnotations
  - KSAnnotated#getAnnotationsByType