### PR TITLE
Mute a warning from ScriptingGradleSubplugin

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -537,6 +537,10 @@ abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
         // * It doesn't consider private / internal changes when computing dirty sets.
         // * It compiles iteratively; Sources can be compiled in different rounds.
         incremental = false
+
+        // Mute a warning from ScriptingGradleSubplugin, which tries to get `sourceSetName` before this task is
+        // configured.
+        sourceSetName.set("main")
     }
 
     override fun setupCompilerArgs(

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -90,6 +90,8 @@ class KMPImplementedIT {
             result.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SUCCESS ||
                 result.task(":workload:kspKotlinMingwX64")?.outcome == TaskOutcome.SKIPPED
         )
+
+        Assert.assertFalse(result.output.contains("kotlin scripting plugin:"))
     }
 
     @Test


### PR DESCRIPTION
which tries to get `sourceSetName` before this task is configured.