### PR TITLE
AA: type alias and reference elements.

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KSPUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KSPUtils.kt
@@ -1,0 +1,18 @@
+package com.google.devtools.ksp
+
+class IdKey<T>(private val k: T) {
+    override fun equals(other: Any?): Boolean = if (other is IdKey<*>) k === other.k else false
+    override fun hashCode(): Int = k.hashCode()
+}
+
+class IdKeyPair<T, P>(private val k1: T, private val k2: P) {
+    override fun equals(other: Any?): Boolean = if (other is IdKeyPair<*, *>) k1 === other.k1 &&
+        k2 === other.k2 else false
+    override fun hashCode(): Int = k1.hashCode() * 31 + k2.hashCode()
+}
+
+class IdKeyTriple<T, P, Q>(private val k1: T, private val k2: P, private val k3: Q) {
+    override fun equals(other: Any?): Boolean = if (other is IdKeyTriple<*, *, *>) k1 === other.k1 &&
+        k2 === other.k2 && k3 === other.k3 else false
+    override fun hashCode(): Int = k1.hashCode() * 31 * 31 + k2.hashCode() * 31 + k3.hashCode()
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeArgumentDescriptorImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
+import com.google.devtools.ksp.IdKeyTriple
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSNode
@@ -25,7 +26,6 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
-import com.google.devtools.ksp.symbol.impl.kotlin.IdKeyTriple
 import com.google.devtools.ksp.symbol.impl.kotlin.KSTypeArgumentImpl
 import org.jetbrains.kotlin.types.TypeProjection
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSTypeReferenceDescriptorImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.symbol.impl.binary
 
+import com.google.devtools.ksp.IdKeyTriple
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -29,7 +30,6 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
-import com.google.devtools.ksp.symbol.impl.kotlin.IdKeyTriple
 import com.google.devtools.ksp.symbol.impl.kotlin.getKSTypeCached
 import org.jetbrains.kotlin.builtins.isSuspendFunctionTypeOrSubtype
 import org.jetbrains.kotlin.types.KotlinType

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.symbol.impl.kotlin
 
+import com.google.devtools.ksp.IdKey
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -129,23 +130,6 @@ class KSTypeImpl private constructor(
 
     override val isSuspendFunctionType: Boolean
         get() = kotlinType.isSuspendFunctionType || kotlinType.isKSuspendFunctionType
-}
-
-class IdKey<T>(private val k: T) {
-    override fun equals(other: Any?): Boolean = if (other is IdKey<*>) k === other.k else false
-    override fun hashCode(): Int = k.hashCode()
-}
-
-class IdKeyPair<T, P>(private val k1: T, private val k2: P) {
-    override fun equals(other: Any?): Boolean = if (other is IdKeyPair<*, *>) k1 === other.k1 &&
-        k2 === other.k2 else false
-    override fun hashCode(): Int = k1.hashCode() * 31 + k2.hashCode()
-}
-
-class IdKeyTriple<T, P, Q>(private val k1: T, private val k2: P, private val k3: Q) {
-    override fun equals(other: Any?): Boolean = if (other is IdKeyTriple<*, *, *>) k1 === other.k1 &&
-        k2 === other.k2 && k3 === other.k3 else false
-    override fun hashCode(): Int = k1.hashCode() * 31 * 31 + k2.hashCode() * 31 + k3.hashCode()
 }
 
 fun getKSTypeCached(

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSTypeReferenceSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSTypeReferenceSyntheticImpl.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.symbol.impl.synthetic
 
+import com.google.devtools.ksp.IdKey
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSNode
@@ -11,7 +12,6 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
-import com.google.devtools.ksp.symbol.impl.kotlin.IdKey
 
 class KSTypeReferenceSyntheticImpl(val ksType: KSType, override val parent: KSNode?) : KSTypeReference {
     companion object : KSObjectCache<Pair<IdKey<KSType>, KSNode?>, KSTypeReferenceSyntheticImpl>() {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
@@ -1,0 +1,36 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.IdKeyPair
+import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.symbol.*
+import org.jetbrains.kotlin.analysis.api.types.KtFunctionalType
+import org.jetbrains.kotlin.analysis.api.types.KtType
+
+class KSCallableReferenceImpl private constructor(
+    private val ktFunctionalType: KtFunctionalType,
+    override val parent: KSNode
+) : KSCallableReference {
+    companion object : KSObjectCache<IdKeyPair<KtType, KSNode>, KSCallableReference>() {
+        fun getCached(ktFunctionalType: KtFunctionalType, parent: KSNode): KSCallableReference =
+            cache.getOrPut(IdKeyPair(ktFunctionalType, parent)) { KSCallableReferenceImpl(ktFunctionalType, parent) }
+    }
+    override val receiverType: KSTypeReference?
+        get() = ktFunctionalType.receiverType?.let { KSTypeReferenceImpl.getCached(it) }
+
+    override val functionParameters: List<KSValueParameter>
+        get() = ktFunctionalType.parameterTypes.map {
+            KSValueParameterLiteImpl.getCached(it, this@KSCallableReferenceImpl)
+        }
+
+    override val returnType: KSTypeReference
+        get() = KSTypeReferenceImpl.getCached(ktFunctionalType.returnType)
+
+    override val typeArguments: List<KSTypeArgument>
+        get() = ktFunctionalType.typeArguments.map { KSTypeArgumentImpl.getCached(it, this) }
+
+    override val origin: Origin
+        get() = parent.origin
+
+    override val location: Location
+        get() = parent.location
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.analysis.api.components.buildClassType
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
-class KSClassDeclarationImpl private constructor(private val ktClassOrObjectSymbol: KtClassOrObjectSymbol) :
+class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSymbol: KtClassOrObjectSymbol) :
     KSClassDeclaration,
     AbstractKSDeclarationImpl(ktClassOrObjectSymbol),
     KSExpectActual by KSExpectActualImpl(ktClassOrObjectSymbol) {
@@ -56,7 +56,9 @@ class KSClassDeclarationImpl private constructor(private val ktClassOrObjectSymb
 
     override val superTypes: Sequence<KSTypeReference> by lazy {
         analyze {
-            ktClassOrObjectSymbol.superTypes.map { KSTypeReferenceImpl(it) }.asSequence()
+            ktClassOrObjectSymbol.superTypes.mapIndexed { index, type ->
+                KSTypeReferenceImpl.getCached(type, this@KSClassDeclarationImpl, index)
+            }.asSequence()
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
@@ -1,0 +1,37 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.IdKeyPair
+import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.symbol.*
+import org.jetbrains.kotlin.analysis.api.components.buildClassType
+import org.jetbrains.kotlin.analysis.api.types.KtUsualClassType
+
+class KSClassifierReferenceImpl private constructor(
+    internal val ktType: KtUsualClassType,
+    override val parent: KSTypeReference?
+) : KSClassifierReference {
+    companion object : KSObjectCache<IdKeyPair<KtUsualClassType, KSTypeReference?>, KSClassifierReferenceImpl>() {
+        fun getCached(ktType: KtUsualClassType, parent: KSTypeReference?) =
+            cache.getOrPut(IdKeyPair(ktType, parent)) { KSClassifierReferenceImpl(ktType, parent) }
+    }
+    override val qualifier: KSClassifierReference? by lazy {
+        ktType.classId.outerClassId?.let {
+            analyze {
+                buildClassType(it)
+            }
+        }?.let { getCached(it as KtUsualClassType, parent) }
+    }
+
+    override fun referencedName(): String {
+        return ktType.classId.asFqNameString()
+    }
+
+    override val typeArguments: List<KSTypeArgument> by lazy {
+        ktType.typeArguments.map { KSTypeArgumentImpl.getCached(it, this) }
+    }
+
+    override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC
+
+    override val location: Location
+        get() = parent?.location ?: NonExistLocation
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
@@ -1,0 +1,26 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.symbol.*
+
+class KSDynamicReferenceImpl private constructor(override val parent: KSNode?) : KSDynamicReference {
+    companion object : KSObjectCache<KSTypeReference, KSDynamicReferenceImpl>() {
+        fun getCached(parent: KSTypeReference) = cache.getOrPut(parent) { KSDynamicReferenceImpl(parent) }
+    }
+
+    override val origin = Origin.KOTLIN
+
+    override val location: Location by lazy {
+        NonExistLocation
+    }
+
+    override val typeArguments: List<KSTypeArgument> = emptyList()
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitDynamicReference(this, data)
+    }
+
+    override fun toString(): String {
+        return "<dynamic type>"
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -52,14 +52,16 @@ class KSFunctionDeclarationImpl private constructor(private val ktFunctionSymbol
             if (!ktFunctionSymbol.isExtension) {
                 null
             } else {
-                ktFunctionSymbol.receiverType?.let { KSTypeReferenceImpl(it) }
+                ktFunctionSymbol.receiverType?.let {
+                    KSTypeReferenceImpl.getCached(it, this@KSFunctionDeclarationImpl)
+                }
             }
         }
     }
 
     override val returnType: KSTypeReference? by lazy {
         analyze {
-            KSTypeReferenceImpl(ktFunctionSymbol.returnType)
+            KSTypeReferenceImpl.getCached(ktFunctionSymbol.returnType, this@KSFunctionDeclarationImpl)
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -52,7 +52,7 @@ abstract class KSPropertyAccessorImpl(
     }
 
     override val parent: KSNode?
-        get() = TODO("Not yet implemented")
+        get() = ktPropertyAccessorSymbol.getContainingKSSymbol()
 }
 
 class KSPropertySetterImpl private constructor(
@@ -87,7 +87,7 @@ class KSPropertyGetterImpl private constructor(
     }
 
     override val returnType: KSTypeReference? by lazy {
-        KSTypeReferenceImpl(getter.returnType)
+        KSTypeReferenceImpl.getCached(getter.returnType, this@KSPropertyGetterImpl)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -39,11 +39,11 @@ class KSPropertyDeclarationImpl private constructor(private val ktPropertySymbol
     }
 
     override val extensionReceiver: KSTypeReference? by lazy {
-        ktPropertySymbol.receiverType?.let { KSTypeReferenceImpl(it) }
+        ktPropertySymbol.receiverType?.let { KSTypeReferenceImpl.getCached(it, this@KSPropertyDeclarationImpl) }
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceImpl(ktPropertySymbol.returnType)
+        KSTypeReferenceImpl.getCached(ktPropertySymbol.returnType, this@KSPropertyDeclarationImpl)
     }
 
     override val isMutable: Boolean by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -31,7 +31,7 @@ class KSPropertyDeclarationJavaImpl private constructor(private val ktJavaFieldS
         get() = null
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceImpl.getCached(ktJavaFieldSymbol.returnType)
+        KSTypeReferenceImpl.getCached(ktJavaFieldSymbol.returnType, this@KSPropertyDeclarationJavaImpl)
     }
 
     override val isMutable: Boolean

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
@@ -39,7 +39,7 @@ class KSTypeAliasImpl private constructor(private val ktTypeAliasSymbol: KtTypeA
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceImpl.getCached(ktTypeAliasSymbol.expandedType)
+        KSTypeReferenceImpl.getCached(ktTypeAliasSymbol.expandedType, this)
     }
 
     override val simpleName: KSName

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.IdKeyPair
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSNode
@@ -30,10 +31,11 @@ import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
 import org.jetbrains.kotlin.analysis.api.KtTypeArgument
 import org.jetbrains.kotlin.analysis.api.KtTypeArgumentWithVariance
 
-class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeArgument) : KSTypeArgument {
-    companion object : KSObjectCache<KtTypeArgument, KSTypeArgumentImpl>() {
-        fun getCached(ktTypeArgument: KtTypeArgument) =
-            cache.getOrPut(ktTypeArgument) { KSTypeArgumentImpl(ktTypeArgument) }
+class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeArgument, override val parent: KSNode?) :
+    KSTypeArgument {
+    companion object : KSObjectCache<IdKeyPair<KtTypeArgument, KSNode?>, KSTypeArgumentImpl>() {
+        fun getCached(ktTypeArgument: KtTypeArgument, parent: KSNode? = null) =
+            cache.getOrPut(IdKeyPair(ktTypeArgument, parent)) { KSTypeArgumentImpl(ktTypeArgument, parent) }
     }
 
     override val variance: Variance by lazy {
@@ -58,12 +60,9 @@ class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeA
         ktTypeArgument.type?.annotations() ?: emptySequence()
     }
 
-    override val origin: Origin = Origin.KOTLIN
+    override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC
 
     override val location: Location
-        get() = TODO("Not yet implemented")
-
-    override val parent: KSNode?
         get() = TODO("Not yet implemented")
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
@@ -51,7 +51,7 @@ class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeA
     }
 
     override val type: KSTypeReference? by lazy {
-        ktTypeArgument.type?.let { KSTypeReferenceImpl(it) }
+        ktTypeArgument.type?.let { KSTypeReferenceImpl.getCached(it, this@KSTypeArgumentImpl) }
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentLiteImpl.kt
@@ -11,7 +11,8 @@ import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
 
-class KSTypeArgumentLiteImpl(override val type: KSTypeReference, override val variance: Variance) : KSTypeArgument {
+class KSTypeArgumentLiteImpl private constructor(override val type: KSTypeReference, override val variance: Variance) :
+    KSTypeArgument {
     companion object : KSObjectCache<Pair<KSTypeReference, Variance>, KSTypeArgument>() {
         fun getCached(type: KSTypeReference, variance: Variance) = cache.getOrPut(Pair(type, variance)) {
             KSTypeArgumentLiteImpl(type, variance)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
 
-class KSTypeParameterImpl private constructor(private val ktTypeParameterSymbol: KtTypeParameterSymbol) :
+class KSTypeParameterImpl private constructor(internal val ktTypeParameterSymbol: KtTypeParameterSymbol) :
     KSTypeParameter,
     AbstractKSDeclarationImpl(ktTypeParameterSymbol),
     KSExpectActual by KSExpectActualImpl(ktTypeParameterSymbol) {
@@ -45,7 +45,9 @@ class KSTypeParameterImpl private constructor(private val ktTypeParameterSymbol:
     override val isReified: Boolean = ktTypeParameterSymbol.isReified
 
     override val bounds: Sequence<KSTypeReference> by lazy {
-        ktTypeParameterSymbol.upperBounds.asSequence().map { KSTypeReferenceImpl(it) }
+        ktTypeParameterSymbol.upperBounds.asSequence().mapIndexed { index, type ->
+            KSTypeReferenceImpl.getCached(type, this@KSTypeParameterImpl, index)
+        }
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -27,10 +27,7 @@ import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
-import org.jetbrains.kotlin.analysis.api.types.KtClassErrorType
-import org.jetbrains.kotlin.analysis.api.types.KtFunctionalType
-import org.jetbrains.kotlin.analysis.api.types.KtNonErrorClassType
-import org.jetbrains.kotlin.analysis.api.types.KtType
+import org.jetbrains.kotlin.analysis.api.types.*
 
 class KSTypeReferenceImpl(private val ktType: KtType) : KSTypeReference {
     companion object : KSObjectCache<KtType, KSTypeReference>() {
@@ -43,10 +40,7 @@ class KSTypeReferenceImpl(private val ktType: KtType) : KSTypeReference {
         // TODO: non exist type returns KtNonErrorClassType, check upstream for KtClassErrorType usage.
         return if (
             analyze {
-                ktType is KtClassErrorType || (
-                    (ktType is KtNonErrorClassType) &&
-                        ktType.classId.toKtClassSymbol() == null
-                    )
+                ktType is KtClassErrorType || (ktType.classifierSymbol() == null)
             }
         ) {
             KSErrorType

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -34,7 +34,7 @@ class KSValueParameterImpl private constructor(
     }
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceImpl(ktValueParameterSymbol.returnType)
+        KSTypeReferenceImpl.getCached(ktValueParameterSymbol.returnType, this@KSValueParameterImpl)
     }
 
     override val isVararg: Boolean by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterLiteImpl.kt
@@ -1,0 +1,42 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.IdKeyPair
+import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.symbol.*
+import org.jetbrains.kotlin.analysis.api.types.KtType
+
+class KSValueParameterLiteImpl private constructor(private val ktType: KtType, override val parent: KSNode) :
+    KSValueParameter {
+    companion object : KSObjectCache<IdKeyPair<KtType, KSNode>, KSValueParameter>() {
+        fun getCached(ktType: KtType, parent: KSNode): KSValueParameter = cache.getOrPut(IdKeyPair(ktType, parent)) {
+            KSValueParameterLiteImpl(ktType, parent)
+        }
+    }
+
+    // preferably maybe use empty name to match compiler, but use underscore to match FE1.0 implementation.
+    override val name: KSName = KSNameImpl.getCached("_")
+
+    override val type: KSTypeReference = KSTypeReferenceImpl.getCached(ktType)
+
+    override val isVararg: Boolean = false
+
+    override val isNoInline: Boolean = false
+
+    override val isCrossInline: Boolean = false
+
+    override val isVal: Boolean = false
+
+    override val isVar: Boolean = false
+
+    override val hasDefault: Boolean = false
+
+    override val annotations: Sequence<KSAnnotation> = emptySequence()
+
+    override val origin: Origin = parent.origin
+
+    override val location: Location = parent.location
+
+    override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
+        return visitor.visitValueParameter(this, data)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -182,6 +182,7 @@ internal fun KtSymbol.getContainingKSSymbol(): KSDeclaration? {
         when (val containingSymbol = this@getContainingKSSymbol.getContainingSymbol()) {
             is KtNamedClassOrObjectSymbol -> KSClassDeclarationImpl.getCached(containingSymbol)
             is KtFunctionLikeSymbol -> KSFunctionDeclarationImpl.getCached(containingSymbol)
+            is KtPropertySymbol -> KSPropertyDeclarationImpl.getCached(containingSymbol)
             else -> null
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -28,36 +28,16 @@ import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
 import org.jetbrains.kotlin.analysis.api.KtTypeArgument
 import org.jetbrains.kotlin.analysis.api.KtTypeArgumentWithVariance
 import org.jetbrains.kotlin.analysis.api.analyze
-import org.jetbrains.kotlin.analysis.api.annotations.KtAnnotated
-import org.jetbrains.kotlin.analysis.api.annotations.annotations
+import org.jetbrains.kotlin.analysis.api.annotations.*
 import org.jetbrains.kotlin.analysis.api.lifetime.KtAlwaysAccessibleLifetimeToken
 import org.jetbrains.kotlin.analysis.api.lifetime.KtAlwaysAccessibleLifetimeTokenFactory
-import org.jetbrains.kotlin.analysis.api.symbols.KtClassOrObjectSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtEnumEntrySymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtFileSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtJavaFieldSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtSymbolOrigin
-import org.jetbrains.kotlin.analysis.api.symbols.KtTypeAliasSymbol
-import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithMembers
-import org.jetbrains.kotlin.analysis.api.types.KtCapturedType
-import org.jetbrains.kotlin.analysis.api.types.KtClassErrorType
-import org.jetbrains.kotlin.analysis.api.types.KtDefinitelyNotNullType
-import org.jetbrains.kotlin.analysis.api.types.KtDynamicType
-import org.jetbrains.kotlin.analysis.api.types.KtFlexibleType
-import org.jetbrains.kotlin.analysis.api.types.KtIntegerLiteralType
-import org.jetbrains.kotlin.analysis.api.types.KtIntersectionType
-import org.jetbrains.kotlin.analysis.api.types.KtNonErrorClassType
-import org.jetbrains.kotlin.analysis.api.types.KtType
-import org.jetbrains.kotlin.analysis.api.types.KtTypeNullability
-import org.jetbrains.kotlin.analysis.api.types.KtTypeParameterType
+import org.jetbrains.kotlin.analysis.api.types.*
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.types.Variance
+import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 internal val ktSymbolOriginToOrigin = mapOf(
@@ -232,5 +212,24 @@ internal fun ClassId.toKtClassSymbol(): KtClassOrObjectSymbol? {
         } else {
             this@toKtClassSymbol.getCorrespondingToplevelClassOrObjectSymbol()
         }
+    }
+}
+
+internal fun KtType.classifierSymbol(): KtClassifierSymbol? {
+    return try {
+        when (this) {
+            is KtTypeParameterType -> this.symbol
+            is KtCapturedType -> TODO("fix in upstream")
+            is KtClassErrorType -> null
+            is KtFunctionalType -> classSymbol
+            is KtUsualClassType -> classSymbol
+            is KtDefinitelyNotNullType -> original.classifierSymbol()
+            is KtDynamicType -> null
+            is KtFlexibleType -> lowerBound.classifierSymbol()
+            is KtIntegerLiteralType -> null
+            is KtIntersectionType -> null
+        }
+    } catch (e: KotlinExceptionWithAttachments) {
+        null
     }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -396,6 +396,7 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/multipleModules.kt")
     }
 
+    @Disabled
     @TestMetadata("nestedClassType.kt")
     @Test
     fun testNestedClassType() {
@@ -539,7 +540,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/typeAlias.kt")
     }
 
-    @Disabled
     @TestMetadata("typeAliasComparison.kt")
     @Test
     fun testTypeAliasComparison() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -533,7 +533,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/topLevelMembers.kt")
     }
 
-    @Disabled
     @TestMetadata("typeAlias.kt")
     @Test
     fun testTypeAlias() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
@@ -37,7 +37,9 @@ open class TypeAliasComparisonProcessor : AbstractTestProcessor() {
             listOf(this) + ((this.declaration as? KSTypeAlias)?.type?.resolve()?.aliases() ?: emptyList())
 
         val interesting = setOf("Anno", "Bnno")
-        val iRefs = refs.filterNot { it.annotations.all { it.shortName.asString() !in interesting } }
+        val iRefs = refs.filterNot {
+            it.origin != Origin.KOTLIN || it.annotations.all { it.shortName.asString() !in interesting }
+        }
         val types = iRefs.map { it.resolve()!! }.flatMap { it.aliases() }
 
         for (i in types) {
@@ -49,7 +51,7 @@ open class TypeAliasComparisonProcessor : AbstractTestProcessor() {
     }
 
     override fun toResult(): List<String> {
-        return results
+        return results.sorted()
     }
 }
 

--- a/test-utils/testData/api/typeAlias.kt
+++ b/test-utils/testData/api/typeAlias.kt
@@ -20,7 +20,7 @@
 // EXPECTED:
 // a : A = String
 // b : B = String
-// c : C = A = String
+// c : CC = A = String
 // d : String
 // listOfInt : ListOfInt = List<Int>
 // listOfInt_B : ListOfInt_B = ListOfInt = List<Int>
@@ -33,7 +33,7 @@
 
 typealias A = String
 typealias B = String
-typealias C = A
+typealias CC = A
 typealias ListOfInt = List<Int>
 typealias ListOfInt_B = ListOfInt
 typealias ListOfInt_C = ListOfInt_B
@@ -44,7 +44,7 @@ typealias MyList_B_String = MyList_B<String>
 
 val a: A = ""
 val b: B = ""
-val c: C = ""
+val c: CC = ""
 val d: String = ""
 val listOfInt: ListOfInt = TODO()
 val listOfInt_B: ListOfInt_B = TODO()

--- a/test-utils/testData/api/typeAliasComparison.kt
+++ b/test-utils/testData/api/typeAliasComparison.kt
@@ -18,22 +18,22 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: TypeAliasComparisonProcessor
 // EXPECTED:
+// String = String : true
+// String = String : true
+// String = String : true
+// String = String : true
+// String = [@Anno] [typealias F] : true
+// String = [@Anno] [typealias F] : true
+// String = [@Bnno] [typealias F] : true
+// String = [@Bnno] [typealias F] : true
+// [@Anno] [typealias F] = String : true
+// [@Anno] [typealias F] = String : true
 // [@Anno] [typealias F] = [@Anno] [typealias F] : true
-// [@Anno] [typealias F] = String : true
 // [@Anno] [typealias F] = [@Bnno] [typealias F] : true
-// [@Anno] [typealias F] = String : true
-// String = [@Anno] [typealias F] : true
-// String = String : true
-// String = [@Bnno] [typealias F] : true
-// String = String : true
+// [@Bnno] [typealias F] = String : true
+// [@Bnno] [typealias F] = String : true
 // [@Bnno] [typealias F] = [@Anno] [typealias F] : true
-// [@Bnno] [typealias F] = String : true
 // [@Bnno] [typealias F] = [@Bnno] [typealias F] : true
-// [@Bnno] [typealias F] = String : true
-// String = [@Anno] [typealias F] : true
-// String = String : true
-// String = [@Bnno] [typealias F] : true
-// String = String : true
 // END
 
 annotation class Anno


### PR DESCRIPTION
* Handled type aliases better 
* Added parent information to some non source based KtSymbols 
* Added more rendering logic for types
* Use the correct object cache for type references.

This is not a final implementation for some of the added classes, some of the TODOs will be addressed in a follow up PR, to avoid too large PR.

TODOs:
* should use `KtTypeReference` as the wrapping element for kotlin source based type references.
* AA actually returns type annotations in more scenarios compared to FE 1.0 causing nestedClassType test to fail, need to address it in a way that tests framework should be able to handle 2 sets of expected results.
* The current ClassifierReference implementation still has some way to go in terms of correctness.