### PR TITLE
use correct type for vararg value parameter descriptor implementation

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSValueParameterDescriptorImpl.kt
@@ -58,7 +58,12 @@ class KSValueParameterDescriptorImpl private constructor(
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin, this)
+        // Descriptor wraps vararg with Array<>, to align with the actual behavior in source.
+        if (isVararg) {
+            KSTypeReferenceDescriptorImpl.getCached(descriptor.varargElementType!!, origin, this)
+        } else {
+            KSTypeReferenceDescriptorImpl.getCached(descriptor.type, origin, this)
+        }
     }
 
     override val hasDefault: Boolean = descriptor.hasDefaultValue()

--- a/compiler-plugin/testData/api/allFunctions.kt
+++ b/compiler-plugin/testData/api/allFunctions.kt
@@ -75,6 +75,28 @@
 // equals(kotlin.Any): kotlin.Boolean
 // hashCode(): kotlin.Int
 // toString(): kotlin.String
+// class: Sub
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: SubAbstract
+// <init>(): SubAbstract
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: Super
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: SuperAbstract
+// <init>(): SuperAbstract
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
 // END
 // FILE: a.kt
 abstract class Foo : C(), List<out Number> {
@@ -94,6 +116,20 @@ abstract class Foo : C(), List<out Number> {
 data class Data(val a: String) {
     override fun equals(other: Any?): Boolean {
         return false
+    }
+}
+
+interface Super {
+    fun foo(vararg values: String)
+}
+
+interface Sub : Super
+
+class SubAbstract: SuperAbstract()
+
+abstract class SuperAbstract {
+    fun foo(vararg values: String) {
+
     }
 }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
@@ -50,6 +50,9 @@ class AllFunctionsProcessor : AbstractTestProcessor() {
                         if (it.hasDefault) {
                             append("(hasDefault)")
                         }
+                        if (it.isVararg) {
+                            append(" ...")
+                        }
                     }
                 }.joinToString(",")})" +
                 ": ${this.returnType?.resolve()?.declaration?.qualifiedName?.asString() ?: ""}"


### PR DESCRIPTION
compiler implementation of `isVararg` is essentially checking `varargElementType != null`.

fixes #958 
