### PR TITLE
Unmutes more single module tests for analysis API.

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
@@ -56,4 +56,8 @@ object KSErrorType : KSType {
     override val isFunctionType: Boolean = false
 
     override val isSuspendFunctionType: Boolean = false
+
+    override fun toString(): String {
+        return "<ERROR TYPE>"
+    }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -43,7 +43,12 @@ abstract class KSPropertyAccessorImpl(
     }
 
     override val origin: Origin by lazy {
-        mapAAOrigin(ktPropertyAccessorSymbol.origin)
+        val symbolOrigin = mapAAOrigin(ktPropertyAccessorSymbol.origin)
+        if (symbolOrigin == Origin.KOTLIN && ktPropertyAccessorSymbol.psi == null) {
+            Origin.SYNTHETIC
+        } else {
+            symbolOrigin
+        }
     }
 
     override val parent: KSNode?

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -90,11 +90,11 @@ internal fun KtType.render(): String {
                 }
             }
         } else ""
-        is KtClassErrorType -> "<error>"
+        is KtClassErrorType -> "<ERROR TYPE>"
         is KtCapturedType -> asStringForDebugging()
         is KtDefinitelyNotNullType -> original.render() + "!"
         is KtDynamicType -> "<dynamic type>"
-        is KtFlexibleType -> "${lowerBound.render()}...${upperBound.render()}"
+        is KtFlexibleType -> "(${lowerBound.render()}..${upperBound.render()})"
         is KtIntegerLiteralType -> "ILT: $value"
         is KtIntersectionType ->
             this.conjuncts.joinToString(separator = " & ", prefix = "(", postfix = ")") { it.render() }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -295,14 +295,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/hello.kt")
     }
 
-    @Disabled
     @TestMetadata("implicitElements.kt")
     @Test
     fun testImplicitElements() {
         runTest("../test-utils/testData/api/implicitElements.kt")
     }
 
-    @Disabled
     @TestMetadata("implicitPropertyAccessors.kt")
     @Test
     fun testImplicitPropertyAccessors() {
@@ -344,7 +342,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/javaToKotlinMapper.kt")
     }
 
-    @Disabled
     @TestMetadata("javaTypes.kt")
     @Test
     fun testJavaTypes() {
@@ -379,7 +376,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/libOrigins.kt")
     }
 
-    @Disabled
     @TestMetadata("makeNullable.kt")
     @Test
     fun testMakeNullable() {
@@ -419,7 +415,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/overridee.kt")
     }
 
-    @Disabled
     @TestMetadata("parameterTypes.kt")
     @Test
     fun testParameterTypes() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
@@ -10,7 +10,7 @@ class ParameterTypeProcessor : AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
-        return result
+        return result.sorted()
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -21,7 +21,7 @@ class ParameterTypeProcessor : AbstractTestProcessor() {
                     }
 
                     override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
-                        result.add(valueParameter.type.resolve().toString())
+                        result.add("${valueParameter.name?.asString()}: ${valueParameter.type.resolve()}")
                     }
                 },
                 Unit

--- a/test-utils/testData/api/parameterTypes.kt
+++ b/test-utils/testData/api/parameterTypes.kt
@@ -17,18 +17,18 @@
 
 // TEST PROCESSOR: ParameterTypeProcessor
 // EXPECTED:
-// <ERROR TYPE>
-// String
-// Int
-// Int
-// <ERROR TYPE>
-// <ERROR TYPE>
+// a: Int
+// b: <ERROR TYPE>
+// c: <ERROR TYPE>
+// errorValue: <ERROR TYPE>
+// v: String
+// value: Int
 // END
 
 class Foo {
     var a: ErrorType
-    set(value) {
-        a = value
+    set(errorValue) {
+        a = errorValue
     }
     var x
         get() = "OK"


### PR DESCRIPTION
* fixed rendering logic for error types and flexible types.
* fixed origin for kotlin synthetic property accessors.
* unmuted implicitElements implicitPropertyAccessors javaTypes makeNullable parameterTypes tests.