### PR TITLE
disable analysis api module on release branch

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,6 @@ include("compiler-plugin")
 include("symbol-processing")
 include("symbol-processing-cmdline")
 include("integration-tests")
-include("kotlin-analysis-api")
 
 val kotlinProjectPath: String? by settings
 if (kotlinProjectPath != null) {


### PR DESCRIPTION
The current failing auto-merge action is caused by an incompatible change in analysis API, our build script applies same kotlin version across the repo. As we are not releasing analysis API implementation yet, disable AA module on release branch to unblock auto-merge.