### PR TITLE
AA: getDeclarationsFromPackage 

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -27,8 +27,11 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.toKSModifiers
 import com.intellij.psi.PsiModifierListOwner
+import org.jetbrains.kotlin.analysis.api.symbols.KtClassOrObjectSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtDeclarationSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtNamedClassOrObjectSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedSymbol
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 
@@ -51,6 +54,12 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationS
         when (val psi = ktDeclarationSymbol.psi) {
             is KtModifierListOwner -> psi.toKSModifiers()
             is PsiModifierListOwner -> psi.toKSModifiers()
+            null -> when (ktDeclarationSymbol) {
+                is KtPropertySymbol -> ktDeclarationSymbol.toModifiers()
+                is KtClassOrObjectSymbol -> ktDeclarationSymbol.toModifiers()
+                is KtFunctionLikeSymbol -> ktDeclarationSymbol.toModifiers()
+                else -> throw IllegalStateException("Unexpected symbol type ${ktDeclarationSymbol.javaClass}")
+            }
             else -> emptySet()
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -60,8 +60,16 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
 
     override val superTypes: Sequence<KSTypeReference> by lazy {
         analyze {
-            ktClassOrObjectSymbol.superTypes.mapIndexed { index, type ->
+            val supers = ktClassOrObjectSymbol.superTypes.mapIndexed { index, type ->
                 KSTypeReferenceImpl.getCached(type, this@KSClassDeclarationImpl, index)
+            }
+            // AA is returning additional kotlin.Any for java classes, explicitly extending kotlin.Any will result in
+            // compile error, therefore filtering by name should work.
+            // TODO: reconsider how to model super types for interface.
+            if (supers.size > 1) {
+                supers.filterNot { it.resolve().declaration.qualifiedName?.asString() == "kotlin.Any" }
+            } else {
+                supers
             }.asSequence()
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -112,3 +112,24 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
         ktClassOrObjectSymbol.declarations()
     }
 }
+
+internal fun KtClassOrObjectSymbol.toModifiers(): Set<Modifier> {
+    val result = mutableSetOf<Modifier>()
+    if (this is KtNamedClassOrObjectSymbol) {
+        result.add(modality.toModifier())
+        result.add(visibility.toModifier())
+        if (isInline) {
+            result.add(Modifier.INLINE)
+        }
+        if (isData) {
+            result.add(Modifier.DATA)
+        }
+        if (isExternal) {
+            result.add(Modifier.EXTERNAL)
+        }
+    }
+    if (classKind == KtClassKind.ENUM_CLASS) {
+        result.add(Modifier.ENUM)
+    }
+    return result
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 
-class KSFunctionDeclarationImpl private constructor(private val ktFunctionSymbol: KtFunctionLikeSymbol) :
+class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbol: KtFunctionLikeSymbol) :
     KSFunctionDeclaration,
     AbstractKSDeclarationImpl(ktFunctionSymbol),
     KSExpectActual by KSExpectActualImpl(ktFunctionSymbol) {
@@ -115,4 +115,34 @@ class KSFunctionDeclarationImpl private constructor(private val ktFunctionSymbol
             this.simpleName.asString()
         }
     }
+}
+
+internal fun KtFunctionLikeSymbol.toModifiers(): Set<Modifier> {
+    val result = mutableSetOf<Modifier>()
+    if (this is KtFunctionSymbol) {
+        result.add(visibility.toModifier())
+        result.add(modality.toModifier())
+        if (isExternal) {
+            result.add(Modifier.EXTERNAL)
+        }
+        if (isInfix) {
+            result.add(Modifier.INFIX)
+        }
+        if (isInline) {
+            result.add(Modifier.INLINE)
+        }
+        if (isStatic) {
+            result.add(Modifier.JAVA_STATIC)
+        }
+        if (isSuspend) {
+            result.add(Modifier.SUSPEND)
+        }
+        if (isOperator) {
+            result.add(Modifier.OPERATOR)
+        }
+        if (isOperator) {
+            result.add(Modifier.OVERRIDE)
+        }
+    }
+    return result
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -21,10 +21,11 @@ import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.annotations.KtAnnotationApplication
 import org.jetbrains.kotlin.analysis.api.annotations.annotations
+import org.jetbrains.kotlin.analysis.api.symbols.KtKotlinPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 
-class KSPropertyDeclarationImpl private constructor(private val ktPropertySymbol: KtPropertySymbol) :
+class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbol: KtPropertySymbol) :
     KSPropertyDeclaration,
     AbstractKSDeclarationImpl(ktPropertySymbol),
     KSExpectActual by KSExpectActualImpl(ktPropertySymbol) {
@@ -90,4 +91,26 @@ internal fun KtAnnotationApplication.isUseSiteTargetAnnotation(): Boolean {
             it == AnnotationUseSiteTarget.PROPERTY_SETTER ||
             it == AnnotationUseSiteTarget.SETTER_PARAMETER
     } ?: false
+}
+
+internal fun KtPropertySymbol.toModifiers(): Set<Modifier> {
+    val result = mutableSetOf<Modifier>()
+    result.add(visibility.toModifier())
+    if (isOverride) {
+        result.add(Modifier.OVERRIDE)
+    }
+    if (isStatic) {
+        Modifier.JAVA_STATIC
+    }
+    result.add(modality.toModifier())
+
+    if (this is KtKotlinPropertySymbol) {
+        if (isLateInit) {
+            result.add(Modifier.LATEINIT)
+        }
+        if (isConst) {
+            result.add(Modifier.CONST)
+        }
+    }
+    return result
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -35,6 +35,8 @@ import org.jetbrains.kotlin.analysis.api.lifetime.KtAlwaysAccessibleLifetimeToke
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithMembers
 import org.jetbrains.kotlin.analysis.api.types.*
+import org.jetbrains.kotlin.descriptors.Modality
+import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.types.Variance
@@ -315,4 +317,23 @@ internal fun KSAnnotated.findAnnotationFromUseSiteTarget(): Sequence<KSAnnotatio
         }
         else -> emptySequence()
     } ?: emptySequence()
+}
+
+internal fun org.jetbrains.kotlin.descriptors.Visibility.toModifier(): Modifier {
+    return when (this) {
+        Visibilities.Public -> Modifier.PUBLIC
+        Visibilities.Private -> Modifier.PRIVATE
+        Visibilities.Internal -> Modifier.INTERNAL
+        Visibilities.Protected -> Modifier.PROTECTED
+        else -> Modifier.PUBLIC
+    }
+}
+
+internal fun Modality.toModifier(): Modifier {
+    return when (this) {
+        Modality.FINAL -> Modifier.FINAL
+        Modality.ABSTRACT -> Modifier.ABSTRACT
+        Modality.OPEN -> Modifier.OPEN
+        Modality.SEALED -> Modifier.SEALED
+    }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -525,7 +525,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/signatureMapper.kt")
     }
 
-    @Disabled
     @TestMetadata("superTypes.kt")
     @Test
     fun testSuperTypes() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -374,7 +374,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/javaWildcards2.kt")
     }
 
-    @Disabled
     @TestMetadata("lateinitProperties.kt")
     @Test
     fun testLateinitProperties() {


### PR DESCRIPTION
also includes additional works to get modifiers for library symbols since they have no psi at this time. Ideally library symbols should also have PSI but it can be either expensive (likely building a stubs with more details not needed for KSP) or take a long time to be available, therefore put the current logic in place.