### PR TITLE
cherry-pick bf6a4014..62793f0d into kotlin-1.5.30

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-[Here's](https://github.com/google/ksp/releases/download/1.5.21-1.0.0-beta06/playground.zip) a sample processor that you can check out.
+[Here's](https://github.com/google/ksp/releases/download/1.5.21-1.0.0-beta07/playground.zip) a sample processor that you can check out.
 
 ## Create a processor of your own
 
@@ -21,7 +21,6 @@
 
 * Add a module for hosting the processor.
 * In the module's `build.gradle.kts` file, do the following:
-    * Add `google()` to repositories so that Gradle can find our plugins.
     * Apply Kotlin plugin
     * Add the KSP API to the `dependencies` block.
 
@@ -32,11 +31,10 @@
 
   repositories {
       mavenCentral()
-      google()
   }
 
   dependencies {
-      implementation("com.google.devtools.ksp:symbol-processing-api:1.5.21-1.0.0-beta06")
+      implementation("com.google.devtools.ksp:symbol-processing-api:1.5.21-1.0.0-beta07")
   }
   ```
 
@@ -65,13 +63,11 @@
 <summary>Setup using Kotlin DSL</summary>
   
 * Create another module that contains a workload where you want to try out your processor.
-* In the project's `settings.gradle.kts`, add `google()` to `repositories` for the KSP plugin.
   
   ```kotlin
   pluginManagement {
       repositories {
          gradlePluginPortal()
-         google()
       }
   }
   ```
@@ -85,7 +81,7 @@
 
   ```kotlin
   plugins {
-      id("com.google.devtools.ksp") version "1.5.21-1.0.0-beta06"
+      id("com.google.devtools.ksp") version "1.5.21-1.0.0-beta07"
       kotlin("jvm") 
   }
 
@@ -93,7 +89,6 @@
 
   repositories {
       mavenCentral()
-      google()
   }
 
   dependencies {
@@ -107,13 +102,11 @@
 <details>
 <summary>Setup using Groovy</summary>
 
-* In the projects `settings.gradle`, add `google()` to `repositories` for the KSP plugin:
     
   ```groovy
   pluginManagement {
     repositories {
         gradlePluginPortal()
-        google()
     }
   }
   ```
@@ -121,7 +114,7 @@
 
   ```groovy
   plugins {
-    id "com.google.devtools.ksp" version "1.5.21-1.0.0-beta06"
+    id "com.google.devtools.ksp" version "1.5.21-1.0.0-beta07"
   }
   ```
   

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -64,7 +64,7 @@ class AndroidPluginIntegration(
     private fun decorateAndroidExtension(project: Project) {
         val sourceSets = when (val androidExt = project.extensions.getByName("android")) {
             is BaseExtension -> androidExt.sourceSets
-            is CommonExtension<*, *, *, *, *, *, *, *> -> androidExt.sourceSets
+            is CommonExtension<*, *, *, *> -> androidExt.sourceSets
             else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=1.5.30-RC
-agpBaseVersion=4.2.0
+agpBaseVersion=7.0.0
 intellijVersion=202.7660.26
 junitVersion=4.12
 googleTruthVersion=1.1

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -16,7 +16,8 @@ class AndroidIT {
     fun testPlaygroundAndroid() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        gradleRunner.withArguments("clean", "build", "minifyReleaseWithR8", "--info", "--stacktrace").build().let { result ->
+        // Disabling configuration cache. See https://github.com/google/ksp/issues/299 for details
+        gradleRunner.withArguments("clean", "build", "minifyReleaseWithR8", "--configuration-cache-problems=warn", "--info", "--stacktrace").build().let { result ->
             Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
             val mergedConfiguration = File(project.root, "workload/build/outputs/mapping/release/configuration.txt")
             assert(mergedConfiguration.exists()) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -34,7 +34,8 @@ class KMPImplementedIT {
     fun testAll() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        val resultCleanBuild = gradleRunner.withArguments("clean", "build").build()
+        // KotlinNative doesn't support configuration cache yet.
+        val resultCleanBuild = gradleRunner.withArguments("--configuration-cache-problems=warn", "clean", "build").build()
 
         Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -35,6 +35,7 @@ class PlaygroundIT {
     fun testPlayground() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
         gradleRunner.buildAndCheck("clean", "build")
+        gradleRunner.buildAndCheck("clean", "build")
     }
 
     // TODO: add another plugin and see if it is blocked.
@@ -45,13 +46,8 @@ class PlaygroundIT {
 
         File(project.root, "workload/build.gradle.kts").appendText("\nksp {\n  blockOtherCompilerPlugins = true\n}\n")
         gradleRunner.buildAndCheck("clean", "build")
+        gradleRunner.buildAndCheck("clean", "build")
         project.restore("workload/build.gradle.kts")
-    }
-
-    @Test
-    fun testBuildWithConfigurationCache() {
-        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
-        gradleRunner.buildAndCheck("--configuration-cache", "clean", "build")
     }
 
     /** Regression test for https://github.com/google/ksp/issues/518. */

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -22,6 +22,7 @@ class TemporaryTestProject(projectName: String, baseProject: String? = null) : T
         gradleProperties.appendText("\nkspVersion=$kspVersion")
         gradleProperties.appendText("\nagpVersion=$agpVersion")
         gradleProperties.appendText("\ntestRepo=$testRepo")
+        gradleProperties.appendText("\norg.gradle.unsafe.configuration-cache=true")
         // Uncomment this to debug compiler and compiler plugin.
         // gradleProperties.appendText("\nkotlin.compiler.execution.strategy=in-process")
     }

--- a/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
@@ -10,7 +10,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/incremental/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/init-plus-provider/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/build.gradle.kts
@@ -5,5 +5,4 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }

--- a/integration-tests/src/test/resources/init-plus-provider/provider-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/provider-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/init-plus-provider/settings.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/settings.gradle.kts
@@ -11,7 +11,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/init-plus-provider/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kmp/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/build.gradle.kts
@@ -8,7 +8,6 @@ subprojects {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        google()
     }
 }
 

--- a/integration-tests/src/test/resources/kmp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/on-error/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/on-error/settings.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/output-deps/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/output-deps/settings.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
     jcenter()
 }
 

--- a/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
@@ -8,7 +8,6 @@ subprojects {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        google()
     }
 }
 

--- a/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/playground/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/playground/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/playground/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/test-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 

--- a/integration-tests/src/test/resources/test-processor/settings.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/settings.gradle.kts
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/test-processor/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/test-processor/build.gradle.kts
@@ -12,7 +12,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/test-processor/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/workload/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    google()
 }
 
 dependencies {


### PR DESCRIPTION
I.e., cherry-pick those

```
commit 62793f0d490311bd0c6af923cec834c43a27665b
Author: Jiaxiang Chen <jiaxiang@google.com>
Date:   Fri Aug 13 10:58:27 2021 -0700

    remove unused gmaven repo from integration tests

commit 03bcaf2cfccec2a7f020670da1741066c0593729
Author: Jiaxiang Chen <jiaxiang@google.com>
Date:   Fri Aug 13 10:57:56 2021 -0700

    update quickstart.md to 1.5.21-1.0.0-beta07

commit 30449ba6c05a60d775ebc896207d1c42e4c66005
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Fri Aug 13 10:57:05 2021 -0700

    Remove a duplicated test and repeat some tests

    testBuildWithConfigurationCache() is redundent after setting
    org.gradle.unsafe.configuration-cache=true

commit 6943ac928adcf273ef58a07fd512ee7f40d6d2d3
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Wed Aug 11 21:26:09 2021 -0700

    Bump AGP to 7.0.0

commit 7359f74dc24ba32df90dc2e9aa90dfd3a6fe1c58
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Wed Aug 11 16:15:54 2021 -0700

    Enable Gradle configurate caching in integration tests

commit 9eb8034998fb73e904a48b3e06df0db5a0e52b1b
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Fri Aug 13 00:35:36 2021 -0700

    blockOtherPlugins: avoid referencing task in execution phase

```
into
```
commit 5a2aa3698acc90e96c17709ffd44820f65fcb7ba
Author: Jiaxiang Chen <jiaxiang@google.com>
Date:   Fri Aug 13 10:58:27 2021 -0700

    remove unused gmaven repo from integration tests

    (cherry picked from commit 62793f0d490311bd0c6af923cec834c43a27665b)

commit e954f3f326eabc78755502b6868b8ba88098edf7
Author: Jiaxiang Chen <jiaxiang@google.com>
Date:   Fri Aug 13 10:57:56 2021 -0700

    update quickstart.md to 1.5.21-1.0.0-beta07

    (cherry picked from commit 03bcaf2cfccec2a7f020670da1741066c0593729)

commit c936864af58af832e3f4c4c4ba3e7d89a537d73d
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Fri Aug 13 10:57:05 2021 -0700

    Remove a duplicated test and repeat some tests

    testBuildWithConfigurationCache() is redundent after setting
    org.gradle.unsafe.configuration-cache=true

    (cherry picked from commit 30449ba6c05a60d775ebc896207d1c42e4c66005)

commit 763adff53af15b030711d6e6ac68cebcb3310582
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Wed Aug 11 21:26:09 2021 -0700

    Bump AGP to 7.0.0

    (cherry picked from commit 6943ac928adcf273ef58a07fd512ee7f40d6d2d3)

commit 666e3f3ecd229acddec649cd0733be668f72a7fd
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Wed Aug 11 16:15:54 2021 -0700

    Enable Gradle configurate caching in integration tests

    (cherry picked from commit 7359f74dc24ba32df90dc2e9aa90dfd3a6fe1c58)

commit c0954c23e969b5459a1cff320e13320316f28e2a
Author: Ting-Yuan Huang <laszio@google.com>
Date:   Fri Aug 13 00:35:36 2021 -0700

    blockOtherPlugins: avoid referencing task in execution phase

    (cherry picked from commit 9eb8034998fb73e904a48b3e06df0db5a0e52b1b)
```
