### PR TITLE
Compare PSIs by PsiManager.areElementsEquivalent

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KSPUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KSPUtils.kt
@@ -1,5 +1,9 @@
 package com.google.devtools.ksp
 
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
+import org.jetbrains.kotlin.psi.psiUtil.startOffset
+
 class IdKey<T>(private val k: T) {
     override fun equals(other: Any?): Boolean = if (other is IdKey<*>) k === other.k else false
     override fun hashCode(): Int = k.hashCode()
@@ -15,4 +19,15 @@ class IdKeyTriple<T, P, Q>(private val k1: T, private val k2: P, private val k3:
     override fun equals(other: Any?): Boolean = if (other is IdKeyTriple<*, *, *>) k1 === other.k1 &&
         k2 === other.k2 && k3 === other.k3 else false
     override fun hashCode(): Int = k1.hashCode() * 31 * 31 + k2.hashCode() * 31 + k3.hashCode()
+}
+
+class PsiKey(private val k: PsiElement) {
+    override fun equals(other: Any?): Boolean =
+        other is PsiKey && k.manager.areElementsEquivalent(k, other.k)
+
+    override fun hashCode(): Int =
+        if (!k.isPhysical || !k.isValid || k.containingFile.fileType.isBinary)
+            k.hashCode()
+        else
+            k.containingFile.virtualFile.path.hashCode() * 31 * 31 + k.startOffset * 31 + k.endOffset
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSAnnotationJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
@@ -32,8 +33,8 @@ import com.intellij.psi.*
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 
 class KSAnnotationJavaImpl private constructor(val psi: PsiAnnotation) : KSAnnotation {
-    companion object : KSObjectCache<PsiAnnotation, KSAnnotationJavaImpl>() {
-        fun getCached(psi: PsiAnnotation) = cache.getOrPut(psi) { KSAnnotationJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSAnnotationJavaImpl>() {
+        fun getCached(psi: PsiAnnotation) = cache.getOrPut(PsiKey(psi)) { KSAnnotationJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
@@ -36,8 +37,8 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
     KSClassDeclaration,
     KSDeclarationJavaImpl(psi),
     KSExpectActual by KSExpectActualNoImpl() {
-    companion object : KSObjectCache<PsiEnumConstant, KSClassDeclarationJavaEnumEntryImpl>() {
-        fun getCached(psi: PsiEnumConstant) = cache.getOrPut(psi) { KSClassDeclarationJavaEnumEntryImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSClassDeclarationJavaEnumEntryImpl>() {
+        fun getCached(psi: PsiEnumConstant) = cache.getOrPut(PsiKey(psi)) { KSClassDeclarationJavaEnumEntryImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.processing.impl.ResolverImpl
@@ -44,8 +45,8 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
     KSClassDeclaration,
     KSDeclarationJavaImpl(psi),
     KSExpectActual by KSExpectActualNoImpl() {
-    companion object : KSObjectCache<PsiClass, KSClassDeclarationJavaImpl>() {
-        fun getCached(psi: PsiClass) = cache.getOrPut(psi) { KSClassDeclarationJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSClassDeclarationJavaImpl>() {
+        fun getCached(psi: PsiClass) = cache.getOrPut(PsiKey(psi)) { KSClassDeclarationJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFileJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFileJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
@@ -25,8 +26,8 @@ import com.google.devtools.ksp.symbol.impl.toLocation
 import com.intellij.psi.PsiJavaFile
 
 class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile {
-    companion object : KSObjectCache<PsiJavaFile, KSFileJavaImpl>() {
-        fun getCached(psi: PsiJavaFile) = cache.getOrPut(psi) { KSFileJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSFileJavaImpl>() {
+        fun getCached(psi: PsiJavaFile) = cache.getOrPut(PsiKey(psi)) { KSFileJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
@@ -35,8 +36,8 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) :
     KSFunctionDeclaration,
     KSDeclarationJavaImpl(psi),
     KSExpectActual by KSExpectActualNoImpl() {
-    companion object : KSObjectCache<PsiMethod, KSFunctionDeclarationJavaImpl>() {
-        fun getCached(psi: PsiMethod) = cache.getOrPut(psi) { KSFunctionDeclarationJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSFunctionDeclarationJavaImpl>() {
+        fun getCached(psi: PsiMethod) = cache.getOrPut(PsiKey(psi)) { KSFunctionDeclarationJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSPropertyDeclarationJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
@@ -32,8 +33,8 @@ class KSPropertyDeclarationJavaImpl private constructor(val psi: PsiField) :
     KSPropertyDeclaration,
     KSDeclarationJavaImpl(psi),
     KSExpectActual by KSExpectActualNoImpl() {
-    companion object : KSObjectCache<PsiField, KSPropertyDeclarationJavaImpl>() {
-        fun getCached(psi: PsiField) = cache.getOrPut(psi) { KSPropertyDeclarationJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSPropertyDeclarationJavaImpl>() {
+        fun getCached(psi: PsiField) = cache.getOrPut(PsiKey(psi)) { KSPropertyDeclarationJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeParameterJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.findParentDeclaration
@@ -31,8 +32,8 @@ class KSTypeParameterJavaImpl private constructor(val psi: PsiTypeParameter) :
     KSTypeParameter,
     KSDeclarationJavaImpl(psi),
     KSExpectActual by KSExpectActualNoImpl() {
-    companion object : KSObjectCache<PsiTypeParameter, KSTypeParameterJavaImpl>() {
-        fun getCached(psi: PsiTypeParameter) = cache.getOrPut(psi) { KSTypeParameterJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSTypeParameterJavaImpl>() {
+        fun getCached(psi: PsiTypeParameter) = cache.getOrPut(PsiKey(psi)) { KSTypeParameterJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSValueParameterJavaImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.symbol.impl.java
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.PsiKey
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
@@ -26,8 +27,8 @@ import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiParameter
 
 class KSValueParameterJavaImpl private constructor(val psi: PsiParameter) : KSValueParameter {
-    companion object : KSObjectCache<PsiParameter, KSValueParameterJavaImpl>() {
-        fun getCached(psi: PsiParameter) = cache.getOrPut(psi) { KSValueParameterJavaImpl(psi) }
+    companion object : KSObjectCache<PsiKey, KSValueParameterJavaImpl>() {
+        fun getCached(psi: PsiParameter) = cache.getOrPut(PsiKey(psi)) { KSValueParameterJavaImpl(psi) }
     }
 
     override val origin = Origin.JAVA

--- a/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/ValidateProcessor.kt
+++ b/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/ValidateProcessor.kt
@@ -8,6 +8,20 @@ class ValidateProcessor(env: SymbolProcessorEnvironment) : SymbolProcessor {
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val javaClass = resolver.getClassDeclarationByName("com.example.JavaClass")!!
+        val nestedClass = javaClass.declarations.filterIsInstance<KSClassDeclaration>()
+            .single { it.simpleName.asString() == "NestedClass" }
+        val provideString = nestedClass.declarations.filterIsInstance<KSFunctionDeclaration>()
+            .single { it.simpleName.asString() == "provideString" }
+
+        if (provideString.returnType!!.resolve().isError) {
+            logger.error("provideString.returnType: not ok")
+        }
+        if (nestedClass.asStarProjectedType().isError == true) {
+            logger.error("$javaClass.asStarProjectedType(): not ok")
+        }
+        if (!nestedClass.validate()) {
+            logger.error("Failed to validate $nestedClass")
+        }
         if (!javaClass.validate()) {
             logger.error("Failed to validate $javaClass")
         }

--- a/integration-tests/src/test/resources/javaNestedClass/workload/src/main/java/com/example/JavaClass.java
+++ b/integration-tests/src/test/resources/javaNestedClass/workload/src/main/java/com/example/JavaClass.java
@@ -9,4 +9,14 @@ public class JavaClass {
     public enum ENUM {
         R,G,B
     }
+
+    void inject(InjectionTarget t) {}
+
+    class InjectionTarget {}
+
+    static final class NestedClass {
+        static String provideString() {
+            return "str";
+        }
+    }
 }


### PR DESCRIPTION
instead of `equals`, for those PSIs returned from
`DeclarationDescripor.findPsi()`. PSIs from descriptors are different instances than PSIs from KSFileJavaImpl. Although they are structurally equivalent, `equals` returns false.