### PR TITLE
Add gRPC Dekorator to supported libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ The table below includes a list of popular libraries on Android and their variou
 |Kotshi|[Experimentally supported](https://github.com/ansman/kotshi)|   |
 |Lyricist|[Experimentally supported](https://github.com/adrielcafe/lyricist)|   |
 |Lich SavedState|[Officially supported](https://github.com/line/lich/tree/master/savedstate)|   |
+|gRPC Dekorator|[Officially supported](https://github.com/mottljan/grpc-dekorator)|   |
 |Auto Factory|Not yet supported|[Link](https://github.com/google/auto/issues/982)|
 |Dagger|Not yet supported|[Link](https://github.com/google/dagger/issues/2349)|
 |Hilt|Not yet supported|[Link](https://issuetracker.google.com/179057202)|


### PR DESCRIPTION
[gRPC Dekorator](https://github.com/mottljan/grpc-dekorator) is a library that you can use to decorate your RPCs to add them some special functionality which is not possible using gRPC's ClientInterceptors. It generates decorator classes using KSP.

I would also like to appreciate and thank you for your amazing job on KSP!