### PR TITLE
Re-include the `ksp` dependency for all targets

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -16,7 +16,7 @@ class KspConfigurations(private val project: Project) {
     }
 
     private val allowAllTargetConfiguration =
-        project.findProperty("ksp.allow_all_target_configuration")?.let {
+        project.findProperty("ksp.allow.all.target.configuration")?.let {
             it.toString().toBoolean()
         } ?: true
 
@@ -74,8 +74,10 @@ class KspConfigurations(private val project: Project) {
             is KotlinMultiplatformExtension -> {
                 kotlin.targets.configureEach(::decorateKotlinTarget)
 
-                project.afterEvaluate {
-                    if (configurationForAll.dependencies.isNotEmpty()) {
+                var reported = false
+                configurationForAll.dependencies.whenObjectAdded {
+                    if (!reported) {
+                        reported = true
                         val msg = "The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. " +
                             "Please use target-specific configurations like 'kspJvm' instead."
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -15,6 +15,14 @@ class KspConfigurations(private val project: Project) {
         private const val PREFIX = "ksp"
     }
 
+    private val allowAllTargetConfiguration =
+        project.findProperty("ksp.allow_all_target_configuration")?.let {
+            it.toString().toBoolean()
+        } ?: true
+
+    // The "ksp" configuration, applied to every compilations.
+    private val configurationForAll = project.configurations.create(PREFIX)
+
     private fun configurationNameOf(vararg parts: String): String {
         return parts.joinToString("") {
             it.replaceFirstChar { it.uppercase() }
@@ -66,13 +74,17 @@ class KspConfigurations(private val project: Project) {
             is KotlinMultiplatformExtension -> {
                 kotlin.targets.configureEach(::decorateKotlinTarget)
 
-                // Adding multiplatform configuration removed support for the root ksp configuration.
-                // Try to make this breaking change less breaking by adding a clear error.
-                project.configurations.create("ksp").dependencies.all {
-                    throw InvalidUserCodeException(
-                        "The 'ksp' configuration cannot be used in Kotlin Multiplatform projects. " +
+                project.afterEvaluate {
+                    if (configurationForAll.dependencies.isNotEmpty()) {
+                        val msg = "The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. " +
                             "Please use target-specific configurations like 'kspJvm' instead."
-                    )
+
+                        if (allowAllTargetConfiguration) {
+                            project.logger.warn(msg)
+                        } else {
+                            throw InvalidUserCodeException(msg)
+                        }
+                    }
                 }
             }
         }
@@ -130,6 +142,12 @@ class KspConfigurations(private val project: Project) {
                 getAndroidConfigurationName(compilation.target, it)
             }
         }
+
+        // Include the `ksp` configuration, if it exists, for all compilations.
+        if (allowAllTargetConfiguration) {
+            results.add(configurationForAll.name)
+        }
+
         return results.mapNotNull {
             compilation.target.project.configurations.findByName(it)
         }.toSet()

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -86,7 +86,7 @@ class ProcessorClasspathConfigurationsTest {
             """.trimIndent()
         )
         testRule.runner()
-            .withArguments(":app:testConfigurations", "-Pksp.allow_all_target_configuration=false")
+            .withArguments(":app:testConfigurations", "-Pksp.allow.all.target.configuration=false")
             .build()
     }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -118,7 +118,7 @@ class KMPImplementedIT {
             "--configuration-cache-problems=warn",
             "clean",
             "build",
-            "-Pksp.allow_all_target_configuration=false"
+            "-Pksp.allow.all.target.configuration=false"
         ).buildAndFail().apply {
             Assert.assertTrue(
                 messages.all {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.test
 
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
@@ -35,11 +36,18 @@ class KMPImplementedIT {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         // KotlinNative doesn't support configuration cache yet.
-        val resultCleanBuild = gradleRunner.withArguments("--configuration-cache-problems=warn", "clean", "build")
-            .build()
+        gradleRunner.withArguments(
+            "--configuration-cache-problems=warn",
+            "clean",
+            "build"
+        ).build().let {
+            verifyAll(it)
+        }
+    }
 
-        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
-        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:kspTestKotlinLinuxX64")?.outcome)
+    private fun verifyAll(result: BuildResult) {
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspTestKotlinLinuxX64")?.outcome)
 
         verify(
             "workload/build/libs/workload-jvm-1.0-SNAPSHOT.jar",
@@ -71,16 +79,66 @@ class KMPImplementedIT {
 
         // TODO: Enable after CI's Xcode version catches up.
         // Assert.assertTrue(
-        //     resultCleanBuild.task(":workload:kspKotlinIosArm64")?.outcome == TaskOutcome.SUCCESS ||
-        //         resultCleanBuild.task(":workload:kspKotlinIosArm64")?.outcome == TaskOutcome.SKIPPED
+        //     result.task(":workload:kspKotlinIosArm64")?.outcome == TaskOutcome.SUCCESS ||
+        //         result.task(":workload:kspKotlinIosArm64")?.outcome == TaskOutcome.SKIPPED
         // )
         // Assert.assertTrue(
-        //     resultCleanBuild.task(":workload:kspKotlinMacosX64")?.outcome == TaskOutcome.SUCCESS ||
-        //         resultCleanBuild.task(":workload:kspKotlinMacosX64")?.outcome == TaskOutcome.SKIPPED
+        //     result.task(":workload:kspKotlinMacosX64")?.outcome == TaskOutcome.SUCCESS ||
+        //         result.task(":workload:kspKotlinMacosX64")?.outcome == TaskOutcome.SKIPPED
         // )
         Assert.assertTrue(
-            resultCleanBuild.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SUCCESS ||
-                resultCleanBuild.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SKIPPED
+            result.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SUCCESS ||
+                result.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SKIPPED
         )
+    }
+
+    @Test
+    fun testMainConfiguration() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val buildScript = File(project.root, "workload/build.gradle.kts")
+        val lines = buildScript.readLines().takeWhile {
+            it.trimEnd() != "dependencies {"
+        }
+        buildScript.writeText(lines.joinToString(System.lineSeparator()))
+        buildScript.appendText(System.lineSeparator())
+        buildScript.appendText("dependencies {")
+        buildScript.appendText(System.lineSeparator())
+        buildScript.appendText("    add(\"ksp\", project(\":test-processor\"))")
+        buildScript.appendText(System.lineSeparator())
+        buildScript.appendText("}")
+
+        val messages = listOf(
+            "The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. ",
+            "Please use target-specific configurations like 'kspJvm' instead."
+        )
+
+        // KotlinNative doesn't support configuration cache yet.
+        gradleRunner.withArguments(
+            "--configuration-cache-problems=warn",
+            "clean",
+            "build",
+            "-Pksp.allow_all_target_configuration=false"
+        ).buildAndFail().apply {
+            Assert.assertTrue(
+                messages.all {
+                    output.contains(it)
+                }
+            )
+        }
+
+        // KotlinNative doesn't support configuration cache yet.
+        gradleRunner.withArguments(
+            "--configuration-cache-problems=warn",
+            "clean",
+            "build"
+        ).build().apply {
+            Assert.assertTrue(
+                messages.all {
+                    output.contains(it)
+                }
+            )
+            verifyAll(this)
+        }
     }
 }


### PR DESCRIPTION
So that the behavior aligns with KSP 1.0.0. Note that the apply-to-all
`ksp` configuration is being deprecated in the following way:

  1. A seperate `kspTest` configuration is available for test source
     sets now. In the future `ksp` won't apply to test source sets.

  2. `ksp` will not be available at all for multiplatform projects.

The `ksp.allow_all_target_configuration` gradle property is also
introduced, so that users can early-access the new behavior by setting
it to false.