### PR TITLE
Class kind AA implementation 

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -18,7 +18,11 @@
 package com.google.devtools.ksp.impl
 
 import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationEnumEntryImpl
+import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl
+import com.google.devtools.ksp.impl.symbol.kotlin.KSNameImpl
+import com.google.devtools.ksp.impl.symbol.kotlin.analyzeWithSymbolAsContext
 import com.google.devtools.ksp.processing.KSBuiltIns
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -35,12 +39,15 @@ import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Variance
-import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.analysis.api.symbols.KtFileSymbol
 
 @OptIn(KspExperimental::class)
 class ResolverAAImpl(
-    val ktFiles: List<KtFile>
+    val ktFiles: List<KtFileSymbol>
 ) : Resolver {
+    private val ksFiles by lazy {
+        ktFiles.map { KSFileImpl(it) }
+    }
     override val builtIns: KSBuiltIns
         get() = TODO("Not yet implemented")
 
@@ -53,7 +60,7 @@ class ResolverAAImpl(
     }
 
     override fun getAllFiles(): Sequence<KSFile> {
-        return ktFiles.asSequence().map { KSFileImpl(it) }
+        return ksFiles.asSequence()
     }
 
     override fun getClassDeclarationByName(name: KSName): KSClassDeclaration? {
@@ -99,8 +106,9 @@ class ResolverAAImpl(
         TODO("Not yet implemented")
     }
 
+    // FIXME: correct implementation after incremental is ready.
     override fun getNewFiles(): Sequence<KSFile> {
-        TODO("Not yet implemented")
+        return getAllFiles().asSequence()
     }
 
     override fun getOwnerJvmClassName(declaration: KSFunctionDeclaration): String? {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -1,0 +1,127 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.symbols.KtEnumEntrySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
+import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+
+class KSClassDeclarationEnumEntryImpl(private val ktEnumEntrySymbol: KtEnumEntrySymbol) : KSClassDeclaration {
+    override val classKind: ClassKind = ClassKind.ENUM_ENTRY
+
+    override val primaryConstructor: KSFunctionDeclaration? = null
+
+    // TODO: Fix when type information is available in upstream.
+    override val superTypes: Sequence<KSTypeReference> = emptySequence()
+
+    override val isCompanionObject: Boolean = false
+
+    override fun getSealedSubclasses(): Sequence<KSClassDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllFunctions(): Sequence<KSFunctionDeclaration> {
+        return analyzeWithSymbolAsContext(ktEnumEntrySymbol) {
+            ktEnumEntrySymbol.getMemberScope().getCallableSymbols().filterIsInstance<KtFunctionLikeSymbol>()
+                .map { KSFunctionDeclarationImpl(it) }
+        }
+    }
+
+    override fun getAllProperties(): Sequence<KSPropertyDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun asType(typeArguments: List<KSTypeArgument>): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override fun asStarProjectedType(): KSType {
+        TODO("Not yet implemented")
+    }
+
+    override val simpleName: KSName by lazy {
+        KSNameImpl(ktEnumEntrySymbol.name.asString())
+    }
+
+    override val qualifiedName: KSName? by lazy {
+        ktEnumEntrySymbol.containingEnumClassIdIfNonLocal?.let {
+            KSNameImpl("${it.asFqNameString()}.${simpleName.asString()}")
+        }
+    }
+
+    override val typeParameters: List<KSTypeParameter> = emptyList()
+
+    override val packageName: KSName by lazy {
+        ktEnumEntrySymbol.toContainingFile()!!.packageName
+    }
+
+    override val parentDeclaration: KSDeclaration? by lazy {
+        analyzeWithSymbolAsContext(ktEnumEntrySymbol) {
+            ktEnumEntrySymbol.getContainingSymbol()
+                .safeAs<KtNamedClassOrObjectSymbol>()?.let { KSClassDeclarationImpl(it) }
+        }
+    }
+
+    override val containingFile: KSFile? by lazy {
+        ktEnumEntrySymbol.toContainingFile()
+    }
+    override val docString: String?
+        get() = TODO("Not yet implemented")
+
+    override val modifiers: Set<Modifier>
+        get() = TODO("Not yet implemented")
+
+    override val origin: Origin
+        get() = TODO("Not yet implemented")
+
+    override val location: Location by lazy {
+        ktEnumEntrySymbol.psi.toLocation()
+    }
+
+    override val parent: KSNode? by lazy {
+        analyzeWithSymbolAsContext(ktEnumEntrySymbol) {
+            ktEnumEntrySymbol.getContainingSymbol()
+                .safeAs<KtNamedClassOrObjectSymbol>()?.let { KSClassDeclarationImpl(it) }
+        }
+    }
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitClassDeclaration(this, data)
+    }
+
+    override val annotations: Sequence<KSAnnotation> = emptySequence()
+
+    override val isActual: Boolean
+        get() = TODO("Not yet implemented")
+    override val isExpect: Boolean
+        get() = TODO("Not yet implemented")
+
+    override fun findActuals(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override fun findExpects(): Sequence<KSDeclaration> {
+        TODO("Not yet implemented")
+    }
+
+    override val declarations: Sequence<KSDeclaration> by lazy {
+        // TODO: fix after .getDeclaredMemberScope() works for enum entry with no initializer.
+        emptySequence()
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -19,15 +19,11 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.toKSModifiers
-import org.jetbrains.kotlin.analysis.api.InvalidWayOfUsingAnalysisSession
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSession
-import org.jetbrains.kotlin.analysis.api.KtAnalysisSessionProvider
 import org.jetbrains.kotlin.analysis.api.annotations.annotations
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtAnnotatedSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -40,9 +36,11 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
             else -> throw IllegalStateException("Unexpected symbol kind ${ktFunctionSymbol.symbolKind}")
         }
     }
+
     override val isAbstract: Boolean by lazy {
         (ktFunctionSymbol as? KtFunctionSymbol)?.modality == Modality.ABSTRACT
     }
+
     override val extensionReceiver: KSTypeReference? by lazy {
         analyzeWithSymbolAsContext(ktFunctionSymbol) {
             if (!ktFunctionSymbol.isExtension) {
@@ -52,6 +50,7 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
             }
         }
     }
+
     override val returnType: KSTypeReference? by lazy {
         analyzeWithSymbolAsContext(ktFunctionSymbol) {
             KSTypeReferenceImpl(ktFunctionSymbol.returnType)
@@ -76,9 +75,11 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
             KSNameImpl("<init>")
         }
     }
+
     override val qualifiedName: KSName? by lazy {
         (ktFunctionSymbol.psi as? KtFunction)?.fqName?.asString()?.let { KSNameImpl(it) }
     }
+
     override val typeParameters: List<KSTypeParameter> by lazy {
         (ktFunctionSymbol as? KtFunctionSymbol)?.typeParameters?.map { KSTypeParameterImpl(it) } ?: emptyList()
     }
@@ -88,7 +89,7 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
     override val parentDeclaration: KSDeclaration?
         get() = TODO("Not yet implemented")
     override val containingFile: KSFile? by lazy {
-        (ktFunctionSymbol.psi?.containingFile as? KtFile)?.let { KSFileImpl(it) }
+        ktFunctionSymbol.toContainingFile()
     }
 
     override val docString: String? by lazy {
@@ -117,8 +118,10 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
     override val annotations: Sequence<KSAnnotation> by lazy {
         (ktFunctionSymbol as KtAnnotatedSymbol).annotations.asSequence().map { KSAnnotationImpl(it) }
     }
+
     override val isActual: Boolean
         get() = TODO("Not yet implemented")
+
     override val isExpect: Boolean
         get() = TODO("Not yet implemented")
 
@@ -130,15 +133,6 @@ class KSFunctionDeclarationImpl(private val ktFunctionSymbol: KtFunctionLikeSymb
         TODO("Not yet implemented")
     }
 
-    override val declarations: Sequence<KSDeclaration>
-        get() = TODO("Not yet implemented")
-}
-
-@OptIn(InvalidWayOfUsingAnalysisSession::class)
-internal inline fun <R> analyzeWithSymbolAsContext(
-    contextSymbol: KtSymbol,
-    action: KtAnalysisSession.() -> R
-): R {
-    return KtAnalysisSessionProvider
-        .getInstance(contextSymbol.psi!!.project).analyzeWithSymbolAsContext(contextSymbol, action)
+    // TODO: Implement with PSI
+    override val declarations: Sequence<KSDeclaration> = emptySequence()
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -23,7 +23,6 @@ import com.google.devtools.ksp.toKSModifiers
 import org.jetbrains.kotlin.analysis.api.annotations.annotations
 import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
-import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -77,7 +76,7 @@ class KSPropertyDeclarationImpl(private val ktPropertySymbol: KtPropertySymbol) 
         get() = TODO("Not yet implemented")
 
     override val containingFile: KSFile? by lazy {
-        (ktPropertySymbol.psi?.containingFile as? KtFile)?.let { KSFileImpl(it) }
+        ktPropertySymbol.toContainingFile()
     }
     override val docString: String? by lazy {
         ktPropertySymbol.psi?.getDocString()
@@ -98,7 +97,7 @@ class KSPropertyDeclarationImpl(private val ktPropertySymbol: KtPropertySymbol) 
     override val parent: KSNode? by lazy {
         analyzeWithSymbolAsContext(ktPropertySymbol) {
             ktPropertySymbol.getContainingSymbol()?.let { KSClassDeclarationImpl(it as KtNamedClassOrObjectSymbol) }
-                ?: KSFileImpl(ktPropertySymbol.psi!!.containingFile as KtFile)
+                ?: ktPropertySymbol.toContainingFile()
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -30,8 +30,8 @@ import org.jetbrains.kotlin.analysis.api.annotations.annotations
 import org.jetbrains.kotlin.analysis.api.types.KtType
 
 class KSTypeReferenceImpl(private val ktType: KtType) : KSTypeReference {
-    override val element: KSReferenceElement?
-        get() = TODO("Not yet implemented")
+    // FIXME: return correct reference element.
+    override val element: KSReferenceElement? = null
 
     override fun resolve(): KSType {
         return KSTypeImpl(ktType)


### PR DESCRIPTION
* implement KSClassDeclaration for KtEnumEntrySymbol
* implement getClassDeclarationByName
* some refactoring to common logics.

tested with `KSPAATest.testClassKinds`, passed test for non-Java symbols.

Expected
```
JA: ANNOTATION_CLASS
JC: CLASS
JE.ENTRY: ENUM_ENTRY
JE: ENUM_CLASS
JI: INTERFACE
KA: ANNOTATION_CLASS
KC: CLASS
KE.ENTRY: ENUM_ENTRY
KE: ENUM_CLASS
KI: INTERFACE
KO: OBJECT
kotlin.Annotation: INTERFACE
kotlin.Any: CLASS
kotlin.Deprecated: ANNOTATION_CLASS
kotlin.DeprecationLevel.WARNING: ENUM_ENTRY
kotlin.DeprecationLevel: ENUM_CLASS
kotlin.Double.Companion: OBJECT
```

Actual
```
KA: ANNOTATION_CLASS
KC: CLASS
KE.ENTRY: ENUM_ENTRY
KE: ENUM_CLASS
KI: INTERFACE
KO: OBJECT
kotlin.Annotation: INTERFACE
kotlin.Any: CLASS
kotlin.Deprecated: ANNOTATION_CLASS
kotlin.DeprecationLevel.WARNING: ENUM_ENTRY
kotlin.DeprecationLevel: ENUM_CLASS
kotlin.Double.Companion: OBJECT
```