### PR TITLE
Supported js(BOTH) and disallow binary generation for non-JVM targets

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -57,7 +57,20 @@ class KspConfigurations(private val project: Project) {
         val isMain = compilation.name == KotlinCompilation.MAIN_COMPILATION_NAME
         val isDefault = sourceSet.name == compilation.defaultSourceSetName
         // Note: on single-platform, target name is conveniently set to "".
-        val name = if (isMain && isDefault) compilation.target.name else sourceSet.name
+        val name = if (isMain && isDefault) {
+            // For js(IR), js(LEGACY), the target "js" is created.
+            //
+            // When js(BOTH) is used, target "jsLegacy" and "jsIr" are created.
+            // Both targets share the same source set. Therefore configurations other than main compilation
+            // are shared. E.g., "kspJsTest".
+            // For simplicity and consistency, let's not distinguish them.
+            when (val targetName = compilation.target.name) {
+                "jsLegacy", "jsIr" -> "js"
+                else -> targetName
+            }
+        } else {
+            sourceSet.name
+        }
         return configurationNameOf(PREFIX, name)
     }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -257,9 +257,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             }
             kspTask.source.filter { !kspOutputDir.isParentOf(it) }
 
-            // Don't support binary generation for K/N yet.
+            // Don't support binary generation for non-JVM platforms yet.
             // FIXME: figure out how to add user generated libraries.
-            if (kspTask !is KspTaskNative) {
+            if (kspTask is KspTaskJvm) {
                 kotlinCompilation.output.classesDirs.from(classOutputDir)
             }
         }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -57,9 +57,16 @@ class KMPImplementedIT {
         )
 
         verify(
-            "workload/build/libs/workload-js-1.0-SNAPSHOT.jar",
+            "workload/build/libs/workload-jslegacy-1.0-SNAPSHOT.jar",
             listOf(
-                "playground-workload.js"
+                "playground-workload-js-legacy.js"
+            )
+        )
+
+        verify(
+            "workload/build/libs/workload-jsir-1.0-SNAPSHOT.klib",
+            listOf(
+                "default/ir/types.knt"
             )
         )
 

--- a/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/workload/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
     jvm {
         withJava()
     }
-    js() {
+    js(BOTH) {
         browser()
         nodejs()
     }


### PR DESCRIPTION
When `js(BOTH)` is used, we map `jsLegacy` and `jsIr` to `js` because both of the compiler created targets share the same source set. For simplicity and consistency, let's not distinguish the two targets when creating and specifying KSP configurations.

The mechanism of generating binary (or js) directly from processors is undefined yet.