### PR TITLE
disable symbol link check on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
   build-and-test:
 
     # The type of runner that the job will run on
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     steps:
     - name: Setup Java 9

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -172,7 +172,11 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                         is KSFileJavaImpl -> it.psi
                         else -> null
                     }?.virtualFile?.let { virtualFile ->
-                        File(virtualFile.path).canonicalPath
+                        if (System.getProperty("os.name").startsWith("windows", ignoreCase = true)) {
+                            virtualFile.canonicalPath ?: virtualFile.path
+                        } else {
+                            File(virtualFile.path).canonicalPath
+                        }
                     } in newFileNames
                 }
                 incrementalContext.registerGeneratedFiles(newFiles)


### PR DESCRIPTION
Previous symbolic link fix is causing issues for incremental on Windows, disabling this fix for Windows for now.