### PR TITLE
change KSDeclaration.containingFile to an extension property on KSNode

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -66,6 +66,20 @@ fun Resolver.getPropertyDeclarationByName(name: String, includeTopLevel: Boolean
     getPropertyDeclarationByName(getKSNameFromString(name), includeTopLevel)
 
 /**
+ * Find the containing file of a KSNode.
+ * @return KSFile if the given KSNode has a containing file.
+ * exmample of symbols without a containing file: symbols from class files, synthetic symbols craeted by user.
+ */
+val KSNode.containingFile: KSFile?
+    get() {
+        var parent = this.parent
+        while (parent != null && parent !is KSFile) {
+            parent = parent.parent
+        }
+        return parent as? KSFile?
+    }
+
+/**
  * Get functions directly declared inside the class declaration.
  *
  * What are included: member functions, constructors, extension functions declared inside it, etc.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSDeclarationJavaImpl.kt
@@ -17,9 +17,11 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.impl.findParentAnnotated
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.getDocString
 import com.intellij.psi.PsiElement
@@ -42,6 +44,6 @@ abstract class KSDeclarationJavaImpl(private val psi: PsiElement) : KSDeclaratio
     }
 
     override val parent: KSNode? by lazy {
-        parentDeclaration
+        psi.findParentAnnotated()
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSDeclarationImpl.kt
@@ -17,7 +17,9 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.findParentAnnotated
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
 import com.google.devtools.ksp.symbol.impl.getDocString
 import com.google.devtools.ksp.symbol.impl.memoized
@@ -50,6 +52,7 @@ abstract class KSDeclarationImpl(val ktDeclaration: KtDeclaration) : KSDeclarati
         // see: https://github.com/google/ksp/issues/378
         ktDeclaration.toKSModifiers()
     }
+
     override val containingFile: KSFile? by lazy {
         KSFileImpl.getCached(ktDeclaration.containingKtFile)
     }
@@ -68,8 +71,8 @@ abstract class KSDeclarationImpl(val ktDeclaration: KtDeclaration) : KSDeclarati
         ktDeclaration.findParentDeclaration()
     }
 
-    override val parent: KSDeclaration? by lazy {
-        parentDeclaration
+    override val parent: KSNode? by lazy {
+        ktDeclaration.findParentAnnotated()
     }
 
     override fun toString(): String {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -222,10 +222,10 @@ fun PsiElement.findParentAnnotated(): KSAnnotated? {
 
     return when (parent) {
         is KtClassOrObject -> KSClassDeclarationImpl.getCached(parent)
-        is KtFile -> null
+        is KtFile -> KSFileImpl.getCached(parent)
         is KtFunction -> KSFunctionDeclarationImpl.getCached(parent)
         is PsiClass -> KSClassDeclarationJavaImpl.getCached(parent)
-        is PsiJavaFile -> null
+        is PsiJavaFile -> KSFileJavaImpl.getCached(parent)
         is PsiMethod -> KSFunctionDeclarationJavaImpl.getCached(parent)
         is KtProperty -> KSPropertyDeclarationImpl.getCached(parent)
         is KtPropertyAccessor -> if (parent.isGetter) { KSPropertyGetterImpl.getCached(parent) } else {

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*

--- a/compiler-plugin/testData/api/parent.kt
+++ b/compiler-plugin/testData/api/parent.kt
@@ -1,7 +1,7 @@
 // TEST PROCESSOR: ParentProcessor
 // EXPECTED:
 // parent of File: a.kt: null
-// parent of Anno: null
+// parent of Anno: File: a.kt
 // parent of Anno: synthetic constructor for Anno
 // parent of synthetic constructor for Anno: Anno
 // parent of Int: Int
@@ -13,7 +13,7 @@
 // parent of Map: Map
 // parent of Map: Alias
 // parent of T: Alias
-// parent of Alias: null
+// parent of Alias: File: a.kt
 // parent of Int: Int
 // parent of Int: INVARIANT Int
 // parent of INVARIANT Int: List
@@ -28,21 +28,21 @@
 // parent of Anno: Anno
 // parent of Anno: @Anno
 // parent of @Anno: topProp
-// parent of topProp: null
+// parent of topProp: File: a.kt
 // parent of T: T
 // parent of T: topFun
 // parent of T: topFun
 // parent of Anno: Anno
 // parent of Anno: @Anno
 // parent of @Anno: topFun
-// parent of topFun: null
-// parent of ITF: null
+// parent of topFun: File: a.kt
+// parent of ITF: File: a.kt
 // parent of ITF: ITF
 // parent of ITF: topClass
 // parent of Anno: Anno
 // parent of Anno: @Anno
 // parent of @Anno: topClass
-// parent of topClass: null
+// parent of topClass: File: a.kt
 // parent of Int: Int
 // parent of Int: i
 // parent of i: memberFun
@@ -81,7 +81,7 @@
 // parent of T: B
 // parent of Anno: @Anno
 // parent of @Anno: B
-// parent of B: null
+// parent of B: File: B.java
 // parent of T: T
 // parent of T: t
 // parent of t: B

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,3 +1,4 @@
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import java.io.OutputStreamWriter

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BuilderProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BuilderProcessor.kt
@@ -1,3 +1,4 @@
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,3 +1,4 @@
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import java.io.OutputStream


### PR DESCRIPTION
also fixed `parent` implementation where `KSFile` is not considered as a valid parent.