### PR TITLE
invoke system file API to get true path for symbol links

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -172,7 +172,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                         is KSFileJavaImpl -> it.psi
                         else -> null
                     }?.virtualFile?.let { virtualFile ->
-                        virtualFile.canonicalPath ?: virtualFile.path
+                        File(virtualFile.path).canonicalPath
                     } in newFileNames
                 }
                 incrementalContext.registerGeneratedFiles(newFiles)


### PR DESCRIPTION
fixes #948 

VirtualFile does not seem to return the true path even though the Javadoc of `canonicalPath` says so, therefore using system API to fix it.

Tested locally with androidx reproduce repo, can't find a good way to reproduce within KSP's test framework.