### PR TITLE
Add script to upload benchmark data.

### DIFF
--- a/benchmark/TachiyomiExhaustive/upload-benchmark-data.sh
+++ b/benchmark/TachiyomiExhaustive/upload-benchmark-data.sh
@@ -17,12 +17,14 @@
 
 set -e
 SCRIPT_DIR=$(dirname "$(realpath $0)")
-ROOT=$SCRIPT_DIR/../..
 cd $SCRIPT_DIR
-rm -rf tachiyomi
-git clone https://github.com/inorichi/tachiyomi.git
-cd tachiyomi
-git checkout 938339690eecdfe309d83264b6a89aff3c767687
-git apply $SCRIPT_DIR/tachi.patch
-./gradlew :app:copyDepsDevDebug
-mkdir -p $SCRIPT_DIR/lib && cp app/build/output/devDebug/lib/* $SCRIPT_DIR/lib
+TEMP_DIR=$(mktemp -d)
+BUNDLE=$TEMP_DIR/tachiyomi-exhaustive.tar.gz
+tar cfz $BUNDLE tachiyomi lib
+BUNDLE_HASH_AND_NAME=$(sha256sum $BUNDLE)
+BUNDLE_HASH=$(echo $BUNDLE_HASH_AND_NAME | cut -d " " -f 1)
+BUNDLE_UPLOAD_LOCATION=gs://r8-deps/ksp-bench/$BUNDLE_HASH.tar.gz
+BUNDLE_DOWNLOAD_LOCATION=http://storage.googleapis.com/r8-deps/ksp-bench/$BUNDLE_HASH.tar.gz
+echo Uploading to: $BUNDLE_UPLOAD_LOCATION
+gsutil.py cp -a public-read $BUNDLE $BUNDLE_UPLOAD_LOCATION
+echo Available for download at: $BUNDLE_DOWNLOAD_LOCATION

--- a/benchmark/runner/runner.sh
+++ b/benchmark/runner/runner.sh
@@ -15,12 +15,33 @@
 # limitations under the License.
 
 set -e
+
+SCRIPT_DIR=$(dirname "$(realpath $0)")
 BENCHMARK_DIR=$1
 PREFIX=$2
 
-SCRIPT_DIR=$(dirname "$(realpath $0)")
+if [ -z $PREFIX ]
+then
+  PREFIX=..
+fi
+
+JAVA_ARG=$3
+
+if [ -z $JAVA_ARG ]
+then
+  JAVA=java
+else
+  JAVA=$(realpath $SCRIPT_DIR/$JAVA_ARG)
+fi
+
+BENCHMARK_DATA_DIR=$(realpath $SCRIPT_DIR/$PREFIX/$BENCHMARK_DIR)
+
+echo Running benchmark: $BENCHMARK_DIR
+echo With benchmark data directory: $BENCHMARK_DATA_DIR
+echo Using java: $JAVA
+
 cd $SCRIPT_DIR
-CP=../build/libs/benchmark.jar:$(echo $SCRIPT_DIR/$PREFIX/$BENCHMARK_DIR/lib/*.jar | tr ' ' ':')
+CP=../build/libs/benchmark.jar:$(echo $BENCHMARK_DATA_DIR/lib/*.jar | tr ' ' ':')
 KSP_PLUGIN_ID=com.google.devtools.ksp.symbol-processing
 KSP_PLUGIN_OPT=plugin:$KSP_PLUGIN_ID
 
@@ -30,7 +51,7 @@ KSP_API_JAR=./com/google/devtools/ksp/symbol-processing-api/2.0.255/symbol-proce
 AP=processor-1.0-SNAPSHOT.jar
 
 mkdir -p out
-find $SCRIPT_DIR/$PREFIX/$BENCHMARK_DIR -name "*.kt" | xargs java -cp $CP com.google.devtools.ksp.BenchRunnerKt $BENCHMARK_DIR\
+find $BENCHMARK_DATA_DIR -name "*.kt" | xargs $JAVA -cp $CP com.google.devtools.ksp.BenchRunnerKt $BENCHMARK_DIR\
         -kotlin-home . \
         -Xplugin=$KSP_PLUGIN_JAR \
         -Xplugin=$KSP_API_JAR \


### PR DESCRIPTION
Minor tweaks to runner and benchmark data build scripts.

Benchmark runner can now be used in the ksp repo with just the
benchmark name as the argument:

`./benchmark/runner/runner.sh TachiyomiExhaustive`