### PR TITLE
fix relative path calculation

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
@@ -27,6 +27,7 @@ class KspOptions(
     val projectBaseDir: File,
     val compileClasspath: List<File>,
     val javaSourceRoots: List<File>,
+    val buildDir: File,
 
     val classOutputDir: File,
     val javaOutputDir: File,
@@ -58,6 +59,7 @@ class KspOptions(
         var projectBaseDir: File? = null
         val compileClasspath: MutableList<File> = mutableListOf()
         val javaSourceRoots: MutableList<File> = mutableListOf()
+        var buildDir: File? = null
 
         var classOutputDir: File? = null
         var javaOutputDir: File? = null
@@ -91,6 +93,7 @@ class KspOptions(
                 requireNotNull(projectBaseDir) { "A non-null projectBaseDir must be provided" },
                 compileClasspath,
                 javaSourceRoots,
+                requireNotNull(buildDir) { "A non-null buildDir must be provided" },
                 requireNotNull(classOutputDir) { "A non-null classOutputDir must be provided" },
                 requireNotNull(javaOutputDir) { "A non-null javaOutputDir must be provided" },
                 requireNotNull(kotlinOutputDir) { "A non-null kotlinOutputDir must be provided" },
@@ -178,6 +181,13 @@ enum class KspCliOption(
         "projectBaseDir",
         "<projectBaseDir>",
         "path to gradle project",
+        false
+    ),
+
+    BUILD_DIR_OPTION(
+        "buildDir",
+        "<buildDir>",
+        "path to build dirs",
         false
     ),
 
@@ -288,6 +298,7 @@ fun KspOptions.Builder.processOption(option: KspCliOption, value: String) = when
     KspCliOption.CACHES_DIR_OPTION -> cachesDir = File(value)
     KspCliOption.KSP_OUTPUT_DIR_OPTION -> kspOutputDir = File(value)
     KspCliOption.PROJECT_BASE_DIR_OPTION -> projectBaseDir = File(value)
+    KspCliOption.BUILD_DIR_OPTION -> buildDir = File(value)
     KspCliOption.PROCESSING_OPTIONS_OPTION -> {
         val (k, v) = value.split('=', ignoreCase = false, limit = 2)
         processingOptions.put(k, v)

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -156,11 +156,13 @@ class CodeGeneratorImpl(
     }
 
     private val File.relativeFile: File
-        get() =
-            if (this.startsWith(buildDir))
+        get() {
+            val buildDirPrefix = if (buildDir.path.startsWith("/")) buildDir.path else buildDir.path.replace("\\", "/")
+            return if (this.startsWith(buildDirPrefix))
                 relativeTo(buildDir)
             else
                 relativeTo(projectBase)
+        }
 
     private fun associate(sources: List<KSFile>, outputPath: File) {
         if (!isIncremental)

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -32,6 +32,7 @@ class CodeGeneratorImpl(
     private val javaDir: File,
     private val kotlinDir: File,
     private val resourcesDir: File,
+    private val projectBase: File,
     private val buildDir: File,
     private val anyChangesWildcard: KSFile,
     private val allSources: List<KSFile>,
@@ -154,13 +155,20 @@ class CodeGeneratorImpl(
         associate(sources, file)
     }
 
+    private val File.relativeFile: File
+        get() =
+            if (this.startsWith(buildDir))
+                relativeTo(buildDir)
+            else
+                relativeTo(projectBase)
+
     private fun associate(sources: List<KSFile>, outputPath: File) {
         if (!isIncremental)
             return
 
         val output = outputPath.relativeTo(buildDir)
         sources.forEach { source ->
-            sourceToOutputs.getOrPut(File(source.filePath).relativeTo(buildDir)) { mutableSetOf() }.add(output)
+            sourceToOutputs.getOrPut(File(source.filePath).relativeFile) { mutableSetOf() }.add(output)
         }
     }
 

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -32,7 +32,7 @@ class CodeGeneratorImpl(
     private val javaDir: File,
     private val kotlinDir: File,
     private val resourcesDir: File,
-    private val projectBase: File,
+    private val buildDir: File,
     private val anyChangesWildcard: KSFile,
     private val allSources: List<KSFile>,
     private val isIncremental: Boolean
@@ -93,7 +93,7 @@ class CodeGeneratorImpl(
     ) {
         val path = pathOf(packageName, fileName, extensionName)
         val files = classes.map {
-            it.containingFile ?: NoSourceFile(projectBase, it.qualifiedName?.asString().toString())
+            it.containingFile ?: NoSourceFile(buildDir, it.qualifiedName?.asString().toString())
         }
         associate(files, path, extensionToDirectory(extensionName))
     }
@@ -158,14 +158,14 @@ class CodeGeneratorImpl(
         if (!isIncremental)
             return
 
-        val output = outputPath.relativeTo(projectBase)
+        val output = outputPath.relativeTo(buildDir)
         sources.forEach { source ->
-            sourceToOutputs.getOrPut(File(source.filePath).relativeTo(projectBase)) { mutableSetOf() }.add(output)
+            sourceToOutputs.getOrPut(File(source.filePath).relativeTo(buildDir)) { mutableSetOf() }.add(output)
         }
     }
 
     val outputs: Set<File>
-        get() = fileMap.values.mapTo(mutableSetOf()) { it.relativeTo(projectBase) }
+        get() = fileMap.values.mapTo(mutableSetOf()) { it.relativeTo(buildDir) }
 
     override val generatedFile: Collection<File>
         get() = fileOutputStreamMap.keys.map { fileMap[it]!! }

--- a/common-util/src/test/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImplTest.kt
+++ b/common-util/src/test/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImplTest.kt
@@ -30,6 +30,7 @@ class CodeGeneratorImplTest {
             kotlinDir,
             resourcesDir,
             baseDir,
+            baseDir,
             AnyChanges(baseDir),
             emptyList(),
             true

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -230,11 +230,14 @@ class IncrementalContext(
 
     // Ugly, but better than copying the private logics out of stdlib.
     // TODO: get rid of `relativeTo` if possible.
-    private fun String.toRelativeFile(): File =
-        if (this.startsWith(buildDir.path))
+    private fun String.toRelativeFile(): File {
+        val buildDirPrefix = if (buildDir.path.startsWith("/")) buildDir.path else buildDir.path.replace("\\", "/")
+        return if (this.startsWith(buildDirPrefix)) {
             File(this).relativeTo(buildDir)
-        else
+        } else {
             File(this).relativeTo(baseDir)
+        }
+    }
 
     private val KSFile.relativeFile
         get() = filePath.toRelativeFile()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -205,7 +205,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                 options.javaOutputDir,
                 options.kotlinOutputDir,
                 options.resourceOutputDir,
-                options.projectBaseDir,
+                options.buildDir,
                 anyChangesWildcard,
                 ksFiles,
                 options.incremental

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -205,6 +205,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                 options.javaOutputDir,
                 options.kotlinOutputDir,
                 options.resourceOutputDir,
+                options.projectBaseDir,
                 options.buildDir,
                 anyChangesWildcard,
                 ksFiles,

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPCompilerPluginTest.kt
@@ -63,6 +63,7 @@ abstract class AbstractKSPCompilerPluginTest : AbstractKSPTest(FrontendKinds.Cla
                     kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
                     resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
                     projectBaseDir = testRoot
+                    buildDir = testRoot
                     cachesDir = File(testRoot, "kspTest/kspCaches")
                     kspOutputDir = File(testRoot, "kspTest")
                 }.build(),

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -163,6 +163,10 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 "returnOkOnError",
                 project.findProperty("ksp.return.ok.on.error")?.toString() ?: "true"
             )
+            options += SubpluginOption(
+                "buildDir",
+                project.project.buildDir.canonicalPath
+            )
 
             kspExtension.apOptions.forEach {
                 options += SubpluginOption("apoption", "${it.key}=${it.value}")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
@@ -38,6 +38,7 @@ class KSPCmdLineOptionsIT {
             "-Xplugin=${kspApiJar.absolutePath}",
             "-P", "plugin:$kspPluginId:apclasspath=${processorJar.absolutePath}",
             "-P", "plugin:$kspPluginId:projectBaseDir=${project.root}/build",
+            "-P", "plugin:$kspPluginId:buildDir=${project.root}/build",
             "-P", "plugin:$kspPluginId:classOutputDir=${project.root}/build",
             "-P", "plugin:$kspPluginId:javaOutputDir=${project.root}/build/out",
             "-P", "plugin:$kspPluginId:kotlinOutputDir=${project.root}/build/out",

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -43,8 +43,8 @@ class PlaygroundIT {
 
     @Test
     fun testPlayground() {
-        // FIXME: `clean` fails to delete files on windows.
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+        // FIXME: `clean` fails to delete files on windows.
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
         gradleRunner.buildAndCheck("clean", "build")
         gradleRunner.buildAndCheck("clean", "build")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -66,6 +66,28 @@ class PlaygroundIT {
     }
 
     @Test
+    fun testArbitraryBuildDir() {
+        Assume.assumeTrue(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        File(project.root, "workload/build.gradle.kts")
+            .appendText("project.buildDir = File(\"D:/build/\")")
+        val result = gradleRunner.withArguments("build").build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
+
+        val artifact = File("D:/build/libs/workload-1.0-SNAPSHOT.jar")
+        Assert.assertTrue(artifact.exists())
+
+        JarFile(artifact).use { jarFile ->
+            Assert.assertTrue(jarFile.getEntry("TestProcessor.log").size > 0)
+            Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("g/G.class").size > 0)
+            Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
+        }
+    }
+
+    @Test
     fun testAllowSourcesFromOtherPlugins() {
         fun checkGBuilder() {
             val artifact = File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -71,6 +71,7 @@ class KotlinSymbolProcessing(
             options.kotlinOutputDir,
             options.resourceOutputDir,
             options.projectBaseDir,
+            options.buildDir,
             anyChangesWildcard,
             ksFiles,
             options.incremental

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
@@ -88,6 +88,7 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
             resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
             projectBaseDir = testRoot
+            buildDir = File(testRoot, "kspTest/build")
             cachesDir = File(testRoot, "kspTest/kspCaches")
             kspOutputDir = File(testRoot, "kspTest")
         }.build()


### PR DESCRIPTION
My concern on the `startsWith` check is true, we have to fallback to try catch for better accuracy.

Open to discussion on better approach other than try catch, hence left one place unchanged, should change to try catch if we deciced to proceed with this approach.

fixes #1079 

