### PR TITLE
#775: Take `static` into account when computing `isAbstract` for java.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -66,7 +66,7 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) :
         this.modifiers.contains(Modifier.ABSTRACT) ||
             (
                 (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE &&
-                    !this.modifiers.contains(Modifier.JAVA_DEFAULT)
+                    !this.modifiers.contains(Modifier.JAVA_DEFAULT) && functionKind != FunctionKind.STATIC
                 )
     }
 

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -47,6 +47,10 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/javaAnnotatedUtil.kt");
     }
 
+    public void testAbstractFunctions() throws Exception {
+        runTest("testData/api/abstractFunctions.kt");
+    }
+
     @TestMetadata("allFunctions.kt")
     public void testAllFunctions() throws Exception {
         runTest("testData/api/allFunctions.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AbstractFunctionsProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/AbstractFunctionsProcessor.kt
@@ -1,0 +1,33 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class AbstractFunctionsProcessor : AbstractTestProcessor() {
+    private val visitor = Visitor()
+
+    override fun toResult(): List<String> {
+        return visitor.abstractFunctionNames.sorted()
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getNewFiles().forEach { it.accept(visitor, Unit) }
+        return emptyList()
+    }
+
+    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+        val abstractFunctionNames = arrayListOf<String>()
+
+        override fun defaultHandler(node: KSNode, data: Unit) {
+        }
+
+        override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
+            if (function.isAbstract) {
+                abstractFunctionNames += function.simpleName.asString()
+            }
+        }
+    }
+}

--- a/compiler-plugin/testData/api/abstractFunctions.kt
+++ b/compiler-plugin/testData/api/abstractFunctions.kt
@@ -1,0 +1,41 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: AbstractFunctionsProcessor
+// EXPECTED:
+// abstractF01
+// abstractF02
+// abstractF04
+// abstractF05
+// END
+// FILE: AbstractClassKotlin.kt
+abstract class AbstractClassKotlin {
+    abstract fun abstractF01()
+    fun concreteF01() = Unit
+    companion object {
+        fun concreteF02() = Unit
+        @JvmStatic fun concreteF02() = Unit
+    }
+}
+
+// FILE: InterfaceKotlin.kt
+interface InterfaceKotlin {
+    fun abstractF02()
+    fun abstractWithDefaultF03() { /*default*/ Unit }
+    companion object {
+        fun concreteF03() = Unit
+        @JvmStatic fun concreteF04() = Unit
+    }
+}
+
+// FILE: AbstractClassJava.java
+public abstract class AbstractClassJava {
+    public abstract void abstractF04();
+    public void concreteF05() {}
+    public static void staticF01() {}
+}
+
+// FILE: InterfaceJava.java
+public interface InterfaceJava {
+    public void abstractF05();
+    public default void abstractWithDefaultF06() { /* default */ }
+    public static void staticF02() {}
+}


### PR DESCRIPTION
Before this CL the method originating from Java interface was presumed abstract
if not marked `default`. This is not entirely correct, as static methods are also
not abstract. This CL fixes the issue.