### PR TITLE
AA: use AAsession, test infra fix, error type fix

### DIFF
--- a/compiler-plugin/testData/api/errorTypes.kt
+++ b/compiler-plugin/testData/api/errorTypes.kt
@@ -32,7 +32,7 @@
 // END
 // FILE: a.kt
 class C {
-    val errorAtTop = mutableMapOf<String, NonExistType>()
+    val errorAtTop = mutableMapOf<String, NonExistType, Int>()
     val errorInComponent: Map<String, NonExistType>
 }
 

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -2,7 +2,7 @@ description = "Kotlin Symbol Processing implementation using Kotlin Analysis API
 
 val intellijVersion: String by project
 val junitVersion: String by project
-val analysisAPIVersion = "1.7.20-dev-2312"
+val analysisAPIVersion = "1.8.0-dev-446"
 val libsForTesting by configurations.creating
 
 plugins {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPCommandLineProcessor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPCommandLineProcessor.kt
@@ -23,8 +23,8 @@ import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
-import org.jetbrains.kotlin.cli.jvm.plugins.ServiceLoaderLite
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.util.ServiceLoaderLite
 import java.io.File
 import java.net.URLClassLoader
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -43,7 +43,6 @@ class KSClassDeclarationImpl private constructor(private val ktNamedClassOrObjec
             KtClassKind.ANNOTATION_CLASS -> ClassKind.ANNOTATION_CLASS
             KtClassKind.INTERFACE -> ClassKind.INTERFACE
             KtClassKind.COMPANION_OBJECT, KtClassKind.ANONYMOUS_OBJECT, KtClassKind.OBJECT -> ClassKind.OBJECT
-            KtClassKind.ENUM_ENTRY -> ClassKind.ENUM_ENTRY
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -27,6 +27,7 @@ import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
+import org.jetbrains.kotlin.analysis.api.types.KtClassErrorType
 import org.jetbrains.kotlin.analysis.api.types.KtNonErrorClassType
 import org.jetbrains.kotlin.analysis.api.types.KtType
 
@@ -41,7 +42,10 @@ class KSTypeReferenceImpl(private val ktType: KtType) : KSTypeReference {
         // TODO: non exist type returns KtNonErrorClassType, check upstream for KtClassErrorType usage.
         return if (
             analyze {
-                (ktType is KtNonErrorClassType) && ktType.classId.getCorrespondingToplevelClassOrObjectSymbol() == null
+                ktType is KtClassErrorType || (
+                    (ktType is KtNonErrorClassType) &&
+                        ktType.classId.getCorrespondingToplevelClassOrObjectSymbol() == null
+                    )
             }
         ) {
             KSErrorType

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -20,7 +20,10 @@ package com.google.devtools.ksp.impl.test
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.parallel.Execution
+import org.junit.jupiter.api.parallel.ExecutionMode
 
+@Execution(ExecutionMode.SAME_THREAD)
 class KSPAATest : AbstractKSPAATest() {
 
     @Disabled
@@ -37,7 +40,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../compiler-plugin/testData/api/javaAnnotatedUtil.kt")
     }
 
-    @Disabled
     @Test
     fun testAbstractFunctions() {
         runTest("../compiler-plugin/testData/api/abstractFunctions.kt")
@@ -134,7 +136,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../compiler-plugin/testData/api/classKinds.kt")
     }
 
-    @Disabled
     @TestMetadata("companion.kt")
     @Test
     fun testCompanion() {


### PR DESCRIPTION
I am open to suggestions on the error type test. Basically AA is capable of resolving a function call with error argument, which actually makes more sense to me, but at this point it might not make a lot of sense to fix old frontend (assume changes in upstream). 

An alternative is to have 2 versions of test result for comparing, as we are expecting more inconsistency between old and new frontend, this also makes sense in terms of long term investment.