### PR TITLE
Do not resolve configuration during configuration phase

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -54,6 +54,13 @@ class PlaygroundIT {
         gradleRunner.buildAndCheck("--configuration-cache", "clean", "build")
     }
 
+    /** Regression test for https://github.com/google/ksp/issues/518. */
+    @Test
+    fun testBuildWithConfigureOnDemand() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.buildAndCheck("--configure-on-demand", ":workload:build")
+    }
+
     @Test
     fun testBuildCache() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)


### PR DESCRIPTION
This change avoid computing SubpluginOption(s) eagerly, and it uses
ListProperty to capture them in a lazy way. This also ensures
that configure on demand works if ksp processor is defined in
a local project.

Fixes #518
Test: PlaygroundIT.testBuildWithConfigureOnDemand