### PR TITLE
Annotations / modifiers for nullable / parenthesized types

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -102,15 +102,21 @@ private val modifierMap = mapOf(
     KtTokens.ACTUAL_KEYWORD to Modifier.ACTUAL
 )
 
-fun KtModifierListOwner.toKSModifiers(): Set<Modifier> {
+fun KtModifierList?.toKSModifiers(): Set<Modifier> {
+    if (this == null)
+        return emptySet()
     val modifiers = mutableSetOf<Modifier>()
-    val modifierList = this.modifierList ?: return emptySet()
     modifiers.addAll(
         modifierMap.entries
-            .filter { modifierList.hasModifier(it.key) }
+            .filter { hasModifier(it.key) }
             .map { it.value }
     )
     return modifiers
+}
+
+fun KtModifierListOwner.toKSModifiers(): Set<Modifier> {
+    val modifierList = this.modifierList
+    return modifierList.toKSModifiers()
 }
 
 fun PsiModifierListOwner.toKSModifiers(): Set<Modifier> {

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -232,6 +232,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/nestedClassType.kt");
     }
 
+    @TestMetadata("nullableTypes.kt")
+    public void testNullableTypes() throws Exception {
+        runTest("testData/api/nullableTypes.kt");
+    }
+
     @TestMetadata(("overridee.kt"))
     public void testOverridee() throws Exception {
         runTest("testData/api/overridee.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/NullableTypeProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/NullableTypeProcessor.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+open class NullableTypeProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    val types = mutableSetOf<KSType>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val files = resolver.getNewFiles()
+
+        files.forEach {
+            it.accept(
+                object : KSTopDownVisitor<Unit, Unit>() {
+                    override fun defaultHandler(node: KSNode, data: Unit) = Unit
+
+                    override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+                        val modifiers = property.type.modifiers.map { it.toString() }.toList().sorted()
+                        val annotations = property.type.annotations.map { it.toString() }.toList().sorted()
+                        val propertyName = property.simpleName.asString()
+                        results.add("$propertyName: $modifiers, $annotations")
+                    }
+                },
+                Unit
+            )
+        }
+
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results.sorted()
+    }
+}

--- a/compiler-plugin/testData/api/nullableTypes.kt
+++ b/compiler-plugin/testData/api/nullableTypes.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ * Copyright 2010-2021 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: NullableTypeProcessor
+// EXPECTED:
+// a: [], [@TA]
+// b: [SUSPEND], [@TA]
+// c: [], [@TA]
+// d: [SUSPEND], [@TA]
+// e: [], [@TA]
+// f: [], [@TA]
+// g: [], [@TA]
+// h: [], [@TA]
+// i: [], [@TA]
+// j: [], [@TA]
+// k: [], [@TA]
+// END
+
+@Target(AnnotationTarget.TYPE)
+annotation class TA
+
+val a: @TA (() -> Unit)? = {}
+val b: (@TA suspend () -> Unit)? = {}
+val c: @TA (() -> Unit) = {}
+val d: (@TA suspend () -> Unit) = {}
+val e: (@TA String)?
+
+// Parser doesn't allow `@TA (String)`
+val f: (@TA String)? = ""
+val g: (@TA String?) = ""
+val h: (@TA String?)? = ""
+val i: @TA String = ""
+val j: (@TA String) = ""
+val k: ((@TA String)?) = ""


### PR DESCRIPTION
Get annotations and modifiers recursively from inner types. Note that
annotations and modifiers can only exist in one of the inner types.

Fixes #354 