### PR TITLE
Fix subtype checking for Java types.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -26,15 +26,14 @@ import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Nullability
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
+import com.google.devtools.ksp.symbol.impl.convertKotlinType
 import com.google.devtools.ksp.symbol.impl.replaceTypeArguments
 import org.jetbrains.kotlin.builtins.isFunctionType
 import org.jetbrains.kotlin.builtins.isKFunctionType
 import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.NotFoundClasses
-import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.getAbbreviation
-import org.jetbrains.kotlin.types.isError
+import org.jetbrains.kotlin.types.*
 import org.jetbrains.kotlin.types.typeUtil.TypeNullability
 import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
 import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
@@ -75,9 +74,10 @@ class KSTypeImpl private constructor(
     }
 
     override fun isAssignableFrom(that: KSType): Boolean {
-        val subType = (that as? KSTypeImpl)?.kotlinType ?: return false
+        val subType = (that as? KSTypeImpl)?.kotlinType?.convertKotlinType() ?: return false
         ResolverImpl.instance.incrementalContext.recordLookupWithSupertypes(subType)
-        return subType.isSubtypeOf(kotlinType)
+        val thisType = (this as? KSTypeImpl)?.kotlinType?.convertKotlinType() ?: return false
+        return subType.isSubtypeOf(thisType)
     }
 
     // TODO: find a better way to reuse the logic in [DescriptorRendererImpl.renderFlexibleType].

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -257,6 +257,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/javaModifiers.kt")
     }
 
+    @TestMetadata("javaSubtype.kt")
+    @Test
+    fun testJavaSubtype() {
+        runTest("testData/api/javaSubtype.kt")
+    }
+
     @TestMetadata("javaToKotlinMapper.kt")
     @Test
     fun testJavaToKotlinMapper() {

--- a/compiler-plugin/testData/api/javaSubtype.kt
+++ b/compiler-plugin/testData/api/javaSubtype.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: JavaSubtypeProcessor
+// EXPECTED:
+// true
+// END
+// FILE: a.kt
+class A
+
+// FILE: Container.java
+
+public class Container {
+    String str;
+}

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaSubtypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaSubtypeProcessor.kt
@@ -1,0 +1,72 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getJavaClassByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.Variance
+
+class JavaSubtypeProcessor : AbstractTestProcessor() {
+    var isOk = true
+    override fun toResult(): List<String> {
+        return listOf(isOk.toString())
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val javaCollection = resolver.getJavaClassByName("kotlin.collections.Collection")!!.asStarProjectedType()
+        val javaSet = resolver.getJavaClassByName("kotlin.collections.Set")!!.asStarProjectedType()
+        val ktCollection = resolver.getClassDeclarationByName("kotlin.collections.Collection")!!.asStarProjectedType()
+        val ktSet = resolver.getClassDeclarationByName("kotlin.collections.Set")!!.asStarProjectedType()
+        val javaCollectionRef = resolver.createKSTypeReferenceFromKSType(javaCollection)
+        val ktCollectionRef = resolver.createKSTypeReferenceFromKSType(ktCollection)
+        val javaSetRef = resolver.createKSTypeReferenceFromKSType(javaSet)
+        val ktSetRef = resolver.createKSTypeReferenceFromKSType(ktSet)
+        val javaSetOfJavaSet = javaSet.replace(listOf(resolver.getTypeArgument(javaSetRef, Variance.INVARIANT)))
+        val javaSetOfKtSet = javaSet.replace(listOf(resolver.getTypeArgument(ktSetRef, Variance.INVARIANT)))
+        val ktSetOfJavaSet = ktSet.replace(listOf(resolver.getTypeArgument(javaSetRef, Variance.INVARIANT)))
+        val ktSetOfKtSet = ktSet.replace(listOf(resolver.getTypeArgument(ktSetRef, Variance.INVARIANT)))
+        val javaCollectionOfJavaSet = javaCollection
+            .replace(listOf(resolver.getTypeArgument(javaSetRef, Variance.INVARIANT)))
+        val javaCollectionOfKtSet = javaCollection
+            .replace(listOf(resolver.getTypeArgument(ktSetRef, Variance.INVARIANT)))
+        val ktCollectionOfJavaSet = ktCollection
+            .replace(listOf(resolver.getTypeArgument(javaSetRef, Variance.INVARIANT)))
+        val ktCollectionOfKtSet = ktCollection
+            .replace(listOf(resolver.getTypeArgument(ktSetRef, Variance.INVARIANT)))
+        val ktCollectionOfJavaCollection = ktCollection
+            .replace(listOf(resolver.getTypeArgument(javaCollectionRef, Variance.INVARIANT)))
+        val javaSetOfKtCollection = javaSet
+            .replace(listOf(resolver.getTypeArgument(ktCollectionRef, Variance.INVARIANT)))
+        val container = resolver.getClassDeclarationByName("Container")!!
+        val strRef = resolver.getTypeArgument(
+            (container.declarations.single { it.simpleName.asString() == "str" } as KSPropertyDeclaration).type,
+            Variance.INVARIANT
+        )
+        val javaStrCollection = javaCollection.replace(listOf(strRef))
+        val javaStrSet = javaSet.replace(listOf(strRef))
+        isOk = isOk && javaCollection.isAssignableFrom(javaSet)
+        isOk = isOk && javaCollection.isAssignableFrom(javaStrCollection)
+        isOk = isOk && !javaStrCollection.isAssignableFrom(javaCollection)
+        isOk = isOk && !javaStrSet.isAssignableFrom(javaStrCollection)
+        isOk = isOk && javaStrCollection.isAssignableFrom(javaStrSet)
+        isOk = isOk && javaSet.isAssignableFrom(javaStrSet)
+        isOk = isOk && javaCollection.isAssignableFrom(ktCollection)
+        isOk = isOk && ktCollection.isAssignableFrom(javaCollection)
+        isOk = isOk && javaSetOfJavaSet.isAssignableFrom(ktSetOfJavaSet)
+        isOk = isOk && ktSetOfJavaSet.isAssignableFrom(javaSetOfJavaSet)
+        isOk = isOk && javaSetOfJavaSet.isAssignableFrom(javaSetOfKtSet)
+        isOk = isOk && javaSetOfKtSet.isAssignableFrom(javaSetOfJavaSet)
+        isOk = isOk && ktSetOfKtSet.isAssignableFrom(ktSetOfJavaSet)
+        isOk = isOk && ktSetOfJavaSet.isAssignableFrom(ktSetOfKtSet)
+        isOk = isOk && javaCollectionOfJavaSet.isAssignableFrom(ktCollectionOfJavaSet)
+        isOk = isOk && ktCollectionOfJavaSet.isAssignableFrom(javaCollectionOfJavaSet)
+        isOk = isOk && javaCollectionOfKtSet.isAssignableFrom(ktCollectionOfKtSet)
+        isOk = isOk && javaCollectionOfKtSet.isAssignableFrom(ktCollectionOfJavaSet)
+        isOk = isOk && ktCollectionOfJavaCollection.isAssignableFrom(javaSetOfKtCollection)
+        isOk = isOk && !javaSetOfKtCollection.isAssignableFrom(ktCollectionOfJavaCollection)
+        return emptyList()
+    }
+}


### PR DESCRIPTION
Compiler subtype checking does not convert Java types to Kotlin types, while getting super types from a java type does the conversion, therefore resulting in subtype checking for Java types to fail.
Check if candidate super type is a Java type, convert to Kotlin type for subtype checking.
Potentially needs an ultimate fix in compiler for subtype checking.

fixes #890 