### PR TITLE
Add support for Java primitives and arrays.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -118,6 +118,15 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
             }
         }
         return when (result) {
+            is PsiPrimitiveType -> {
+                // map Java primitives like int and short to Kotlin counterparts like kotlin.Int, kotlin.Short.
+                KSTypeImpl.getCached(ResolverImpl.instance.resolveJavaType(result))
+            }
+            is PsiArrayType -> {
+                // map Java Array to Kotlin Array.
+                // String[] -> Array<String> with platform nullability.
+                KSTypeImpl.getCached(ResolverImpl.instance.resolveJavaType(result))
+            }
             is PsiType -> {
                 ResolverImpl.instance.getClassDeclarationByName(result.canonicalText)?.asStarProjectedType()
                     ?: KSErrorType

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -77,6 +77,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/annotationWithDefault.kt");
     }
 
+    @TestMetadata("annotationWithJavaTypeValue.kt")
+    public void testAnnotationWithJavaTypeValue() throws Exception {
+        runTest("testData/api/annotationWithJavaTypeValue.kt");
+    }
+
     @TestMetadata("asMemberOf.kt")
     public void testAsMemberOf() throws Exception {
         runTest("testData/api/asMemberOf.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationJavaTypeValueProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationJavaTypeValueProcessor.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+class AnnotationJavaTypeValueProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val javaClass = resolver.getClassDeclarationByName("JavaAnnotated")!!
+        logAnnotations(javaClass)
+        return emptyList()
+    }
+
+    private fun logAnnotations(classDeclaration: KSClassDeclaration) {
+        result.add(classDeclaration.qualifiedName!!.asString())
+        classDeclaration.annotations.forEach { annotation ->
+            result.add("${annotation.shortName.asString()} ->")
+            annotation.arguments.forEach {
+                val value = it.value
+                val key = it.name?.asString()
+                if (value is Array<*>) {
+                    result.add("$key = [${value.joinToString(", ")}]")
+                } else {
+                    result.add("$key = ${it.value}")
+                }
+            }
+        }
+    }
+}

--- a/compiler-plugin/testData/api/annotationWithJavaTypeValue.kt
+++ b/compiler-plugin/testData/api/annotationWithJavaTypeValue.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// TEST PROCESSOR: AnnotationJavaTypeValueProcessor
+// EXPECTED:
+// JavaAnnotated
+// JavaAnnotation ->
+// primitives = [Char, Boolean, Byte, Short, Int, Long, Float, Double]
+// objects = [Character, Boolean, Byte, Short, Integer, Long, Float, Double]
+// primitiveArrays = [(CharArray..CharArray?), (BooleanArray..BooleanArray?), (ByteArray..ByteArray?), (ShortArray..ShortArray?), (IntArray..IntArray?), (LongArray..LongArray?), (FloatArray..FloatArray?), (DoubleArray..DoubleArray?)]
+// objectArrays = [(Array<(Char..Char?)>..Array<out (Char..Char?)>?), (Array<(Boolean..Boolean?)>..Array<out (Boolean..Boolean?)>?), (Array<(Byte..Byte?)>..Array<out (Byte..Byte?)>?), (Array<(Short..Short?)>..Array<out (Short..Short?)>?), (Array<(Int..Int?)>..Array<out (Int..Int?)>?), (Array<(Long..Long?)>..Array<out (Long..Long?)>?), (Array<(Float..Float?)>..Array<out (Float..Float?)>?), (Array<(Double..Double?)>..Array<out (Double..Double?)>?), (Array<(String..String?)>..Array<out (String..String?)>?), (Array<(Any..Any?)>..Array<out (Any..Any?)>?)]
+// END
+// FILE: a.kt
+
+
+// FILE: JavaAnnotation.java
+
+public @ interface JavaAnnotation {
+    Class[] primitives(); // PsiPrimitiveType
+    Class[] objects(); // PsiType
+    Class[] primitiveArrays(); // PsiArrayType
+    Class[] objectArrays(); // PsiArrayType
+}
+
+// FILE: JavaAnnotated.java
+
+import java.util.*;
+
+@JavaAnnotation(
+    primitives = { char.class, boolean .class, byte.class, short.class, int.class, long.class, float.class, double.class },
+    objects = { Character.class, Boolean .class, Byte.class, Short.class, Integer.class, Long.class, Float.class, Double.class },
+    primitiveArrays = { char[].class, boolean [].class, byte[].class, short[].class, int[].class, long[].class, float[].class, double[].class },
+    objectArrays = { Character[].class, Boolean [].class, Byte[].class, Short[].class, Integer[].class, Long[].class, Float[].class, Double[].class, String[].class, Object[].class }
+)
+public class JavaAnnotated {
+}


### PR DESCRIPTION
 KSErrorType will be returned when passing a class of Java primitives or Java arrays into an annotation before. Such Java types should be supported and mapped into the Kotlin counterparts.