### PR TITLE
Defer some updates of symbol and lookup tables

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemovalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemovalIT.kt
@@ -1,0 +1,35 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class IncrementalRemovalIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("incremental-removal")
+
+    @Test
+    fun testRemoveOutputs() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val k1 = "workload/src/main/kotlin/p1/K1.kt"
+
+        gradleRunner.withArguments("run").build().let { result ->
+            Assert.assertTrue(result.output.contains("result: generated"))
+        }
+
+        File(project.root, k1).writeText(
+            "package p1\n\nclass K1\n\nclass Foo : Bar { override fun s() = \"crafted\" }\n"
+        )
+        gradleRunner.withArguments("run").build().let { result ->
+            Assert.assertTrue(result.output.contains("result: crafted"))
+        }
+
+        project.restore(k1)
+        gradleRunner.withArguments("run").build().let { result ->
+            Assert.assertTrue(result.output.contains("result: generated"))
+        }
+    }
+}

--- a/integration-tests/src/test/resources/incremental-removal/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}

--- a/integration-tests/src/test/resources/incremental-removal/gradle.properties
+++ b/integration-tests/src/test/resources/incremental-removal/gradle.properties
@@ -1,0 +1,2 @@
+ksp.incremental=true
+ksp.incremental.log=true

--- a/integration-tests/src/test/resources/incremental-removal/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}
+
+rootProject.name = "incremental-test"
+
+include(":workload")
+include(":validator")

--- a/integration-tests/src/test/resources/incremental-removal/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/validator/build.gradle.kts
@@ -1,0 +1,24 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}

--- a/integration-tests/src/test/resources/incremental-removal/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental-removal/validator/src/main/kotlin/Validator.kt
@@ -1,0 +1,48 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.OutputStreamWriter
+
+class Validator : SymbolProcessor {
+    lateinit var codeGenerator: CodeGenerator
+    lateinit var logger: KSPLogger
+
+    fun init(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger,
+    ) {
+        this.codeGenerator = codeGenerator
+        this.logger = logger
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("p1.MyAnnotation").singleOrNull()?.let { decl ->
+            decl as KSClassDeclaration
+            val file = decl.containingFile!!
+            OutputStreamWriter(
+                codeGenerator.createNewFile(
+                    Dependencies(false, file),
+                    "p1", "Foo"
+                )
+            ).use {
+                it.write("package p1\n\nclass Foo : Bar { override fun s() = \"generated\" }\n")
+            }
+        }
+        resolver.getNewFiles().forEach {
+            it.validate()
+        }
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        env: SymbolProcessorEnvironment,
+    ): SymbolProcessor {
+        return Validator().apply {
+            init(env.options, env.kotlinVersion, env.codeGenerator, env.logger)
+        }
+    }
+}

--- a/integration-tests/src/test/resources/incremental-removal/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/incremental-removal/validator/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider

--- a/integration-tests/src/test/resources/incremental-removal/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/workload/build.gradle.kts
@@ -1,0 +1,27 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+    application
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":validator"))
+    testImplementation("junit:junit:4.12")
+    ksp(project(":validator"))
+    kspTest(project(":validator"))
+}
+
+application {
+    mainClassName = "p1.MainKt"
+}

--- a/integration-tests/src/test/resources/incremental-removal/workload/src/main/kotlin/p1/K1.kt
+++ b/integration-tests/src/test/resources/incremental-removal/workload/src/main/kotlin/p1/K1.kt
@@ -1,0 +1,4 @@
+package p1
+
+@MyAnnotation
+class K1

--- a/integration-tests/src/test/resources/incremental-removal/workload/src/main/kotlin/p1/Main.kt
+++ b/integration-tests/src/test/resources/incremental-removal/workload/src/main/kotlin/p1/Main.kt
@@ -1,0 +1,12 @@
+package p1
+
+interface Bar {
+    fun s(): String
+}
+val bar: Foo = Foo()
+
+annotation class MyAnnotation
+
+fun main() {
+    println("result: ${bar.s()}")
+}


### PR DESCRIPTION
Output files that disappeared in previous compilation can also
participate in dirtyness propagation and should only be removed after
calculating the dirty set.

fixes #767 