### PR TITLE
Recover `lateinit` modifier for descriptor-based implementations.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSPropertyDeclarationDescriptorImpl.kt
@@ -64,6 +64,9 @@ class KSPropertyDeclarationDescriptorImpl private constructor(val descriptor: Pr
         if (descriptor.isConst) {
             modifiers.add(Modifier.CONST)
         }
+        if (descriptor.isLateInit) {
+            modifiers.add(Modifier.LATEINIT)
+        }
 
         if (this.origin == Origin.JAVA_LIB) {
             if (this.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -296,6 +296,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/javaWildcards2.kt")
     }
 
+    @TestMetadata("lateinitProperties.kt")
+    @Test
+    fun testLateinitProperties() {
+        runTest("testData/api/lateinitProperties.kt")
+    }
+
     @TestMetadata("libOrigins.kt")
     @Test
     fun testLibOrigins() {

--- a/compiler-plugin/testData/api/lateinitProperties.kt
+++ b/compiler-plugin/testData/api/lateinitProperties.kt
@@ -1,0 +1,39 @@
+// WITH_RUNTIME
+// TEST PROCESSOR: LateinitPropertiesProcessor
+// EXPECTED:
+// prop1
+// prop2
+// prop3
+// propSource1
+// propSource2
+// propSource3
+// END
+// MODULE: lib
+// FILE: compiledProperties.kt
+package test.compiled
+
+open class Foo {
+    lateinit var prop1: Any
+    companion object {
+        lateinit var prop2: Any
+    }
+}
+
+object Bar : Foo() {
+    lateinit var prop3: Any
+}
+
+// MODULE: main(lib)
+// FILE: sourceProperties.kt
+package test.source
+
+open class FooSource {
+    lateinit var propSource1: Any
+    companion object {
+        lateinit var propSource2: Any
+    }
+}
+
+object BarSource : Foo() {
+    lateinit var propSource3: Any
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -322,6 +322,13 @@ class KSPAATest : AbstractKSPAATest() {
     }
 
     @Disabled
+    @TestMetadata("lateinitProperties.kt")
+    @Test
+    fun testLateinitProperties() {
+        runTest("../compiler-plugin/testData/api/lateinitProperties.kt")
+    }
+
+    @Disabled
     @TestMetadata("libOrigins.kt")
     @Test
     fun testLibOrigins() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LateinitPropertiesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LateinitPropertiesProcessor.kt
@@ -1,0 +1,39 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class LateinitPropertiesProcessor : AbstractTestProcessor() {
+    private val visitor = Visitor()
+
+    override fun toResult(): List<String> {
+        return visitor.lateinitPropertiesNames.sorted()
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getDeclarationsFromPackage("test.compiled").forEach {
+            it.accept(visitor, Unit)
+        }
+        resolver.getNewFiles().forEach { it.accept(visitor, Unit) }
+        return emptyList()
+    }
+
+    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+        val lateinitPropertiesNames = arrayListOf<String>()
+
+        override fun defaultHandler(node: KSNode, data: Unit) {
+        }
+
+        override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+            if (Modifier.LATEINIT in property.modifiers) {
+                lateinitPropertiesNames += property.simpleName.asString()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Very similar to what I did with `const` modifier once.