### PR TITLE
#851: Add isJavaRawType function to Resolver.

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -162,6 +162,7 @@ package com.google.devtools.ksp.processing {
     method @Nullable public com.google.devtools.ksp.symbol.KSPropertyDeclaration getPropertyDeclarationByName(@NonNull com.google.devtools.ksp.symbol.KSName name, boolean includeTopLevel = false);
     method @NonNull public kotlin.sequences.Sequence<com.google.devtools.ksp.symbol.KSAnnotated> getSymbolsWithAnnotation(@NonNull String annotationName, boolean inDepth = false);
     method @NonNull public com.google.devtools.ksp.symbol.KSTypeArgument getTypeArgument(@NonNull com.google.devtools.ksp.symbol.KSTypeReference typeRef, @NonNull com.google.devtools.ksp.symbol.Variance variance);
+    method @com.google.devtools.ksp.KspExperimental public boolean isJavaRawType(@NonNull com.google.devtools.ksp.symbol.KSType type);
     method @Nullable @com.google.devtools.ksp.KspExperimental public com.google.devtools.ksp.symbol.KSName mapJavaNameToKotlin(@NonNull com.google.devtools.ksp.symbol.KSName javaName);
     method @Nullable @com.google.devtools.ksp.KspExperimental public com.google.devtools.ksp.symbol.KSName mapKotlinNameToJava(@NonNull com.google.devtools.ksp.symbol.KSName kotlinName);
     method @Nullable @com.google.devtools.ksp.KspExperimental public String mapToJvmSignature(@NonNull com.google.devtools.ksp.symbol.KSDeclaration declaration);

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -291,4 +291,13 @@ interface Resolver {
      */
     @KspExperimental
     fun getJavaWildcard(reference: KSTypeReference): KSTypeReference
+
+    /**
+     * Tests a type if it was declared as legacy "raw" type in Java - a type with its type arguments fully omitted.
+     *
+     * @param type a type to check.
+     * @return True if the type is a "raw" type.
+     */
+    @KspExperimental
+    fun isJavaRawType(type: KSType): Boolean
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1457,6 +1457,11 @@ class ResolverImpl(
 
         return KSTypeReferenceSyntheticImpl.getCached(wildcardType, null)
     }
+
+    @KspExperimental
+    override fun isJavaRawType(type: KSType): Boolean {
+        return type is KSTypeImpl && type.kotlinType is RawType
+    }
 }
 
 // TODO: cross module resolution

--- a/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
+++ b/compiler-plugin/src/test/java/com/google/devtools/ksp/test/KotlinKSPTestGenerated.java
@@ -301,6 +301,11 @@ public class KotlinKSPTestGenerated extends AbstractKotlinKSPTest {
         runTest("testData/api/platformDeclaration.kt");
     }
 
+    @TestMetadata("rawTypes.kt")
+    public void testRawTypes() throws Exception {
+        runTest("testData/api/rawTypes.kt");
+    }
+
     @TestMetadata("recordJavaAnnotationTypes.kt")
     public void testRecordJavaAnnotationTypes() throws Exception {
         runTest("testData/api/recordJavaAnnotationTypes.kt");

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RawTypesProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RawTypesProcessor.kt
@@ -1,0 +1,48 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class RawTypesProcessor : AbstractTestProcessor() {
+    private val rawTypedEntityNames = arrayListOf<String>()
+
+    override fun toResult(): List<String> {
+        return rawTypedEntityNames.sorted()
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val visitor = object : KSTopDownVisitor<Unit, Unit>() {
+            private val KSType.isRawType
+                get() = resolver.isJavaRawType(this)
+
+            override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
+                function.parameters.forEach { param ->
+                    val type = param.type.resolve()
+                    if (type.isRawType) {
+                        rawTypedEntityNames += param.name?.asString() ?: "???"
+                    }
+                }
+                val returnType = function.returnType?.resolve() ?: return
+                if (returnType.isRawType) {
+                    rawTypedEntityNames += function.simpleName.asString()
+                }
+            }
+
+            override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+                val type = property.type.resolve()
+                if (type.isRawType) {
+                    rawTypedEntityNames += property.simpleName.asString()
+                }
+            }
+
+            override fun defaultHandler(node: KSNode, data: Unit) = Unit
+        }
+
+        resolver.getDeclarationsFromPackage("").forEach { it.accept(visitor, Unit) }
+
+        return emptyList()
+    }
+}

--- a/compiler-plugin/testData/api/rawTypes.kt
+++ b/compiler-plugin/testData/api/rawTypes.kt
@@ -1,0 +1,83 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: RawTypesProcessor
+// EXPECTED:
+// barRaw
+// barRawField
+// barRawGet
+// barRawGetCompiled
+// fooRaw
+// fooRawField
+// fooRawGet
+// fooRawGetCompiled
+// p4
+// p5
+// END
+// MODULE: lib
+// FILE: dummy.kt
+// FILE: Api.java
+public interface Api {}
+
+// FILE: Foo.java
+public class Foo<T> {}
+
+// FILE: Bar.java
+public class Bar<T extends Api> {}
+
+// FILE: UsageCompiled.java
+public abstract class UsageCompiled {
+    public static void usage(
+        Foo<?> fooWildcardCompiled,
+        Foo<? super Api> fooWildcardExCompiled,
+        Bar<?> barWildcardCompiled,
+        Bar<? extends Api> barWildcardExCompiled,
+        Foo fooRawCompiled,
+        Bar barRawCompiled
+    ) {}
+
+    public abstract Foo<?> fooWildcardGetCompiled();
+    public abstract Foo<? super Api> fooWildcardExGetCompiled();
+    public abstract Bar<?> barWildcardGetCompiled();
+    public abstract Bar<? extends Api> barWildcardExGetCompiled();
+    public abstract Foo fooRawGetCompiled();
+    public abstract Bar barRawGetCompiled();
+}
+
+// MODULE: main(lib)
+// FILE: usage.kt
+fun usage(
+    fooStar: Foo<*>,
+    fooIn: Foo<in Api>,
+    fooOut: Foo<out Api>,
+    barStar: Bar<*>,
+) = Unit
+
+val fooStarProp: Foo<*>
+val fooInProp: Foo<in Api>
+val fooOutProp: Foo<out Api>
+val barStarProp: Bar<*>
+
+// FILE: Usage.java
+public abstract class Usage {
+    public Foo<?> fooWildcardField;
+    public Foo<? super Api> fooWildcardExField;
+    public Bar<?> barWildcardField;
+    public Bar<? extends Api> barWildcardExField;
+    public Foo fooRawField;
+    public Bar barRawField;
+
+    public static void usage(
+        Foo<?> fooWildcard,
+        Foo<? super Api> fooWildcardEx,
+        Bar<?> barWildcard,
+        Bar<? extends Api> barWildcardEx,
+        Foo fooRaw,
+        Bar barRaw
+    ) {}
+
+    public abstract Foo<?> fooWildcardGet();
+    public abstract Foo<? super Api> fooWildcardExGet();
+    public abstract Bar<?> barWildcardGet();
+    public abstract Bar<? extends Api> barWildcardExGet();
+    public abstract Foo fooRawGet();
+    public abstract Bar barRawGet();
+}


### PR DESCRIPTION
This is required for checking if the underlying type is Java's raw type.
Such information is sometimes required to correctly override Java methods
 while generating Java code.