### PR TITLE
Set Java compatibility to Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,4 +71,9 @@ subprojects {
             }
         }
     }
+
+    tasks.withType<JavaCompile>().configureEach {
+        sourceCompatibility = JavaVersion.VERSION_1_8.toString()
+        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+    }
 }


### PR DESCRIPTION
so that it doesn't depend on the JDK used to build KSP.

Kotlin compiler defaults to Java 8.