### PR TITLE
manually look up in scope when annotation argument type is nested annotation.

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -230,6 +230,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/functionTypes.kt")
     }
 
+    @TestMetadata("getAnnotationByTypeWithInnerDefault.kt")
+    @Test
+    fun testGetAnnotationByTypeWithInnerDefault() {
+        runTest("testData/api/getAnnotationByTypeWithInnerDefault.kt")
+    }
+
     @DisabledOnOs(OS.WINDOWS)
     @TestMetadata("getPackage.kt")
     @Test

--- a/compiler-plugin/testData/api/getAnnotationByTypeWithInnerDefault.kt
+++ b/compiler-plugin/testData/api/getAnnotationByTypeWithInnerDefault.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: GetAnnotationByTypeProcessor
+// EXPECTED:
+// com.google.devtools.ksp.processor.KotlinAnnotationWithInnerDefaults.InnerAnnotation[innerAnnotationDefault=7, moreInnerAnnotation=com.google.devtools.ksp.processor.KotlinAnnotationWithInnerDefaults.InnerAnnotation.MoreInnerAnnotation[moreInnerAnnotationDefault=OK]]
+// END
+// MODULE: lib
+// FILE: KotlinAnnotationWithInnerDefaults.kt
+package com.google.devtools.ksp.processor
+annotation class KotlinAnnotationWithInnerDefaults(
+    val innerAnnotationVal: InnerAnnotation = InnerAnnotation(innerAnnotationDefault = 7)
+) {
+    annotation class InnerAnnotation(
+        val innerAnnotationDefault: Int,
+        val moreInnerAnnotation: MoreInnerAnnotation  = MoreInnerAnnotation("OK")
+    ) {
+        annotation class MoreInnerAnnotation(val moreInnerAnnotationDefault: String)
+    }
+}
+
+// MODULE: main(lib)
+// FILE: com/google/devtools/ksp/processor/a.kt
+package com.google.devtools.ksp.processor
+
+@KotlinAnnotationWithInnerDefaults
+class A

--- a/compiler-plugin/testData/api/getByName.kt
+++ b/compiler-plugin/testData/api/getByName.kt
@@ -28,6 +28,8 @@ open class Foo {
     fun overload(a: Int) = "Overload"
     fun overload() = "Overload"
     val lib1MemberProp = 1.0
+
+    class FooNested {}
 }
 
 fun lib1TopFun(): Int {
@@ -61,6 +63,7 @@ package source
 class FooInSource {
     fun sourceMemberFun() = 1
     val sourceMemberProp = 1.0
+    class FooInSourceNested
 }
 
 val propInSource = 1

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeProcessor.kt
@@ -1,0 +1,36 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+annotation class KotlinAnnotationWithInnerDefaults(
+    val innerAnnotationVal: InnerAnnotation = InnerAnnotation(innerAnnotationDefault = 7)
+) {
+    annotation class InnerAnnotation(
+        val innerAnnotationDefault: Int,
+        val moreInnerAnnotation: MoreInnerAnnotation = MoreInnerAnnotation("OK")
+    ) {
+        annotation class MoreInnerAnnotation(val moreInnerAnnotationDefault: String)
+    }
+}
+
+class GetAnnotationByTypeProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    private val annotationKClass = KotlinAnnotationWithInnerDefaults::class
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val decl = resolver.getAllFiles().single().declarations
+            .single { it.simpleName.asString() == "A" } as KSClassDeclaration
+        val anno = decl.getAnnotationsByType(annotationKClass).first()
+        results.add(anno.innerAnnotationVal.toString())
+        return emptyList()
+    }
+}

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetByNameProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetByNameProcessor.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getFunctionDeclarationsByName
 import com.google.devtools.ksp.getPropertyDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
@@ -13,6 +14,12 @@ class GetByNameProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        val classNames = listOf(
+            "lib1.Foo",
+            "lib1.Foo.FooNested",
+            "source.FooInSource",
+            "source.FooInSource.FooInSourceNested"
+        )
         val funNames = listOf(
             "lib1.Foo.lib1MemberFun",
             "lib1.lib1TopFun",
@@ -28,6 +35,11 @@ class GetByNameProcessor : AbstractTestProcessor() {
             "source.FooInSource.sourceMemberProp",
             "source.propInSource",
         )
+        for (className in classNames) {
+            if (resolver.getClassDeclarationByName(className) == null) {
+                results.add("failed to get $className")
+            }
+        }
         for (funName in funNames) {
             if (resolver.getFunctionDeclarationsByName(funName, true).none()) {
                 results.add("failed to get $funName")


### PR DESCRIPTION

* fixes #989

The root cause might be in compiler, as the compiler returns a `NotFoundClasses` for nested annotation types. 