### PR TITLE
Fix DeclarationDescriptor.findPsi

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/DescriptorUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/DescriptorUtils.kt
@@ -20,11 +20,7 @@ package com.google.devtools.ksp
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Variance
-import com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
-import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.DescriptorVisibilities
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.MemberDescriptor
@@ -133,12 +129,6 @@ fun org.jetbrains.kotlin.types.Variance.toKSVariance(): Variance {
         org.jetbrains.kotlin.types.Variance.INVARIANT -> Variance.INVARIANT
         else -> throw IllegalStateException("Unexpected variance value $this, $ExceptionMessage")
     }
-}
-
-fun DeclarationDescriptor.findPsi(): PsiElement? {
-    // For synthetic members.
-    if ((this is CallableMemberDescriptor) && this.kind != CallableMemberDescriptor.Kind.DECLARATION) return null
-    return (this as? DeclarationDescriptorWithSource)?.source?.getPsi()
 }
 
 /**

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp
 
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.KSFunctionDeclarationJavaImpl
 import com.google.devtools.ksp.symbol.impl.java.KSPropertyDeclarationJavaImpl
 import com.google.devtools.ksp.visitor.KSDefaultVisitor

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -27,6 +27,7 @@ import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.impl.binary.*
 import com.google.devtools.ksp.symbol.impl.declarationsInSourceOrder
 import com.google.devtools.ksp.symbol.impl.findParentAnnotated
+import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.getInstanceForCurrentRound
 import com.google.devtools.ksp.symbol.impl.java.*
 import com.google.devtools.ksp.symbol.impl.jvmAccessFlag
@@ -1419,6 +1420,12 @@ class ResolverImpl(
     override fun isJavaRawType(type: KSType): Boolean {
         return type is KSTypeImpl && type.kotlinType.unwrap() is RawType
     }
+
+    private val psiJavaFiles = allKSFiles.filterIsInstance<KSFileJavaImpl>().map {
+        Pair(it.psi.virtualFile.path, it.psi)
+    }.toMap()
+
+    internal fun findPsiJavaFile(path: String): PsiFile? = psiJavaFiles.get(path)
 }
 
 // TODO: cross module resolution

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -19,10 +19,10 @@ package com.google.devtools.ksp.symbol.impl.binary
 
 import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.KSObjectCache
-import com.google.devtools.ksp.findPsi
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.findPsi
 import com.google.devtools.ksp.symbol.impl.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 import com.google.devtools.ksp.symbol.impl.kotlin.KSNameImpl

--- a/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/ValidateProcessor.kt
+++ b/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/ValidateProcessor.kt
@@ -8,6 +8,20 @@ class ValidateProcessor(env: SymbolProcessorEnvironment) : SymbolProcessor {
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val javaClass = resolver.getClassDeclarationByName("com.example.JavaClass")!!
+        val nestedClass = javaClass.declarations.filterIsInstance<KSClassDeclaration>()
+            .single { it.simpleName.asString() == "NestedClass" }
+        val provideString = nestedClass.declarations.filterIsInstance<KSFunctionDeclaration>()
+            .single { it.simpleName.asString() == "provideString" }
+
+        if (provideString.returnType!!.resolve().isError) {
+            logger.error("provideString.returnType: not ok")
+        }
+        if (nestedClass.asStarProjectedType().isError == true) {
+            logger.error("$javaClass.asStarProjectedType(): not ok")
+        }
+        if (!nestedClass.validate()) {
+            logger.error("Failed to validate $nestedClass")
+        }
         if (!javaClass.validate()) {
             logger.error("Failed to validate $javaClass")
         }

--- a/integration-tests/src/test/resources/javaNestedClass/workload/src/main/java/com/example/JavaClass.java
+++ b/integration-tests/src/test/resources/javaNestedClass/workload/src/main/java/com/example/JavaClass.java
@@ -9,4 +9,14 @@ public class JavaClass {
     public enum ENUM {
         R,G,B
     }
+
+    void inject(InjectionTarget t) {}
+
+    class InjectionTarget {}
+
+    static final class NestedClass {
+        static String provideString() {
+            return "str";
+        }
+    }
 }


### PR DESCRIPTION
By mapping PSIs from SourceElements to PSIs loaded by KSP.

PSIs from descriptors are different instances than PSIs from KSFileJavaImpl. Although they are structurally equivalent, `equals` returns false.