### PR TITLE
Support typealias in getSymbolsWithAnnotation

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
@@ -16,6 +16,14 @@ class GetSymbolsFromAnnotationProcessor : AbstractTestProcessor() {
         resolver.getSymbolsWithAnnotation("Bnno").forEach { result.add(it.toString()) }
         result.add("==== Bnno in depth ====")
         resolver.getSymbolsWithAnnotation("Bnno", true).forEach { result.add(it.toString()) }
+        result.add("==== A1 superficial====")
+        resolver.getSymbolsWithAnnotation("A1").forEach { result.add(it.toString()) }
+        result.add("==== A1 in depth ====")
+        resolver.getSymbolsWithAnnotation("A1", true).forEach { result.add(it.toString()) }
+        result.add("==== A2 superficial====")
+        resolver.getSymbolsWithAnnotation("A2").forEach { result.add(it.toString()) }
+        result.add("==== A2 in depth ====")
+        resolver.getSymbolsWithAnnotation("A2", true).forEach { result.add(it.toString()) }
         return emptyList()
     }
 }

--- a/compiler-plugin/testData/api/getSymbolsFromAnnotation.kt
+++ b/compiler-plugin/testData/api/getSymbolsFromAnnotation.kt
@@ -8,6 +8,8 @@
 // constructorParameterFoo
 // <init>
 // param
+// Bar
+// Baz
 // ==== Anno in depth ====
 // Foo
 // propertyFoo
@@ -17,6 +19,8 @@
 // constructorParameterFoo
 // <init>
 // param
+// Bar
+// Baz
 // ==== Bnno superficial====
 // File: Foo.kt
 // <init>
@@ -27,10 +31,54 @@
 // <init>
 // propertyFoo.getter()
 // p2
+// ==== A1 superficial====
+// Foo
+// propertyFoo
+// functionFoo
+// p1
+// constructorParameterFoo
+// <init>
+// param
+// Bar
+// Baz
+// ==== A1 in depth ====
+// Foo
+// propertyFoo
+// functionFoo
+// p1
+// local
+// constructorParameterFoo
+// <init>
+// param
+// Bar
+// Baz
+// ==== A2 superficial====
+// Foo
+// propertyFoo
+// functionFoo
+// p1
+// constructorParameterFoo
+// <init>
+// param
+// Bar
+// Baz
+// ==== A2 in depth ====
+// Foo
+// propertyFoo
+// functionFoo
+// p1
+// local
+// constructorParameterFoo
+// <init>
+// param
+// Bar
+// Baz
 // END
 //FILE: annotations.kt
 annotation class Anno
 annotation class Bnno
+typealias A1 = Anno
+typealias A2 = A1
 
 //FILE: Foo.kt
 @file:Bnno
@@ -50,3 +98,9 @@ class Foo @Anno constructor(@Anno val constructorParameterFoo: Int, @Anno param:
         @Anno val local = 1
     }
 }
+
+@A1
+class Bar
+
+@A2
+class Baz


### PR DESCRIPTION
so that aliasing names can be used in
1. argument to getSymbolsWithAnnotation, and
2. annotations on program elements.

For example, for input source

    typealias Alias = Anno

    @Alias
    class C

A processor can obtain the KSAnnotated for C via

    Resolver.getSymbolsWithAnnotation("Alias")

as well as

    Resolver.getSymbolsWithAnnotation("Anno")