### PR TITLE
getJavaWildcard: fix cases for nested type args

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1208,6 +1208,30 @@ class ResolverImpl(
         SUPER_TYPE
     }
 
+    // Search in self and parents for the first type reference that is not part of a type argument.
+    private fun KSTypeReference.findOuterMostRef(): Pair<KSTypeReference, List<Int>> {
+        fun KSNode.findParentRef(): KSTypeReference? {
+            var parent = parent
+            while (parent != null && parent !is KSTypeReference)
+                parent = parent.parent
+            return parent as? KSTypeReference
+        }
+
+        val fallback = Pair<KSTypeReference, List<Int>>(this, emptyList())
+        val indexes = mutableListOf<Int>()
+        var candidate: KSTypeReference = this
+        // KSTypeArgument's parent can be either KSReferenceElement or KSType.
+        while (candidate.parent is KSTypeArgument) {
+            // If the parent is a KSType, it's a synthetic reference.
+            // Do nothing and reply on the fallback behavior.
+            val referenceElement = candidate.parent!!.parent.safeAs<KSReferenceElement>() ?: return fallback
+            indexes.add(referenceElement.typeArguments.indexOf(candidate.parent))
+            // In case the program isn't properly structured, fallback.
+            candidate = referenceElement.findParentRef() ?: return fallback
+        }
+        return Pair(candidate, indexes)
+    }
+
     // TODO: Strict mode for catching unhandled cases.
     private fun findRefPosition(ref: KSTypeReference): RefPosition = when (val parent = ref.parent) {
         is KSCallableReference -> when (ref) {
@@ -1266,11 +1290,17 @@ class ResolverImpl(
         return replace(wildcardArguments)
     }
 
+    // Type arguments need to be resolved recursively in a top-down manner. So we find and resolve the outer most
+    // reference that contains this argument. Then locate and return the argument.
     @KspExperimental
-    override fun getJavaWildcard(ref: KSTypeReference): KSTypeReference {
+    override fun getJavaWildcard(reference: KSTypeReference): KSTypeReference {
+        // If the outer-most reference cannot be found, e.g., when this reference is nested in KSType.arguments,
+        // fallback to PARAMETER_TYPE effectively.
+        val (ref, indexes) = reference.findOuterMostRef()
+
         val type = ref.resolve()
         if (type.isError)
-            return ref
+            return reference
 
         val position = findRefPosition(ref)
         val kotlinType = (type as KSTypeImpl).kotlinType
@@ -1297,7 +1327,11 @@ class ResolverImpl(
         }
 
         val wildcardType = kotlinType.toWildcard(typeMappingMode)?.let {
-            getKSTypeCached(it)
+            var candidate: KotlinType = it
+            for (i in indexes.reversed()) {
+                candidate = candidate.arguments[i].type
+            }
+            getKSTypeCached(candidate)
         } ?: KSErrorType
 
         return KSTypeReferenceSyntheticImpl.getCached(wildcardType, null)

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/EquivalentJavaWildcardProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/EquivalentJavaWildcardProcessor.kt
@@ -29,7 +29,7 @@ open class EquivalentJavaWildcardProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
             resolver.getNewFiles().forEach {
-                it.accept(RefVisitor(results, resolver), Unit)
+                it.accept(RefVisitor(results, resolver), "")
             }
         }
 
@@ -37,32 +37,28 @@ open class EquivalentJavaWildcardProcessor : AbstractTestProcessor() {
     }
 
     override fun toResult(): List<String> {
-        return results.sorted()
+        return results
     }
 
     private class RefVisitor(
         val results: MutableList<String>,
         val resolver: Resolver
-    ) : KSTopDownVisitor<Unit, Unit>() {
-        override fun defaultHandler(node: KSNode, data: Unit) = Unit
-
-        override fun visitTypeArgument(typeArgument: KSTypeArgument, data: Unit) {
-            // Do nothing; Otherwise it'd be too verbose.
-        }
+    ) : KSTopDownVisitor<String, Unit>() {
+        override fun defaultHandler(node: KSNode, data: String) = Unit
 
         private fun KSTypeReference.pretty(): String {
             return resolve().toString()
         }
 
         @OptIn(KspExperimental::class)
-        override fun visitTypeReference(typeReference: KSTypeReference, data: Unit) {
-            super.visitTypeReference(typeReference, data)
+        override fun visitTypeReference(typeReference: KSTypeReference, data: String) {
             val wildcard = resolver.getJavaWildcard(typeReference)
             results.add(
-                typeReference.parent.toString() +
+                data + typeReference.parent.toString() +
                     " : " + typeReference.pretty() +
                     " -> " + wildcard.pretty()
             )
+            super.visitTypeReference(typeReference, data + "- ")
         }
     }
 }

--- a/compiler-plugin/testData/api/equivalentJavaWildcards.kt
+++ b/compiler-plugin/testData/api/equivalentJavaWildcards.kt
@@ -107,7 +107,7 @@
 // - INVARIANT X : X -> X
 // <init> : C3 -> C3
 // C4 : B<A<X, out Y>> -> B<A<in X, out Y>>
-// - INVARIANT A : A<X, out Y> -> A<in X, Y>
+// - INVARIANT A : A<X, out Y> -> A<in X, out Y>
 // - - INVARIANT X : X -> X
 // - - COVARIANT Y : Y -> Y
 // <init> : C4 -> C4

--- a/compiler-plugin/testData/api/equivalentJavaWildcards.kt
+++ b/compiler-plugin/testData/api/equivalentJavaWildcards.kt
@@ -18,76 +18,145 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: EquivalentJavaWildcardProcessor
 // EXPECTED:
-// <init> : A1 -> A1
-// <init> : A<T1, T2> -> A<T1, T2>
-// <init> : C1 -> C1
-// <init> : C2 -> C2
-// <init> : C3 -> C3
-// <init> : C4 -> C4
 // <init> : X -> X
-// <init> : Y -> Y
-// @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
-// @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
-// @JvmWildcard : JvmWildcard -> JvmWildcard
-// C1 : A<X, X> -> A<X, X>
-// C2 : A<Any, Y> -> A<Any, Y>
-// C3 : B<X> -> B<X>
-// C4 : B<A<X, out Y>> -> B<A<in X, out Y>>
 // Y : X -> X
-// a1 : A<in X, out X> -> A<in X, out X>
-// a1 : A<in X, out X> -> A<in X, out X>
-// a1.getter() : A<in X, out X> -> A<in X, out X>
-// a2 : A<Any, Y> -> A<Any, Y>
-// a2 : A<Any, Y> -> A<Any, Y>
-// a2.getter() : A<Any, Y> -> A<in Any, out Y>
-// a3 : A<*, *> -> A<out Any?, out Any?>
-// a3 : A<*, *> -> A<out Any?, out Any?>
-// a3.getter() : A<*, *> -> A<out Any?, out Any?>
-// a4 : B<X> -> B<X>
-// a4 : B<X> -> B<X>
-// a4.getter() : B<X> -> B<X>
-// a5 : B<in X> -> B<in X>
-// a5 : B<in X> -> B<in X>
-// a5.getter() : B<in X> -> B<in X>
-// a6 : B<out X> -> B<out X>
-// a6 : B<out X> -> B<out X>
-// a6.getter() : B<out X> -> B<out X>
-// a7 : B<*> -> B<out Any?>
-// a7 : B<*> -> B<out Any?>
-// a7.getter() : B<*> -> B<out Any?>
+// <init> : Y -> Y
+// <init> : A<T1, T2> -> A<T1, T2>
+// synthetic constructor for B : B<*> -> B<out Any?>
 // bar1 : [@kotlin.jvm.JvmSuppressWildcards] A<X, X> -> [@kotlin.jvm.JvmSuppressWildcards] A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
 // bar2 : [@kotlin.jvm.JvmSuppressWildcards] A<X, X> -> [@kotlin.jvm.JvmSuppressWildcards] A<in X, out X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
 // bar3 : [@kotlin.jvm.JvmWildcard] A<X, X> -> [@kotlin.jvm.JvmWildcard] A<in X, out X>
-// foo : Unit -> Unit
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmWildcard : JvmWildcard -> JvmWildcard
 // p1 : A<in X, out X> -> A<X, X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
 // p1.getter() : A<in X, out X> -> A<X, X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
 // p2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
 // p2.getter() : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
 // p3 : A<*, *> -> A<Any?, Any?>
 // p3.getter() : A<*, *> -> A<Any?, Any?>
+// - STAR Any : Any? -> Any?
+// - STAR Any : Any? -> Any?
 // p4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
 // p4.getter() : B<X> -> B<X>
+// - INVARIANT X : X -> X
 // p5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
 // p5.getter() : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
 // p6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
 // p6.getter() : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
 // p7 : B<*> -> B<out Any?>
 // p7.getter() : B<*> -> B<out Any?>
-// r1 : A<X, X> -> A<X, X>
-// r2 : A<Any, Y> -> A<Any, Y>
-// r3 : A<*, *> -> A<Any?, Any?>
-// r4 : B<X> -> B<X>
-// r5 : B<in X> -> B<in X>
-// r6 : B<out X> -> B<out X>
-// r7 : B<*> -> B<out Any?>
-// synthetic constructor for B : B<*> -> B<out Any?>
+// - STAR Any : Any? -> Any?
 // v1 : A<X, X> -> A<in X, out X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
 // v2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
 // v3 : A<*, *> -> A<out Any?, out Any?>
 // v4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
 // v5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
 // v6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
 // v7 : B<*> -> B<out Any?>
+// foo : Unit -> Unit
+// r1 : A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// r2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// r3 : A<*, *> -> A<Any?, Any?>
+// r4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// r5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// r6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// r7 : B<*> -> B<out Any?>
+// C1 : A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// <init> : C1 -> C1
+// C2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// <init> : C2 -> C2
+// C3 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// <init> : C3 -> C3
+// C4 : B<A<X, out Y>> -> B<A<in X, out Y>>
+// - INVARIANT A : A<X, out Y> -> A<in X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// <init> : C4 -> C4
+// a1 : A<in X, out X> -> A<in X, out X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
+// a2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// a3 : A<*, *> -> A<out Any?, out Any?>
+// a4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// a5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// a6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// a7 : B<*> -> B<out Any?>
+// <init> : A1 -> A1
+// a1 : A<in X, out X> -> A<in X, out X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
+// a1.getter() : A<in X, out X> -> A<in X, out X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
+// a2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// a2.getter() : A<Any, Y> -> A<in Any, out Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// a3 : A<*, *> -> A<out Any?, out Any?>
+// a3.getter() : A<*, *> -> A<out Any?, out Any?>
+// - STAR Any : Any? -> Any?
+// - STAR Any : Any? -> Any?
+// a4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// a4.getter() : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// a5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// a5.getter() : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// a6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// a6.getter() : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// a7 : B<*> -> B<out Any?>
+// a7.getter() : B<*> -> B<out Any?>
+// - STAR Any : Any? -> Any?
 // END
 
 open class X()

--- a/compiler-plugin/testData/api/equivalentJavaWildcards.kt
+++ b/compiler-plugin/testData/api/equivalentJavaWildcards.kt
@@ -66,6 +66,14 @@
 // p7 : B<*> -> B<out Any?>
 // p7.getter() : B<*> -> B<out Any?>
 // - STAR Any : Any? -> Any?
+// p8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// p8.getter() : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A<X, out Y> : A<X, out Y> -> A<in X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
 // v1 : A<X, X> -> A<in X, out X>
 // - INVARIANT X : X -> X
 // - INVARIANT X : X -> X
@@ -80,6 +88,10 @@
 // v6 : B<out X> -> B<out X>
 // - COVARIANT X : X -> X
 // v7 : B<*> -> B<out Any?>
+// v8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
 // foo : Unit -> Unit
 // r1 : A<X, X> -> A<X, X>
 // - INVARIANT X : X -> X
@@ -95,6 +107,10 @@
 // r6 : B<out X> -> B<out X>
 // - COVARIANT X : X -> X
 // r7 : B<*> -> B<out Any?>
+// r8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
 // C1 : A<X, X> -> A<X, X>
 // - INVARIANT X : X -> X
 // - INVARIANT X : X -> X
@@ -111,52 +127,6 @@
 // - - INVARIANT X : X -> X
 // - - COVARIANT Y : Y -> Y
 // <init> : C4 -> C4
-// a1 : A<in X, out X> -> A<in X, out X>
-// - CONTRAVARIANT X : X -> X
-// - COVARIANT X : X -> X
-// a2 : A<Any, Y> -> A<Any, Y>
-// - INVARIANT Any : Any -> Any
-// - INVARIANT Y : Y -> Y
-// a3 : A<*, *> -> A<out Any?, out Any?>
-// a4 : B<X> -> B<X>
-// - INVARIANT X : X -> X
-// a5 : B<in X> -> B<in X>
-// - CONTRAVARIANT X : X -> X
-// a6 : B<out X> -> B<out X>
-// - COVARIANT X : X -> X
-// a7 : B<*> -> B<out Any?>
-// <init> : A1 -> A1
-// a1 : A<in X, out X> -> A<in X, out X>
-// - CONTRAVARIANT X : X -> X
-// - COVARIANT X : X -> X
-// a1.getter() : A<in X, out X> -> A<in X, out X>
-// - CONTRAVARIANT X : X -> X
-// - COVARIANT X : X -> X
-// a2 : A<Any, Y> -> A<Any, Y>
-// - INVARIANT Any : Any -> Any
-// - INVARIANT Y : Y -> Y
-// a2.getter() : A<Any, Y> -> A<in Any, out Y>
-// - INVARIANT Any : Any -> Any
-// - INVARIANT Y : Y -> Y
-// a3 : A<*, *> -> A<out Any?, out Any?>
-// a3.getter() : A<*, *> -> A<out Any?, out Any?>
-// - STAR Any : Any? -> Any?
-// - STAR Any : Any? -> Any?
-// a4 : B<X> -> B<X>
-// - INVARIANT X : X -> X
-// a4.getter() : B<X> -> B<X>
-// - INVARIANT X : X -> X
-// a5 : B<in X> -> B<in X>
-// - CONTRAVARIANT X : X -> X
-// a5.getter() : B<in X> -> B<in X>
-// - CONTRAVARIANT X : X -> X
-// a6 : B<out X> -> B<out X>
-// - COVARIANT X : X -> X
-// a6.getter() : B<out X> -> B<out X>
-// - COVARIANT X : X -> X
-// a7 : B<*> -> B<out Any?>
-// a7.getter() : B<*> -> B<out Any?>
-// - STAR Any : Any? -> Any?
 // END
 
 open class X()
@@ -169,18 +139,31 @@ open class B<T>
 // @JvmSuppressWildcards(false)
 // fun bar(): A<X, X> = TODO()
 
+// A<X, X>
 fun bar1(): @JvmSuppressWildcards(true) A<X, X> = TODO()
+// A<? super X, ? extends X>
 fun bar2(): @JvmSuppressWildcards(false) A<X, X> = TODO()
+// FIXME: A<X, X>
 fun bar3(): @JvmWildcard A<X, X> = TODO()
 
+// A<X, X>
 val p1: A<in X, out X> = TODO()
+// A<java.lang.Object, Y>
 val p2: A<Any, Y> = TODO()
+// A<?, ?>
 val p3: A<*, *> = TODO()
+// B<X>
 val p4: B<X> = TODO()
+// B<? super X>
 val p5: B<in X> = TODO()
+// B<? extends X>
 val p6: B<out X> = TODO()
+// B<?>
 val p7: B<*> = TODO()
+// B<A<X, Y>>
+val p8: B<A<X, out Y>>
 
+// void foo(A<? super X, ? extends X>, A<java.lang.Object, Y>, A<?, ?>, B<X>, B<? super X>, B<? extends X>, B<?>, B<A<X, Y>>);
 fun foo(
     v1: A<X, X>,
     v2: A<Any, Y>,
@@ -189,27 +172,31 @@ fun foo(
     v5: B<in X>,
     v6: B<out X>,
     v7: B<*>,
+    v8: B<A<X, out Y>>,
 ): Unit = Unit
 
+// A<X, X>
 fun r1(): A<X, X> = TODO()
+// A<java.lang.Object, Y>
 fun r2(): A<Any, Y> = TODO()
+// A<?, ?>
 fun r3(): A<*, *> = TODO()
+// B<X>
 fun r4(): B<X> = TODO()
+// B<? super X>
 fun r5(): B<in X> = TODO()
+// B<? extends X>
 fun r6(): B<out X> = TODO()
+// B<?>
 fun r7(): B<*> = TODO()
+// B<A<X, Y>>
+fun r8(): B<A<X, out Y>> = TODO()
 
+// extends A<X, X>
 class C1() : A<X, X>()
+// A<java.lang.Object, Y>
 class C2() : A<Any, Y>()
+// B<X>
 class C3() : B<X>()
+// B<A<? super X, ? extends Y>>
 class C4() : B<A<X, out Y>>()
-
-annotation class A1(
-    val a1: A<in X, out X>,
-    val a2: A<Any, Y>,
-    val a3: A<*, *>,
-    val a4: B<X>,
-    val a5: B<in X>,
-    val a6: B<out X>,
-    val a7: B<*>
-)


### PR DESCRIPTION
by resolving the containing reference that is not a part of type arguments, and then locate the reference of interest.