### PR TITLE
cherry-pick: Unconditionally disable FIR in KSP Gradle tasks

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -567,6 +567,7 @@ abstract class KspTaskJvm : KotlinCompile(KotlinJvmOptionsImpl()), KspTask {
         args.addPluginOptions(options.get())
         args.destinationAsFile = destination
         args.allowNoSourceFiles = true
+        args.useFir = false
     }
 
     // Overrding an internal function is hacky.
@@ -658,6 +659,7 @@ abstract class KspTaskJS @Inject constructor(
         args.addPluginOptions(options.get())
         args.outputFile = File(destination, "dummyOutput.js").canonicalPath
         kotlinOptions.copyFreeCompilerArgsToArgs(args)
+        args.useFir = false
     }
 
     // Overrding an internal function is hacky.
@@ -732,6 +734,7 @@ abstract class KspTaskMetadata : KotlinCompileCommon(KotlinMultiplatformCommonOp
         args.classpath = classpathList.joinToString(File.pathSeparator)
         args.friendPaths = friendPaths.files.map { it.absolutePath }.toTypedArray()
         args.refinesPaths = refinesMetadataPaths.map { it.absolutePath }.toTypedArray()
+        args.useFir = false
     }
 
     // Overrding an internal function is hacky.

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -131,4 +131,17 @@ class PlaygroundIT {
             Assert.assertTrue(result.output.contains("kotlin.io.FileAlreadyExistsException"))
         }
     }
+
+    // Test -Xuse-fir for compilation; KSP still uses FE1.0
+    @Test
+    fun testFirPreview() {
+        val gradleProperties = File(project.root, "gradle.properties")
+        gradleProperties.appendText("\nkotlin.useFir=true")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.buildAndCheck("clean", "build") { result ->
+            Assert.assertTrue(result.output.contains("This build uses in-dev FIR"))
+            Assert.assertTrue(result.output.contains("-Xuse-fir"))
+        }
+        project.restore(gradleProperties.path)
+    }
 }


### PR DESCRIPTION
KSP for FIR is still under development. This change allows KSP to be
used with compiler tasks where FIR is enabled.

(cherry picked from commit b5867e6af5e30193d7a11c6ee39262c0cba193ab)