### PR TITLE
Allowing getting sources from compile tasks

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -32,4 +32,9 @@ open class KspExtension {
     }
 
     open var blockOtherCompilerPlugins: Boolean = false
+
+    // Instruct KSP to pickup sources from compile tasks, instead of source sets.
+    // Note that it depends on behaviors of other Gradle plugins, that may bring surprises and can be hard to debug.
+    // Use your discretion.
+    open var allowSourcesFromOtherPlugins: Boolean = false
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -297,7 +297,13 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 classOutputDir,
                 resourceOutputDir
             )
-            kotlinCompilation.allKotlinSourceSets.forEach { sourceSet -> kspTask.source(sourceSet.kotlin) }
+            kspTask.source(kotlinCompileTask.source)
+            if (kotlinCompileTask is AbstractKotlinCompile<*>) {
+                val sourceRoots = kotlinCompileTask.getSourceRoots()
+                if (sourceRoots is SourceRoots.ForJvm) {
+                    kspTask.source(sourceRoots.javaSourceRoots)
+                }
+            }
 
             // Don't support binary generation for K/N yet.
             // FIXME: figure out how to add user generated libraries.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -63,6 +63,7 @@ import org.jetbrains.kotlin.incremental.isJavaFile
 import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.io.File
+import java.nio.file.Paths
 import java.util.*
 import java.util.concurrent.Callable
 import javax.inject.Inject
@@ -304,6 +305,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                     kspTask.source(sourceRoots.javaSourceRoots)
                 }
             }
+            kspTask.source.filter { !kspOutputDir.isParentOf(it) }
 
             // Don't support binary generation for K/N yet.
             // FIXME: figure out how to add user generated libraries.
@@ -862,4 +864,11 @@ internal inline fun <reified T : CommonCompilerArguments> dumpArgs(args: T): Map
         }
 
     return argumentProperties.associate(args::toPair).toSortedMap()
+}
+
+internal fun File.isParentOf(childCandidate: File): Boolean {
+    val parentPath = Paths.get(this.absolutePath).normalize()
+    val childCandidatePath = Paths.get(childCandidate.absolutePath).normalize()
+
+    return childCandidatePath.startsWith(parentPath)
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -298,12 +298,16 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 classOutputDir,
                 resourceOutputDir
             )
-            kspTask.source(kotlinCompileTask.source)
-            if (kotlinCompileTask is AbstractKotlinCompile<*>) {
-                val sourceRoots = kotlinCompileTask.getSourceRoots()
-                if (sourceRoots is SourceRoots.ForJvm) {
-                    kspTask.source(sourceRoots.javaSourceRoots)
+            if (kspExtension.allowSourcesFromOtherPlugins) {
+                kspTask.source(kotlinCompileTask.source)
+                if (kotlinCompileTask is AbstractKotlinCompile<*>) {
+                    val sourceRoots = kotlinCompileTask.getSourceRoots()
+                    if (sourceRoots is SourceRoots.ForJvm) {
+                        kspTask.source(sourceRoots.javaSourceRoots)
+                    }
                 }
+            } else {
+                kotlinCompilation.allKotlinSourceSets.forEach { sourceSet -> kspTask.source(sourceSet.kotlin) }
             }
             kspTask.source.filter { !kspOutputDir.isParentOf(it) }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -26,7 +26,6 @@ class PlaygroundIT {
             Assert.assertTrue(jarFile.getEntry("TestProcessor.log").size > 0)
             Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
             Assert.assertTrue(jarFile.getEntry("g/G.class").size > 0)
-            Assert.assertTrue(jarFile.getEntry("g/GBuilder.class").size > 0)
             Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
         }
 
@@ -46,9 +45,29 @@ class PlaygroundIT {
     fun testBlockOtherCompilerPlugins() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        File(project.root, "workload/build.gradle.kts").appendText("\nksp {\n  blockOtherCompilerPlugins = true\n}\n")
+        File(project.root, "workload/build.gradle.kts")
+            .appendText("\nksp {\n  blockOtherCompilerPlugins = true\n}\n")
         gradleRunner.buildAndCheck("clean", "build")
         gradleRunner.buildAndCheck("clean", "build")
+        project.restore("workload/build.gradle.kts")
+    }
+
+    @Test
+    fun testAllowSourcesFromOtherPlugins() {
+        fun checkGBuilder() {
+            val artifact = File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar")
+
+            JarFile(artifact).use { jarFile ->
+                Assert.assertTrue(jarFile.getEntry("g/GBuilder.class").size > 0)
+            }
+        }
+
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        File(project.root, "workload/build.gradle.kts")
+            .appendText("\nksp {\n  allowSourcesFromOtherPlugins = true\n}\n")
+        gradleRunner.buildAndCheck("clean", "build") { checkGBuilder() }
+        gradleRunner.buildAndCheck("clean", "build") { checkGBuilder() }
         project.restore("workload/build.gradle.kts")
     }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -25,6 +25,8 @@ class PlaygroundIT {
         JarFile(artifact).use { jarFile ->
             Assert.assertTrue(jarFile.getEntry("TestProcessor.log").size > 0)
             Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("g/G.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("g/GBuilder.class").size > 0)
             Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
         }
 

--- a/integration-tests/src/test/resources/playground/workload/G.kt
+++ b/integration-tests/src/test/resources/playground/workload/G.kt
@@ -1,0 +1,6 @@
+package g
+
+import com.example.annotation.Builder
+
+@Builder
+class G

--- a/integration-tests/src/test/resources/playground/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/workload/build.gradle.kts
@@ -23,3 +23,12 @@ ksp {
     arg("option1", "value1")
     arg("option2", "value2")
 }
+
+val compileKotlin: AbstractCompile by tasks
+tasks.register<Copy>("copyG") {
+    from("G.kt")
+    into(File(buildDir, "generatedSources").apply { mkdirs() })
+}.let {
+    // Magic. `map` creates a provider to propagate task dependency.
+    compileKotlin.source(it.map { it.destinationDir })
+}


### PR DESCRIPTION
instead of default source set and its dependencies.

There are 3 ways (that I know of) to register extra sources to
compilation tasks:

  1. Add to default source sets.
  2. Add to dependencies of default source sets.
  3. Add to compile task directly, e.g., via AbstractCompile.source

KSP picked up from the first 2 only. Now it also does third.