### PR TITLE
getJavaWildcard: fix annotation search

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -40,8 +40,9 @@ import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.codegen.ClassBuilderMode
 import org.jetbrains.kotlin.codegen.OwnerKind
+import org.jetbrains.kotlin.codegen.state.JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME
+import org.jetbrains.kotlin.codegen.state.JVM_WILDCARD_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
-import org.jetbrains.kotlin.codegen.state.updateArgumentModeFromAnnotations
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.get
@@ -83,6 +84,7 @@ import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.*
 import org.jetbrains.kotlin.resolve.*
+import org.jetbrains.kotlin.resolve.annotations.argumentValue
 import org.jetbrains.kotlin.resolve.calls.inference.components.NewTypeSubstitutor
 import org.jetbrains.kotlin.resolve.calls.inference.components.composeWith
 import org.jetbrains.kotlin.resolve.calls.inference.substitute
@@ -284,6 +286,14 @@ class ResolverImpl(
         }
     }
 
+    internal fun checkAnnotation(annotation: KSAnnotation, ksName: KSName, shortName: String): Boolean {
+        val annotationType = annotation.annotationType
+        val referencedName = (annotationType.element as? KSClassifierReference)?.referencedName()
+        val simpleName = referencedName?.substringAfterLast('.')
+        return (simpleName == shortName || simpleName in aliasingNames) &&
+            annotationType.resolveToUnderlying().declaration.qualifiedName == ksName
+    }
+
     override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> {
         // If annotationName is a typealias, resolve to underlying type.
         val realAnnotationName =
@@ -293,18 +303,14 @@ class ResolverImpl(
         val ksName = KSNameImpl.getCached(realAnnotationName)
         val shortName = ksName.getShortName()
 
-        fun checkAnnotation(annotated: KSAnnotated): Boolean {
+        fun checkAnnotated(annotated: KSAnnotated): Boolean {
             return annotated.annotations.any {
-                val annotationType = it.annotationType
-                val referencedName = (annotationType.element as? KSClassifierReference)?.referencedName()
-                val simpleName = referencedName?.substringAfterLast('.')
-                (simpleName == shortName || simpleName in aliasingNames) &&
-                    annotationType.resolveToUnderlying().declaration.qualifiedName == ksName
+                checkAnnotation(it, ksName, shortName)
             }
         }
 
         val allAnnotated = if (inDepth) newAnnotatedSymbolsWithLocals else newAnnotatedSymbols
-        return allAnnotated.asSequence().filter { checkAnnotation(it) }
+        return allAnnotated.asSequence().filter(::checkAnnotated)
     }
 
     private fun collectAnnotatedSymbols(inDepth: Boolean): Collection<KSAnnotated> {
@@ -1267,7 +1273,6 @@ class ResolverImpl(
     private fun KotlinType.toWildcard(mode: TypeMappingMode): KotlinType? {
         val parameters = constructor.parameters
         val arguments = arguments
-        val argMode = mode.updateArgumentModeFromAnnotations(this, SimpleClassicTypeSystemContext)
 
         val wildcardArguments = parameters.zip(arguments).map { (parameter, argument) ->
             if (!argument.isStarProjection &&
@@ -1280,6 +1285,7 @@ class ResolverImpl(
                 return null
             }
 
+            val argMode = mode.updateFromAnnotations(argument.type)
             val variance = KotlinTypeMapper.getVarianceForWildcard(parameter, argument, argMode)
             val genericMode = argMode.toGenericArgumentMode(
                 getEffectiveVariance(parameter.variance, argument.projectionKind)
@@ -1288,6 +1294,68 @@ class ResolverImpl(
         }
 
         return replace(wildcardArguments)
+    }
+
+    private val JVM_SUPPRESS_WILDCARDS_NAME = KSNameImpl.getCached("kotlin.jvm.JvmSuppressWildcards")
+    private val JVM_SUPPRESS_WILDCARDS_SHORT = "JvmSuppressWildcards"
+    private fun KSTypeReference.findJvmSuppressWildcards(): Boolean? {
+        var candidate: KSNode? = this
+
+        while (candidate != null) {
+            if ((candidate is KSTypeReference || candidate is KSDeclaration)) {
+                (candidate as KSAnnotated).annotations.firstOrNull {
+                    checkAnnotation(it, JVM_SUPPRESS_WILDCARDS_NAME, JVM_SUPPRESS_WILDCARDS_SHORT)
+                }?.arguments?.firstOrNull()?.value.safeAs<Boolean>()?.let {
+                    // KSAnnotated.getAnnotationsByType is handy but it uses reflection.
+                    return it
+                }
+            }
+            candidate = candidate.parent
+        }
+
+        return null
+    }
+
+    private fun TypeMappingMode.updateFromAnnotations(
+        type: KotlinType
+    ): TypeMappingMode {
+        type.annotations.findAnnotation(JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME)
+            ?.argumentValue("suppress")?.value.safeAs<Boolean>()?.let {
+                return this.suppressJvmWildcards(it)
+            }
+
+        if (type.annotations.hasAnnotation(JVM_WILDCARD_ANNOTATION_FQ_NAME)) {
+            return TypeMappingMode.createWithConstantDeclarationSiteWildcardsMode(
+                skipDeclarationSiteWildcards = false,
+                isForAnnotationParameter = isForAnnotationParameter,
+                fallbackMode = this,
+                needInlineClassWrapping = needInlineClassWrapping,
+                mapTypeAliases = mapTypeAliases
+            )
+        }
+
+        return this
+    }
+
+    private fun TypeMappingMode.suppressJvmWildcards(
+        suppress: Boolean
+    ): TypeMappingMode {
+        return TypeMappingMode.createWithConstantDeclarationSiteWildcardsMode(
+            skipDeclarationSiteWildcards = suppress,
+            isForAnnotationParameter = isForAnnotationParameter,
+            needInlineClassWrapping = needInlineClassWrapping,
+            mapTypeAliases = mapTypeAliases
+        )
+    }
+
+    private fun TypeMappingMode.updateFromParents(
+        ref: KSTypeReference
+    ): TypeMappingMode {
+        ref.findJvmSuppressWildcards()?.let {
+            return this.suppressJvmWildcards(it)
+        }
+
+        return this
     }
 
     // Type arguments need to be resolved recursively in a top-down manner. So we find and resolve the outer most
@@ -1311,7 +1379,7 @@ class ResolverImpl(
             RefPosition.RETURN_TYPE ->
                 typeSystem.getOptimalModeForReturnType(kotlinType, ref.isReturnTypeOfAnnotationMethod())
             RefPosition.SUPER_TYPE -> TypeMappingMode.SUPER_TYPE
-        }
+        }.updateFromParents(ref)
 
         val parameters = kotlinType.constructor.parameters
         val arguments = kotlinType.arguments

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -241,6 +241,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/javaTypes2.kt");
     }
 
+    @TestMetadata("javaWildcards2.kt")
+    public void testJavaWildcards2() throws Exception {
+        runTest("testData/api/javaWildcards2.kt");
+    }
+
     @TestMetadata("libOrigins.kt")
     public void testLibOrigins() throws Exception {
         runTest("testData/api/libOrigins.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/JavaWildcard2Processor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/JavaWildcard2Processor.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+open class JavaWildcard2Processor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getNewFiles().forEach {
+            resolver.getNewFiles().forEach {
+                it.accept(RefVisitor(results, resolver), "")
+            }
+        }
+
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    private class RefVisitor(
+        val results: MutableList<String>,
+        val resolver: Resolver
+    ) : KSTopDownVisitor<String, Unit>() {
+        override fun defaultHandler(node: KSNode, data: String) = Unit
+
+        private fun KSTypeReference.pretty(): String {
+            return resolve().toString()
+        }
+
+        override fun visitTypeArgument(typeArgument: KSTypeArgument, data: String) = Unit
+
+        override fun visitAnnotation(annotation: KSAnnotation, data: String) = Unit
+
+        @OptIn(KspExperimental::class)
+        override fun visitTypeReference(typeReference: KSTypeReference, data: String) {
+            val wildcard = resolver.getJavaWildcard(typeReference)
+            results.add(
+                data + typeReference.parent.toString() + " : " + wildcard.pretty()
+            )
+            super.visitTypeReference(typeReference, data + "- ")
+        }
+    }
+}

--- a/compiler-plugin/testData/api/equivalentJavaWildcards.kt
+++ b/compiler-plugin/testData/api/equivalentJavaWildcards.kt
@@ -31,7 +31,7 @@
 // - INVARIANT X : X -> X
 // - INVARIANT X : X -> X
 // - @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
-// bar3 : [@kotlin.jvm.JvmWildcard] A<X, X> -> [@kotlin.jvm.JvmWildcard] A<in X, out X>
+// bar3 : [@kotlin.jvm.JvmWildcard] A<X, X> -> [@kotlin.jvm.JvmWildcard] A<X, X>
 // - INVARIANT X : X -> X
 // - INVARIANT X : X -> X
 // - @JvmWildcard : JvmWildcard -> JvmWildcard
@@ -143,7 +143,7 @@ open class B<T>
 fun bar1(): @JvmSuppressWildcards(true) A<X, X> = TODO()
 // A<? super X, ? extends X>
 fun bar2(): @JvmSuppressWildcards(false) A<X, X> = TODO()
-// FIXME: A<X, X>
+// A<X, X>
 fun bar3(): @JvmWildcard A<X, X> = TODO()
 
 // A<X, X>

--- a/compiler-plugin/testData/api/javaWildcards2.kt
+++ b/compiler-plugin/testData/api/javaWildcards2.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: JavaWildcard2Processor
+// EXPECTED:
+// <init> : MyEnum
+// starList : List<Any?>
+// typeArgList : List<R>
+// numberList : List<Number>
+// stringList : List<String>
+// enumList : List<MyEnum>
+// jvmWildcard : List<out [@kotlin.jvm.JvmWildcard] String>
+// suppressJvmWildcard : List<[@kotlin.jvm.JvmSuppressWildcards] Number>
+// <init> : VarianceSubjectSuppressed<R>
+// propWithFinalType : String
+// propWithFinalType.getter() : String
+// <set-?> : String
+// propWithOpenType : Number
+// propWithOpenType.getter() : Number
+// <set-?> : Number
+// propWithFinalGeneric : List<String>
+// propWithFinalGeneric.getter() : List<String>
+// <set-?> : List<String>
+// propWithOpenGeneric : List<Number>
+// propWithOpenGeneric.getter() : List<Number>
+// <set-?> : List<Number>
+// propWithTypeArg : R
+// propWithTypeArg.getter() : R
+// <set-?> : R
+// propWithTypeArgGeneric : List<R>
+// propWithTypeArgGeneric.getter() : List<R>
+// <set-?> : List<R>
+// propWithOpenTypeButSuppressAnnotation : Number
+// propWithOpenTypeButSuppressAnnotation.getter() : Number
+// <set-?> : Number
+// list2 : List<Any?>
+// list1 : List<Any?>
+// list3 : List<R>
+// listTypeArg : List<R>
+// list4 : List<Number>
+// listTypeArgNumber : List<Number>
+// list5 : List<String>
+// listTypeArgString : List<String>
+// list6 : List<MyEnum>
+// listTypeArgEnum : List<MyEnum>
+// list7 : List<out [@kotlin.jvm.JvmWildcard] String>
+// explicitJvmWildcard : List<out [@kotlin.jvm.JvmWildcard] String>
+// list8 : List<[@kotlin.jvm.JvmSuppressWildcards] Number>
+// explicitJvmSuppressWildcard_OnType : List<[@kotlin.jvm.JvmSuppressWildcards] Number>
+// list9 : [@kotlin.jvm.JvmSuppressWildcards] List<Number>
+// explicitJvmSuppressWildcard_OnType2 : [@kotlin.jvm.JvmSuppressWildcards] List<Number>
+// END
+
+enum class MyEnum()
+
+@JvmSuppressWildcards
+class VarianceSubjectSuppressed<R>(
+    starList: List<*>,
+    typeArgList: List<R>,
+    numberList: List<Number>,
+    stringList: List<String>,
+    enumList: List<MyEnum>,
+    jvmWildcard: List<@JvmWildcard String>,
+    suppressJvmWildcard: List<@JvmSuppressWildcards Number>
+) {
+    var propWithFinalType: String = ""
+    var propWithOpenType: Number = 3
+    var propWithFinalGeneric: List<String> = TODO()
+    var propWithOpenGeneric: List<Number> = TODO()
+    var propWithTypeArg: R = TODO()
+    var propWithTypeArgGeneric: List<R> = TODO()
+    @JvmSuppressWildcards
+    var propWithOpenTypeButSuppressAnnotation: Number = 3
+    fun list1(list2: List<*>): List<*> { TODO() }
+    fun listTypeArg(list3: List<R>): List<R> { TODO() }
+    fun listTypeArgNumber(list4: List<Number>): List<Number> { TODO() }
+    fun listTypeArgString(list5: List<String>): List<String> { TODO() }
+    fun listTypeArgEnum(list6: List<MyEnum>): List<MyEnum> { TODO() }
+    fun explicitJvmWildcard(
+        list7: List<@JvmWildcard String>
+    ): List<@JvmWildcard String> { TODO() }
+
+    fun explicitJvmSuppressWildcard_OnType(
+        list8: List<@JvmSuppressWildcards Number>
+    ): List<@JvmSuppressWildcards Number> { TODO() }
+
+    fun explicitJvmSuppressWildcard_OnType2(
+        list9: @JvmSuppressWildcards List<Number>
+    ): @JvmSuppressWildcards List<Number> { TODO() }
+}


### PR DESCRIPTION
@JvmSuppressWildcards can be inherited from containing declarations or
types.

@JvmWildcard only applies to the immeidate type.

Fixes #773 