### PR TITLE
support referenced element for KSTypeReferenceLiteJavaImpl

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -282,7 +282,7 @@ class ResolverImpl(
                 val annotationType = it.annotationType
                 val referencedName = (annotationType.element as? KSClassifierReference)?.referencedName()
                 val simpleName = referencedName?.substringAfterLast('.')
-                (simpleName == null || simpleName == shortName || simpleName in aliasingNames) &&
+                (simpleName == shortName || simpleName in aliasingNames) &&
                     annotationType.resolveToUnderlying().declaration.qualifiedName == ksName
             }
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -64,13 +64,7 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
     }
 
     override val annotationType: KSTypeReference by lazy {
-        val psiClass = psi.nameReferenceElement!!.resolve() as? PsiClass
-        psiClass?.let {
-            (psi.containingFile as? PsiJavaFile)?.let {
-                ResolverImpl.instance.incrementalContext.recordLookup(it, psiClass.qualifiedName!!)
-            }
-        }
-        KSTypeReferenceLiteJavaImpl.getCached(psiClass, this)
+        KSTypeReferenceLiteJavaImpl.getCached(psi, this)
     }
 
     override val arguments: List<KSValueArgument> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -65,13 +65,12 @@ class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnot
 
     override val annotationType: KSTypeReference by lazy {
         val psiClass = psi.nameReferenceElement!!.resolve() as? PsiClass
-            ?: return@lazy KSTypeReferenceLiteJavaImpl.getCached(KSErrorType, this)
-        (psi.containingFile as? PsiJavaFile)?.let {
-            ResolverImpl.instance.incrementalContext.recordLookup(it, psiClass.qualifiedName!!)
+        psiClass?.let {
+            (psi.containingFile as? PsiJavaFile)?.let {
+                ResolverImpl.instance.incrementalContext.recordLookup(it, psiClass.qualifiedName!!)
+            }
         }
-        KSTypeReferenceLiteJavaImpl.getCached(
-            KSClassDeclarationJavaImpl.getCached(psiClass).asType(emptyList()), this
-        )
+        KSTypeReferenceLiteJavaImpl.getCached(psiClass, this)
     }
 
     override val arguments: List<KSValueArgument> by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
@@ -10,16 +10,27 @@ import com.google.devtools.ksp.symbol.impl.KSObjectCache
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiMethod
 
-class KSClassifierReferenceLiteImplForJava(override val parent: KSTypeReferenceLiteJavaImpl) : KSClassifierReference {
-    companion object : KSObjectCache<KSTypeReferenceLiteJavaImpl, KSClassifierReference>() {
-        fun getCached(parent: KSTypeReferenceLiteJavaImpl) = KSClassifierReferenceLiteImplForJava.cache
-            .getOrPut(parent) { KSClassifierReferenceLiteImplForJava(parent) }
+class KSClassifierReferenceLiteImplForJava(
+    override val parent: KSTypeReferenceLiteJavaImpl,
+    private val name: String?
+) : KSClassifierReference {
+    companion object : KSObjectCache<Pair<KSTypeReferenceLiteJavaImpl, String?>, KSClassifierReference>() {
+        fun getCached(parent: KSTypeReferenceLiteJavaImpl, name: String? = null) =
+            KSClassifierReferenceLiteImplForJava.cache
+                .getOrPut(Pair(parent, name)) { KSClassifierReferenceLiteImplForJava(parent, name) }
     }
-    override val qualifier: KSClassifierReference? = null
+    override val qualifier: KSClassifierReference? by lazy {
+        val referencedName = referencedName()
+        if (referencedName.lastIndexOf('.') == -1) {
+            null
+        } else {
+            getCached(parent, referencedName.substringBeforeLast('.'))
+        }
+    }
 
     override fun referencedName(): String {
-        return when (parent.psiElement) {
-            is PsiAnnotation -> parent.psiElement.nameReferenceElement?.referenceName ?: "<ERROR>"
+        return name ?: when (parent.psiElement) {
+            is PsiAnnotation -> parent.psiElement.nameReferenceElement?.text ?: "<ERROR>"
             is PsiMethod -> parent.psiElement.name
             else -> throw IllegalStateException(
                 "Unexpected psi type in KSTypeReferenceLiteJavaImpl: ${parent.psiElement.javaClass}, $ExceptionMessage"

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
@@ -1,11 +1,14 @@
 package com.google.devtools.ksp.symbol.impl.java
 
+import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.symbol.KSClassifierReference
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.impl.KSObjectCache
+import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiMethod
 
 class KSClassifierReferenceLiteImplForJava(override val parent: KSTypeReferenceLiteJavaImpl) : KSClassifierReference {
     companion object : KSObjectCache<KSTypeReferenceLiteJavaImpl, KSClassifierReference>() {
@@ -15,7 +18,13 @@ class KSClassifierReferenceLiteImplForJava(override val parent: KSTypeReferenceL
     override val qualifier: KSClassifierReference? = null
 
     override fun referencedName(): String {
-        return parent.psiClass?.name ?: "<ERROR>"
+        return when (parent.psiElement) {
+            is PsiAnnotation -> parent.psiElement.nameReferenceElement?.referenceName ?: "<ERROR>"
+            is PsiMethod -> parent.psiElement.name
+            else -> throw IllegalStateException(
+                "Unexpected psi type in KSTypeReferenceLiteJavaImpl: ${parent.psiElement.javaClass}, $ExceptionMessage"
+            )
+        }
     }
 
     override val typeArguments: List<KSTypeArgument> = emptyList()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassifierReferenceLiteImplForJava.kt
@@ -1,0 +1,30 @@
+package com.google.devtools.ksp.symbol.impl.java
+
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.NonExistLocation
+import com.google.devtools.ksp.symbol.Origin
+import com.google.devtools.ksp.symbol.impl.KSObjectCache
+
+class KSClassifierReferenceLiteImplForJava(override val parent: KSTypeReferenceLiteJavaImpl) : KSClassifierReference {
+    companion object : KSObjectCache<KSTypeReferenceLiteJavaImpl, KSClassifierReference>() {
+        fun getCached(parent: KSTypeReferenceLiteJavaImpl) = KSClassifierReferenceLiteImplForJava.cache
+            .getOrPut(parent) { KSClassifierReferenceLiteImplForJava(parent) }
+    }
+    override val qualifier: KSClassifierReference? = null
+
+    override fun referencedName(): String {
+        return parent.psiClass?.name ?: "<ERROR>"
+    }
+
+    override val typeArguments: List<KSTypeArgument> = emptyList()
+
+    override val origin: Origin = Origin.JAVA
+
+    override val location: Location = NonExistLocation
+
+    override fun toString(): String {
+        return referencedName()
+    }
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -92,9 +92,7 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) :
                 KSTypeReferenceJavaImpl.getCached(psi.returnType!!, this)
             }
             psi.isConstructor -> {
-                psi.containingClass?.let { containingClass ->
-                    KSTypeReferenceLiteJavaImpl.getCached(containingClass, this)
-                }
+                KSTypeReferenceLiteJavaImpl.getCached(psi, this)
             }
             else -> {
                 null

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -93,9 +93,7 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) :
             }
             psi.isConstructor -> {
                 psi.containingClass?.let { containingClass ->
-                    KSTypeReferenceLiteJavaImpl.getCached(
-                        KSClassDeclarationJavaImpl.getCached(containingClass).asStarProjectedType(), this
-                    )
+                    KSTypeReferenceLiteJavaImpl.getCached(containingClass, this)
                 }
             }
             else -> {

--- a/compiler-plugin/testData/api/libOrigins.kt
+++ b/compiler-plugin/testData/api/libOrigins.kt
@@ -27,6 +27,7 @@
 // classifier ref: Anno2: KOTLIN_LIB
 // classifier ref: Anno3: KOTLIN
 // classifier ref: Anno3: KOTLIN_LIB
+// classifier ref: Anno4: JAVA
 // classifier ref: Anno4: KOTLIN_LIB
 // classifier ref: Annotation: KOTLIN_LIB
 // classifier ref: Annotation: KOTLIN_LIB

--- a/compiler-plugin/testData/api/parent.kt
+++ b/compiler-plugin/testData/api/parent.kt
@@ -1,5 +1,9 @@
 // TEST PROCESSOR: ParentProcessor
 // EXPECTED:
+// parent of File: Bnno.kt: null
+// parent of Bnno: File: Bnno.kt
+// parent of Bnno: synthetic constructor for Bnno
+// parent of synthetic constructor for Bnno: Bnno
 // parent of File: a.kt: null
 // parent of Anno: File: a.kt
 // parent of Anno: synthetic constructor for Anno
@@ -82,6 +86,10 @@
 // parent of Anno: Anno
 // parent of Anno: @Anno
 // parent of @Anno: B
+// parent of p: Bnno
+// parent of p.Bnno: Bnno
+// parent of Bnno: @Bnno
+// parent of @Bnno: B
 // parent of B: File: B.java
 // parent of T: T
 // parent of T: t
@@ -126,8 +134,14 @@ class topClass: ITF {
     get() = "1"
 }
 
+// FILE: Bnno.kt
+package p
+
+annotation class Bnno
+
 // FILE: B.java
 @Anno
+@p.Bnno
 public class B<T> implements ITF {
     private T t;
     public int foo(T t, int i) {

--- a/compiler-plugin/testData/api/parent.kt
+++ b/compiler-plugin/testData/api/parent.kt
@@ -79,6 +79,7 @@
 // parent of ITF: ITF
 // parent of ITF: B
 // parent of T: B
+// parent of Anno: Anno
 // parent of Anno: @Anno
 // parent of @Anno: B
 // parent of B: File: B.java


### PR DESCRIPTION
also fixes #707 
verified locally with a resolve counter to verify that total resolve call has reduced with this change, unable to add a test due to the need to add debug code into implementation code. The test here reflect the correct `KSClassifierReference` has been populated for the missing cases.