### PR TITLE
Enable multiplatform configurations

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -18,7 +18,6 @@ package com.google.devtools.ksp.gradle
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.BaseExtension
-import com.android.build.gradle.api.AndroidSourceSet
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -36,7 +36,7 @@ object AndroidPluginIntegration {
 
     private val agpPluginIds = listOf("com.android.application", "com.android.library", "com.android.dynamic-feature")
 
-    fun findSourceSets(project: Project, onSourceSet: (String) -> Unit) {
+    fun forEachAndroidSourceSet(project: Project, onSourceSet: (String) -> Unit) {
         agpPluginIds.forEach { agpPluginId ->
             project.pluginManager.withPlugin(agpPluginId) {
                 // for android apps, we need a configuration per source set

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -19,7 +19,6 @@ package com.google.devtools.ksp.gradle
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.AndroidSourceSet
-import org.gradle.api.Named
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -53,7 +53,7 @@ object AndroidPluginIntegration {
             is CommonExtension<*, *, *, *> -> androidExt.sourceSets
             else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
         }
-        sourceSets.configureEach {
+        sourceSets.all {
             onSourceSet(it.name)
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -60,7 +60,6 @@ object AndroidPluginIntegration {
     fun getCompilationSourceSets(kotlinCompilation: KotlinJvmAndroidCompilation): List<String> {
         return kotlinCompilation.androidVariant
             .sourceSets
-            .filterIsInstance(AndroidSourceSet::class.java)
             .map { it.name }
     }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -1,0 +1,106 @@
+package com.google.devtools.ksp.gradle
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.jetbrains.kotlin.gradle.dsl.*
+import org.jetbrains.kotlin.gradle.plugin.*
+import java.util.*
+
+/**
+ * Creates and retrieves ksp-related configurations.
+ */
+class KspConfigurations(private val project: Project) {
+    companion object {
+        const val ROOT = "ksp"
+    }
+
+    // "ksp" configuration. In single-platform projects, it is applied to the "main" sourceSet.
+    // In multi-platform projects, it is applied to the "main" sourceSet of all targets.
+    private val rootMainConfiguration = project.configurations.create(ROOT)
+
+    // Stores all saved configurations for quick access.
+    private val configurations = mutableMapOf<KotlinSourceSet, Configuration>()
+
+    @OptIn(ExperimentalStdlibApi::class)
+    private fun addConfiguration(owner: KotlinSourceSet, parent: Configuration?, name: String): Configuration {
+        val configName = ROOT + name.replaceFirstChar { it.uppercase() }
+        val existingConfig = project.configurations.findByName(configName)
+        if (existingConfig != null && configName != ROOT) {
+            error("Unexpected duplicate configuration ($configName).")
+        }
+
+        val config = existingConfig ?: project.configurations.create(configName)
+        if (parent != null) config.extendsFrom(parent)
+        configurations[owner] = config
+        return config
+    }
+
+    init {
+        project.plugins.withType(KotlinBasePluginWrapper::class.java).configureEach {
+            // 1.6.0: decorateKotlinProject(project.kotlinExtension)
+            decorateKotlinProject(project.extensions.getByName("kotlin") as KotlinProjectExtension)
+        }
+    }
+
+    private fun decorateKotlinProject(kotlin: KotlinProjectExtension) {
+        when (kotlin) {
+            is KotlinMultiplatformExtension -> kotlin.targets.configureEach(::decorateKotlinTarget)
+            is KotlinSingleTargetExtension -> decorateKotlinTarget(kotlin.target)
+        }
+    }
+
+    private fun decorateKotlinTarget(target: KotlinTarget) {
+        if (target.platformType == KotlinPlatformType.androidJvm) {
+            /**
+             * TODO: Android might need special handling. Discuss. Tricky points:
+             * 1) KotlinSourceSets are defined in terms of AGP Variants - a resolved, compilable entity.
+             *    Using them would be consistent with other targets and simple.
+             * 2) AGP AndroidSourceSets represent a hierarchy: we have "test", "debug", but also "testDebug"
+             *    which depends on the other two. Not clear if this dependency should be reflected in the
+             *    configurations.
+             * 3) Need to find a way to retrieve the correct configurations in applyToCompilation
+             */
+            Unit
+        } else {
+            // We could add target-specific configurations here (kspJvm, parent of kspJvmMain & kspJvmTest)
+            // but we decided that kspJvm should actually mean kspJvmMain, which in turn is not created.
+            target.compilations.configureEach { compilation ->
+                val isMain = compilation.name == KotlinCompilation.MAIN_COMPILATION_NAME
+                compilation.kotlinSourceSets.forEach { sourceSet ->
+                    val isDefault = sourceSet.name == compilation.defaultSourceSetName
+                    decorateKotlinSourceSet(compilation, isMain, sourceSet, isDefault)
+                }
+            }
+        }
+    }
+
+    private fun decorateKotlinSourceSet(
+        compilation: KotlinCompilation<*>,
+        isMainCompilation: Boolean,
+        sourceSet: KotlinSourceSet,
+        isDefaultSourceSet: Boolean
+    ) {
+        val parent = if (isMainCompilation) rootMainConfiguration else null
+        if (isMainCompilation && isDefaultSourceSet) {
+            // Use target name instead of sourceSet name, to avoid creating "kspMain" or "kspJvmMain".
+            // Note: on single-platform, target name is conveniently set to "" so this resolves to "ksp".
+            addConfiguration(sourceSet, parent, compilation.target.name)
+        } else {
+            addConfiguration(sourceSet, parent, sourceSet.name)
+        }
+    }
+
+    /**
+     * Returns the user-facing configurations involved in the given compilation.
+     * We use [KotlinCompilation.kotlinSourceSets], not [KotlinCompilation.allKotlinSourceSets] for a few reasons:
+     * 1) consistency with how we created the configurations
+     * 2) all* can return sets belonging to other compilations. In this case the dependency should be tracked
+     *    by Gradle at the task level, not by us through configurations.
+     * 3) all* can return user-defined sets belonging to no compilation, like intermediate source sets defined
+     *    to share code between targets. They do not currently have their own ksp configuration.
+     */
+    fun find(compilation: KotlinCompilation<*>): Set<Configuration> {
+        val sourceSets = compilation.kotlinSourceSets
+        return sourceSets.mapNotNull { configurations[it] }.toSet()
+    }
+}

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -115,6 +115,8 @@ class KspConfigurations(private val project: Project) {
      *    that don't belong to any compilation, like user-defined intermediate source sets (e.g. iosMain).
      *    These do not currently have their own ksp configuration.
      * 2) all* can return sets belonging to other [KotlinCompilation]s
+     *
+     * See test: SourceSetConfigurationsTest.configurationsForMultiplatformApp_doesNotCrossCompilationBoundaries
      */
     fun find(compilation: KotlinCompilation<*>): Set<Configuration> {
         val kotlinConfigurations = compilation.kotlinSourceSets.mapNotNull { kotlinConfigurations[it] }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -82,7 +82,7 @@ class KspConfigurations(private val project: Project) {
      */
     private fun decorateKotlinTarget(target: KotlinTarget) {
         if (target.platformType == KotlinPlatformType.androidJvm) {
-            AndroidPluginIntegration.findSourceSets(target.project) { sourceSet ->
+            AndroidPluginIntegration.forEachAndroidSourceSet(target.project) { sourceSet ->
                 val isMain = sourceSet.endsWith("main", ignoreCase = true)
                 val nameWithoutMain = when {
                     isMain -> sourceSet.substring(0, sourceSet.length - 4)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -15,7 +15,6 @@ class KspConfigurations(private val project: Project) {
         private const val PREFIX = "ksp"
     }
 
-
     // Store all ksp configurations for quick retrieval.
     private val kotlinConfigurations = mutableMapOf<KotlinSourceSet, Configuration>()
     private val androidConfigurations = mutableMapOf<String, Configuration>()

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -205,10 +205,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             val processorClasspath = project.configurations.maybeCreate("${kspTaskName}ProcessorClasspath")
                 .extendsFrom(*nonEmptyKspConfigurations.toTypedArray())
             kspTask.processorClasspath.from(processorClasspath)
-
-            nonEmptyKspConfigurations.forEach {
-                kspTask.dependsOn(it.buildDependencies)
-            }
+            kspTask.dependsOn(processorClasspath.buildDependencies)
 
             if (kspExtension.blockOtherCompilerPlugins) {
                 // FIXME: ask upstream to provide an API to make this not implementation-dependent.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -131,14 +131,10 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
     }
 
     private lateinit var kspConfigurations: KspConfigurations
-    private val androidIntegration by lazy {
-        AndroidPluginIntegration(this)
-    }
 
-    override fun apply(project: Project) {
-        project.extensions.create("ksp", KspExtension::class.java)
-        kspConfigurations = KspConfigurations(project)
-        androidIntegration.applyIfAndroidProject(project)
+    override fun apply(target: Project) {
+        target.extensions.create("ksp", KspExtension::class.java)
+        kspConfigurations = KspConfigurations(target)
         registry.register(KspModelBuilder())
     }
 
@@ -330,7 +326,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             }
         }
         if (kotlinCompilation is KotlinJvmAndroidCompilation) {
-            androidIntegration.registerGeneratedJavaSources(
+            AndroidPluginIntegration.registerGeneratedJavaSources(
                 project = project,
                 kotlinCompilation = kotlinCompilation,
                 kspTaskProvider = kspTaskProvider as TaskProvider<KspTaskJvm>,

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -207,7 +207,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             kspTask.apOptions.value(kspExtension.arguments).disallowChanges()
             kspTask.kspCacheDir.fileValue(getKspCachesDir(project, sourceSetName)).disallowChanges()
 
-
             if (kspExtension.blockOtherCompilerPlugins) {
                 // FIXME: ask upstream to provide an API to make this not implementation-dependent.
                 val cfg = project.configurations.getByName(kotlinCompilation.pluginConfigurationName)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -138,29 +138,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         registry.register(KspModelBuilder())
     }
 
-    /**
-     * Creates a KSP configuration for each element in the object container.
-     * TODO: remove after revisiting AndroidPluginIntegration.
-     */
-    internal fun <T> NamedDomainObjectContainer<T>.createKspConfigurations(
-        project: Project,
-        getKspConfigurationNames: (T) -> List<String>,
-    ) {
-        val mainConfiguration = project.configurations.maybeCreate(KSP_MAIN_CONFIGURATION_NAME)
-        all {
-            getKspConfigurationNames(it).forEach { kspConfigurationName ->
-                if (kspConfigurationName != KSP_MAIN_CONFIGURATION_NAME) {
-                    val existing = project.configurations.findByName(kspConfigurationName)
-                    if (existing == null) {
-                        project.configurations.create(kspConfigurationName) {
-                            it.extendsFrom(mainConfiguration)
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean {
         val project = kotlinCompilation.target.project
         val kspVersion = javaClass.`package`.implementationVersion

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -130,49 +130,21 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         }
     }
 
+    private lateinit var kspConfigurations: KspConfigurations
     private val androidIntegration by lazy {
         AndroidPluginIntegration(this)
     }
 
-    @OptIn(ExperimentalStdlibApi::class)
-    private val KotlinSourceSet.kspConfigurationName: String
-        get() {
-            return if (name == SourceSet.MAIN_SOURCE_SET_NAME) {
-                KSP_MAIN_CONFIGURATION_NAME
-            } else {
-                "$KSP_MAIN_CONFIGURATION_NAME${name.capitalize(Locale.US)}"
-            }
-        }
-
-    private fun KotlinSourceSet.kspConfiguration(project: Project): Configuration? {
-        return project.configurations.findByName(kspConfigurationName)
-    }
-
     override fun apply(project: Project) {
         project.extensions.create("ksp", KspExtension::class.java)
-        // Always include the main `ksp` configuration.
-        // TODO: multiplatform
-        project.configurations.create(KSP_MAIN_CONFIGURATION_NAME)
-        project.plugins.withType(KotlinPluginWrapper::class.java) {
-            // kotlin extension has the compilation target that we need to look for to create configurations
-            decorateKotlinExtension(project)
-        }
+        kspConfigurations = KspConfigurations(project)
         androidIntegration.applyIfAndroidProject(project)
         registry.register(KspModelBuilder())
     }
 
-    private fun decorateKotlinExtension(project: Project) {
-        project.extensions.configure(KotlinSingleTargetExtension::class.java) { kotlinExtension ->
-            kotlinExtension.target.compilations.createKspConfigurations(project) { kotlinCompilation ->
-                kotlinCompilation.kotlinSourceSets.map {
-                    it.kspConfigurationName
-                }
-            }
-        }
-    }
-
     /**
      * Creates a KSP configuration for each element in the object container.
+     * TODO: remove after revisiting AndroidPluginIntegration.
      */
     internal fun <T> NamedDomainObjectContainer<T>.createKspConfigurations(
         project: Project,
@@ -215,17 +187,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             project.locateTask(kotlinCompilation.compileKotlinTaskName) ?: return project.provider { emptyList() }
         val javaCompile = findJavaTaskForKotlinCompilation(kotlinCompilation)?.get()
         val kspExtension = project.extensions.getByType(KspExtension::class.java)
-        val kspConfigurations = LinkedHashSet<Configuration>()
-        kotlinCompilation.allKotlinSourceSets.forEach {
-            it.kspConfiguration(project)?.let {
-                kspConfigurations.add(it)
-            }
-        }
-        // Always include the main `ksp` configuration.
-        // TODO: multiplatform
-        project.configurations.findByName(KSP_MAIN_CONFIGURATION_NAME)?.let {
-            kspConfigurations.add(it)
-        }
+        val kspConfigurations = kspConfigurations.find(kotlinCompilation)
         val nonEmptyKspConfigurations = kspConfigurations.filter { it.dependencies.isNotEmpty() }
         if (nonEmptyKspConfigurations.isEmpty()) {
             return project.provider { emptyList() }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -20,7 +20,6 @@
 package com.google.devtools.ksp.gradle
 
 import com.google.devtools.ksp.gradle.model.builder.KspModelBuilder
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -161,7 +161,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         val javaCompile = findJavaTaskForKotlinCompilation(kotlinCompilation)?.get()
         val kspExtension = project.extensions.getByType(KspExtension::class.java)
         val kspConfigurations = kspConfigurations.find(kotlinCompilation)
-        val nonEmptyKspConfigurations = kspConfigurations.filter { it.dependencies.isNotEmpty() }
+        val nonEmptyKspConfigurations = kspConfigurations.filter { it.allDependencies.isNotEmpty() }
         if (nonEmptyKspConfigurations.isEmpty()) {
             return project.provider { emptyList() }
         }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -111,7 +111,7 @@ class GradleCompilationTest {
 
         testRule.runner()
             .withDebug(true)
-            .withArguments("app:assemble", "--stacktrace")
+            .withArguments("app:assemble")
             .forwardOutput()
             .build()
     }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -111,7 +111,7 @@ class GradleCompilationTest {
 
         testRule.runner()
             .withDebug(true)
-            .withArguments("app:assemble")
+            .withArguments("app:assemble", "--stacktrace")
             .forwardOutput()
             .build()
     }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -40,22 +40,24 @@ class ProcessorClasspathConfigurationsTest {
     fun testConfigurationsForSinglePlatformApp() {
         testRule.setupAppAsJvmApp()
         testRule.appModule.addSource("Foo.kt", "class Foo")
-        testRule.appModule.buildFileAdditions.add("""
-            $kspConfigs.all {
-                // Make sure ksp configs are not empty.
-                project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
-            }
-            tasks.register("testConfigurations") {
-                // Resolve all tasks to trigger classpath config creation
-                dependsOn(tasks["tasks"])
-                doLast {
-                    val main = configurations["kspKotlinProcessorClasspath"]
-                    val test = configurations["kspTestKotlinProcessorClasspath"]
-                    require(main.extendsFrom.map { it.name } == listOf("ksp"))
-                    require(test.extendsFrom.map { it.name } == listOf("kspTest"))
+        testRule.appModule.buildFileAdditions.add(
+            """
+                $kspConfigs.all {
+                    // Make sure ksp configs are not empty.
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
                 }
-            }
-        """.trimIndent())
+                tasks.register("testConfigurations") {
+                    // Resolve all tasks to trigger classpath config creation
+                    dependsOn(tasks["tasks"])
+                    doLast {
+                        val main = configurations["kspKotlinProcessorClasspath"]
+                        val test = configurations["kspTestKotlinProcessorClasspath"]
+                        require(main.extendsFrom.map { it.name } == listOf("ksp"))
+                        require(test.extendsFrom.map { it.name } == listOf("kspTest"))
+                    }
+                }
+            """.trimIndent()
+        )
         testRule.runner()
             .withArguments(":app:testConfigurations")
             .build()
@@ -63,33 +65,37 @@ class ProcessorClasspathConfigurationsTest {
 
     @Test
     fun testConfigurationsForMultiPlatformApp() {
-        testRule.setupAppAsMultiplatformApp("""
-            kotlin {
-                jvm { }
-                js { browser() }
-            }
-        """.trimIndent())
-        testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
-        testRule.appModule.buildFileAdditions.add("""
-            $kspConfigs.matching { it.name != "ksp" }.all {
-                // Make sure ksp configs are not empty.
-                project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
-            }
-            tasks.register("testConfigurations") {
-                // Resolve all tasks to trigger classpath config creation
-                dependsOn(tasks["tasks"])
-                doLast {
-                    val jvmMain = configurations["kspKotlinJvmProcessorClasspath"]
-                    val jvmTest = configurations["kspTestKotlinJvmProcessorClasspath"]
-                    val jsMain = configurations["kspKotlinJsProcessorClasspath"]
-                    val jsTest = configurations["kspTestKotlinJsProcessorClasspath"]
-                    require(jvmMain.extendsFrom.map { it.name } == listOf("kspJvm"))
-                    require(jvmTest.extendsFrom.map { it.name } == listOf("kspJvmTest"))
-                    require(jsMain.extendsFrom.map { it.name } == listOf("kspJs"))
-                    require(jsTest.extendsFrom.map { it.name } == listOf("kspJsTest"))
+        testRule.setupAppAsMultiplatformApp(
+            """
+                kotlin {
+                    jvm { }
+                    js { browser() }
                 }
-            }
-        """.trimIndent())
+            """.trimIndent()
+        )
+        testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
+        testRule.appModule.buildFileAdditions.add(
+            """
+                $kspConfigs.matching { it.name != "ksp" }.all {
+                    // Make sure ksp configs are not empty.
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+                }
+                tasks.register("testConfigurations") {
+                    // Resolve all tasks to trigger classpath config creation
+                    dependsOn(tasks["tasks"])
+                    doLast {
+                        val jvmMain = configurations["kspKotlinJvmProcessorClasspath"]
+                        val jvmTest = configurations["kspTestKotlinJvmProcessorClasspath"]
+                        val jsMain = configurations["kspKotlinJsProcessorClasspath"]
+                        val jsTest = configurations["kspTestKotlinJsProcessorClasspath"]
+                        require(jvmMain.extendsFrom.map { it.name } == listOf("kspJvm"))
+                        require(jvmTest.extendsFrom.map { it.name } == listOf("kspJvmTest"))
+                        require(jsMain.extendsFrom.map { it.name } == listOf("kspJs"))
+                        require(jsTest.extendsFrom.map { it.name } == listOf("kspJsTest"))
+                    }
+                }
+            """.trimIndent()
+        )
         testRule.runner()
             .withArguments(":app:testConfigurations")
             .build()

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.devtools.ksp.gradle
+
+import com.google.devtools.ksp.gradle.testing.KspIntegrationTestRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class ProcessorClasspathConfigurationsTest {
+    @Rule
+    @JvmField
+    val tmpDir = TemporaryFolder()
+
+    @Rule
+    @JvmField
+    val testRule = KspIntegrationTestRule(tmpDir)
+
+    private val kspConfigs by lazy {
+        """configurations.matching { it.name.startsWith("ksp") && !it.name.endsWith("ProcessorClasspath") }"""
+    }
+
+    // config name is <KotlinCompileTaskName>.replace("compile", "ksp") + "ProcessorClasspath"
+    // they should extend all non-empty ksp configurations
+    @Test
+    fun testConfigurationsForSinglePlatformApp() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.addSource("Foo.kt", "class Foo")
+        testRule.appModule.buildFileAdditions.add("""
+            $kspConfigs.all {
+                // Make sure ksp configs are not empty.
+                project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+            }
+            tasks.register("testConfigurations") {
+                // Resolve all tasks to trigger classpath config creation
+                dependsOn(tasks["tasks"])
+                doLast {
+                    val main = configurations["kspKotlinProcessorClasspath"]
+                    val test = configurations["kspTestKotlinProcessorClasspath"]
+                    require(main.extendsFrom.map { it.name } == listOf("ksp"))
+                    require(test.extendsFrom.map { it.name } == listOf("kspTest"))
+                }
+            }
+        """.trimIndent())
+        testRule.runner()
+            .withArguments(":app:testConfigurations")
+            .build()
+    }
+
+    @Test
+    fun testConfigurationsForMultiPlatformApp() {
+        testRule.setupAppAsMultiplatformApp("""
+            kotlin {
+                jvm { }
+                js { browser() }
+            }
+        """.trimIndent())
+        testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
+        testRule.appModule.buildFileAdditions.add("""
+            $kspConfigs.matching { it.name != "ksp" }.all {
+                // Make sure ksp configs are not empty.
+                project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+            }
+            tasks.register("testConfigurations") {
+                // Resolve all tasks to trigger classpath config creation
+                dependsOn(tasks["tasks"])
+                doLast {
+                    val jvmMain = configurations["kspKotlinJvmProcessorClasspath"]
+                    val jvmTest = configurations["kspTestKotlinJvmProcessorClasspath"]
+                    val jsMain = configurations["kspKotlinJsProcessorClasspath"]
+                    val jsTest = configurations["kspTestKotlinJsProcessorClasspath"]
+                    require(jvmMain.extendsFrom.map { it.name } == listOf("kspJvm"))
+                    require(jvmTest.extendsFrom.map { it.name } == listOf("kspJvmTest"))
+                    require(jsMain.extendsFrom.map { it.name } == listOf("kspJs"))
+                    require(jsTest.extendsFrom.map { it.name } == listOf("kspJsTest"))
+                }
+            }
+        """.trimIndent())
+        testRule.runner()
+            .withArguments(":app:testConfigurations")
+            .build()
+    }
+}

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -74,13 +74,15 @@ class SourceSetConfigurationsTest {
 
     @Test
     fun configurationsForMultiplatformApp() {
-        testRule.setupAppAsMultiplatformApp(
-            "jvm { }",
-            "android(name = \"foo\") { }",
-            "js { browser() }",
-            "androidNativeX86 { }",
-            "androidNativeX64(name = \"bar\") { }",
-        )
+        testRule.setupAppAsMultiplatformApp("""
+            kotlin {
+                jvm { }
+                android(name = "foo") { }
+                js { browser() }
+                androidNativeX86 { }
+                androidNativeX64(name = "bar") { }
+            }
+        """.trimIndent())
         testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
         val result = testRule.runner()
             .withArguments(":app:dependencies")

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -73,6 +73,47 @@ class SourceSetConfigurationsTest {
     }
 
     @Test
+    fun configurationsForMultiplatformApp() {
+        testRule.setupAppAsMultiplatformApp(
+            "jvm { }",
+            "android(name = \"foo\") { }",
+            "js { browser() }",
+            "androidNativeX86 { }",
+            "androidNativeX64(name = \"bar\") { }",
+        )
+        testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
+        val result = testRule.runner()
+            .withArguments(":app:dependencies")
+            .build()
+
+        assertThat(result.output.lines()).containsAtLeast(
+            "ksp",
+            // jvm target:
+            "kspJvm",
+            "kspJvmTest",
+            // android target, named foo:
+            "kspFoo",
+            "kspFooAndroidTest",
+            "kspFooAndroidTestDebug",
+            "kspFooAndroidTestRelease",
+            "kspFooDebug",
+            "kspFooRelease",
+            "kspFooTest",
+            "kspFooTestDebug",
+            "kspFooTestRelease",
+            // js target:
+            "kspJs",
+            "kspJsTest",
+            // androidNativeX86 target:
+            "kspAndroidNativeX86",
+            "kspAndroidNativeX86Test",
+            // androidNative64 target, named bar:
+            "kspBar",
+            "kspBarTest"
+        )
+    }
+
+    @Test
     fun registerJavaSourcesToAndroid() {
         testRule.setupAppAsAndroidApp()
         testRule.appModule.dependencies.addAll(

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -89,7 +89,6 @@ class SourceSetConfigurationsTest {
             .build()
 
         assertThat(result.output.lines()).containsAtLeast(
-            "ksp",
             // jvm target:
             "kspJvm",
             "kspJvmTest",

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -76,15 +76,17 @@ class SourceSetConfigurationsTest {
 
     @Test
     fun configurationsForMultiplatformApp() {
-        testRule.setupAppAsMultiplatformApp("""
-            kotlin {
-                jvm { }
-                android(name = "foo") { }
-                js { browser() }
-                androidNativeX86 { }
-                androidNativeX64(name = "bar") { }
-            }
-        """.trimIndent())
+        testRule.setupAppAsMultiplatformApp(
+            """
+                kotlin {
+                    jvm { }
+                    android(name = "foo") { }
+                    js { browser() }
+                    androidNativeX86 { }
+                    androidNativeX64(name = "bar") { }
+                }
+            """.trimIndent()
+        )
         testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
         val result = testRule.runner()
             .withArguments(":app:dependencies")
@@ -122,32 +124,36 @@ class SourceSetConfigurationsTest {
         // Adding a ksp dependency on jvmParent should not leak into jvmChild compilation,
         // even if the source sets depend on each other. This works because we use
         // KotlinCompilation.kotlinSourceSets instead of KotlinCompilation.allKotlinSourceSets
-        testRule.setupAppAsMultiplatformApp("""
-            kotlin {
-                jvm("jvmParent") { }
-                jvm("jvmChild") { }
-            }
-        """.trimIndent())
+        testRule.setupAppAsMultiplatformApp(
+            """
+                kotlin {
+                    jvm("jvmParent") { }
+                    jvm("jvmChild") { }
+                }
+            """.trimIndent()
+        )
         testRule.appModule.addMultiplatformSource("commonMain", "Foo.kt", "class Foo")
-        testRule.appModule.buildFileAdditions.add("""
-            kotlin {
-                sourceSets {
-                    this["jvmChildMain"].dependsOn(this["jvmParentMain"])
+        testRule.appModule.buildFileAdditions.add(
+            """
+                kotlin {
+                    sourceSets {
+                        this["jvmChildMain"].dependsOn(this["jvmParentMain"])
+                    }
                 }
-            }
-            dependencies {
-                add("kspJvmParent", "androidx.room:room-compiler:2.3.0")
-            }
-            tasks.register("checkConfigurations") {
-                doLast {
-                    // child has no dependencies, so task is not created.
-                    val parent = tasks.findByName("kspKotlinJvmParent")
-                    val child = tasks.findByName("kspKotlinJvmChild")
-                    require(parent != null)
-                    require(child == null)
+                dependencies {
+                    add("kspJvmParent", "androidx.room:room-compiler:2.3.0")
                 }
-            }
-        """.trimIndent())
+                tasks.register("checkConfigurations") {
+                    doLast {
+                        // child has no dependencies, so task is not created.
+                        val parent = tasks.findByName("kspKotlinJvmParent")
+                        val child = tasks.findByName("kspKotlinJvmChild")
+                        require(parent != null)
+                        require(child == null)
+                    }
+                }
+            """.trimIndent()
+        )
         testRule.runner()
             .withArguments(":app:checkConfigurations")
             .build()

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -119,7 +119,7 @@ class KspIntegrationTestRule(
         testProject.appModule.buildFileAdditions.add(
             """
             kotlin {
-                ${targets.joinToString(separator = "\n") { it.trimIndent()} }
+                ${targets.joinToString(separator = "\n") { it.trimIndent() } }
             }
             """.trimIndent()
         )

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -108,7 +108,7 @@ class KspIntegrationTestRule(
     /**
      * Sets up the app module as a multiplatform app with the specified [targets], wrapped in a kotlin { } block.
      */
-    fun setupAppAsMultiplatformApp(vararg targets: String) {
+    fun setupAppAsMultiplatformApp(targets: String) {
         testProject.appModule.plugins.addAll(
             listOf(
                 PluginDeclaration.id("com.android.application", testConfig.androidBaseVersion),
@@ -116,13 +116,7 @@ class KspIntegrationTestRule(
                 PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion)
             )
         )
-        testProject.appModule.buildFileAdditions.add(
-            """
-            kotlin {
-                ${targets.joinToString(separator = "\n") { it.trimIndent() } }
-            }
-            """.trimIndent()
-        )
+        testProject.appModule.buildFileAdditions.add(targets)
         addAndroidBoilerplate()
     }
 

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -102,6 +102,31 @@ class KspIntegrationTestRule(
                 PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion)
             )
         )
+        addAndroidBoilerplate()
+    }
+
+    /**
+     * Sets up the app module as a multiplatform app with the specified [targets], wrapped in a kotlin { } block.
+     */
+    fun setupAppAsMultiplatformApp(vararg targets: String) {
+        testProject.appModule.plugins.addAll(
+            listOf(
+                PluginDeclaration.id("com.android.application", testConfig.androidBaseVersion),
+                PluginDeclaration.kotlin("multiplatform", testConfig.kotlinBaseVersion),
+                PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion)
+            )
+        )
+        testProject.appModule.buildFileAdditions.add(
+            """
+            kotlin {
+                ${targets.joinToString(separator = "\n") { it.trimIndent()} }
+            }
+            """.trimIndent()
+        )
+        addAndroidBoilerplate()
+    }
+
+    private fun addAndroidBoilerplate() {
         testProject.appModule.buildFileAdditions.add(
             """
             android {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestModule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestModule.kt
@@ -77,6 +77,19 @@ class TestModule(
         srcDir.resolve(name).writeText(contents)
     }
 
+    /**
+     * Adds the given source file to the given KotlinSourceSet in a multiplatform project.
+     */
+    fun addMultiplatformSource(sourceSet: String, name: String, contents: String) {
+        require(name.endsWith(".kt")) { "multiplatform source extension needs to be *.kt." }
+        val srcDir = multiplatformKotlinSourceDir(sourceSet)
+        srcDir.resolve(name).writeText(contents)
+    }
+
+    private fun multiplatformKotlinSourceDir(sourceSet: String) = moduleRoot.resolve("src/$sourceSet/kotlin").also {
+        it.mkdirs()
+    }
+
     private val kotlinSourceDir
         get() = moduleRoot.resolve("src/main/kotlin").also {
             it.mkdirs()

--- a/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
@@ -18,4 +18,5 @@ dependencies {
     implementation(project(":validator"))
     testImplementation("junit:junit:4.12")
     ksp(project(":validator"))
+    kspTest(project(":validator"))
 }

--- a/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
@@ -42,6 +42,17 @@ kotlin {
 }
 
 dependencies {
-    ksp(project(":test-processor"))
+    add("kspMetadata", project(":test-processor"))
+    add("kspJvm", project(":test-processor"))
+    add("kspJvmTest", project(":test-processor"))
+    add("kspJs", project(":test-processor"))
+    add("kspJsTest", project(":test-processor"))
+    add("kspAndroidNativeX64", project(":test-processor"))
+    add("kspAndroidNativeX64Test", project(":test-processor"))
+    add("kspAndroidNativeArm64", project(":test-processor"))
+    add("kspAndroidNativeArm64Test", project(":test-processor"))
+    add("kspLinuxX64", project(":test-processor"))
     add("kspLinuxX64Test", project(":test-processor"))
+    add("kspMingwX64", project(":test-processor"))
+    add("kspMingwX64Test", project(":test-processor"))
 }

--- a/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
@@ -43,4 +43,5 @@ kotlin {
 
 dependencies {
     ksp(project(":test-processor"))
+    add("kspLinuxX64Test", project(":test-processor"))
 }

--- a/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(project(":test-processor"))
-                configurations.get("ksp").dependencies.add(project(":test-processor"))
+                project.dependencies.add("kspJvm", project(":test-processor"))
             }
             kotlin.srcDir("src/main/java")
         }


### PR DESCRIPTION
This PR introduces sourceSet specific gradle configurations for multiplatform users, so that ksp processors can be applied selectively to only one target, for example. Relevant discussion: https://kotlinlang.slack.com/archives/C013BA8EQSE/p1630359069041200

#### Before PR
- Root configuration `ksp` incorrectly? applied to everything
- Source set configurations `ksp<Set>` available only in single-platform projects (like kotlin-jvm)
- Android treated as a special case, creating `ksp<Set>` configurations from AGP `AndroidSourceSet`s, but without dedicated logic when picking up the correct configurations to apply to a given compilation.

#### After PR
- <strike>Root configuration `ksp` is applied to main sets of all targets - does not apply to test compilations anymore</strike> 
- **Single-platform projects** (like kotlin-jvm): no changes, one configuration per set named `ksp<Set>`. Use `ksp` for the main set, and `kspTest` for the test set.
- **Multi-platform projects** (kotlin-multiplatform): just like single-platform. Note though that multiplatform source sets are named after the target, so the configuration name will also include it. For example for a JVM target, we have `kspJvm` and `kspJvmTest`. **This also means that the `ksp` configuration will not be available. See discussion here: https://github.com/google/ksp/pull/609#discussion_r714226247 for why.** This is a breaking change for multiplatform users - I tried to mitigate the impact of this change by throwing a clear error.
- Android still treated as before, but in multi-platform we add the target name prefix. If target is named `android`, configurations are named `kspAndroid<AndroidSourceSet>`. This is needed to avoid conflicts with other targets.

Note that I moved configuration logic to a separate `KspConfigurations` class for readability, and also fixed a few issues when creating the `ksp<>ProcessorClasspath` configuration.