### PR TITLE
Analysis API implementation

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -53,7 +53,6 @@ dependencies {
     }
 
     implementation(project(":api"))
-
 }
 
 tasks.register<Copy>("CopyLibsForTesting") {

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -2,8 +2,7 @@ description = "Kotlin Symbol Processing implementation using Kotlin Analysis API
 
 val intellijVersion: String by project
 val junitVersion: String by project
-val kotlinVersionFir = "1.6.20-dev-2497"
-val analysisAPIVersion = "1.6.20-dev-3387"
+val analysisAPIVersion = "1.6.20-dev-4603"
 val libsForTesting by configurations.creating
 
 plugins {
@@ -28,8 +27,8 @@ fun ModuleDependency.includeJars(vararg names: String) {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.1")
-    implementation(kotlin("stdlib", kotlinVersionFir))
-    implementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinVersionFir")
+    implementation(kotlin("stdlib", analysisAPIVersion))
+    implementation("org.jetbrains.kotlin:kotlin-compiler:$analysisAPIVersion")
 
     implementation("org.jetbrains.kotlin:high-level-api-fir-for-ide:$analysisAPIVersion") {
         isTransitive = false
@@ -46,18 +45,21 @@ dependencies {
     implementation("org.jetbrains.kotlin:analysis-project-structure-for-ide:$analysisAPIVersion") {
         isTransitive = false
     }
+    implementation("org.jetbrains.kotlin:high-level-api-impl-base-for-ide:$analysisAPIVersion") {
+        isTransitive = false
+    }
+    implementation("org.jetbrains.kotlin:high-level-api-impl-base-for-ide:$analysisAPIVersion") {
+        isTransitive = false
+    }
 
     implementation(project(":api"))
 
-    libsForTesting(kotlin("stdlib", kotlinVersionFir))
-    libsForTesting(kotlin("test", kotlinVersionFir))
-    libsForTesting(kotlin("script-runtime", kotlinVersionFir))
 }
 
 tasks.register<Copy>("CopyLibsForTesting") {
     from(configurations.get("libsForTesting"))
     into("dist/kotlinc/lib")
-    val escaped = Regex.escape(kotlinVersionFir)
+    val escaped = Regex.escape(analysisAPIVersion)
     rename("(.+)-$escaped\\.jar", "$1.jar")
 }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -29,6 +29,8 @@ import org.jetbrains.kotlin.analysis.api.InvalidWayOfUsingAnalysisSession
 import org.jetbrains.kotlin.analysis.api.KtAnalysisSessionProvider
 import org.jetbrains.kotlin.analysis.api.analyseWithReadAction
 import org.jetbrains.kotlin.analysis.api.fir.KtFirAnalysisSessionProvider
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.services.FirSealedClassInheritorsProcessorFactory
 import org.jetbrains.kotlin.analysis.low.level.api.fir.api.services.PackagePartProviderFactory
 import org.jetbrains.kotlin.analysis.project.structure.KtModuleScopeProvider
@@ -177,8 +179,8 @@ fun main() {
     val ktFile = factory.trySetupPsiForFile(virtualFile, KotlinLanguage.INSTANCE, true, false) as KtFile
     registerComponents(project, env, listOf(ktFile))
     analyseWithReadAction(ktFile) {
-        val mainRef = ktFile.mainReference
-        val reference = findSomeReference(ktFile)
-        reference?.resolveToSymbol()
+        val fileSymbol = ktFile.getFileSymbol()
+        val members = fileSymbol.getFileScope().getAllSymbols()
+        members.filterIsInstance<KtFunctionSymbol>()
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ProjectStructureProviderImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ProjectStructureProviderImpl.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.resolve.jvm.platform.JvmPlatformAnalyzerServices
 
 class ProjectStructureProviderImpl : ProjectStructureProvider() {
     override fun getKtModuleForKtElement(element: PsiElement): KtModule {
-        return object: KtSourceModule {
+        return object : KtSourceModule {
             override val analyzerServices: PlatformDependentAnalyzerServices
                 get() = JvmPlatformAnalyzerServices
             override val contentScope: GlobalSearchScope

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -1,0 +1,34 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueArgument
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtAnnotationCall
+
+class KSAnnotationImpl(private val annotationCall: KtAnnotationCall) : KSAnnotation {
+    override val annotationType: KSTypeReference
+        get() = TODO("Not yet implemented")
+    override val arguments: List<KSValueArgument> by lazy {
+        annotationCall.arguments.map { KSValueArgumentImpl(it) }
+    }
+    override val shortName: KSName
+        get() = TODO("Not yet implemented")
+    override val useSiteTarget: AnnotationUseSiteTarget?
+        get() = TODO("Not yet implemented")
+    override val origin: Origin = Origin.KOTLIN
+
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitAnnotation(this, data)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -1,0 +1,123 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
+
+class KSClassDeclarationImpl(private val ktNamedClassOrObjectSymbol: KtNamedClassOrObjectSymbol) : KSClassDeclaration {
+    override val classKind: ClassKind
+        get() = TODO("Not yet implemented")
+    override val primaryConstructor: KSFunctionDeclaration? by lazy {
+        analyzeWithSymbolAsContext(ktNamedClassOrObjectSymbol) {
+            ktNamedClassOrObjectSymbol.getMemberScope().getConstructors().singleOrNull { it.isPrimary }?.let {
+                KSFunctionDeclarationImpl(it)
+            }
+        }
+    }
+    override val superTypes: Sequence<KSTypeReference> by lazy {
+        analyzeWithSymbolAsContext(ktNamedClassOrObjectSymbol) {
+            ktNamedClassOrObjectSymbol.superTypes.map { KSTypeReferenceImpl(it) }.asSequence()
+        }
+    }
+
+    override val isCompanionObject: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllFunctions(): Sequence<KSFunctionDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllProperties(): Sequence<KSPropertyDeclaration> {
+        return analyzeWithSymbolAsContext(ktNamedClassOrObjectSymbol) {
+            ktNamedClassOrObjectSymbol.getMemberScope().getAllSymbols().filterIsInstance<KtPropertySymbol>()
+                .map { KSPropertyDeclarationImpl(it) }
+        }
+    }
+
+    override fun asType(typeArguments: List<KSTypeArgument>): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override fun asStarProjectedType(): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override val simpleName: KSName
+        get() = TODO("Not yet implemented")
+    override val qualifiedName: KSName?
+        get() = TODO("Not yet implemented")
+    override val typeParameters: List<KSTypeParameter>
+        get() = TODO("Not yet implemented")
+    override val packageName: KSName
+        get() = TODO("Not yet implemented")
+    override val parentDeclaration: KSDeclaration?
+        get() = TODO("Not yet implemented")
+    override val containingFile: KSFile?
+        get() = TODO("Not yet implemented")
+    override val docString: String?
+        get() = TODO("Not yet implemented")
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitClassDeclaration(this, data)
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazy {
+        analyzeWithSymbolAsContext(ktNamedClassOrObjectSymbol) {
+            ktNamedClassOrObjectSymbol.annotations.map { KSAnnotationImpl(it) }.asSequence()
+        }
+    }
+    override val isActual: Boolean
+        get() = TODO("Not yet implemented")
+    override val isExpect: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun findActuals(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findExpects(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override val declarations: Sequence<KSDeclaration> by lazy {
+        analyzeWithSymbolAsContext(ktNamedClassOrObjectSymbol) {
+            ktNamedClassOrObjectSymbol.getDeclaredMemberScope().getAllSymbols().map {
+                when (it) {
+                    is KtNamedClassOrObjectSymbol -> KSClassDeclarationImpl(it)
+                    is KtFunctionSymbol -> KSFunctionDeclarationImpl(it)
+                    is KtPropertySymbol -> KSPropertyDeclarationImpl(it)
+                    else -> throw IllegalStateException()
+                }
+            }
+        }
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileSymbolImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileSymbolImpl.kt
@@ -1,0 +1,55 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.analyseWithReadAction
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
+import org.jetbrains.kotlin.psi.KtFile
+
+class KSFileSymbolImpl(private val ktFile: KtFile) : KSFile {
+    override val packageName: KSName by lazy {
+        KSNameImpl(ktFile.packageFqName.asString())
+    }
+    override val fileName: String by lazy {
+        ktFile.name
+    }
+    override val filePath: String by lazy {
+        ktFile.virtualFilePath
+    }
+    override val declarations: Sequence<KSDeclaration> by lazy {
+        analyseWithReadAction(ktFile) {
+            ktFile.getFileSymbol().getFileScope().getAllSymbols().map {
+                when (it) {
+                    is KtNamedClassOrObjectSymbol -> KSClassDeclarationImpl(it)
+                    is KtFunctionSymbol -> KSFunctionDeclarationImpl(it)
+                    is KtPropertySymbol -> KSPropertyDeclarationImpl(it)
+                    else -> throw IllegalStateException("Unhandled ")
+                }
+            }
+        }
+    }
+    override val origin: Origin = Origin.KOTLIN
+
+    override val location: Location
+        get() = TODO("Not yet implemented")
+
+    override val parent: KSNode? = null
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitFile(this, data)
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazy {
+        analyseWithReadAction(ktFile) {
+            ktFile.getFileSymbol().annotations.map { KSAnnotationImpl(it) }.asSequence()
+        }
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -1,0 +1,123 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.FunctionKind
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.InvalidWayOfUsingAnalysisSession
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
+import org.jetbrains.kotlin.analysis.api.KtAnalysisSessionProvider
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtAnnotatedSymbol
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.psi.KtFile
+
+class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymbol) : KSFunctionDeclaration {
+    override val functionKind: FunctionKind
+        get() = TODO("Not yet implemented")
+    override val isAbstract: Boolean by lazy {
+        (ktFunctionSymbol as? KtFunctionSymbol)?.modality == Modality.ABSTRACT
+    }
+    override val extensionReceiver: KSTypeReference? by lazy {
+        analyzeWithSymbolAsContext(ktFunctionSymbol) {
+            if (!ktFunctionSymbol.isExtension) {
+                null
+            } else {
+                ktFunctionSymbol.receiverType?.let { KSTypeReferenceImpl(it) }
+            }
+        }
+    }
+    override val returnType: KSTypeReference? by lazy {
+        analyzeWithSymbolAsContext(ktFunctionSymbol) {
+            KSTypeReferenceImpl(ktFunctionSymbol.annotatedType)
+        }
+    }
+    override val parameters: List<KSValueParameter> by lazy {
+        ktFunctionSymbol.valueParameters.map { KSValueParameterImpl(it) }
+    }
+
+    override fun findOverridee(): KSDeclaration? {
+        TODO("Not yet implemented")
+    }
+
+    override fun asMemberOf(containing: KSType): KSFunction {
+        TODO("Not yet implemented")
+    }
+
+    override val simpleName: KSName by lazy {
+        if (ktFunctionSymbol is KtFunctionSymbol) {
+            KSNameImpl(ktFunctionSymbol.name.asString())
+        } else {
+            KSNameImpl("<init>")
+        }
+    }
+    override val qualifiedName: KSName?
+        get() = TODO("Not yet implemented")
+    override val typeParameters: List<KSTypeParameter> by lazy {
+        (ktFunctionSymbol as? KtFunctionSymbol)?.typeParameters?.map { KSTypeParameterImpl(it) } ?: emptyList()
+    }
+    override val packageName: KSName by lazy {
+        containingFile?.packageName ?: KSNameImpl("")
+    }
+    override val parentDeclaration: KSDeclaration?
+        get() = TODO("Not yet implemented")
+    override val containingFile: KSFile? by lazy {
+        (ktFunctionSymbol.psi?.containingFile as? KtFile)?.let { KSFileSymbolImpl(it) }
+    }
+    override val docString: String?
+        get() = TODO("Not yet implemented")
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitFunctionDeclaration(this, data)
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazy {
+        (ktFunctionSymbol as KtAnnotatedSymbol).annotations.asSequence().map { KSAnnotationImpl(it) }
+    }
+    override val isActual: Boolean
+        get() = TODO("Not yet implemented")
+    override val isExpect: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun findActuals(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findExpects(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override val declarations: Sequence<KSDeclaration>
+        get() = TODO("Not yet implemented")
+}
+
+@OptIn(InvalidWayOfUsingAnalysisSession::class)
+internal inline fun <R> analyzeWithSymbolAsContext(
+    contextSymbol: KtSymbol,
+    action: KtAnalysisSession.() -> R
+): R {
+    return KtAnalysisSessionProvider
+        .getInstance(contextSymbol.psi!!.project).analyzeWithSymbolAsContext(contextSymbol, action)
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSNameImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSNameImpl.kt
@@ -1,0 +1,17 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSName
+
+class KSNameImpl(val name: String) : KSName {
+    override fun asString(): String {
+        return name
+    }
+
+    override fun getQualifier(): String {
+        return name.split(".").dropLast(1).joinToString(".")
+    }
+
+    override fun getShortName(): String {
+        return name.split(".").last()
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -1,0 +1,97 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
+import org.jetbrains.kotlin.psi.KtFile
+
+class KSPropertyDeclarationImpl(private val ktPropertySymbol: KtPropertySymbol) : KSPropertyDeclaration {
+    override val getter: KSPropertyGetter?
+        get() = TODO("Not yet implemented")
+    override val setter: KSPropertySetter?
+        get() = TODO("Not yet implemented")
+    override val extensionReceiver: KSTypeReference?
+        get() = TODO("Not yet implemented")
+    override val type: KSTypeReference by lazy {
+        KSTypeReferenceImpl(ktPropertySymbol.annotatedType)
+    }
+    override val isMutable: Boolean by lazy {
+        !ktPropertySymbol.isVal
+    }
+    override val hasBackingField: Boolean by lazy {
+        ktPropertySymbol.hasBackingField
+    }
+
+    override fun isDelegated(): Boolean {
+        return ktPropertySymbol.isDelegatedProperty
+    }
+
+    override fun findOverridee(): KSPropertyDeclaration? {
+        TODO("Not yet implemented")
+    }
+
+    override fun asMemberOf(containing: KSType): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override val simpleName: KSName
+        get() = TODO("Not yet implemented")
+    override val qualifiedName: KSName?
+        get() = TODO("Not yet implemented")
+    override val typeParameters: List<KSTypeParameter> by lazy {
+        ktPropertySymbol.type
+    }
+    override val packageName: KSName
+        get() = TODO("Not yet implemented")
+    override val parentDeclaration: KSDeclaration?
+        get() = TODO("Not yet implemented")
+    override val containingFile: KSFile?
+        get() = TODO("Not yet implemented")
+    override val docString: String?
+        get() = TODO("Not yet implemented")
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode? by lazy {
+        analyzeWithSymbolAsContext(ktPropertySymbol) {
+            ktPropertySymbol.getContainingSymbol()?.let{ KSClassDeclarationImpl(it as KtNamedClassOrObjectSymbol)}
+                ?: KSFileSymbolImpl(ktPropertySymbol.psi!!.containingFile as KtFile)
+        }
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        TODO("Not yet implemented")
+    }
+
+    override val annotations: Sequence<KSAnnotation>
+        get() = TODO("Not yet implemented")
+    override val isActual: Boolean
+        get() = TODO("Not yet implemented")
+    override val isExpect: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun findActuals(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findExpects(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
@@ -1,0 +1,43 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import com.google.devtools.ksp.symbol.Variance
+import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
+import org.jetbrains.kotlin.analysis.api.KtTypeArgument
+import org.jetbrains.kotlin.analysis.api.KtTypeArgumentWithVariance
+
+class KSTypeArgumentImpl(private val ktTypeArgument: KtTypeArgument) : KSTypeArgument {
+    override val variance: Variance by lazy {
+        when (ktTypeArgument) {
+            is KtStarProjectionTypeArgument -> Variance.STAR
+            is KtTypeArgumentWithVariance -> {
+                when (ktTypeArgument.variance) {
+                    org.jetbrains.kotlin.types.Variance.INVARIANT -> Variance.INVARIANT
+                    org.jetbrains.kotlin.types.Variance.IN_VARIANCE -> Variance.COVARIANT
+                    org.jetbrains.kotlin.types.Variance.OUT_VARIANCE -> Variance.CONTRAVARIANT
+                    else -> throw IllegalStateException("Unexpected variance")
+                }
+            }
+        }
+    }
+
+    override val type: KSTypeReference?
+        get() = TODO("Not yet implemented")
+    override val annotations: Sequence<KSAnnotation>
+        get() = TODO("Not yet implemented")
+    override val origin: Origin = Origin.KOTLIN
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitTypeArgument(this, data)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -1,0 +1,62 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.Nullability
+import org.jetbrains.kotlin.analysis.api.types.KtType
+import org.jetbrains.kotlin.analysis.api.types.KtTypeNullability
+
+class KSTypeImpl(private val type: KtType) : KSType {
+    override val declaration: KSDeclaration
+        get() = TODO("Not yet implemented")
+    override val nullability: Nullability by lazy {
+        if (type.nullability == KtTypeNullability.NON_NULLABLE) {
+            Nullability.NOT_NULL
+        } else {
+            Nullability.NULLABLE
+        }
+    }
+    override val arguments: List<KSTypeArgument>
+        get() = TODO("Not yet implemented")
+    override val annotations: Sequence<KSAnnotation>
+        get() = TODO("Not yet implemented")
+
+    override fun isAssignableFrom(that: KSType): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isMutabilityFlexible(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun isCovarianceFlexible(): Boolean {
+        TODO("Not yet implemented")
+    }
+
+    override fun replace(arguments: List<KSTypeArgument>): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override fun starProjection(): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override fun makeNullable(): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override fun makeNotNullable(): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override val isMarkedNullable: Boolean
+        get() = TODO("Not yet implemented")
+    override val isError: Boolean
+        get() = TODO("Not yet implemented")
+    override val isFunctionType: Boolean
+        get() = TODO("Not yet implemented")
+    override val isSuspendFunctionType: Boolean
+        get() = TODO("Not yet implemented")
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -1,0 +1,67 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import com.google.devtools.ksp.symbol.Variance
+import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
+
+class KSTypeParameterImpl(private val ktTypeParameterSymbol: KtTypeParameterSymbol) : KSTypeParameter {
+    override val name: KSName
+        get() = TODO("Not yet implemented")
+    override val variance: Variance
+        get() = TODO("Not yet implemented")
+    override val isReified: Boolean
+        get() = TODO("Not yet implemented")
+    override val bounds: Sequence<KSTypeReference>
+        get() = TODO("Not yet implemented")
+    override val simpleName: KSName
+        get() = TODO("Not yet implemented")
+    override val qualifiedName: KSName?
+        get() = TODO("Not yet implemented")
+    override val typeParameters: List<KSTypeParameter>
+        get() = TODO("Not yet implemented")
+    override val packageName: KSName
+        get() = TODO("Not yet implemented")
+    override val parentDeclaration: KSDeclaration?
+        get() = TODO("Not yet implemented")
+    override val containingFile: KSFile?
+        get() = TODO("Not yet implemented")
+    override val docString: String?
+        get() = TODO("Not yet implemented")
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        TODO("Not yet implemented")
+    }
+
+    override val annotations: Sequence<KSAnnotation>
+        get() = TODO("Not yet implemented")
+    override val isActual: Boolean
+        get() = TODO("Not yet implemented")
+    override val isExpect: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun findActuals(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findExpects(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -1,0 +1,38 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSReferenceElement
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtTypeAndAnnotations
+
+class KSTypeReferenceImpl(private val ktTypeAndAnnotations: KtTypeAndAnnotations) : KSTypeReference {
+    override val element: KSReferenceElement?
+        get() = TODO("Not yet implemented")
+
+    override fun resolve(): KSType {
+        return KSTypeImpl(ktTypeAndAnnotations.type)
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazy {
+        ktTypeAndAnnotations.annotations.map { KSAnnotationImpl(it) }.asSequence()
+    }
+    override val origin: Origin = Origin.KOTLIN
+
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitTypeReference(this, data)
+    }
+
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
@@ -1,0 +1,31 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSValueArgument
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedConstantValue
+
+class KSValueArgumentImpl(private val namedConstantValue: KtNamedConstantValue) : KSValueArgument {
+    override val name: KSName? by lazy {
+        KSNameImpl(namedConstantValue.name)
+    }
+    override val isSpread: Boolean = false
+    override val value: Any? = namedConstantValue.expression
+
+    override val annotations: Sequence<KSAnnotation> = emptySequence()
+
+    override val origin: Origin = Origin.KOTLIN
+
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitValueArgument(this, data)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -1,0 +1,47 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.KtValueParameterSymbol
+
+class KSValueParameterImpl(private val ktValueParameterSymbol: KtValueParameterSymbol) : KSValueParameter {
+    override val name: KSName?
+        get() = TODO("Not yet implemented")
+    override val type: KSTypeReference by lazy {
+        KSTypeReferenceImpl(ktValueParameterSymbol.annotatedType)
+    }
+
+    override val isVararg: Boolean by lazy {
+        ktValueParameterSymbol.isVararg
+    }
+    override val isNoInline: Boolean
+        get() = TODO("Not yet implemented")
+    override val isCrossInline: Boolean
+        get() = TODO("Not yet implemented")
+    override val isVal: Boolean
+        get() = TODO("Not yet implemented")
+    override val isVar: Boolean
+        get() = TODO("Not yet implemented")
+    override val hasDefault: Boolean by lazy {
+        ktValueParameterSymbol.hasDefaultValue
+    }
+    override val annotations: Sequence<KSAnnotation> by lazy {
+        ktValueParameterSymbol.annotations.asSequence().map { KSAnnotationImpl(it) }
+    }
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+    override val location: Location
+        get() = TODO("Not yet implemented")
+    override val parent: KSNode?
+        get() = TODO("Not yet implemented")
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitValueParameter(this, data)
+    }
+}

--- a/kotlin-analysis-api/testData/api/hello.kt
+++ b/kotlin-analysis-api/testData/api/hello.kt
@@ -10,3 +10,7 @@ class Foo() {
         return 3
     }
 }
+
+val topProp = 1
+
+fun topFun() = "Fun"


### PR DESCRIPTION
* All KSSymbols skeleton.
* use same bootstrap version for compiler and analysis api.
* implemented some no resolution involved KSSymbol functions, many are still missing, e.g. modifiers conversion (this should be able to be reused from current frontend implementation).
* implemented simple resolution logic as analysis api resolution concept proofing. 
* Note that analysis API unifies symbols implementation, so there is no need to have 3 implementations for java symbols, kotlin symbols, and descriptor symbols anymore, however, for certain functions, we still need to type check the wrapped element inside a KtSymbol and performance operations accordingly. 