### PR TITLE
Cherry pick #875 manually

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -214,6 +214,9 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                 }
                 processor?.also { deferredSymbols[it] = mutableListOf() }
             }
+            /* Kotlin compiler expects a source dir to exist, but processors might not generate Kotlin source.
+               Create it during initialization just in case. */
+            options.kotlinOutputDir.mkdirs()
             initialized = true
         }
         if (!logger.hasError()) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnlyResourcesFileIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnlyResourcesFileIT.kt
@@ -1,0 +1,21 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Rule
+import org.junit.Test
+
+class OnlyResourcesFileIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("only-resources-file")
+
+    @Test
+    fun test() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(
+            "--configuration-cache-problems=warn",
+            "jvmJar",
+        ).build()
+    }
+}

--- a/integration-tests/src/test/resources/only-resources-file/build.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    kotlin("multiplatform") apply false
+}
+
+val testRepo: String by project
+subprojects {
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}

--- a/integration-tests/src/test/resources/only-resources-file/settings.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("multiplatform") version kotlinVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}
+
+rootProject.name = "playground"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/only-resources-file/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/test-processor/build.gradle.kts
@@ -1,0 +1,12 @@
+val kspVersion: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+dependencies {
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}

--- a/integration-tests/src/test/resources/only-resources-file/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/only-resources-file/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,24 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+
+class TestProcessor(val codeGenerator: CodeGenerator) : SymbolProcessor {
+
+    var invoked = false
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (invoked) {
+            return emptyList()
+        }
+
+        codeGenerator.createNewFile(Dependencies(false), "", "HelloSwift", "swift")
+
+        invoked = true
+        return emptyList()
+    }
+
+    class Provider : SymbolProcessorProvider {
+        override fun create(
+            environment: SymbolProcessorEnvironment
+        ): SymbolProcessor = TestProcessor(environment.codeGenerator)
+    }
+}

--- a/integration-tests/src/test/resources/only-resources-file/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/only-resources-file/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessor$Provider

--- a/integration-tests/src/test/resources/only-resources-file/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/workload/build.gradle.kts
@@ -12,5 +12,5 @@ kotlin {
 }
 
 dependencies {
-    add("kspCommonMainMetadata", project(":test-processor"))
+    add("kspMetadata", project(":test-processor"))
 }

--- a/integration-tests/src/test/resources/only-resources-file/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/workload/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.google.devtools.ksp")
+}
+
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm {
+        withJava()
+    }
+}
+
+dependencies {
+    add("kspCommonMainMetadata", project(":test-processor"))
+}

--- a/integration-tests/src/test/resources/only-resources-file/workload/src/commonMain/kotlin/MyStub.kt
+++ b/integration-tests/src/test/resources/only-resources-file/workload/src/commonMain/kotlin/MyStub.kt
@@ -1,0 +1,2 @@
+class MyStub {
+}

--- a/integration-tests/src/test/resources/only-resources-file/workload/src/commonMain/kotlin/MyStub.kt
+++ b/integration-tests/src/test/resources/only-resources-file/workload/src/commonMain/kotlin/MyStub.kt
@@ -1,2 +1,1 @@
-class MyStub {
-}
+class MyStub


### PR DESCRIPTION
1.0.5-release is still on Kotlin 1.6.10 and doesn't have `kspCommonMainMetadata`.