### PR TITLE
Including CommandLineArgument as SubpluginOption with KspTask

### DIFF
--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -131,7 +131,7 @@ class GradleCompilationTest {
             import androidx.room.Entity
             import androidx.room.PrimaryKey
             import androidx.room.ColumnInfo
-            
+
             @Entity
             data class User(
                 @PrimaryKey val uid: Int,
@@ -145,7 +145,7 @@ class GradleCompilationTest {
             """
             import androidx.room.Dao
             import androidx.room.Query
-            
+
             @Dao
             interface UserDao {
                 @Query("SELECT * FROM User")
@@ -158,7 +158,7 @@ class GradleCompilationTest {
             """
             import androidx.room.Database
             import androidx.room.RoomDatabase
-            
+
             @Database(entities = [User::class], version = 1)
             abstract class Database : RoomDatabase() {
                 abstract fun userDao(): UserDao
@@ -187,14 +187,14 @@ class GradleCompilationTest {
                         )
                     }
                 }
-                tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach { 
+                tasks.withType<com.google.devtools.ksp.gradle.KspTask>().configureEach {
                     doFirst {
                         options.get().forEach { option ->
                             println("${'$'}{option.key}=${'$'}{option.value}")
                         }
                     }
                 }
-                
+
             """.trimIndent()
         )
         val result = testRule.runner().withArguments(":app:assembleDebug").build()
@@ -269,7 +269,7 @@ class GradleCompilationTest {
                      }
                    }
                  }
-             """.trimIndent()
+            """.trimIndent()
         )
         val result = testRule.runner().withDebug(true).withArguments(":app:assembleDebug").build()
         val pattern1 = Regex.escape("apoption=room.schemaLocation=")


### PR DESCRIPTION
This PR proposes a solution for the issue explained in #1167

CommandLineArguments are included as SubpluginOptions through the KspExtension. With this change, we include the CommandLineArguments from the KspTask allowing ad-hoc configurations for arguments in the task:

```kotlin
tasks.withType<KspTask>().configureEach {
    commandLineArgumentProviders.add(Provider(project.layout.projectDirectory.dir("schemas-${name}").asFile))
}
```