### PR TITLE
AA: add visibility check for getAllFunctions/getAllProperties 

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -38,6 +38,7 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/javaAnnotatedUtil.kt")
     }
 
+    @TestMetadata("abstractFunctions.kt")
     @Test
     fun testAbstractFunctions() {
         runTest("testData/api/abstractFunctions.kt")

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -44,10 +44,22 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/abstractFunctions.kt")
     }
 
-    @TestMetadata("allFunctions.kt")
+    @TestMetadata("allFunctions_java_inherits_kt.kt")
     @Test
-    fun testAllFunctions() {
-        runTest("testData/api/allFunctions.kt")
+    fun testAllFunctions_java_inherits_kt() {
+        runTest("testData/api/allFunctions_java_inherits_kt.kt")
+    }
+
+    @TestMetadata("allFunctions_kotlin.kt")
+    @Test
+    fun testAllFunctions_kotlin() {
+        runTest("testData/api/allFunctions_java_inherits_kt.kt")
+    }
+
+    @TestMetadata("allFunctions_kt_inherits_java.kt")
+    @Test
+    fun testAllFunctions_kt_inherits_java() {
+        runTest("testData/api/allFunctions_kt_inherits_java.kt")
     }
 
     @TestMetadata("annotationInDependencies.kt")

--- a/compiler-plugin/testData/api/allFunctions_java_inherits_kt.kt
+++ b/compiler-plugin/testData/api/allFunctions_java_inherits_kt.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: AllFunctionsProcessor
+// EXPECTED:
+// class: JavaImplOfKotlinInterface
+// x
+// <init>(): JavaImplOfKotlinInterface
+// equals(kotlin.Any): kotlin.Boolean
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: KotlinInterfaceWithProperty
+// x
+// equals(kotlin.Any): kotlin.Boolean
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// END
+
+// FILE: KotlinInterfaceWithProperty.kt
+interface KotlinInterfaceWithProperty {
+    var x:Int
+}
+
+// FILE: JavaImplOfKotlinInterface.java
+class JavaImplOfKotlinInterface implements KotlinInterfaceWithProperty {
+    public int getX() {
+        return 1;
+    }
+    public void setX(int value) {
+    }
+}

--- a/compiler-plugin/testData/api/allFunctions_kotlin.kt
+++ b/compiler-plugin/testData/api/allFunctions_kotlin.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: AllFunctionsProcessor
+// class: Data
+// a
+// <init>(kotlin.String): Data
+// component1(): kotlin.String
+// copy(kotlin.String(hasDefault)): Data
+// equals(kotlin.Any): kotlin.Boolean
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: Sub
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: SubAbstract
+// <init>(): SubAbstract
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: Super
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// class: SuperAbstract
+// <init>(): SuperAbstract
+// equals(kotlin.Any): kotlin.Boolean
+// foo(kotlin.String ...): kotlin.Unit
+// hashCode(): kotlin.Int
+// toString(): kotlin.String
+// EXPECTED:
+// END
+// FILE: a.kt
+data class Data(val a: String) {
+    override fun equals(other: Any?): Boolean {
+        return false
+    }
+}
+
+interface Super {
+    fun foo(vararg values: String)
+}
+
+interface Sub : Super
+
+class SubAbstract: SuperAbstract()
+
+abstract class SuperAbstract {
+    fun foo(vararg values: String) {
+
+    }
+}
+

--- a/compiler-plugin/testData/api/allFunctions_kt_inherits_java.kt
+++ b/compiler-plugin/testData/api/allFunctions_kt_inherits_java.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2020 Google LLC
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +29,6 @@
 // javaPrivateFun(): kotlin.Unit
 // javaStrFun(): kotlin.String
 // toString(): kotlin.String
-// class: Data
-// a
-// <init>(kotlin.String): Data
-// component1(): kotlin.String
-// copy(kotlin.String(hasDefault)): Data
-// equals(kotlin.Any): kotlin.Boolean
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
 // class: Foo
 // aFromC
 // cFromC
@@ -64,39 +56,6 @@
 // subList(kotlin.Int,kotlin.Int): kotlin.collections.List
 // toArray(java.util.function.IntFunction): kotlin.Array
 // toString(): kotlin.String
-// class: JavaImplOfKotlinInterface
-// x
-// <init>(): JavaImplOfKotlinInterface
-// equals(kotlin.Any): kotlin.Boolean
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
-// class: KotlinInterfaceWithProperty
-// x
-// equals(kotlin.Any): kotlin.Boolean
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
-// class: Sub
-// equals(kotlin.Any): kotlin.Boolean
-// foo(kotlin.String ...): kotlin.Unit
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
-// class: SubAbstract
-// <init>(): SubAbstract
-// equals(kotlin.Any): kotlin.Boolean
-// foo(kotlin.String ...): kotlin.Unit
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
-// class: Super
-// equals(kotlin.Any): kotlin.Boolean
-// foo(kotlin.String ...): kotlin.Unit
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
-// class: SuperAbstract
-// <init>(): SuperAbstract
-// equals(kotlin.Any): kotlin.Boolean
-// foo(kotlin.String ...): kotlin.Unit
-// hashCode(): kotlin.Int
-// toString(): kotlin.String
 // END
 // FILE: a.kt
 abstract class Foo : C(), List<out Number> {
@@ -110,26 +69,6 @@ abstract class Foo : C(), List<out Number> {
 
     fun baz(input: String, input2: String? = null, input3: String = ""): Boolean {
         return false
-    }
-}
-
-data class Data(val a: String) {
-    override fun equals(other: Any?): Boolean {
-        return false
-    }
-}
-
-interface Super {
-    fun foo(vararg values: String)
-}
-
-interface Sub : Super
-
-class SubAbstract: SuperAbstract()
-
-abstract class SuperAbstract {
-    fun foo(vararg values: String) {
-
     }
 }
 
@@ -150,19 +89,5 @@ class C {
 
     public String javaStrFun() {
         return "str"
-    }
-}
-
-// FILE: KotlinInterfaceWithProperty.kt
-interface KotlinInterfaceWithProperty {
-    var x:Int
-}
-
-// FILE: JavaImplOfKotlinInterface.java
-class JavaImplOfKotlinInterface implements KotlinInterfaceWithProperty {
-    public int getX() {
-        return 1;
-    }
-    public void setX(int value) {
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -54,11 +54,11 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
     }
 
     override fun getAllFunctions(): Sequence<KSFunctionDeclaration> {
-        return ktEnumEntrySymbol.getAllFunctions()
+        return ktEnumEntrySymbol.declarations().filterIsInstance<KSFunctionDeclaration>()
     }
 
     override fun getAllProperties(): Sequence<KSPropertyDeclaration> {
-        return ktEnumEntrySymbol.getAllProperties()
+        return ktEnumEntrySymbol.declarations().filterIsInstance<KSPropertyDeclaration>()
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -47,10 +47,24 @@ class KSPAATest : AbstractKSPAATest() {
     }
 
     @Disabled
-    @TestMetadata("allFunctions.kt")
+    @TestMetadata("allFunctions_java_inherits_kt.kt")
     @Test
-    fun testAllFunctions() {
-        runTest("../compiler-plugin/testData/api/allFunctions.kt")
+    fun testAllFunctions_java_inherits_kt() {
+        runTest("../compiler-plugin/testData/api/allFunctions_java_inherits_kt.kt")
+    }
+
+    @Disabled
+    @TestMetadata("allFunctions_kotlin.kt")
+    @Test
+    fun testAllFunctions_kotlin() {
+        runTest("../compiler-plugin/testData/api/allFunctions_java_inherits_kt.kt")
+    }
+
+    @Disabled
+    @TestMetadata("allFunctions_kt_inherits_java.kt")
+    @Test
+    fun testAllFunctions_kt_inherits_java() {
+        runTest("../compiler-plugin/testData/api/allFunctions_kt_inherits_java.kt")
     }
 
     @Disabled

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -46,14 +46,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../compiler-plugin/testData/api/abstractFunctions.kt")
     }
 
-    @Disabled
     @TestMetadata("allFunctions_java_inherits_kt.kt")
     @Test
     fun testAllFunctions_java_inherits_kt() {
         runTest("../compiler-plugin/testData/api/allFunctions_java_inherits_kt.kt")
     }
 
-    @Disabled
     @TestMetadata("allFunctions_kotlin.kt")
     @Test
     fun testAllFunctions_kotlin() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -40,6 +40,7 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../compiler-plugin/testData/api/javaAnnotatedUtil.kt")
     }
 
+    @TestMetadata("abstractFunctions.kt")
     @Test
     fun testAbstractFunctions() {
         runTest("../compiler-plugin/testData/api/abstractFunctions.kt")


### PR DESCRIPTION
* getAllSymbols returns all symbols including invisible ones, check vibility for the target class to filter out unneeded symbols.
* Include a temporary workaround for checking containing class due to FIR compiler limitation.
* unmutes allFunctions_kotlin allFunctions_java_inherits_kt test.