### PR TITLE
Handle more errors when replacing type arguments

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
+import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.kotlin.KSFunctionDeclarationImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationParameterImpl
@@ -145,7 +146,9 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType =
-        getKSTypeCached(descriptor.defaultType.replaceTypeArguments(typeArguments), typeArguments)
+        descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
+            getKSTypeCached(it, typeArguments)
+        } ?: KSErrorType
 
     override fun asStarProjectedType(): KSType {
         return getKSTypeCached(descriptor.defaultType.replaceArgumentsWithStarProjections())

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -22,13 +22,13 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
 import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
+import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.kotlin.KSExpectActualNoImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import com.intellij.psi.PsiEnumConstant
 import com.intellij.psi.PsiJavaFile
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.types.typeUtil.replaceArgumentsWithStarProjections
 
 class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumConstant) :
     KSClassDeclaration,
@@ -92,12 +92,15 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
 
     override val typeParameters: List<KSTypeParameter> = emptyList()
 
+    // Enum can't have type parameters.
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return getKSTypeCached(descriptor!!.defaultType.replaceTypeArguments(typeArguments), typeArguments)
+        if (typeArguments.isNotEmpty())
+            return KSErrorType
+        return asStarProjectedType()
     }
 
     override fun asStarProjectedType(): KSType {
-        return getKSTypeCached(descriptor!!.defaultType.replaceArgumentsWithStarProjections())
+        return getKSTypeCached(descriptor!!.defaultType)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -144,7 +144,9 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         return descriptor?.let {
-            getKSTypeCached(it.defaultType.replaceTypeArguments(typeArguments), typeArguments)
+            it.defaultType.replaceTypeArguments(typeArguments)?.let {
+                getKSTypeCached(it, typeArguments)
+            }
         } ?: KSErrorType
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -108,7 +108,9 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return getKSTypeCached(descriptor.defaultType.replaceTypeArguments(typeArguments), typeArguments)
+        return descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
+            getKSTypeCached(it, typeArguments)
+        } ?: KSErrorType
     }
 
     override fun asStarProjectedType(): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -91,7 +91,9 @@ class KSTypeImpl private constructor(
     }
 
     override fun replace(arguments: List<KSTypeArgument>): KSType {
-        return getKSTypeCached(kotlinType.replaceTypeArguments(arguments), arguments)
+        return kotlinType.replaceTypeArguments(arguments)?.let {
+            getKSTypeCached(it, arguments)
+        } ?: KSErrorType
     }
 
     override fun starProjection(): KSType {

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -321,6 +321,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/referenceElement.kt");
     }
 
+    @TestMetadata("replaceWithErrorTypeArgs.kt")
+    public void testReplaceWithErrorTypeArgs() throws Exception {
+        runTest("testData/api/replaceWithErrorTypeArgs.kt");
+    }
+
     @TestMetadata("resolveJavaType.kt")
     public void testResolveJavaType() throws Exception {
         runTest("testData/api/resolveJavaType.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
@@ -51,10 +51,11 @@ open class ReplaceWithErrorTypeArgsProcessor : AbstractTestProcessor() {
         val yargs = y.type.element!!.typeArguments
 
         for (decl in decls) {
-            results.add(decl.asStarProjectedType().replace(xargs).toString())
-            results.add(decl.asStarProjectedType().replace(yargs).toString())
-            results.add(decl.asType(xargs).toString())
-            results.add(decl.asType(yargs).toString())
+            val declName = decl.qualifiedName!!.asString()
+            results.add("$declName.star.replace($xargs): ${decl.asStarProjectedType().replace(xargs)}")
+            results.add("$declName.star.replace($yargs): ${decl.asStarProjectedType().replace(yargs)}")
+            results.add("$declName.asType($xargs): ${decl.asType(xargs)}")
+            results.add("$declName.asType($yargs): ${decl.asType(yargs)}")
         }
         return emptyList()
     }

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+
+open class ReplaceWithErrorTypeArgsProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val decls = listOf(
+            // Those have 2 type parameters
+            resolver.getClassDeclarationByName("KS")!!,
+            resolver.getClassDeclarationByName("KL")!!,
+            resolver.getClassDeclarationByName("JS")!!,
+            resolver.getClassDeclarationByName("JL")!!,
+            // Those have 0 or 1 parameters
+            resolver.getClassDeclarationByName("KS1")!!,
+            resolver.getClassDeclarationByName("KL1")!!,
+            resolver.getClassDeclarationByName("JS1")!!,
+            resolver.getClassDeclarationByName("JL1")!!,
+            resolver.getClassDeclarationByName("JSE")!!,
+            resolver.getClassDeclarationByName("JSE.E")!!,
+            resolver.getClassDeclarationByName("JLE")!!,
+            resolver.getClassDeclarationByName("JLE.E")!!,
+            resolver.getClassDeclarationByName("KSE")!!,
+            resolver.getClassDeclarationByName("KSE.E")!!,
+            resolver.getClassDeclarationByName("KLE")!!,
+            resolver.getClassDeclarationByName("KLE.E")!!,
+        )
+        val x = resolver.getPropertyDeclarationByName(resolver.getKSNameFromString("x"), true)!!
+        val xargs = x.type.element!!.typeArguments
+        val y = resolver.getPropertyDeclarationByName(resolver.getKSNameFromString("y"), true)!!
+        val yargs = y.type.element!!.typeArguments
+
+        for (decl in decls) {
+            results.add(decl.asStarProjectedType().replace(xargs).toString())
+            results.add(decl.asStarProjectedType().replace(yargs).toString())
+            results.add(decl.asType(xargs).toString())
+            results.add(decl.asType(yargs).toString())
+        }
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+}

--- a/compiler-plugin/testData/api/replaceWithErrorTypeArgs.kt
+++ b/compiler-plugin/testData/api/replaceWithErrorTypeArgs.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: ReplaceWithErrorTypeArgsProcessor
+// EXPECTED:
+// KS<Int, String>
+// <ERROR TYPE>
+// KS<Int, String>
+// <ERROR TYPE>
+// KL<Int, String>
+// <ERROR TYPE>
+// KL<Int, String>
+// <ERROR TYPE>
+// JS<Int, String>
+// <ERROR TYPE>
+// JS<Int, String>
+// <ERROR TYPE>
+// JL<Int, String>
+// <ERROR TYPE>
+// JL<Int, String>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// <ERROR TYPE>
+// END
+
+// MODULE: lib
+// FILE: JL.java
+class JL<T1, T2> {}
+class JL1<T> {}
+enum JLE {
+    E
+}
+
+// FILE: KL.kt
+class KL<T1, T2>
+class KL1<T>
+enum class KLE {
+    E
+}
+
+// MODULE: main(lib)
+// FILE: JS.java
+class JS<T1, T2> {}
+class JS1<T> {}
+enum JSE {
+    E
+}
+
+// FILE: KS.kt
+class KS<T1, T2>
+class KS1<T>
+enum class KSE {
+    E
+}
+
+val x: KS<Int, String> = TODO()
+val y: KS<NotExist1, NotExist2> = TODO()

--- a/compiler-plugin/testData/api/replaceWithErrorTypeArgs.kt
+++ b/compiler-plugin/testData/api/replaceWithErrorTypeArgs.kt
@@ -18,70 +18,70 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: ReplaceWithErrorTypeArgsProcessor
 // EXPECTED:
-// KS<Int, String>
-// <ERROR TYPE>
-// KS<Int, String>
-// <ERROR TYPE>
-// KL<Int, String>
-// <ERROR TYPE>
-// KL<Int, String>
-// <ERROR TYPE>
-// JS<Int, String>
-// <ERROR TYPE>
-// JS<Int, String>
-// <ERROR TYPE>
-// JL<Int, String>
-// <ERROR TYPE>
-// JL<Int, String>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
-// <ERROR TYPE>
+// KS.star.replace([INVARIANT Int, INVARIANT String]): KS<Int, String>
+// KS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS.asType([INVARIANT Int, INVARIANT String]): KS<Int, String>
+// KS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL.star.replace([INVARIANT Int, INVARIANT String]): KL<Int, String>
+// KL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL.asType([INVARIANT Int, INVARIANT String]): KL<Int, String>
+// KL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS.star.replace([INVARIANT Int, INVARIANT String]): JS<Int, String>
+// JS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS.asType([INVARIANT Int, INVARIANT String]): JS<Int, String>
+// JS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL.star.replace([INVARIANT Int, INVARIANT String]): JL<Int, String>
+// JL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL.asType([INVARIANT Int, INVARIANT String]): JL<Int, String>
+// JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// JLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
+// KLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
 // END
 
 // MODULE: lib


### PR DESCRIPTION
Cases are:
* #arguments doesn't match
* There are error types in arguments