### PR TITLE
retrieve annotations for KSType from KotlinType instead of KSTypeReference

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Nullability
 import com.google.devtools.ksp.symbol.Origin
+import com.google.devtools.ksp.symbol.impl.binary.KSAnnotationDescriptorImpl
 import com.google.devtools.ksp.symbol.impl.binary.KSTypeArgumentDescriptorImpl
 import com.google.devtools.ksp.symbol.impl.convertKotlinType
 import com.google.devtools.ksp.symbol.impl.replaceTypeArguments
@@ -33,6 +34,7 @@ import org.jetbrains.kotlin.builtins.isKFunctionType
 import org.jetbrains.kotlin.builtins.isKSuspendFunctionType
 import org.jetbrains.kotlin.builtins.isSuspendFunctionType
 import org.jetbrains.kotlin.descriptors.NotFoundClasses
+import org.jetbrains.kotlin.descriptors.SourceElement
 import org.jetbrains.kotlin.types.*
 import org.jetbrains.kotlin.types.typeUtil.TypeNullability
 import org.jetbrains.kotlin.types.typeUtil.isSubtypeOf
@@ -156,6 +158,13 @@ fun getKSTypeCached(
     ) {
         KSErrorType
     } else {
-        KSTypeImpl.getCached(kotlinType, ksTypeArguments, annotations)
+        KSTypeImpl.getCached(
+            kotlinType,
+            ksTypeArguments,
+            annotations + kotlinType.annotations
+                .filter { it.source == SourceElement.NO_SOURCE }
+                .map { KSAnnotationDescriptorImpl.getCached(it, null) }
+                .asSequence()
+        )
     }
 }

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -224,6 +224,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("testData/api/functionTypeAlias.kt")
     }
 
+    @TestMetadata("functionTypeAnnotation.kt")
+    @Test
+    fun testFunctionTypeAnnotation() {
+        runTest("testData/api/functionTypeAnnotation.kt")
+    }
+
     @TestMetadata("functionTypes.kt")
     @Test
     fun testFunctionTypes() {

--- a/compiler-plugin/testData/api/functionTypeAnnotation.kt
+++ b/compiler-plugin/testData/api/functionTypeAnnotation.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+// WITH_RUNTIME
+// TEST PROCESSOR: FunctionTypeAnnotationProcessor
+// EXPECTED:
+// strExt0: Function1 @ExtensionFunctionType
+// strExt1: Function2 @ExtensionFunctionType
+// strWithAnnoExt0: Function1 @A, @ExtensionFunctionType
+// strWithAnnoExt1: Function2 @A, @ExtensionFunctionType
+// END
+// FILE: a.kt
+annotation class A
+
+val strExt0: String.() -> Unit = TODO()
+val strExt1: String.(Int) -> Unit = TODO()
+val strWithAnnoExt0: @A String.() -> Unit = TODO()
+val strWithAnnoExt1: @A String.(@A Int) -> Unit = TODO()

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -241,6 +241,13 @@ class KSPAATest : AbstractKSPAATest() {
     }
 
     @Disabled
+    @TestMetadata("functionTypeAnnotation.kt")
+    @Test
+    fun testFunctionTypeAnnotation() {
+        runTest("testData/api/functionTypeAnnotation.kt")
+    }
+
+    @Disabled
     @TestMetadata("functionTypes.kt")
     @Test
     fun testFunctionTypes() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAnnotationProcessor.kt
@@ -1,0 +1,36 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class FunctionTypeAnnotationProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val files = resolver.getNewFiles()
+
+        files.forEach {
+            it.accept(
+                object : KSTopDownVisitor<Unit, Unit>() {
+                    override fun defaultHandler(node: KSNode, data: Unit) = Unit
+
+                    override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+                        val type = property.type.resolve()
+                        val propertyName = property.simpleName.asString()
+                        val typeName = type.declaration.simpleName.asString()
+                        results.add("$propertyName: $typeName ${type.annotations.joinToString { it.toString() }}")
+                    }
+                },
+                Unit
+            )
+        }
+        return emptyList()
+    }
+}

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeProcessor.kt
@@ -23,12 +23,10 @@ import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 open class FunctionTypeProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollector()
     val types = mutableSetOf<KSType>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val files = resolver.getNewFiles()
-        val ignoredNames = mutableSetOf<String>()
 
         files.forEach {
             it.accept(


### PR DESCRIPTION
fixes #985 

several open questions:

* defining annotations origin for KSType is tricky, as type is not part of source code. with this PR actually all annotation origins from KSType becomes library, which I actually found more meaningful, but this can be breaking change.
*  since `KotlinType.annotations` contains the full picture of the actual annotations of a kotlin type, the `annotations` parameter in `getKSTypeCached` is no longer necessary, might want to clean up in a future patch.