### PR TITLE
K/N: delete outputs upfront

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -808,6 +808,14 @@ abstract class KspTaskNative @Inject constructor(
     // new / changed / removed files.
     // Long term solution: contribute to upstream to support incremental compilation.
     // Short term workaround: declare a @TaskAction function and call super.compile().
+    // Use a name that gets sorted in the front just in case. `_$` is lower, but it might be too hacky.
+    @TaskAction
+    fun _0() {
+        options.get().single { it.key == "kspOutputDir" }.value.let {
+            File(it).deleteRecursively()
+        }
+        super.compile()
+    }
 }
 
 // This forces rebuild.

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -154,6 +154,7 @@ class KMPImplementedIT {
     @Test
     fun testLinuxX64() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val genDir = File(project.root, "workload-linuxX64/build/generated/ksp/linuxX64/linuxX64Main/kotlin")
 
         gradleRunner.withArguments(
             "--configuration-cache-problems=warn",
@@ -180,6 +181,21 @@ class KMPImplementedIT {
             )
             Assert.assertFalse(it.output.contains("kotlin scripting plugin:"))
             Assert.assertTrue(it.output.contains("w: [ksp] platforms: [Native"))
+            Assert.assertTrue(File(genDir, "Main_dot_kt.kt").exists())
+            Assert.assertTrue(File(genDir, "ToBeRemoved_dot_kt.kt").exists())
+        }
+
+        File(project.root, "workload-linuxX64/src/linuxX64Main/kotlin/ToBeRemoved.kt").delete()
+        gradleRunner.withArguments(
+            "--configuration-cache-problems=warn",
+            ":workload-linuxX64:build"
+        ).build().let {
+            Assert.assertEquals(TaskOutcome.SUCCESS, it.task(":workload-linuxX64:build")?.outcome)
+            Assert.assertEquals(TaskOutcome.SUCCESS, it.task(":workload-linuxX64:kspTestKotlinLinuxX64")?.outcome)
+            verifyKexe("workload-linuxX64/build/bin/linuxX64/debugExecutable/workload-linuxX64.kexe")
+            verifyKexe("workload-linuxX64/build/bin/linuxX64/releaseExecutable/workload-linuxX64.kexe")
+            Assert.assertTrue(File(genDir, "Main_dot_kt.kt").exists())
+            Assert.assertFalse(File(genDir, "ToBeRemoved_dot_kt.kt").exists())
         }
     }
 

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
@@ -37,6 +37,15 @@ class TestProcessor(
                 writer.write("}\n")
             }
         }
+
+        allFiles.forEach {
+            val fn = it.replace(".", "_dot_")
+            codeGenerator.createNewFile(Dependencies(false), "", fn, "kt").use { output ->
+                OutputStreamWriter(output).use { writer ->
+                    writer.write("// empty\n")
+                }
+            }
+        }
         return emptyList()
     }
 }

--- a/integration-tests/src/test/resources/kmp/workload-linuxX64/src/linuxX64Main/kotlin/ToBeRemoved.kt
+++ b/integration-tests/src/test/resources/kmp/workload-linuxX64/src/linuxX64Main/kotlin/ToBeRemoved.kt
@@ -1,0 +1,1 @@
+class ToBeRemoved


### PR DESCRIPTION
In other platforms, outputs are deleted in AbstractKotlinCompile, which
is not inherited by K/N.