### PR TITLE
replace deprecated compatibility jvm-default flag with all-compatibility

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,7 +8,7 @@ val signingPassword: String? by project
 val kotlinBaseVersion: String by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
+    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all-compatibility"
 }
 
 plugins {


### PR DESCRIPTION
flag `compatibility ` has been deprecated since 1.5.0

https://kotlinlang.org/docs/whatsnew15.html#deprecation-of-jvmdefault-and-old-xjvm-default-modes