### PR TITLE
AA: use KtSymbolProviderByJavaPsiMixIn for converting PSI class to AA symbols.

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -40,12 +40,7 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
 
     override val primaryConstructor: KSFunctionDeclaration? = null
 
-    override val superTypes: Sequence<KSTypeReference> by lazy {
-        analyze {
-            this@KSClassDeclarationEnumEntryImpl.ktEnumEntrySymbol.returnType
-                .getDirectSuperTypes().asSequence().map { KSTypeReferenceImpl.getCached(it) }
-        }
-    }
+    override val superTypes: Sequence<KSTypeReference> = emptySequence()
 
     override val isCompanionObject: Boolean = false
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
@@ -18,8 +18,6 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
-import com.google.devtools.ksp.getClassDeclarationByName
-import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
@@ -43,7 +41,9 @@ class KSFileJavaImpl private constructor(private val psi: PsiJavaFile) : KSFile 
 
     override val declarations: Sequence<KSDeclaration> by lazy {
         psi.classes.asSequence().mapNotNull { psi ->
-            psi.qualifiedName?.let { ResolverAAImpl.instance.getClassDeclarationByName(it) }
+            analyze {
+                psi.getNamedClassSymbol()?.let { KSClassDeclarationImpl.getCached(it) }
+            }
         }
     }
 

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -129,7 +129,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../compiler-plugin/testData/api/checkOverride.kt")
     }
 
-    @Disabled
     @TestMetadata("classKinds.kt")
     @Test
     fun testClassKinds() {


### PR DESCRIPTION
* fixes super types for enum entry.
* unmute classKind test.