### PR TITLE
Enable configuration cache in integration tests

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -64,7 +64,7 @@ class AndroidPluginIntegration(
     private fun decorateAndroidExtension(project: Project) {
         val sourceSets = when (val androidExt = project.extensions.getByName("android")) {
             is BaseExtension -> androidExt.sourceSets
-            is CommonExtension<*, *, *, *, *, *, *, *> -> androidExt.sourceSets
+            is CommonExtension<*, *, *, *> -> androidExt.sourceSets
             else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=1.6.0-dev-2458
-agpBaseVersion=4.2.0
+agpBaseVersion=7.0.0
 intellijVersion=203.8084.24
 junitVersion=4.12
 googleTruthVersion=1.1

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -16,7 +16,8 @@ class AndroidIT {
     fun testPlaygroundAndroid() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        gradleRunner.withArguments("clean", "build", "minifyReleaseWithR8", "--info", "--stacktrace").build().let { result ->
+        // Disabling configuration cache. See https://github.com/google/ksp/issues/299 for details
+        gradleRunner.withArguments("clean", "build", "minifyReleaseWithR8", "--configuration-cache-problems=warn", "--info", "--stacktrace").build().let { result ->
             Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
             val mergedConfiguration = File(project.root, "workload/build/outputs/mapping/release/configuration.txt")
             assert(mergedConfiguration.exists()) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -34,7 +34,8 @@ class KMPImplementedIT {
     fun testAll() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        val resultCleanBuild = gradleRunner.withArguments("clean", "build").build()
+        // KotlinNative doesn't support configuration cache yet.
+        val resultCleanBuild = gradleRunner.withArguments("--configuration-cache-problems=warn", "clean", "build").build()
 
         Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -35,6 +35,7 @@ class PlaygroundIT {
     fun testPlayground() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
         gradleRunner.buildAndCheck("clean", "build")
+        gradleRunner.buildAndCheck("clean", "build")
     }
 
     // TODO: add another plugin and see if it is blocked.
@@ -45,13 +46,8 @@ class PlaygroundIT {
 
         File(project.root, "workload/build.gradle.kts").appendText("\nksp {\n  blockOtherCompilerPlugins = true\n}\n")
         gradleRunner.buildAndCheck("clean", "build")
+        gradleRunner.buildAndCheck("clean", "build")
         project.restore("workload/build.gradle.kts")
-    }
-
-    @Test
-    fun testBuildWithConfigurationCache() {
-        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
-        gradleRunner.buildAndCheck("--configuration-cache", "clean", "build")
     }
 
     /** Regression test for https://github.com/google/ksp/issues/518. */

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -22,6 +22,7 @@ class TemporaryTestProject(projectName: String, baseProject: String? = null) : T
         gradleProperties.appendText("\nkspVersion=$kspVersion")
         gradleProperties.appendText("\nagpVersion=$agpVersion")
         gradleProperties.appendText("\ntestRepo=$testRepo")
+        gradleProperties.appendText("\norg.gradle.unsafe.configuration-cache=true")
         // Uncomment this to debug compiler and compiler plugin.
         // gradleProperties.appendText("\nkotlin.compiler.execution.strategy=in-process")
     }


### PR DESCRIPTION
...for most of the tests. It is still disabled in 2 test:
1. AndroidIT's assembleRelease is still failing and under investigation.
2. K/N compilation doesn't support configuration cache yet.

Real change is in ea681b3, which avoids referencing project in execution phase.

Also upgraded AGP to 7.0.0.