### PR TITLE
Add support for default Class or KClass values

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
@@ -86,9 +86,6 @@ annotation class ParametersTestAnnotation(
     val intValue: Int = 6,
     val longValue: Long = 7L,
     val stringValue: String = "emptystring",
-    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
-    // the declaration. Throws an NPE with using a default value
-    // https://github.com/google/ksp/issues/53
     val kClassValue: KClass<*> = ParametersTestAnnotation::class,
     val enumValue: TestEnum = TestEnum.NONE,
 )

--- a/compiler-plugin/testData/api/annotatedUtil.kt
+++ b/compiler-plugin/testData/api/annotatedUtil.kt
@@ -23,8 +23,8 @@
 // ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, shortValue=202, charValue=k, doubleValue=5.12, floatValue=123.3, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
 // Test: ParametersTestAnnotationWithDefaultsTest
 // IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
-// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
-// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, enumValue=NONE]
 // Test: ParametersTestWithNegativeDefaultsAnnotationTest
 // IsPresent: class com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation
 // ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
@@ -56,8 +56,6 @@ annotation class ParametersTestAnnotation(
     val intValue: Int = 6,
     val longValue: Long = 7L,
     val stringValue: String = "emptystring",
-    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
-    // the declaration. Throws an NPE with using a default value
     val kClassValue: KClass<*> = ParametersTestAnnotation::class,
     val enumValue: TestEnum = TestEnum.NONE,
 )
@@ -120,8 +118,8 @@ class OnlyTestAnnotation
 @Test
 class ParametersTestAnnotationWithValuesTest
 
-@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
-@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation::class)
+@ParametersTestAnnotation
+@ParametersTestAnnotation
 @Test
 class ParametersTestAnnotationWithDefaultsTest
 

--- a/compiler-plugin/testData/api/javaAnnotatedUtil.kt
+++ b/compiler-plugin/testData/api/javaAnnotatedUtil.kt
@@ -26,8 +26,8 @@
 // ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=true, byteValue=5, shortValue=202, charValue=k, doubleValue=5.0, floatValue=123.0, intValue=2, longValue=4, stringValue=someValue, kClassValue=class java.lang.Throwable, enumValue=VALUE1]
 // Test: ParametersTestAnnotationWithDefaultsTest
 // IsPresent: class com.google.devtools.ksp.processor.ParametersTestAnnotation
-// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
-// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, enumValue=NONE]
+// ByType: com.google.devtools.ksp.processor.ParametersTestAnnotation[booleanValue=false, byteValue=2, shortValue=3, charValue=b, doubleValue=4.0, floatValue=5.0, intValue=6, longValue=7, stringValue=emptystring, kClassValue=interface com.google.devtools.ksp.processor.ParametersTestAnnotation, enumValue=NONE]
 // Test: ParametersTestWithNegativeDefaultsAnnotationTest
 // IsPresent: class com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation
 // ByType: com.google.devtools.ksp.processor.ParametersTestWithNegativeDefaultsAnnotation[byteValue=-2, shortValue=-3, doubleValue=-4.0, floatValue=-5.0, intValue=-6, longValue=-7]
@@ -59,8 +59,6 @@ public @interface ParametersTestAnnotation {
     Int intValue() default 6;
     Long longValue() default 7L;
     String stringValue() default "emptystring";
-    // fails on getting the arguments from the KSAnnotation when no value is set for the kClassValue in
-    // the declaration. Throws an NPE with using a default value
     Class<?> kClassValue() default ParametersTestAnnotation.class;
     TestEnum enumValue() default TestEnum.NONE;
 }
@@ -140,8 +138,8 @@ public class ParametersTestAnnotationWithValuesTest {}
 @Test
 public class ParametersTestAnnotationWithIntegerLiteralValuesTest {}
 
-@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
-@ParametersTestAnnotation(kClassValue = ParametersTestAnnotation.class)
+@ParametersTestAnnotation
+@ParametersTestAnnotation
 @Test
 public class ParametersTestAnnotationWithDefaultsTest {}
 


### PR DESCRIPTION
- add support after blocking issue https://github.com/google/ksp/issues/53 was fixed
- remove NPE catch
- add tests for default KClass and Class for getAnnotationsByType
- handle Java Class default value retrieval using reflection for PsiImmediateClassType