### PR TITLE
`KotlinType.unwrap()` has to be used for correct `is` checks.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1407,7 +1407,7 @@ class ResolverImpl(
 
     @KspExperimental
     override fun isJavaRawType(type: KSType): Boolean {
-        return type is KSTypeImpl && type.kotlinType is RawType
+        return type is KSTypeImpl && type.kotlinType.unwrap() is RawType
     }
 }
 


### PR DESCRIPTION
Sometimes raw types may be wrapped into "enhanced" types by the compiler,
 so the old naive check didn't work on them.

 `UnwrappedType`'s doc states, that it's only safe to use `instanceof` checks on unwrapped types.

I ran into this issue in my closed-source project yet was unable to reproduce it with KSP testing infra,
 so no test changes here.