### PR TITLE
Adds generated resources folder to Android's variant `processJavaResourcesProvider` task

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -90,6 +90,8 @@ class AndroidPluginIntegration(
         kspClassOutput.include("**/*.class")
         kotlinCompilation.androidVariant.registerExternalAptJavaOutput(kspJavaOutput)
         kotlinCompilation.androidVariant.registerPreJavacGeneratedBytecode(kspClassOutput)
-        kotlinCompilation.androidVariant.registerPostJavacGeneratedBytecode(resourcesOutputDir)
+        kotlinCompilation.androidVariant.processJavaResourcesProvider.configure {
+            it.from(resourcesOutputDir)
+        }
     }
 }


### PR DESCRIPTION
Replaces `registerPostJavacGeneratedBytecode` by `processJavaResources.from` to allow generated resources by KSP processor to be present on the final classpath of an Android module.

We just discovered this issue today as we are using `ServiceLoader` to find implementation generated by KSP and it was returning none even that `META-INF/services/xxx` was present on `build/generated/ksp/${variantName}/resources`.

I confirmed the bug by introducing this workaround in our code:
```kotlin
        android.applicationVariant.all {
            processJavaResourcesProvider.configure {
                from("$buildDir/generated/ksp/${this@all.name}/resources")
            }
        }
 ```
 