### PR TITLE
introduce processorName option for KSP.

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
@@ -189,6 +189,13 @@ enum class KspCliOption(
         false
     ),
 
+    PROCESSOR_NAME_OPTION(
+        "processorNames",
+        "<processorNames>",
+        "only executes following processor(s)",
+        false
+    ),
+
     KNOWN_MODIFIED_OPTION(
         "knownModified",
         "<knownModified>",
@@ -259,6 +266,7 @@ fun KspOptions.Builder.processOption(option: KspCliOption, value: String) = when
     KspCliOption.PROCESSOR_CLASSPATH_OPTION -> processingClasspath += value.split(File.pathSeparator).map {
         File(it)
     }
+    KspCliOption.PROCESSOR_NAME_OPTION -> processors += value.split(File.pathSeparator)
     KspCliOption.CLASS_OUTPUT_DIR_OPTION -> classOutputDir = File(value)
     KspCliOption.JAVA_OUTPUT_DIR_OPTION -> javaOutputDir = File(value)
     KspCliOption.KOTLIN_OUTPUT_DIR_OPTION -> kotlinOutputDir = File(value)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -74,7 +74,9 @@ class KotlinSymbolProcessingExtension(
                 val classLoader =
                     URLClassLoader(processingClasspath.map { it.toURI().toURL() }.toTypedArray(), javaClass.classLoader)
 
-                ServiceLoaderLite.loadImplementations(SymbolProcessorProvider::class.java, classLoader)
+                ServiceLoaderLite.loadImplementations(SymbolProcessorProvider::class.java, classLoader).filter {
+                    options.processors.isEmpty() || it.javaClass.name in options.processors
+                }
             }
             if (providers.isEmpty()) {
                 logger.error("No providers found in processor classpath.")


### PR DESCRIPTION
This option will allow users to specify certain processors(s) to be
executed, if not specified, all processors found in apclasspath will be
executed.

