### PR TITLE
respect nullability annotations on Java type references.

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -297,6 +297,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("../test-utils/testData/api/javaModifiers.kt")
     }
 
+    @TestMetadata("javaNonNullTypes.kt")
+    @Test
+    fun testJavaNonNullTypes() {
+        runTest("../test-utils/testData/api/javaNonNullTypes.kt")
+    }
+
     @TestMetadata("javaSubtype.kt")
     @Test
     fun testJavaSubtype() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -329,6 +329,13 @@ class KSPAATest : AbstractKSPAATest() {
     }
 
     @Disabled
+    @TestMetadata("javaNonNullTypes.kt")
+    @Test
+    fun testJavaNonNullTypes() {
+        runTest("../test-utils/testData/api/javaNonNullTypes.kt")
+    }
+
+    @Disabled
     @TestMetadata("javaSubtype.kt")
     @Test
     fun testJavaSubtype() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaNonNullProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaNonNullProcessor.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.visitor.KSTopDownVisitor
+
+class JavaNonNullProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getNewFiles().forEach {
+            it.accept(
+                object : KSTopDownVisitor<Unit, Unit>() {
+                    override fun defaultHandler(node: KSNode, data: Unit) {
+                    }
+
+                    override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
+                        if (function.isConstructor()) {
+                            return
+                        }
+                        results.add("${function.simpleName.asString()}: ${function.returnType?.resolve()?.nullability}")
+                        super.visitFunctionDeclaration(function, data)
+                    }
+
+                    override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {
+                        results.add("${property.simpleName.asString()}: ${property.type.resolve().nullability}")
+                    }
+
+                    override fun visitValueParameter(valueParameter: KSValueParameter, data: Unit) {
+                        results.add("${valueParameter.name?.asString()}: ${valueParameter.type.resolve().nullability}")
+                    }
+                },
+                Unit
+            )
+        }
+        return emptyList()
+    }
+}

--- a/test-utils/testData/api/javaNonNullTypes.kt
+++ b/test-utils/testData/api/javaNonNullTypes.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: JavaNonNullProcessor
+// EXPECTED:
+// javaNotNullFieldRef: NOT_NULL
+// javaNullableFieldRef: NULLABLE
+// javaBothFieldRef: PLATFORM
+// javaNoneFieldRef: NULLABLE
+// bothField: PLATFORM
+// nullableField: NULLABLE
+// notNullField: NOT_NULL
+// noneField: PLATFORM
+// notNullFun: NOT_NULL
+// nullableParam: NULLABLE
+// END
+// MODULE: lib
+// FILE: dummy.kt
+class dummy
+
+// FILE: org/jetbrains/annotations/NotNull.java
+package org.jetbrains.annotations;
+
+public @interface NotNull {
+
+}
+
+// FILE: org/jetbrains/annotations/Nullable.java
+package org.jetbrains.annotations;
+
+public @interface Nullable {
+
+}
+
+// MODULE: main(lib)
+// FILE: a.kt
+val javaNotNullFieldRef = JavaNonNull().notNullField
+val javaNullableFieldRef = JavaNonNull().nullableField
+val javaBothFieldRef = JavaNonNull().bothField
+val javaNoneFieldRef = JavaNonNull().nonField
+
+
+// FILE: JavaNonNull.java
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+
+public class JavaNonNull {
+    @Nullable
+    @NotNull
+    public String bothField;
+
+    @Nullable
+    public String nullableField;
+
+    @NotNull
+    public String notNullField;
+
+    public String noneField;
+
+    @NotNull
+    public String notNullFun(@Nullable String nullableParam) {}
+}


### PR DESCRIPTION
* for referenced java types, compiler already handles nullability annotations.
* fixes #167