### PR TITLE
First verbose mode support.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -76,6 +76,14 @@ class KotlinSymbolProcessingExtension(
 
                 ServiceLoaderLite.loadImplementations(SymbolProcessorProvider::class.java, classLoader)
             }
+            if (providers.isEmpty()) {
+                logger.error("No providers found in processor classpath.")
+            } else {
+                logger.info(
+                    "loaded provider(s): " +
+                        "${providers.joinToString(separator = ", ", prefix = "[", postfix = "]") { it.javaClass.name }}"
+                )
+            }
         }
         return providers
     }
@@ -126,6 +134,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
         if (rounds > MULTI_ROUND_THRESHOLD) {
             logger.warn("Current processing rounds exceeds 100, check processors for potential infinite rounds")
         }
+        logger.logging("round $rounds of processing")
         val psiManager = PsiManager.getInstance(project)
         if (initialized) {
             psiManager.dropPsiCaches()

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/VerboseIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/VerboseIT.kt
@@ -1,0 +1,67 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.JarFile
+
+class VerboseIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground")
+
+    private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
+        buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)
+
+    private fun GradleRunner.buildAndCheckOutcome(
+        vararg args: String,
+        outcome: TaskOutcome,
+        extraCheck: (BuildResult) -> Unit = {}
+    ) {
+        val result = this.withArguments(*args).build()
+
+        Assert.assertEquals(outcome, result.task(":workload:build")?.outcome)
+
+        val artifact = File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar")
+        Assert.assertTrue(artifact.exists())
+
+        JarFile(artifact).use { jarFile ->
+            Assert.assertTrue(jarFile.getEntry("TestProcessor.log").size > 0)
+            Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("g/G.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
+        }
+
+        extraCheck(result)
+    }
+
+    @Test
+    fun testNoProvider() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        File(
+            project.root,
+            "test-processor/src/main/resources/META-INF/services/" +
+                "com.google.devtools.ksp.processing.SymbolProcessorProvider"
+        ).delete()
+        gradleRunner.withArguments("build").buildAndFail().let { result ->
+            Assert.assertTrue(result.output.contains("No providers found in processor classpath."))
+        }
+    }
+
+    @Test
+    fun testProviderAndRoundLogging() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.buildAndCheck("--debug", "clean", "build") { result ->
+            Assert.assertTrue(
+                result.output.contains(
+                    "i: [ksp] loaded provider(s): [TestProcessorProvider, TestProcessorProvider2]"
+                )
+            )
+            Assert.assertTrue(result.output.contains("v: [ksp] round 3 of processing"))
+        }
+    }
+}


### PR DESCRIPTION
* Logs current round number of processing.
* Logs loaded providers.
* Logs an error when there is no providers found in AP classpath.

fixes #927 

also fulfills a providers related logging request from Donald.