### PR TITLE
add else to when

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -235,41 +235,41 @@ internal fun ModuleClassResolver.resolveContainingClass(psiMethod: PsiMethod): C
 }
 
 internal fun getInstanceForCurrentRound(node: KSNode): KSNode? {
-    when (node.origin) {
+    return when (node.origin) {
         Origin.KOTLIN_LIB, Origin.JAVA_LIB -> return null
-    }
-    return when (node) {
-        is KSClassDeclarationImpl -> KSClassDeclarationImpl.getCached(node.ktClassOrObject)
-        is KSFileImpl -> KSFileImpl.getCached(node.file)
-        is KSFunctionDeclarationImpl -> KSFunctionDeclarationImpl.getCached(node.ktFunction)
-        is KSPropertyDeclarationImpl -> KSPropertyDeclarationImpl.getCached(node.ktProperty)
-        is KSPropertyGetterImpl -> KSPropertyGetterImpl.getCached(node.ktPropertyAccessor)
-        is KSPropertySetterImpl -> KSPropertySetterImpl.getCached(node.ktPropertyAccessor)
-        is KSTypeAliasImpl -> KSTypeAliasImpl.getCached(node.ktTypeAlias)
-        is KSTypeArgumentLiteImpl -> KSTypeArgumentLiteImpl.getCached(node.type, node.variance)
-        is KSTypeArgumentKtImpl -> KSTypeArgumentKtImpl.getCached(node.ktTypeArgument)
-        is KSTypeParameterImpl -> KSTypeParameterImpl.getCached(node.ktTypeParameter)
-        is KSTypeReferenceImpl -> KSTypeReferenceImpl.getCached(node.ktTypeReference)
-        is KSValueParameterImpl -> KSValueParameterImpl.getCached(node.ktParameter)
-        is KSClassDeclarationJavaEnumEntryImpl -> KSClassDeclarationJavaEnumEntryImpl.getCached(node.psi)
-        is KSClassDeclarationJavaImpl -> KSClassDeclarationJavaImpl.getCached(node.psi)
-        is KSFileJavaImpl -> KSFileJavaImpl.getCached(node.psi)
-        is KSFunctionDeclarationJavaImpl -> KSFunctionDeclarationJavaImpl.getCached(node.psi)
-        is KSPropertyDeclarationJavaImpl -> KSPropertyDeclarationJavaImpl.getCached(node.psi)
-        is KSTypeArgumentJavaImpl -> KSTypeArgumentJavaImpl.getCached(node.psi, node.parent)
-        is KSTypeParameterJavaImpl -> KSTypeParameterJavaImpl.getCached(node.psi)
-        is KSTypeReferenceJavaImpl ->
-            KSTypeReferenceJavaImpl.getCached(node.psi, (node.parent as? KSAnnotated)?.getInstanceForCurrentRound())
-        is KSValueParameterJavaImpl -> KSValueParameterJavaImpl.getCached(node.psi)
-        is KSPropertyGetterSyntheticImpl -> KSPropertyGetterSyntheticImpl.getCached(node.ksPropertyDeclaration)
-        is KSPropertySetterSyntheticImpl -> KSPropertySetterSyntheticImpl.getCached(node.ksPropertyDeclaration)
-        is KSValueParameterSyntheticImpl -> KSPropertySetterImpl.getCached(node.owner as KtPropertyAccessor).parameter
-        is KSAnnotationJavaImpl -> KSAnnotationJavaImpl.getCached(node.psi)
-        is KSAnnotationImpl -> KSAnnotationImpl.getCached(node.ktAnnotationEntry)
-        is KSClassifierReferenceJavaImpl -> KSClassifierReferenceJavaImpl.getCached(node.psi, node.parent)
-        is KSValueArgumentJavaImpl ->
-            KSValueArgumentJavaImpl.getCached(node.name, node.value, getInstanceForCurrentRound(node.parent!!))
-        else -> null
+        else -> when (node) {
+            is KSClassDeclarationImpl -> KSClassDeclarationImpl.getCached(node.ktClassOrObject)
+            is KSFileImpl -> KSFileImpl.getCached(node.file)
+            is KSFunctionDeclarationImpl -> KSFunctionDeclarationImpl.getCached(node.ktFunction)
+            is KSPropertyDeclarationImpl -> KSPropertyDeclarationImpl.getCached(node.ktProperty)
+            is KSPropertyGetterImpl -> KSPropertyGetterImpl.getCached(node.ktPropertyAccessor)
+            is KSPropertySetterImpl -> KSPropertySetterImpl.getCached(node.ktPropertyAccessor)
+            is KSTypeAliasImpl -> KSTypeAliasImpl.getCached(node.ktTypeAlias)
+            is KSTypeArgumentLiteImpl -> KSTypeArgumentLiteImpl.getCached(node.type, node.variance)
+            is KSTypeArgumentKtImpl -> KSTypeArgumentKtImpl.getCached(node.ktTypeArgument)
+            is KSTypeParameterImpl -> KSTypeParameterImpl.getCached(node.ktTypeParameter)
+            is KSTypeReferenceImpl -> KSTypeReferenceImpl.getCached(node.ktTypeReference)
+            is KSValueParameterImpl -> KSValueParameterImpl.getCached(node.ktParameter)
+            is KSClassDeclarationJavaEnumEntryImpl -> KSClassDeclarationJavaEnumEntryImpl.getCached(node.psi)
+            is KSClassDeclarationJavaImpl -> KSClassDeclarationJavaImpl.getCached(node.psi)
+            is KSFileJavaImpl -> KSFileJavaImpl.getCached(node.psi)
+            is KSFunctionDeclarationJavaImpl -> KSFunctionDeclarationJavaImpl.getCached(node.psi)
+            is KSPropertyDeclarationJavaImpl -> KSPropertyDeclarationJavaImpl.getCached(node.psi)
+            is KSTypeArgumentJavaImpl -> KSTypeArgumentJavaImpl.getCached(node.psi, node.parent)
+            is KSTypeParameterJavaImpl -> KSTypeParameterJavaImpl.getCached(node.psi)
+            is KSTypeReferenceJavaImpl ->
+                KSTypeReferenceJavaImpl.getCached(node.psi, (node.parent as? KSAnnotated)?.getInstanceForCurrentRound())
+            is KSValueParameterJavaImpl -> KSValueParameterJavaImpl.getCached(node.psi)
+            is KSPropertyGetterSyntheticImpl -> KSPropertyGetterSyntheticImpl.getCached(node.ksPropertyDeclaration)
+            is KSPropertySetterSyntheticImpl -> KSPropertySetterSyntheticImpl.getCached(node.ksPropertyDeclaration)
+            is KSValueParameterSyntheticImpl -> KSPropertySetterImpl.getCached(node.owner as KtPropertyAccessor).parameter
+            is KSAnnotationJavaImpl -> KSAnnotationJavaImpl.getCached(node.psi)
+            is KSAnnotationImpl -> KSAnnotationImpl.getCached(node.ktAnnotationEntry)
+            is KSClassifierReferenceJavaImpl -> KSClassifierReferenceJavaImpl.getCached(node.psi, node.parent)
+            is KSValueArgumentJavaImpl ->
+                KSValueArgumentJavaImpl.getCached(node.name, node.value, getInstanceForCurrentRound(node.parent!!))
+            else -> null
+        }
     }
 }
 


### PR DESCRIPTION
Hello.
I know this will be updated in Kotlin 1.6.
```
We will soon prohibit non-exhaustive when statements to make the behavior consistent with when expressions. To ensure smooth migration, Kotlin 1.6.0 reports warnings about non-exhaustive when statements with an enum, sealed, or Boolean subject. These warnings will become errors in future releases.
```

It seems to be a violation of this, so I will correct it and PR.
thank you.