### PR TITLE
Fix ClassNotFoundException for initializing annotation arguments in a…

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -402,7 +402,7 @@ private fun KSAnnotation.asAnnotation(
     annotationInterface: Class<*>,
 ): Any {
     return Proxy.newProxyInstance(
-        this.javaClass.classLoader, arrayOf(annotationInterface),
+        annotationInterface.classLoader, arrayOf(annotationInterface),
         this.createInvocationHandler(annotationInterface)
     ) as Proxy
 }


### PR DESCRIPTION
Fix ClassNotFoundException for initializing annotation arguments in an annotation. The classloader may not be the same with the 'this' class.

In my case: 

```kotlin
@Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.CLASS)
@Retention(AnnotationRetention.BINARY)
annotation class Builder(
    ...
    /**
     * For Activities Only
     */
    val pendingTransition: PendingTransition = PendingTransition(),
    ...
)
```

I use `val builder = ksClassDeclaration.getAnnotationByType(Builder::class).first()` to get the instance of Builder, but get '[ksp] java.lang.IllegalArgumentException: interface PendingTransition is not visible from class loader'.