### PR TITLE
Handle illegal function declarations

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/KSPCompilationError.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/KSPCompilationError.kt
@@ -1,0 +1,7 @@
+package com.google.devtools.ksp.processing.impl
+
+import com.google.devtools.ksp.symbol.Location
+import com.intellij.psi.PsiFile
+
+// PsiElement.toLocation() isn't available before ResolveImpl is initialized.
+class KSPCompilationError(val file: PsiFile, val offset: Int, override val message: String) : Exception()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -22,12 +22,14 @@ import com.google.devtools.ksp.ExceptionMessage
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import com.google.devtools.ksp.isOpen
 import com.google.devtools.ksp.isVisibleFrom
+import com.google.devtools.ksp.processing.impl.KSPCompilationError
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.resolve.OverridingUtil
 import org.jetbrains.kotlin.resolve.calls.inference.returnTypeOrNothing
 import java.lang.IllegalStateException
@@ -47,6 +49,9 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
         if (ktFunction is KtConstructor<*>) {
             KSNameImpl.getCached("<init>")
         } else {
+            if (ktFunction.name == null) {
+                throw KSPCompilationError(ktFunction.containingFile, ktFunction.startOffset, "Function declaration must have a name")
+            }
             KSNameImpl.getCached(ktFunction.name!!)
         }
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -34,6 +34,7 @@ import com.google.devtools.ksp.symbol.impl.kotlin.*
 import com.google.devtools.ksp.symbol.impl.synthetic.KSPropertyGetterSyntheticImpl
 import com.google.devtools.ksp.symbol.impl.synthetic.KSPropertySetterSyntheticImpl
 import com.google.devtools.ksp.symbol.impl.synthetic.KSValueParameterSyntheticImpl
+import com.intellij.openapi.project.Project
 import com.intellij.psi.impl.source.PsiClassImpl
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.load.java.JavaDescriptorVisibilities
@@ -232,6 +233,14 @@ fun PsiElement.toLocation(): Location {
     val file = this.containingFile
     val document = ResolverImpl.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
     return FileLocation(file.virtualFile.path, document.getLineNumber(this.textOffset) + 1)
+}
+
+fun Project.findLocationString(file: PsiFile, offset: Int): String {
+    val psiDocumentManager = PsiDocumentManager.getInstance(this)
+    val document = psiDocumentManager.getDocument(file) ?: return "<unknown>"
+    val lineNumber = document.getLineNumber(offset)
+    val offsetInLine = offset - document.getLineStartOffset(lineNumber)
+    return "${file.virtualFile.path}: (${lineNumber + 1}, ${offsetInLine + 1})"
 }
 
 private fun parseDocString(raw: String): String? {


### PR DESCRIPTION
Instead of throwing an NPE, report compilation error with proper error message.