### PR TITLE
Fix backing fields for properties that are set from an explicit constructor

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -509,9 +509,12 @@ internal fun <T> Sequence<T>.memoized() = MemoizedSequence(this)
  * The compiler API always returns true for them even when they don't have backing fields.
  */
 internal fun PropertyDescriptor.hasBackingFieldWithBinaryClassSupport(): Boolean {
+    // partially take from https://github.com/JetBrains/kotlin/blob/master/compiler/light-classes/src/org/jetbrains/kotlin/asJava/classes/ultraLightMembersCreator.kt#L104
     return when {
         extensionReceiverParameter != null -> false // extension properties do not have backing fields
         compileTimeInitializer != null -> true // compile time initialization requires backing field
+        isLateInit -> true // lateinit requires property, faster than parsing class declaration
+        modality == Modality.ABSTRACT -> false // abstract means false, faster than parsing class declaration
         this is DeserializedPropertyDescriptor -> this.hasBackingFieldInBinaryClass() // kotlin class, check binary
         this.source is KotlinSourceElement -> this.declaresDefaultValue // kotlin source
         else -> true // Java source or class

--- a/compiler-plugin/testData/api/backingFields.kt
+++ b/compiler-plugin/testData/api/backingFields.kt
@@ -34,6 +34,7 @@
 // lib.ChildClass.lateinit_var_3: true
 // lib.ChildClass.overriddenBaseProp_willBeBacked: true
 // lib.ChildClass.overriddenBaseProp_wontBeBacked: false
+// lib.ConstructorSetProp.propSetInConstructor: true
 // lib.DataClass.value_Param: true
 // lib.DataClass.variable_Param: true
 // lib.JavaClass.javaField: true
@@ -82,6 +83,7 @@
 // main.ChildClass.lateinit_var_3: true
 // main.ChildClass.overriddenBaseProp_willBeBacked: true
 // main.ChildClass.overriddenBaseProp_wontBeBacked: false
+// main.ConstructorSetProp.propSetInConstructor: true
 // main.DataClass.value_Param: true
 // main.DataClass.variable_Param: true
 // main.JavaClass.javaField: true
@@ -215,6 +217,13 @@ class ChildClass: BaseClass(), MyInterface {
     override lateinit var lateinit_var_3: String
 }
 
+class ConstructorSetProp {
+    private val propSetInConstructor: Boolean
+    constructor(propSetInConstructor: Boolean) {
+        this.propSetInConstructor = propSetInConstructor
+    }
+}
+
 // FILE: lib/JavaClass.java
 package lib;
 public class JavaClass {
@@ -328,6 +337,13 @@ class ChildClass: BaseClass(), MyInterface {
         set(v: String) = Unit
     override var lateinit_var_2: String = ""
     override lateinit var lateinit_var_3: String
+}
+
+class ConstructorSetProp {
+    private val propSetInConstructor: Boolean
+    constructor(propSetInConstructor: Boolean) {
+        this.propSetInConstructor = propSetInConstructor
+    }
 }
 
 // FILE: main/JavaClass.java


### PR DESCRIPTION
This PR fixes a bug where KSP fails to find a backing field for a property that is set from an explicit constructor.

I couldn't find anything in KtProperty that would give me this information so I fall back to the descriptor implementation. Assuming that is more expensive, I still kept the existing checks for faster resolutions.

Also added a minor change for the descriptor path to check for lateinit or abstract before checking the .class file which should be faster