### PR TITLE
Scan Kotlin constants for JavaPsiFacade

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinConstsInJavaIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinConstsInJavaIT.kt
@@ -1,0 +1,42 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class KotlinConstsInJavaIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("kotlin-consts-in-java")
+
+    private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
+        buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)
+
+    private fun GradleRunner.buildAndCheckOutcome(
+        vararg args: String,
+        outcome: TaskOutcome,
+        extraCheck: (BuildResult) -> Unit = {}
+    ) {
+        val result = this.withArguments(*args).build()
+
+        Assert.assertEquals(outcome, result.task(":workload:kspKotlin")?.outcome)
+
+        extraCheck(result)
+    }
+
+    @Test
+    fun testKotlinConstsInJava() {
+        // FIXME: `clean` fails to delete files on windows.
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withDebug(true)
+        gradleRunner.buildAndCheck(":workload:kspKotlin")
+
+        File(project.root, "workload/src/main/java/com/example/JavaClass.java").appendText("\n")
+        gradleRunner.buildAndCheck(":workload:kspKotlin")
+    }
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/settings.gradle.kts
@@ -1,0 +1,19 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}
+
+rootProject.name = "playground"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/build.gradle.kts
@@ -1,0 +1,24 @@
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,27 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+
+class TestProcessor(
+    private val codeGenerator: CodeGenerator,
+    private val options: Map<String, String>,
+    private val logger: KSPLogger
+) : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver
+            .getSymbolsWithAnnotation("com.example.ann.MyAnn")
+            .filterIsInstance<KSFunctionDeclaration>()
+            .forEach { func ->
+                val arg = func.annotations.first().arguments.first().value.toString()
+                if (!arg.startsWith("REPLACE"))
+                    throw IllegalStateException(arg)
+            }
+
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor =
+        TestProcessor(environment.codeGenerator, environment.options, environment.logger)
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/workload/build.gradle.kts
@@ -1,0 +1,20 @@
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    mavenCentral()
+    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation(project(":test-processor"))
+    ksp(project(":test-processor"))
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/JavaClass.java
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/JavaClass.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import com.example.ann.MyAnn;
+
+public class JavaClass {
+    @MyAnn(KotlinConsts.ACTION)
+    public void f() {
+    }
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/KotlinConsts.kt
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/KotlinConsts.kt
@@ -1,0 +1,8 @@
+package com.example
+
+class KotlinConsts {
+    companion object {
+        const val ACTION = "REPLACE"
+        const val ACTION2 = "REPLACE"
+    }
+}

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/ann/MyAnn.kt
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/workload/src/main/java/com/example/ann/MyAnn.kt
@@ -1,0 +1,3 @@
+package com.example.ann
+
+annotation class MyAnn(val value: String)


### PR DESCRIPTION
so that constants in light classes can be resolved by JavaPsiFacade.

Fixes #997.