### PR TITLE
[opt] Throw exception while ksp options is null

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingPlugin.kt
@@ -70,7 +70,7 @@ class KotlinSymbolProcessingComponentRegistrar : ComponentRegistrar {
             languageVersion = configuration.languageVersionSettings.languageVersion.toKotlinVersion()
             apiVersion = configuration.languageVersionSettings.apiVersion.toKotlinVersion()
             compilerVersion = KotlinCompilerVersion.getVersion().toKotlinVersion()
-        }?.build() ?: return
+        }?.build() ?: throw IllegalStateException("ksp: ksp options not found!")
         val messageCollector = configuration.get(CLIConfigurationKeys.ORIGINAL_MESSAGE_COLLECTOR_KEY)
             ?: throw IllegalStateException("ksp: message collector not found!")
         val wrappedMessageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY)


### PR DESCRIPTION
* For ksp options is null, we shoudld consider it an anomaly, because normally ksp options should not be null. If we do not throw exception but just return, it will be considered as successful execution, so build cache and up to date will store normally. But this is a wrong execution, the plugin does not know why it is not executed, the code is not generated correctly, if the subsequent compilation depends on the code generated by ksp, an error will be reported. At the same time, if the build cache is enabled, the cache will also be saved locally. The wrong cache is obtained in the next execution, and you need clean output and clean build cache to solve this compilation error