### PR TITLE
Added corner case for KSP with Gradle plugin

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -177,3 +177,26 @@ kotlin {
     }
 }
 ```
+
+If you are using Idea and KSP in a Gradle plugin then the above snippet will give the following warning:
+
+> Execution optimizations have been disabled for task ':publishPluginJar' to ensure correctness due to the following reasons:
+>  - Gradle detected a problem with the following location: '../build/generated/ksp/main/kotlin'. Reason: Task ':publishPluginJar' uses this output of task ':kspKotlin' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.2/userguide/validation_problems.html#implicit_dependency for more details about this problem.
+
+In this case, use this instead:
+
+```kotlin
+plugins {
+    // …
+    idea
+}
+// …
+idea {
+    module {
+        // Not using += due to https://github.com/gradle/gradle/issues/8749
+        sourceDirs = sourceDirs + file("build/generated/ksp/main/kotlin") // or tasks["kspKotlin"].destination
+        testSourceDirs = testSourceDirs + file("build/generated/ksp/test/kotlin")
+        generatedSourceDirs = generatedSourceDirs + file("build/generated/ksp/main/kotlin") + file("build/generated/ksp/test/kotlin")
+    }
+}
+```


### PR DESCRIPTION
Kudos to Thomas Broyer

> So the kspKotlin task reads from the kotlin.sourceSets.main.kotlin and writes to one of the dirs that make up the kotlin.sourceSets.main.kotlin. There's something wrong with that setup.

[Related](https://gradle-community.slack.com/archives/CAHSN3LDN/p1634282692029100)