### PR TITLE
Fix enum lookup in annotation proxies

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -451,7 +451,12 @@ private fun List<*>.toArray(method: Method, valueProvider: (Any) -> Any): Array<
 
 @Suppress("UNCHECKED_CAST")
 private fun <T> Any.asEnum(returnType: Class<T>): T =
-    returnType.getDeclaredMethod("valueOf", String::class.java).invoke(null, this.toString()) as T
+  returnType.getDeclaredMethod("valueOf", String::class.java)
+    .invoke(
+      null,
+      // Change from upstream KSP - pull out the simple name to safely look it up
+      (this as KSType).declaration.simpleName.getShortName()
+    ) as T
 
 private fun Any.asByte(): Byte = if (this is Int) this.toByte() else this as Byte
 


### PR DESCRIPTION
Before, this would take the `toString()` of the KSType, but that's wrong because then you have something like `AnnotationRetention.valueOf("kotlin.annotation.AnnotationRetention.RUNTIME")`, which obviously won't work. This unpacks the short name from the `KSType` directly so that it actually looks up just `RUNTIME` in the given example.