### PR TITLE
#850: Recover `CONST` modifier in descriptor-based property impl.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -61,6 +61,9 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
     override val modifiers: Set<Modifier> by lazy {
         val modifiers = mutableSetOf<Modifier>()
         modifiers.addAll(descriptor.toKSModifiers())
+        if (descriptor.isConst) {
+            modifiers.add(Modifier.CONST)
+        }
 
         if (this.origin == Origin.JAVA_LIB) {
             if (this.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -121,6 +121,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/companion.kt");
     }
 
+    @TestMetadata("constProperties.kt")
+    public void testConstProperties() throws Exception {
+        runTest("testData/api/constProperties.kt");
+    }
+
     @TestMetadata("constructorDeclarations.kt")
     public void testConstructorDeclarations() throws Exception {
         runTest("testData/api/constructorDeclarations.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ConstPropertiesProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/ConstPropertiesProcessor.kt
@@ -1,0 +1,39 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class ConstPropertiesProcessor : AbstractTestProcessor() {
+    private val visitor = Visitor()
+
+    override fun toResult(): List<String> {
+        return visitor.constPropertiesNames.sorted()
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getDeclarationsFromPackage("foo.compiled").forEach {
+            it.accept(visitor, Unit)
+        }
+        resolver.getNewFiles().forEach { it.accept(visitor, Unit) }
+        return emptyList()
+    }
+
+    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+        val constPropertiesNames = arrayListOf<String>()
+
+        override fun defaultHandler(node: KSNode, data: Unit) {
+        }
+
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+            if (Modifier.CONST in property.modifiers) {
+                constPropertiesNames += property.simpleName.asString()
+            }
+        }
+    }
+}

--- a/compiler-plugin/testData/api/constProperties.kt
+++ b/compiler-plugin/testData/api/constProperties.kt
@@ -1,0 +1,57 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: ConstPropertiesProcessor
+// EXPECTED:
+// insideCompanionConstCompiled
+// insideCompanionConstSource
+// insideObjectConstCompiled
+// insideObjectConstSource
+// topLevelConstCompiled
+// topLevelConstSource
+// END
+// MODULE: lib
+// FILE: compiledProperties.kt
+package foo.compiled
+
+const val topLevelConstCompiled: String = "hello"
+val topLevelCompiled: String = "hello"
+val topLevelDelegatedCompiled by lazy { "hello" }
+var topLevelVarCompiled: String = "hello"
+val topLevelCustomGetterCompiled: String get() = "hello"
+object TestObject {
+    const val insideObjectConstCompiled: Boolean = true
+    val insideObjectCompiled: String = "hello"
+    val insideObjectDelegatedCompiled by lazy { "hello" }
+    var insideVarObjectCompiled: String = "hello"
+    val insideObjectCustomGetterCompiled: String get() = "hello"
+}
+interface Foo {
+    val abstractCompiled: Long
+    val abstractWithDefaultCompiled: Long get() = 100L
+    companion object {
+        const val insideCompanionConstCompiled: Int = 34
+    }
+}
+
+// MODULE: main(lib)
+// FILE: sourceProperties.kt
+package foo.source
+
+const val topLevelConstSource: String = "hello"
+val topLevelSource: String = "hello"
+val topLevelDelegatedSource by lazy { "hello" }
+var topLevelVarSource: String = "hello"
+val topLevelCustomGetterSource: String get() = "hello"
+object TestObject {
+    const val insideObjectConstSource: Boolean = true
+    val insideObjectSource: String = "hello"
+    val insideObjectDelegatedSource by lazy { "hello" }
+    var insideVarObjectSource: String = "hello"
+    val insideObjectCustomGetterSource: String get() = "hello"
+}
+interface Foo {
+    val abstractSource: Long
+    val abstractWithDefaultSource: Long get() = 100L
+    companion object {
+        const val insideCompanionConstSource: Int = 34
+    }
+}


### PR DESCRIPTION
Before this CL, `CONST` modifier was present only in
 `KSPropertyDeclarationImpl` for `const` properties.
`KSPropertyDeclarationDescriptorImpl` lacked this modifier for
 the same property when deserialized from compiled code.
This CL fixes the inconsistency.