### PR TITLE
Block other compiler plugins by default

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -37,7 +37,8 @@ open class KspExtension {
         commandLineArgumentProviders.add(arg)
     }
 
-    open var blockOtherCompilerPlugins: Boolean = false
+    @Deprecated("KSP will stop supporting other compiler plugins in KSP's Gradle tasks after 1.0.8.")
+    open var blockOtherCompilerPlugins: Boolean = true
 
     // Instruct KSP to pickup sources from compile tasks, instead of source sets.
     // Note that it depends on behaviors of other Gradle plugins, that may bring surprises and can be hard to debug.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -358,6 +358,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                         // KotlinNativeCompile computes -Xplugin=... from compilerPluginClasspath.
                         kspTask.compilerPluginClasspath = project.configurations.getByName(pluginConfigurationName)
                         kspTask.commonSources.from(kotlinCompileTask.commonSources)
+                        kspTask.compilerPluginOptions.addPluginArgument(kotlinCompileTask.compilerPluginOptions)
                     }
                 }
             }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -59,7 +59,7 @@ class PlaygroundIT {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         File(project.root, "workload/build.gradle.kts")
-            .appendText("\nksp {\n  blockOtherCompilerPlugins = true\n}\n")
+            .appendText("\nksp {\n  blockOtherCompilerPlugins = false\n}\n")
         gradleRunner.buildAndCheck("clean", "build")
         gradleRunner.buildAndCheck("clean", "build")
         project.restore("workload/build.gradle.kts")


### PR DESCRIPTION
and deprecate `blockOtherPlugins`.

Fixes #897 

There's still no real test yet because no built-in plugin runs before `AnalysisHandlerExtension`; The existing test only checks whether it builds.