### PR TITLE
Explicitly set root project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "ksp"
+
 pluginManagement {
     repositories {
         gradlePluginPortal()


### PR DESCRIPTION
This recommended practice also removes a warning in certain cases involving composite builds.