### PR TITLE
Remove jcenter() from Gradle repositories

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This project follows
 
 ## Testing
 For incoming PRs, we would like to request changes covered by tests for good practice.
- We do end to end test for KSP, which means you need to write a lightweight processor to be loaded with KSP for testing.
+We do end-to-end test for KSP, which means you need to write a lightweight processor to be loaded with KSP for testing.
 The form of the test itself is flexible as long as the logic is being covered. 
 
 Here are some [sample test processors](compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor) for your reference.
@@ -47,7 +47,7 @@ it should be extending [AbstractTestProcessor](compiler-plugin/src/test/kotlin/c
     excess filtering when traveling along the program.
 * Write your test case to work with test processor.
     * Create a test kt file under [testData](compiler-plugin/testData/api) folder. 
-    Every kt file under this folder corrsponds to a test case.
+    Every kt file under this folder corresponds to a test case.
     * Inside the test file:
         * [optional] Add ```// WITH_RUNTIME``` to the top if you need access to standard library.
         * Add ```// TEST PROCESSOR:<Your test processor name>``` to provide the test processor for this test case. Processors can 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -10,8 +10,8 @@ pluginManagement {
     }["kotlinBaseVersion"] as String
     resolutionStrategy {
         eachPlugin {
-            if ( requested.id.id == "org.jetbrains.kotlin.jvm" ) {
-                useModule( "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion" )
+            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
             }
         }
     }

--- a/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
@@ -11,7 +11,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    jcenter()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android-multi/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        jcenter()
         google()
     }
 }
@@ -23,7 +22,6 @@ allprojects {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        jcenter()
         google()
     }
 }

--- a/integration-tests/src/test/resources/playground-android-multi/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/settings.gradle.kts
@@ -14,7 +14,6 @@ pluginManagement {
         maven(testRepo)
         gradlePluginPortal()
         google()
-        jcenter()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }

--- a/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    jcenter()
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/build.gradle.kts
@@ -5,7 +5,6 @@ buildscript {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        jcenter()
         google()
     }
 }
@@ -16,7 +15,6 @@ allprojects {
         maven(testRepo)
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-        jcenter()
         google()
     }
 }

--- a/integration-tests/src/test/resources/playground-android/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/settings.gradle.kts
@@ -13,7 +13,6 @@ pluginManagement {
         maven(testRepo)
         gradlePluginPortal()
         google()
-        jcenter()
         mavenCentral()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
     }

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -13,7 +13,6 @@ repositories {
     maven(testRepo)
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
-    jcenter()
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
     val kotlinBaseVersion: String by settings
     resolutionStrategy {
         eachPlugin {
-            if ( requested.id.id == "org.jetbrains.kotlin.jvm" ) {
-                useModule( "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion" )
+            if (requested.id.id == "org.jetbrains.kotlin.jvm") {
+                useModule("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
             }
         }
     }
@@ -26,7 +26,7 @@ val kotlinProjectPath: String? by settings
 if (kotlinProjectPath != null) {
     includeBuild(kotlinProjectPath!!) {
         dependencySubstitution {
-            substitute(module("org.jetbrains.kotlin:kotlin-compiler")).with(project(":include:kotlin-compiler"))
+            substitute(module("org.jetbrains.kotlin:kotlin-compiler")).using(project(":include:kotlin-compiler"))
         }
     }
 }


### PR DESCRIPTION
Hey, a small PR to fix a personal bug bear of mine.

Using `jcenter()` raises deprecation warnings in Gradle https://blog.gradle.org/jcenter-shutdown

I also fixed a couple of minor warnings and a couple of typos.

I can't build the project locally (see error below), so if this PR is more trouble than it's worth then feel free to reject it 👍 

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':common-util:instrumentCode'.
> D:\Users\...\scoop\apps\microsoft11-jdk\current\Packages does not exist.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 1s
18:40:54: Execution finished 'build'.
```

I've signed the CLA 