### PR TITLE
Don't mark nested classes as open

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -215,7 +215,7 @@ fun KSDeclaration.isOpen() = !this.isLocal() &&
             this.modifiers.contains(Modifier.OVERRIDE) ||
             this.modifiers.contains(Modifier.ABSTRACT) ||
             this.modifiers.contains(Modifier.OPEN) ||
-            (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE ||
+            (this !is KSClassDeclaration && (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE) ||
             (!this.modifiers.contains(Modifier.FINAL) && this.origin == Origin.JAVA)
         )
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -215,7 +215,10 @@ fun KSDeclaration.isOpen() = !this.isLocal() &&
             this.modifiers.contains(Modifier.OVERRIDE) ||
             this.modifiers.contains(Modifier.ABSTRACT) ||
             this.modifiers.contains(Modifier.OPEN) ||
-            (this !is KSClassDeclaration && (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE) ||
+            (
+                this !is KSClassDeclaration &&
+                    (this.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE
+                ) ||
             (!this.modifiers.contains(Modifier.FINAL) && this.origin == Origin.JAVA)
         )
 

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
@@ -52,9 +52,16 @@ class DeclarationCollector : KSTopDownVisitor<MutableCollection<String>, Unit>()
 
     override fun visitDeclaration(declaration: KSDeclaration, data: MutableCollection<String>) {
         data.add(
-            "${declaration.toSignature()}: ${declaration.isInternal()}: ${declaration.isLocal()}: " +
-                "${declaration.isPrivate()}: ${declaration.isProtected()}: ${declaration.isPublic()}: " +
-                "${declaration.isOpen()}"
+            "${declaration.toSignature()}: " + listOf(
+                "internal" to declaration.isInternal(),
+                "local" to declaration.isLocal(),
+                "private" to declaration.isPrivate(),
+                "protected" to declaration.isProtected(),
+                "public" to declaration.isPublic(),
+                "open" to declaration.isOpen()
+            ).filter { it.second }.joinToString(" ") {
+                it.first
+            }
         )
     }
 }

--- a/compiler-plugin/testData/api/declarationUtil.kt
+++ b/compiler-plugin/testData/api/declarationUtil.kt
@@ -18,22 +18,33 @@
 // TEST PROCESSOR: DeclarationUtilProcessor
 // FORMAT: <name>: isInternal: isLocal: isPrivate: isProtected: isPublic: isOpen
 // EXPECTED:
-// Cls: true: false: false: false: false: false
-// Cls / <init>: false: false: false: false: true: false
-// Cls.b: false: false: false: false: true: true
-// Cls / <init>: false: false: false: false: true: false
-// Cls / <init> / aaa: false: true: false: false: false: false
-// Cls.prop: false: false: false: false: true: true
-// Cls.protectedProp: false: false: false: true: false: true
-// Cls.abstractITFFun: false: false: false: false: true: true
-// Cls.pri: false: false: true: false: false: false
-// ITF: false: false: false: false: true: true
-// ITF.prop: false: false: false: false: true: true
-// ITF.protectedProp: false: false: false: true: false: true
-// ITF.b: false: false: false: false: true: true
-// ITF.abstractITFFun: false: false: false: false: true: true
-// ITF.nonAbstractITFFun: false: false: false: false: true: true
-// ITF.nonAbstractITFFun / aa: false: true: false: false: false: false
+// Cls: internal
+// Cls / <init>: public
+// Cls.b: public open
+// Cls / <init>: public
+// Cls / <init> / aaa: local
+// Cls.prop: public open
+// Cls.protectedProp: protected open
+// Cls.abstractITFFun: public open
+// Cls.pri: private
+// ITF: public open
+// ITF.prop: public open
+// ITF.protectedProp: protected open
+// ITF.b: public open
+// ITF.abstractITFFun: public open
+// ITF.nonAbstractITFFun: public open
+// ITF.nonAbstractITFFun / aa: local
+// NestedClassSubjects: public open
+// NestedClassSubjects.NestedDataClass: public
+// NestedClassSubjects.NestedDataClass / <init>: public
+// NestedClassSubjects.NestedDataClass.field: public
+// NestedClassSubjects.NestedFinalClass: public
+// NestedClassSubjects.NestedFinalClass / <init>: public
+// NestedClassSubjects.NestedFinalClass.field: public
+// NestedClassSubjects.NestedOpenClass: public open
+// NestedClassSubjects.NestedOpenClass / <init>: public
+// NestedClassSubjects.NestedOpenClass.field: public
+// NestedClassSubjects.NestedInterface: public open
 // END
 // FILE: a.kt
 internal class Cls(override val b: Int) : ITF {
@@ -65,4 +76,17 @@ interface ITF {
         val aa = "local"
         return 1
     }
+}
+
+interface NestedClassSubjects {
+    data class NestedDataClass(
+        val field: String,
+    )
+    class NestedFinalClass(
+        val field: String,
+    )
+    open class NestedOpenClass(
+        val field: String,
+    )
+    interface NestedInterface
 }


### PR DESCRIPTION
This CL fixes a bug in in KSP where we were marking nested
classes as public by mistake (the code seems to focus on
properties and methods of interfaces).

To keep a similar logic, I just excluded KSClassDeclarations
from that check.

I've also updated the test to be a bit more readable to only
list properties that return true.

Fixes: #876
Test: declarationUtil.kt