### PR TITLE
Sign with in-memory pgp keys

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -50,7 +50,8 @@ publishing {
 }
 
 signing {
-    isRequired = hasProperty("signingKey") && !gradle.taskGraph.hasTask("publishToMavenLocal")
+    isRequired = hasProperty("signingKey")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(extensions.getByType<PublishingExtension>().publications)
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -85,7 +85,8 @@ publishing {
 }
 
 signing {
-    isRequired = hasProperty("signingKey") && !gradle.taskGraph.hasTask("publishToMavenLocal")
+    isRequired = hasProperty("signingKey")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(extensions.getByType<PublishingExtension>().publications)
 }
 

--- a/symbol-processing-cmdline/build.gradle.kts
+++ b/symbol-processing-cmdline/build.gradle.kts
@@ -73,6 +73,7 @@ publishing {
 }
 
 signing {
-    isRequired = hasProperty("signingKey") && !gradle.taskGraph.hasTask("publishToMavenLocal")
+    isRequired = hasProperty("signingKey")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(extensions.getByType<PublishingExtension>().publications)
 }

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -77,6 +77,7 @@ publishing {
 }
 
 signing {
-    isRequired = hasProperty("signingKey") && !gradle.taskGraph.hasTask("publishToMavenLocal")
+    isRequired = hasProperty("signingKey")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(extensions.getByType<PublishingExtension>().publications)
 }


### PR DESCRIPTION
Now, instead of specifying keyring and key id in gradle.properties:
```
$ export ORG_GRADLE_PROJECT_signingKey=$(gpg --export-secret-keys --armor)
$ export ORG_GRADLE_PROJECT_signingPassword=...
```