### PR TITLE
AA: support use site annotations

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -44,7 +44,7 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationS
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {
-        ktDeclarationSymbol.annotations()
+        originalAnnotations
     }
 
     override val modifiers: Set<Modifier> by lazy {
@@ -86,4 +86,6 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationS
 
     override val docString: String?
         get() = ktDeclarationSymbol.toDocString()
+
+    internal val originalAnnotations = ktDeclarationSymbol.annotations()
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -66,7 +66,7 @@ class KSFunctionDeclarationImpl private constructor(private val ktFunctionSymbol
     }
 
     override val parameters: List<KSValueParameter> by lazy {
-        ktFunctionSymbol.valueParameters.map { KSValueParameterImpl.getCached(it) }
+        ktFunctionSymbol.valueParameters.map { KSValueParameterImpl.getCached(it, this) }
     }
 
     override fun findOverridee(): KSDeclaration? {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
@@ -59,8 +59,9 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
         }
     }
 
-    private fun compileKotlin(sourcesPath: String, outDir: File) {
+    private fun compileKotlin(dependencies: List<File>, sourcesPath: String, javaSourcePath: String, outDir: File) {
         val classpath = mutableListOf<String>()
+        classpath.addAll(dependencies.map { it.canonicalPath })
         if (File(sourcesPath).isDirectory) {
             classpath += sourcesPath
         }
@@ -68,6 +69,7 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
 
         val args = mutableListOf(
             sourcesPath,
+            javaSourcePath,
             "-d", outDir.absolutePath,
             "-no-stdlib",
             "-classpath", classpath.joinToString(File.pathSeparator)
@@ -86,8 +88,8 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
     override fun compileModule(module: TestModule, testServices: TestServices) {
         module.writeKtFiles()
         val javaFiles = module.writeJavaFiles()
-        compileKotlin(module.kotlinSrc.path, module.outDir)
         val dependencies = module.allDependencies.map { outDirForModule(it.moduleName) }
+        compileKotlin(dependencies, module.kotlinSrc.path, module.javaDir.path, module.outDir)
         val classpath = (dependencies + KtTestUtil.getAnnotationsJar() + module.outDir)
             .joinToString(File.pathSeparator) { it.absolutePath }
         val options = listOf(

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -68,7 +68,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/allFunctions_kt_inherits_java.kt")
     }
 
-    @Disabled
     @TestMetadata("annotationInDependencies.kt")
     @Test
     fun testAnnotationsInDependencies() {


### PR DESCRIPTION
there is some code copied with minor modification from FE1.0 implementation, unfortunately not reusable due to relying on implementation details, with more similar case discovered, it is also worth considering how to better abstract common logics.