### PR TITLE
fix getSymbolsWithAnnotation for @setparam and @param use site target

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -307,6 +307,7 @@ class ResolverImpl(
             }
 
             override fun visitPropertySetter(setter: KSPropertySetter, data: Unit) {
+                setter.parameter.accept(this, data)
                 visitAnnotated(setter, data)
             }
 
@@ -332,9 +333,6 @@ class ResolverImpl(
             }
 
             override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
-                if (valueParameter.isVal || valueParameter.isVar) {
-                    return
-                }
                 visitAnnotated(valueParameter, data)
             }
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -37,6 +37,7 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
 
     override val annotations: Sequence<KSAnnotation> by lazy {
         ktParameter.filterUseSiteTargetAnnotations().map { KSAnnotationImpl.getCached(it) }
+            .filter { it.useSiteTarget != AnnotationUseSiteTarget.PARAM }
     }
 
     override val parentDeclaration: KSDeclaration? by lazy {

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -49,7 +49,8 @@ class CheckOverrideProcessor : AbstractTestProcessor() {
         val equalFunJava = javaList.getAllFunctions().single { it.simpleName.asString() == "equals" }
         val bazPropKt = resolver.getSymbolsWithAnnotation("BazAnno").single() as KSPropertyDeclaration
         val baz2PropKt = resolver.getSymbolsWithAnnotation("Baz2Anno").single() as KSPropertyDeclaration
-        val bazzPropKt = resolver.getSymbolsWithAnnotation("BazzAnno").single() as KSPropertyDeclaration
+        val bazzPropKt = resolver.getSymbolsWithAnnotation("BazzAnno")
+            .filterIsInstance<KSPropertyDeclaration>().single()
         val bazz2PropKt = resolver.getSymbolsWithAnnotation("Bazz2Anno").single() as KSPropertyDeclaration
         checkOverride(getFunKt, getFunJava)
         checkOverride(fooFunKt, fooFunJava)

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
@@ -9,21 +9,27 @@ class GetSymbolsFromAnnotationProcessor : AbstractTestProcessor() {
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         result.add("==== Anno superficial====")
-        resolver.getSymbolsWithAnnotation("Anno").forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("Anno").forEach { result.add(toString(it)) }
         result.add("==== Anno in depth ====")
-        resolver.getSymbolsWithAnnotation("Anno", true).forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("Anno", true).forEach { result.add(toString(it)) }
         result.add("==== Bnno superficial====")
-        resolver.getSymbolsWithAnnotation("Bnno").forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("Bnno").forEach { result.add(toString(it)) }
         result.add("==== Bnno in depth ====")
-        resolver.getSymbolsWithAnnotation("Bnno", true).forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("Bnno", true).forEach { result.add(toString(it)) }
         result.add("==== A1 superficial====")
-        resolver.getSymbolsWithAnnotation("A1").forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("A1").forEach { result.add(toString(it)) }
         result.add("==== A1 in depth ====")
-        resolver.getSymbolsWithAnnotation("A1", true).forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("A1", true).forEach { result.add(toString(it)) }
         result.add("==== A2 superficial====")
-        resolver.getSymbolsWithAnnotation("A2").forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("A2").forEach { result.add(toString(it)) }
         result.add("==== A2 in depth ====")
-        resolver.getSymbolsWithAnnotation("A2", true).forEach { result.add(it.toString()) }
+        resolver.getSymbolsWithAnnotation("A2", true).forEach { result.add(toString(it)) }
+        result.add("==== Cnno in depth ====")
+        resolver.getSymbolsWithAnnotation("Cnno", true).forEach { result.add(toString(it)) }
         return emptyList()
+    }
+
+    fun toString(annotated: KSAnnotated): String {
+        return "$annotated:${annotated::class.supertypes.first().classifier.toString().substringAfterLast('.')}"
     }
 }

--- a/compiler-plugin/testData/api/getSymbolsFromAnnotation.kt
+++ b/compiler-plugin/testData/api/getSymbolsFromAnnotation.kt
@@ -1,82 +1,94 @@
 // TEST PROCESSOR: GetSymbolsFromAnnotationProcessor
 // EXPECTED:
 // ==== Anno superficial====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
 // ==== Anno in depth ====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// local
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// local:KSPropertyDeclaration
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
 // ==== Bnno superficial====
-// File: Foo.kt
-// <init>
-// propertyFoo.getter()
-// p2
+// File: Foo.kt:KSFile
+// <init>:KSFunctionDeclaration
+// propertyFoo.getter():KSPropertyAccessorImpl
+// p2:KSValueParameter
 // ==== Bnno in depth ====
-// File: Foo.kt
-// <init>
-// propertyFoo.getter()
-// p2
+// File: Foo.kt:KSFile
+// <init>:KSFunctionDeclaration
+// propertyFoo.getter():KSPropertyAccessorImpl
+// p2:KSValueParameter
 // ==== A1 superficial====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
 // ==== A1 in depth ====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// local
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// local:KSPropertyDeclaration
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
 // ==== A2 superficial====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
 // ==== A2 in depth ====
-// Foo
-// propertyFoo
-// functionFoo
-// p1
-// local
-// constructorParameterFoo
-// <init>
-// param
-// Bar
-// Baz
+// Foo:KSClassDeclaration
+// propertyFoo:KSPropertyDeclaration
+// functionFoo:KSFunctionDeclaration
+// p1:KSValueParameter
+// local:KSPropertyDeclaration
+// constructorParameterFoo:KSPropertyDeclaration
+// <init>:KSFunctionDeclaration
+// constructorParameterFoo:KSValueParameter
+// param:KSValueParameter
+// Bar:KSClassDeclaration
+// Baz:KSClassDeclaration
+// ==== Cnno in depth ====
+// <set-?>:KSValueParameter
+// constructorParameterFoo:KSValueParameter
+// x:KSPropertyDeclaration
+// x:KSValueParameter
 // END
 //FILE: annotations.kt
 annotation class Anno
 annotation class Bnno
+annotation class Cnno
 typealias A1 = Anno
 typealias A2 = A1
 
@@ -84,7 +96,7 @@ typealias A2 = A1
 @file:Bnno
 
 @Anno
-class Foo @Anno constructor(@Anno val constructorParameterFoo: Int, @Anno param: Int){
+class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, @Anno param: Int){
     @Bnno constructor() {
 
     }
@@ -97,7 +109,12 @@ class Foo @Anno constructor(@Anno val constructorParameterFoo: Int, @Anno param:
     fun functionFoo(@Anno p1: Int, @Bnno p2: Int) {
         @Anno val local = 1
     }
+
+    @setparam:Cnno
+    var a = 1
 }
+
+class C(@Cnno val x: Int)
 
 @A1
 class Bar


### PR DESCRIPTION
fixes #636 

also handled the annotation use site target for constructor parameter. note that with such handling logic, 2 symbols will be returned (one for property declaration and one for value parameter) for a property declared in primary constructor, unless `@param` is specified.