### PR TITLE
Update CI for the kotlin-1.6.0 -> 1.0.1-release rename

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        ref: kotlin-1.6.0
+        ref: 1.0.1-release
 
     - name: merge commits from main to release branch
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, kotlin-1.6.0, 1.0.0-release ]
+    branches: [ main, 1.0.1-release, 1.0.0-release ]
   pull_request:
-    branches: [ main, kotlin-1.6.0, 1.0.0-release ]
+    branches: [ main, 1.0.1-release, 1.0.0-release ]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Don't merge before the branch is renamed.