### PR TITLE
Skip synthetic Java methods when constructing resolution scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -540,6 +540,9 @@ class ResolverImpl(
         for (e in stack) {
             when (e) {
                 is KSFunctionDeclarationJavaImpl -> {
+                    // Non-physical methods have no interesting scope and may have no containing class
+                    if (!e.psi.isPhysical || e.psi.containingClass == null)
+                        continue
                     resolverContext = resolverContext
                         .childForMethod(
                             resolveJavaDeclaration(e.psi)!!,

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
@@ -40,10 +40,12 @@ class ResolveJavaTypeProcessor : AbstractTestProcessor() {
         val symbol = resolver.getClassDeclarationByName(resolver.getKSNameFromString("C"))
         val symbolTypeParameter = resolver.getClassDeclarationByName(resolver.getKSNameFromString("Base"))
         val another = resolver.getClassDeclarationByName(resolver.getKSNameFromString("Another"))
+        val javaEnum = resolver.getClassDeclarationByName(resolver.getKSNameFromString("JavaEnum"))
         assert(symbol?.origin == Origin.JAVA)
         symbol!!.accept(visitor, Unit)
         symbolTypeParameter!!.accept(visitor, Unit)
         another!!.accept(visitor, Unit)
+        javaEnum!!.accept(visitor, Unit)
         return emptyList()
     }
 

--- a/compiler-plugin/testData/api/resolveJavaType.kt
+++ b/compiler-plugin/testData/api/resolveJavaType.kt
@@ -50,6 +50,13 @@
 // kotlin.Array<Base.T?>?
 // kotlin.Unit
 // Base<Another.T?, Another.T?>?
+// kotlin.Int
+// kotlin.Int
+// JavaEnum
+// kotlin.Unit
+// kotlin.Array<JavaEnum?>?
+// kotlin.String?
+// JavaEnum?
 // END
 // FILE: a.kt
 annotation class Test
@@ -113,4 +120,16 @@ class Base<T,P> {
 
 class Another<T> {
     Base<T, T> base;
+}
+
+public enum JavaEnum {
+    VAL1(1),
+    VAL2(2);
+
+    private int x;
+
+    JavaEnum(int x) {
+        this.x = x;
+    }
+    void enumMethod() {}
 }


### PR DESCRIPTION
Also tested with Room.