### PR TITLE
try to get psi before creating sealed sub class declarations

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -23,15 +23,12 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
-import com.google.devtools.ksp.symbol.impl.kotlin.KSFunctionDeclarationImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.KSPropertyDeclarationParameterImpl
-import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
+import com.google.devtools.ksp.symbol.impl.kotlin.*
 import com.google.devtools.ksp.symbol.impl.replaceTypeArguments
 import com.intellij.psi.PsiField
 import com.intellij.psi.PsiMethod
 import org.jetbrains.kotlin.descriptors.*
+import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
@@ -189,5 +186,10 @@ internal fun ClassDescriptor.sealedSubclassesSequence(): Sequence<KSClassDeclara
     // TODO record incremental subclass lookups in Kotlin 1.5.x?
     return sealedSubclasses
         .asSequence()
-        .map { KSClassDeclarationDescriptorImpl.getCached(it) }
+        .map { sealedSubClass ->
+            when (val psi = sealedSubClass.findPsi()) {
+                is KtClassOrObject -> KSClassDeclarationImpl.getCached(psi)
+                else -> KSClassDeclarationDescriptorImpl.getCached(sealedSubClass)
+            }
+        }
 }

--- a/compiler-plugin/testData/api/sealedClass.kt
+++ b/compiler-plugin/testData/api/sealedClass.kt
@@ -17,13 +17,25 @@
 
 // TEST PROCESSOR: SealedClassProcessor
 // EXPECTED:
-// Expr : [Const, NotANumber, Sum]
+// from lib
+// [Const: KOTLIN_LIB, NotANumber: KOTLIN_LIB, Sum: KOTLIN_LIB]
+// from source
+// Expr : [Const: KOTLIN, NotANumber: KOTLIN, Sum: KOTLIN]
 // Const : []
 // Sum : []
 // NotANumber : []
 // END
 
-//FILE: sealed.kt
+// MODULE: lib
+// FILE: lib.kt
+package lib
+sealed class Expr
+data class Const(val number: Double) : Expr()
+data class Sum(val e1: Expr, val e2: Expr) : Expr()
+object NotANumber : Expr()
+
+// MODULE: main(lib)
+// FILE: sealed.kt
 sealed class Expr
 data class Const(val number: Double) : Expr()
 data class Sum(val e1: Expr, val e2: Expr) : Expr()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SealedClassProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SealedClassProcessor.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
@@ -28,10 +29,22 @@ class SealedClassProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        result.add("from lib")
+        resolver.getClassDeclarationByName("lib.Expr")!!.let {
+            result.add(
+                it.getSealedSubclasses().map { sub ->
+                    "${sub.simpleName.asString()}: ${sub.origin}"
+                }.toList().sorted().toString()
+            )
+        }
+
+        result.add("from source")
         resolver.getNewFiles().forEach { f ->
             f.declarations.forEach {
                 if (it is KSClassDeclaration) {
-                    val subs = it.getSealedSubclasses().map { it.simpleName.asString() }.toList().sorted()
+                    val subs = it.getSealedSubclasses().map { sub ->
+                        "${sub.simpleName.asString()}: ${sub.origin}"
+                    }.toList().sorted()
                     result.add("${it.simpleName.asString()} : $subs")
                 }
             }


### PR DESCRIPTION
fixes #936 

Cause is that we did not check the psi for the sealed sub classes descriptors.

Testing `toLocation()` is not possible in our test infrastructure, hence test the origin instead, when origin is `KOTLIN` there will be a location value from the psi.