### PR TITLE
Add experimental KSDeclarationContainer.declarationsInSourceOrder

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1046,6 +1046,13 @@ class ResolverImpl(
     @KspExperimental
     override fun mapKotlinNameToJava(kotlinName: KSName): KSName? =
         JavaToKotlinClassMap.mapKotlinToJava(FqNameUnsafe(kotlinName.asString()))?.toKSName()
+
+    @KspExperimental
+    internal fun mapToJvmSignature(accessor: KSPropertyAccessor): String {
+        return resolvePropertyAccessorDeclaration(accessor)?.let {
+            typeMapper.mapAsmMethod(it).descriptor
+        } ?: ""
+    }
 }
 
 // TODO: cross module resolution

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -127,6 +127,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/declarationPackageName.kt");
     }
 
+    @TestMetadata("declarationOrder.kt")
+    public void testDeclarationOrder() throws Exception {
+        runTest("testData/api/declarationOrder.kt");
+    }
+
     @TestMetadata("declarationUtil.kt")
     public void testDeclarationUtil() throws Exception {
         runTest("testData/api/declarationUtil.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
@@ -1,0 +1,45 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.impl.declarationsInSourceOrder
+
+@KspExperimental
+class DeclarationOrderProcessor : AbstractTestProcessor() {
+    private val result = mutableListOf<String>()
+    override fun toResult() = result
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val classNames = listOf(
+            "lib.KotlinClass", "lib.JavaClass",
+            "KotlinClass", "JavaClass"
+        )
+        classNames.map {
+            checkNotNull(resolver.getClassDeclarationByName(it)) {
+                "cannot find $it"
+            }
+        }.forEach { klass ->
+            result.add(klass.qualifiedName!!.asString())
+            result.addAll(
+                klass.declarationsInSourceOrder.filterIsInstance<KSPropertyDeclaration>().map {
+                    it.toSignature(resolver)
+                }
+            )
+            result.addAll(
+                klass.declarationsInSourceOrder.filterIsInstance<KSFunctionDeclaration>().map {
+                    it.toSignature(resolver)
+                }
+            )
+        }
+        return emptyList()
+    }
+
+    private fun KSDeclaration.toSignature(
+        resolver: Resolver
+    ) = "${simpleName.asString()}:${resolver.mapToJvmSignature(this)}"
+}

--- a/compiler-plugin/testData/api/declarationOrder.kt
+++ b/compiler-plugin/testData/api/declarationOrder.kt
@@ -1,0 +1,139 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: DeclarationOrderProcessor
+// EXPECTED:
+// lib.KotlinClass
+// b:Ljava/lang/String;
+// a:Ljava/lang/String;
+// c:Ljava/lang/String;
+// isB:Ljava/lang/String;
+// isA:Ljava/lang/String;
+// isC:Ljava/lang/String;
+// noBackingB:Ljava/lang/String;
+// noBackingA:Ljava/lang/String;
+// noBackingC:Ljava/lang/String;
+// noBackingVarB:Ljava/lang/String;
+// noBackingVarA:Ljava/lang/String;
+// noBackingVarC:Ljava/lang/String;
+// overloaded:(Ljava/lang/String;)Ljava/lang/String;
+// overloaded:(I)Ljava/lang/String;
+// overloaded:()Ljava/lang/String;
+// overloaded:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+// <init>:()V
+// lib.JavaClass
+// b:Ljava/lang/String;
+// a:Ljava/lang/String;
+// c:Ljava/lang/String;
+// overloaded:(Ljava/lang/String;)V
+// overloaded:(I)V
+// overloaded:()V
+// overloaded:(Ljava/lang/String;Ljava/lang/String;)V
+// <init>:()V
+// KotlinClass
+// b:Ljava/lang/String;
+// a:Ljava/lang/String;
+// c:Ljava/lang/String;
+// isB:Ljava/lang/String;
+// isA:Ljava/lang/String;
+// isC:Ljava/lang/String;
+// noBackingB:Ljava/lang/String;
+// noBackingA:Ljava/lang/String;
+// noBackingC:Ljava/lang/String;
+// noBackingVarB:Ljava/lang/String;
+// noBackingVarA:Ljava/lang/String;
+// noBackingVarC:Ljava/lang/String;
+// overloaded:(Ljava/lang/String;)Ljava/lang/String;
+// overloaded:(I)Ljava/lang/String;
+// overloaded:()Ljava/lang/String;
+// overloaded:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+// <init>:()V
+// JavaClass
+// b:Ljava/lang/String;
+// a:Ljava/lang/String;
+// c:Ljava/lang/String;
+// overloaded:(Ljava/lang/String;)V
+// overloaded:(I)V
+// overloaded:()V
+// overloaded:(Ljava/lang/String;Ljava/lang/String;)V
+// <init>:()V
+// END
+// MODULE: module1
+// FILE: lib/KotlinClass.kt
+package lib;
+class KotlinClass {
+    val b: String = TODO()
+    val a: String = TODO()
+    val c: String = TODO()
+    val isB:String = TODO()
+    val isA:String = TODO()
+    val isC:String = TODO()
+    val noBackingB: String
+        get() = ""
+    val noBackingA: String
+        get() = ""
+    val noBackingC: String
+        get() = ""
+    var noBackingVarB: String
+        get() = ""
+        set(value) {}
+    var noBackingVarA: String
+        get() = ""
+        set(value) {}
+    var noBackingVarC: String
+        get() = ""
+        set(value) {}
+    fun overloaded(x:String): String = TODO()
+    fun overloaded(x:Int): String = TODO()
+    fun overloaded(): String = TODO()
+    fun overloaded(x:String, y:String): String = TODO()
+}
+// FILE: lib/JavaClass.java
+package lib;
+public class JavaClass {
+    // notice the non alphabetic order, which is triggering the problem
+    String b = "";
+    String a = "";
+    String c = "";
+    void overloaded(String x) {}
+    void overloaded(int x) {}
+    void overloaded() {}
+    void overloaded(String x, String y) {}
+}
+// MODULE: main(module1)
+// FILE: main.kt
+class KotlinClass {
+    val b: String? = TODO()
+    val a: String = TODO()
+    val c: String? = TODO()
+    val isB:String = TODO()
+    val isA:String = TODO()
+    val isC:String = TODO()
+    val noBackingB: String
+        get() = ""
+    val noBackingA: String
+        get() = ""
+    val noBackingC: String
+        get() = ""
+    var noBackingVarB: String
+        get() = ""
+        set(value) {}
+    var noBackingVarA: String
+        get() = ""
+        set(value) {}
+    var noBackingVarC: String
+        get() = ""
+        set(value) {}
+    fun overloaded(x:String): String = TODO()
+    fun overloaded(x:Int): String = TODO()
+    fun overloaded(): String = TODO()
+    fun overloaded(x:String, y:String): String = TODO()
+}
+// FILE: JavaClass.java
+public class JavaClass {
+    String b = "";
+    String a = "";
+    String c = "";
+    void overloaded(String x) {}
+    void overloaded(int x) {}
+    void overloaded() {}
+    void overloaded(String x, String y) {}
+}


### PR DESCRIPTION
which is same as KSDeclarationContainer.declarations, except that the
order of retrived declarations match their positions in source.

This is adapted from https://github.com/google/ksp/pull/260, which is
authored by Yigit Boyar <yboyar@google.com>.