### PR TITLE
APIs for api/compiler versions and target info

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/PlatformInfo.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/PlatformInfo.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processing
+
+/**
+ * Platform specific information
+ */
+interface PlatformInfo {
+    val platformName: String
+}
+
+/*
+ * Platform information for JVM
+ */
+interface JvmPlatformInfo : PlatformInfo {
+    /**
+     * JVM target version. Correspond to `-jvm-target` to Kotlin compiler
+     */
+    val jvmTarget: String
+}
+
+/**
+ * Platform information for JS
+ */
+interface JsPlatformInfo : PlatformInfo
+
+/**
+ * Platform information for native platforms
+ */
+interface NativePlatformInfo : PlatformInfo {
+    val targetName: String
+}
+
+/**
+ * Unknown platform to KSP
+ */
+interface UnknownPlatformInfo : PlatformInfo

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.ksp.processing
 
 class SymbolProcessorEnvironment(
@@ -5,16 +22,36 @@ class SymbolProcessorEnvironment(
      * passed from command line, Gradle, etc.
      */
     val options: Map<String, String>,
+
     /**
      * language version of compilation environment.
      */
     val kotlinVersion: KotlinVersion,
+
     /**
      * creates managed files.
      */
     val codeGenerator: CodeGenerator,
+
     /**
      * for logging to build output.
      */
-    val logger: KSPLogger
+    val logger: KSPLogger,
+
+    /**
+     * Kotlin API version of compilation environment.
+     */
+    val apiVersion: KotlinVersion,
+
+    /**
+     * Kotlin compiler version of compilation environment.
+     */
+    val compilerVersion: KotlinVersion,
+
+    /**
+     * Information of target platforms
+     *
+     * There can be multiple platforms in a metadata compilation.
+     */
+    val platforms: List<PlatformInfo>,
 )

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/PlatformInfoImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/PlatformInfoImpl.kt
@@ -1,0 +1,32 @@
+package com.google.devtools.ksp.processing.impl
+
+import com.google.devtools.ksp.processing.JsPlatformInfo
+import com.google.devtools.ksp.processing.JvmPlatformInfo
+import com.google.devtools.ksp.processing.NativePlatformInfo
+import com.google.devtools.ksp.processing.UnknownPlatformInfo
+
+internal class JvmPlatformInfoImpl(
+    override val platformName: String,
+    override val jvmTarget: String
+) : JvmPlatformInfo {
+    override fun toString() = "$platformName ($jvmTarget)"
+}
+
+internal class JsPlatformInfoImpl(
+    override val platformName: String
+) : JsPlatformInfo {
+    override fun toString() = platformName
+}
+
+internal class NativePlatformInfoImpl(
+    override val platformName: String,
+    override val targetName: String
+) : NativePlatformInfo {
+    override fun toString() = "$platformName ($targetName)"
+}
+
+internal class UnknownPlatformInfoImpl(
+    override val platformName: String
+) : UnknownPlatformInfo {
+    override fun toString() = platformName
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -48,6 +48,7 @@ class KMPImplementedIT {
                 )
             )
             Assert.assertFalse(it.output.contains("kotlin scripting plugin:"))
+            Assert.assertTrue(it.output.contains("w: [ksp] platforms: [JVM"))
         }
     }
 
@@ -74,6 +75,7 @@ class KMPImplementedIT {
                 )
             )
             Assert.assertFalse(it.output.contains("kotlin scripting plugin:"))
+            Assert.assertTrue(it.output.contains("w: [ksp] platforms: [JS"))
         }
     }
 
@@ -113,6 +115,7 @@ class KMPImplementedIT {
                 "workload-androidNative/build/bin/androidNativeArm64/releaseExecutable/workload-androidNative.so"
             )
             Assert.assertFalse(it.output.contains("kotlin scripting plugin:"))
+            Assert.assertTrue(it.output.contains("w: [ksp] platforms: [Native"))
         }
     }
 
@@ -144,6 +147,7 @@ class KMPImplementedIT {
                     it.task(":workload-linuxX64:kspKotlinMingwX64")?.outcome == TaskOutcome.SKIPPED
             )
             Assert.assertFalse(it.output.contains("kotlin scripting plugin:"))
+            Assert.assertTrue(it.output.contains("w: [ksp] platforms: [Native"))
         }
     }
 
@@ -194,6 +198,9 @@ class KMPImplementedIT {
         )
 
         Assert.assertFalse(result.output.contains("kotlin scripting plugin:"))
+        Assert.assertTrue(result.output.contains("w: [ksp] platforms: [JVM"))
+        Assert.assertTrue(result.output.contains("w: [ksp] platforms: [JS"))
+        Assert.assertTrue(result.output.contains("w: [ksp] platforms: [Native"))
     }
 
     @Test

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -144,4 +144,23 @@ class PlaygroundIT {
         }
         project.restore(gradleProperties.path)
     }
+
+    @Test
+    fun testVersions() {
+        val kotlinCompile = "org.jetbrains.kotlin.gradle.tasks.KotlinCompile"
+        val buildFile = File(project.root, "workload/build.gradle.kts")
+        buildFile.appendText("\ntasks.withType<$kotlinCompile> {")
+        buildFile.appendText("\n    kotlinOptions.apiVersion = \"1.5\"")
+        buildFile.appendText("\n    kotlinOptions.languageVersion = \"1.5\"")
+        buildFile.appendText("\n}")
+
+        val kotlinVersion = System.getProperty("kotlinVersion").split('-').first()
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.buildAndCheck("clean", "build") { result ->
+            Assert.assertTrue(result.output.contains("language version: 1.5"))
+            Assert.assertTrue(result.output.contains("api version: 1.5"))
+            Assert.assertTrue(result.output.contains("compiler version: $kotlinVersion"))
+        }
+        project.restore(buildFile.path)
+    }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -24,7 +24,7 @@ class TemporaryTestProject(projectName: String, baseProject: String? = null) : T
         gradleProperties.appendText("\ntestRepo=$testRepo")
         gradleProperties.appendText("\norg.gradle.unsafe.configuration-cache=true")
         // Uncomment this to debug compiler and compiler plugin.
-        // gradleProperties.appendText("\nkotlin.compiler.execution.strategy=in-process")
+        // gradleProperties.appendText("\nsystemProp.kotlin.compiler.execution.strategy=in-process")
     }
 
     fun restore(file: String) {

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
@@ -3,7 +3,11 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 import java.io.OutputStreamWriter
 
-class TestProcessor(val codeGenerator: CodeGenerator, val logger: KSPLogger) : SymbolProcessor {
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger,
+    val env: SymbolProcessorEnvironment
+) : SymbolProcessor {
     var invoked = false
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -13,6 +17,12 @@ class TestProcessor(val codeGenerator: CodeGenerator, val logger: KSPLogger) : S
             return emptyList()
         }
         invoked = true
+
+        logger.warn("language version: ${env.kotlinVersion}")
+        logger.warn("api version: ${env.apiVersion}")
+        logger.warn("compiler version: ${env.compilerVersion}")
+        val platforms = env.platforms.map { it.toString() }
+        logger.warn("platforms: $platforms")
 
         codeGenerator.createNewFile(Dependencies(false), "", "Foo", "kt").use { output ->
             OutputStreamWriter(output).use { writer ->
@@ -47,6 +57,6 @@ class ClassVisitor : KSTopDownVisitor<OutputStreamWriter, Unit>() {
 
 class TestProcessorProvider : SymbolProcessorProvider {
     override fun create(env: SymbolProcessorEnvironment): SymbolProcessor {
-        return TestProcessor(env.codeGenerator, env.logger)
+        return TestProcessor(env.codeGenerator, env.logger, env)
     }
 }

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
@@ -269,6 +269,10 @@ class TestProcessorProvider2 : SymbolProcessorProvider {
     ): SymbolProcessor {
         return TestProcessor().apply {
             init(env.options, env.kotlinVersion, env.codeGenerator, env.logger)
+
+            env.logger.warn("language version: ${env.kotlinVersion}")
+            env.logger.warn("api version: ${env.apiVersion}")
+            env.logger.warn("compiler version: ${env.compilerVersion}")
         }
     }
 }


### PR DESCRIPTION
New APIs:
```
class SymbolProcessorEnvironment(
    ...
    val apiVersion: KotlinVersion,
    val compilerVersion: KotlinVersion,
    val platforms: List<PlatformInfo>,
}
```

Also fixed `SymbolProcessorEnvironment.kotlinVersion` to return language version instead of some random compiler version.

