### PR TITLE
Add CommandLineArgumentProvider

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
     // replace AGP dependency w/ gradle-api when we have source registering API available.
     compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
+    compileOnly(gradleApi())
     testImplementation(gradleApi())
     testImplementation(project(":api"))
     testImplementation("junit:junit:$junitVersion")

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -18,9 +18,11 @@
 package com.google.devtools.ksp.gradle
 
 import org.gradle.api.GradleException
+import org.gradle.process.CommandLineArgumentProvider
 
 open class KspExtension {
     internal val apOptions = mutableMapOf<String, String>()
+    internal val commandLineArgumentProviders = mutableListOf<CommandLineArgumentProvider>()
 
     open val arguments: Map<String, String> get() = apOptions.toMap()
 
@@ -29,6 +31,10 @@ open class KspExtension {
             throw GradleException("'=' is not allowed in custom option's name.")
         }
         apOptions.put(k, v)
+    }
+
+    open fun arg(arg: CommandLineArgumentProvider) {
+        commandLineArgumentProviders.add(arg)
     }
 
     open var blockOtherCompilerPlugins: Boolean = false

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -139,8 +139,8 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             }
             kspExtension.commandLineArgumentProviders.forEach {
                 val argument = it.asArguments().joinToString("")
-                if (!argument.matches(Regex("/S=/S"))) {
-                    throw IllegalArgumentException("KSP apoption does not match /S=/S: $argument")
+                if (!argument.matches(Regex("\\S+=\\S+"))) {
+                    throw IllegalArgumentException("KSP apoption does not match \\S+=\\S+: $argument")
                 }
                 options += SubpluginOption("apoption", argument)
             }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -138,7 +138,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 options += SubpluginOption("apoption", "${it.key}=${it.value}")
             }
             kspExtension.commandLineArgumentProviders.forEach {
-                options += SubpluginOption("apoption", it.asArguments().joinToString(""))
+                val argument = it.asArguments().joinToString("")
+                if (!argument.matches(Regex("/S=/S"))) {
+                    throw IllegalArgumentException("KSP apoption does not match /S=/S: $argument")
+                }
+                options += SubpluginOption("apoption", argument)
             }
             return options
         }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -38,6 +38,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
 import org.gradle.work.Incremental
@@ -136,6 +137,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             kspExtension.apOptions.forEach {
                 options += SubpluginOption("apoption", "${it.key}=${it.value}")
             }
+            kspExtension.commandLineArgumentProviders.forEach {
+                options += SubpluginOption("apoption", it.asArguments().joinToString(""))
+            }
             return options
         }
     }
@@ -228,6 +232,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                     )
                 }
             )
+            kspTask.commandLineArgumentProviders.addAll(kspExtension.commandLineArgumentProviders)
             kspTask.destination = kspOutputDir
             kspTask.blockOtherCompilerPlugins = kspExtension.blockOtherCompilerPlugins
             kspTask.apOptions.value(kspExtension.arguments).disallowChanges()
@@ -392,6 +397,9 @@ internal fun findJavaTaskForKotlinCompilation(compilation: KotlinCompilation<*>)
 interface KspTask : Task {
     @get:Internal
     val options: ListProperty<SubpluginOption>
+
+    @get:Nested
+    val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
 
     @get:OutputDirectory
     var destination: File

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -207,7 +207,8 @@ class GradleCompilationTest {
     fun invalidArguments() {
         testRule.setupAppAsJvmApp()
         testRule.appModule.addSource("Foo.kt", "class Foo")
-        testRule.appModule.buildFileAdditions.add("""
+        testRule.appModule.buildFileAdditions.add(
+            """
             ksp {
                 arg(Provider())
             }
@@ -218,7 +219,8 @@ class GradleCompilationTest {
                     )
                 }
             }
-        """.trimIndent())
+            """.trimIndent()
+        )
         testRule.appModule.dependencies.addAll(
             listOf(
                 artifact(configuration = "ksp", "androidx.room:room-compiler:2.4.2")
@@ -226,6 +228,6 @@ class GradleCompilationTest {
         )
 
         val result = testRule.runner().withArguments(":app:assemble").buildAndFail()
-        assertThat(result.output).contains("KSP apoption does not match /S=/S: invalid")
+        assertThat(result.output).contains("KSP apoption does not match \\S+=\\S+: invalid")
     }
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -44,7 +44,7 @@ class ProcessorClasspathConfigurationsTest {
             """
                 $kspConfigs.all {
                     // Make sure ksp configs are not empty.
-                    project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
                 }
                 tasks.register("testConfigurations") {
                     // Resolve all tasks to trigger classpath config creation
@@ -71,7 +71,7 @@ class ProcessorClasspathConfigurationsTest {
             """
                 $kspConfigs.all {
                     // Make sure ksp configs are not empty.
-                    project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
                 }
                 tasks.register("testConfigurations") {
                     // Resolve all tasks to trigger classpath config creation
@@ -105,7 +105,7 @@ class ProcessorClasspathConfigurationsTest {
             """
                 $kspConfigs.matching { it.name != "ksp" }.all {
                     // Make sure ksp configs are not empty.
-                    project.dependencies.add(name, "androidx.room:room-compiler:2.3.0")
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
                 }
                 tasks.register("testConfigurations") {
                     // Resolve all tasks to trigger classpath config creation

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -141,7 +141,7 @@ class SourceSetConfigurationsTest {
                     }
                 }
                 dependencies {
-                    add("kspJvmParent", "androidx.room:room-compiler:2.3.0")
+                    add("kspJvmParent", "androidx.room:room-compiler:2.4.2")
                 }
                 tasks.register("checkConfigurations") {
                     doLast {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -121,10 +121,14 @@ class KspIntegrationTestRule(
     }
 
     private fun addAndroidBoilerplate() {
+        testProject.writeAndroidGradlePropertiesFile()
         testProject.appModule.buildFileAdditions.add(
             """
             android {
-                compileSdkVersion="android-29"
+                compileSdkVersion(31)
+                defaultConfig {
+                    minSdkVersion(24)
+                }
             }
             """.trimIndent()
         )

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
@@ -71,6 +71,13 @@ class TestProject(
         rootDir.resolve("settings.gradle.kts").writeText(contents)
     }
 
+    fun writeAndroidGradlePropertiesFile() {
+        val contents = """
+            android.useAndroidX=true
+        """.trimIndent()
+        rootDir.resolve("gradle.properties").writeText(contents)
+    }
+
     private fun writeBuildFile() {
         val rootBuildFile = buildString {
             appendln("plugins {")


### PR DESCRIPTION
This allows one to configure the KspExtension with a CommandLineArgumentProvider.
Inputs and outputs can now properly declared on any additional input or output directories to the KSP compilation.

Fixes #847

Note: this also upgrades the Room dependency to 2.4.2 across the project since 2.3.0 does not support KSP.