### PR TITLE
Analysis api test framework

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ if (!extra.has("kspVersion")) {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
 }
 
 plugins {
@@ -39,6 +40,7 @@ subprojects {
         mavenCentral()
         google()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
         maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
     pluginManager.withPlugin("maven-publish") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,4 +6,5 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
     }
     val kotlinBaseVersion: String = java.util.Properties().also { props ->
         settingsDir.parentFile.resolve("gradle.properties").inputStream().use {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -135,6 +135,7 @@ repositories {
         }
     }
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
     maven("https://www.jetbrains.com/intellij-repository/snapshots")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=1.8.0-dev-2843
+kotlinBaseVersion=1.8.0-dev-3460
 agpBaseVersion=7.0.0
 intellijVersion=203.8084.24
 junitVersion=4.12

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$kotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-scripting-compiler:$kotlinBaseVersion")
+    testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$kotlinBaseVersion")
 
     libsForTesting(kotlin("stdlib", kotlinBaseVersion))
     libsForTesting(kotlin("test", kotlinBaseVersion))

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -103,6 +103,13 @@ tasks.test {
     environment("NO_FS_ROOTS_ACCESS_CHECK", "true")
     environment("PROJECT_CLASSES_DIRS", testSourceSet.output.classesDirs.asPath)
     environment("PROJECT_BUILD_DIR", buildDir)
+
+    // those properties should point to valid jars, they are needed for test environment setup and consumed by EnvironmentBasedStandardLibrariesPathProvider (if one is used as KotlinStandardLibrariesPathProvider)
+    systemProperty("org.jetbrains.kotlin.test.kotlin-stdlib", "NOT_SET")
+    systemProperty("org.jetbrains.kotlin.test.kotlin-script-runtime", "NOT_SET")
+    systemProperty("org.jetbrains.kotlin.test.kotlin-test", "NOT_SET")
+    systemProperty("org.jetbrains.kotlin.test.kotlin-annotations-jvm", "NOT_SET")
+
     testLogging {
         events("passed", "skipped", "failed")
     }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -15,6 +15,12 @@ intellij {
     version = intellijVersion
 }
 
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev")
+}
+
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
     implementation(kotlin("stdlib", kotlinBaseVersion))
@@ -116,6 +122,7 @@ repositories {
         dirs("${project.rootDir}/third_party/prebuilt/repo/")
     }
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
     maven("https://www.jetbrains.com/intellij-repository/releases")
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -230,7 +230,7 @@ internal fun ClassId.toKtClassSymbol(): KtClassOrObjectSymbol? {
                 it.asString() == this@toKtClassSymbol.shortClassName.asString()
             }?.singleOrNull() as? KtClassOrObjectSymbol
         } else {
-            this@toKtClassSymbol.getCorrespondingToplevelClassOrObjectSymbol()
+            getClassOrObjectSymbolByClassId(this@toKtClassSymbol)
         }
     }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/DummyAnalysisApiBasedTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/DummyAnalysisApiBasedTest.kt
@@ -1,0 +1,31 @@
+package com.google.devtools.ksp.impl.test
+
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KtDeclarationSymbol
+import org.jetbrains.kotlin.analysis.test.framework.base.AbstractAnalysisApiSingleFileTest
+import org.jetbrains.kotlin.analysis.test.framework.test.configurators.AnalysisApiTestConfigurator
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.test.TestMetadata
+import org.jetbrains.kotlin.test.model.TestModule
+import org.jetbrains.kotlin.test.services.*
+import org.junit.jupiter.api.Test
+
+class DummyAnalysisApiBasedTest: AbstractAnalysisApiSingleFileTest() {
+    override val configurator: AnalysisApiTestConfigurator = KspAnalysisApiTestConfigurator
+
+    override fun doTestByFileStructure(ktFile: KtFile, module: TestModule, testServices: TestServices) {
+        val actual = analyze(ktFile) {
+            ktFile.declarations
+                .map { (it.getSymbol() as KtDeclarationSymbol).render() }
+                .joinToString(separator = "\n")
+        }
+        testServices.assertions.assertEqualsToTestDataFileSibling(actual)
+    }
+
+
+    @TestMetadata("annotationValue_kt.kt")
+    @Test
+    fun testAnnotationValue_kt() {
+        runTest("../test-utils/testData/api/annotationValue_kt.kt")
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KspAnalysisApiTestConfigurator.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KspAnalysisApiTestConfigurator.kt
@@ -1,0 +1,44 @@
+package com.google.devtools.ksp.impl.test
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.analysis.api.standalone.base.project.structure.KtModuleProjectStructure
+import org.jetbrains.kotlin.analysis.api.standalone.fir.test.StandaloneModeConfigurator
+import org.jetbrains.kotlin.analysis.test.framework.test.configurators.AnalysisApiTestConfigurator
+import org.jetbrains.kotlin.analysis.test.framework.test.configurators.AnalysisApiTestServiceRegistrar
+import org.jetbrains.kotlin.analysis.test.framework.test.configurators.FrontendKind
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
+import org.jetbrains.kotlin.test.services.EnvironmentBasedStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.KotlinStandardLibrariesPathProvider
+import org.jetbrains.kotlin.test.services.TestModuleStructure
+import org.jetbrains.kotlin.test.services.TestServices
+
+object KspAnalysisApiTestConfigurator : AnalysisApiTestConfigurator() {
+    override val analyseInDependentSession: Boolean get() = false
+    override val frontendKind: FrontendKind get() = FrontendKind.Fir
+
+    override val serviceRegistrars: List<AnalysisApiTestServiceRegistrar> = buildList {
+        addAll(StandaloneModeConfigurator.serviceRegistrars)
+    }
+
+    override fun configureTest(builder: TestConfigurationBuilder, disposable: Disposable) {
+        StandaloneModeConfigurator.configureTest(builder, disposable)
+
+        with(builder) {
+            useAdditionalService<KotlinStandardLibrariesPathProvider> { EnvironmentBasedStandardLibrariesPathProvider }
+        }
+    }
+
+    override fun createModules(
+        moduleStructure: TestModuleStructure,
+        testServices: TestServices,
+        project: Project
+    ): KtModuleProjectStructure {
+        return StandaloneModeConfigurator.createModules(moduleStructure, testServices, project)
+    }
+
+    override fun doOutOfBlockModification(file: KtFile) {
+        StandaloneModeConfigurator.doOutOfBlockModification(file)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
     repositories {
         gradlePluginPortal()
         maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
         maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
     val kotlinBaseVersion: String by settings

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,6 @@ include("compiler-plugin")
 include("symbol-processing")
 include("symbol-processing-cmdline")
 include("integration-tests")
-include("kotlin-analysis-api")
 
 val kotlinProjectPath: String? by settings
 if (kotlinProjectPath != null) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ include("compiler-plugin")
 include("symbol-processing")
 include("symbol-processing-cmdline")
 include("integration-tests")
+include("kotlin-analysis-api")
 
 val kotlinProjectPath: String? by settings
 if (kotlinProjectPath != null) {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -30,5 +30,6 @@ dependencies {
 
 repositories {
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/dev/")
     maven("https://www.jetbrains.com/intellij-repository/releases")
 }

--- a/test-utils/testData/api/annotationValue_kt.txt
+++ b/test-utils/testData/api/annotationValue_kt.txt
@@ -1,0 +1,5 @@
+enum class RGB
+class ThrowsClass
+annotation class Foo
+annotation class Bar
+fun Fun()


### PR DESCRIPTION
While publishing the Analysis API test framework, I checked how it works on the KSP side (this PR). I've published a special nightly Kotlin build `1.8.0-dev-3460`, where the Analysis API test framework is available. Added `DummyAnalysisApiBasedTest` does not integrate with KSP in any way; it just checks that Analysis API-related functionality works. 

Feel free to close this PR :)
