### PR TITLE
Use abbreviation when returning arguments for a KSType

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -33,7 +33,6 @@ import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.NotFoundClasses
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.getAbbreviatedType
 import org.jetbrains.kotlin.types.getAbbreviation
 import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.types.typeUtil.TypeNullability

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -33,6 +33,7 @@ import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.NotFoundClasses
 import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.getAbbreviatedType
 import org.jetbrains.kotlin.types.getAbbreviation
 import org.jetbrains.kotlin.types.isError
 import org.jetbrains.kotlin.types.typeUtil.TypeNullability
@@ -71,7 +72,9 @@ class KSTypeImpl private constructor(
 
     // TODO: fix calls to getKSTypeCached and use ksTypeArguments when available.
     override val arguments: List<KSTypeArgument> by lazy {
-        kotlinType.arguments.map { KSTypeArgumentDescriptorImpl.getCached(it, Origin.SYNTHETIC, null) }
+        (kotlinType.getAbbreviation() ?: kotlinType).arguments.map {
+            KSTypeArgumentDescriptorImpl.getCached(it, Origin.SYNTHETIC, null)
+        }
     }
 
     override fun isAssignableFrom(that: KSType): Boolean {

--- a/compiler-plugin/testData/api/typeAlias.kt
+++ b/compiler-plugin/testData/api/typeAlias.kt
@@ -18,20 +18,17 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: TypeAliasProcessor
 // EXPECTED:
-// A = String
-// A = String
-// B = String
-// C = A = String
-// Int
-// List<Int>
-// ListOfInt = List<Int>
-// ListOfInt = List<Int>
-// ListOfInt_B = ListOfInt = List<Int>
-// ListOfInt_B = ListOfInt = List<Int>
-// ListOfInt_C = ListOfInt_B = ListOfInt = List<Int>
-// String
-// String
-// String
+// a : A = String
+// b : B = String
+// c : C = A = String
+// d : String
+// listOfInt : ListOfInt = List<Int>
+// listOfInt_B : ListOfInt_B = ListOfInt = List<Int>
+// listOfInt_C : ListOfInt_C = ListOfInt_B = ListOfInt = List<Int>
+// myList : MyList<Long> = List<T>
+// myList_B : List<Number>
+// myList_String : MyList_String = MyList<String> = List<T>
+// myList_b_String : MyList_B_String = MyList_B<String> = MyList<R> = List<T>
 // END
 
 typealias A = String
@@ -40,6 +37,11 @@ typealias C = A
 typealias ListOfInt = List<Int>
 typealias ListOfInt_B = ListOfInt
 typealias ListOfInt_C = ListOfInt_B
+typealias MyList<T> = List<T>
+typealias MyList_B<R> = MyList<R>
+typealias MyList_String = MyList<String>
+typealias MyList_B_String = MyList_B<String>
+
 val a: A = ""
 val b: B = ""
 val c: C = ""
@@ -47,3 +49,7 @@ val d: String = ""
 val listOfInt: ListOfInt = TODO()
 val listOfInt_B: ListOfInt_B = TODO()
 val listOfInt_C: ListOfInt_C = TODO()
+val myList: MyList<Long> = TODO()
+val myList_B: List<Number> = TODO()
+val myList_String: MyList_String = TODO()
+val myList_b_String: MyList_B_String = TODO()

--- a/compiler-plugin/testData/api/typeAlias.kt
+++ b/compiler-plugin/testData/api/typeAlias.kt
@@ -22,6 +22,13 @@
 // A = String
 // B = String
 // C = A = String
+// Int
+// List<Int>
+// ListOfInt = List<Int>
+// ListOfInt = List<Int>
+// ListOfInt_B = ListOfInt = List<Int>
+// ListOfInt_B = ListOfInt = List<Int>
+// ListOfInt_C = ListOfInt_B = ListOfInt = List<Int>
 // String
 // String
 // String
@@ -30,7 +37,13 @@
 typealias A = String
 typealias B = String
 typealias C = A
+typealias ListOfInt = List<Int>
+typealias ListOfInt_B = ListOfInt
+typealias ListOfInt_C = ListOfInt_B
 val a: A = ""
 val b: B = ""
 val c: C = ""
 val d: String = ""
+val listOfInt: ListOfInt = TODO()
+val listOfInt_B: ListOfInt_B = TODO()
+val listOfInt_C: ListOfInt_C = TODO()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -33,23 +33,45 @@ open class TypeAliasProcessor : AbstractTestProcessor() {
         }
 
         val sortedTypes = types.sortedBy { it.declaration.simpleName.asString() }
-
+        val byFinalSignature = mutableMapOf<String, MutableList<KSType>>()
         for (i in sortedTypes) {
             val r = mutableListOf<String>()
             var a: KSType? = i
-            do {
-                r.add(a!!.declaration.simpleName.asString())
+            while(a != null) {
+                r.add(a.toSignature())
                 a = (a.declaration as? KSTypeAlias)?.type?.resolve()
-            } while (a != null)
+            }
             results.add(r.joinToString(" = "))
+            byFinalSignature.getOrPut(r.last()) {
+                mutableListOf()
+            }.add(i)
         }
-
-        for (i in types) {
-            for (j in types) {
-                assert(i == j)
+        byFinalSignature.forEach { (signature, sameTypeAliases) ->
+            for (i in sameTypeAliases) {
+                for (j in sameTypeAliases) {
+                    assert(i == j) {
+                        "$i and $j both map to $signature, equals should return true"
+                    }
+                }
+            }
+            assert(sameTypeAliases.map { it.hashCode() }.distinct().size == 1) {
+                "different hashcodes for members of $signature"
             }
         }
+
+
         return emptyList()
+    }
+
+    private fun KSType.toSignature(): String = buildString {
+        append(declaration.simpleName.asString())
+        if (arguments.isNotEmpty()) {
+            append("<")
+            arguments.map {
+                it.type?.resolve()?.toSignature() ?: "<error>"
+            }.forEach(this::append)
+            append(">")
+        }
     }
 
     override fun toResult(): List<String> {


### PR DESCRIPTION
This PR fixes a problem in KSType where it was not returning the right type arguments for TypeAliases.

For input:
```
typealias MyList = MyList<Int>
val x: MyList = TODO()
```

Querying the typeArguments of `x` would return `[Int]` while also returning its declaration as `MyList`.
This makes it looks like `MyList<Int><Int>`.
To fix it, I updated `KSType.arguments` to use the abbreviation type instead of the KotlinType.
Also, updated the test to add more cases and make it print the arguments for each type. I refactored the
test a bit to print types of properties instead of all found types to make the output more readable (happy to revert that part).


Fixes: #881
Test: typeAlias.kt