### PR TITLE
Set version in root build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ nexusPublishing {
     }
 }
 
+version = rootProject.extra.get("kspVersion") as String
+
 project.configureKtlintApplyToIdea()
 subprojects {
     group = "com.google.devtools.ksp"


### PR DESCRIPTION
Gradle Nexus Publish Plugin relies on it to determine correct
destination repository, i.e., release staging or snapshot.