### PR TITLE
Android Gradle Plugin: add generated kotlin sources 

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -78,7 +78,7 @@ object AndroidPluginIntegration {
         kspKotlinOutput.include("**/*.kt")
         kspClassOutput.include("**/*.class")
         kotlinCompilation.androidVariant.registerExternalAptJavaOutput(kspJavaOutput)
-        kotlinCompilation.androidVariant.addJavaSourceFoldersToModel(kspKotlinOutput.files)
+        kotlinCompilation.androidVariant.addJavaSourceFoldersToModel(kspKotlinOutput.dir)
         kotlinCompilation.androidVariant.registerPreJavacGeneratedBytecode(kspClassOutput)
         kotlinCompilation.androidVariant.registerPostJavacGeneratedBytecode(resourcesOutputDir)
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -62,19 +62,23 @@ object AndroidPluginIntegration {
             .map { it.name }
     }
 
-    fun registerGeneratedJavaSources(
+    fun registerGeneratedSources(
         project: Project,
         kotlinCompilation: KotlinJvmAndroidCompilation,
         kspTaskProvider: TaskProvider<KspTaskJvm>,
         javaOutputDir: File,
+        kotlinOutputDir: File,
         classOutputDir: File,
         resourcesOutputDir: FileCollection,
     ) {
         val kspJavaOutput = project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
+        val kspKotlinOutput = project.fileTree(kotlinOutputDir).builtBy(kspTaskProvider)
         val kspClassOutput = project.fileTree(classOutputDir).builtBy(kspTaskProvider)
         kspJavaOutput.include("**/*.java")
+        kspKotlinOutput.include("**/*.kt")
         kspClassOutput.include("**/*.class")
         kotlinCompilation.androidVariant.registerExternalAptJavaOutput(kspJavaOutput)
+        kotlinCompilation.androidVariant.addJavaSourceFoldersToModel(kspKotlinOutput.files)
         kotlinCompilation.androidVariant.registerPreJavacGeneratedBytecode(kspClassOutput)
         kotlinCompilation.androidVariant.registerPostJavacGeneratedBytecode(resourcesOutputDir)
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -448,11 +448,12 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             }
         }
         if (kotlinCompilation is KotlinJvmAndroidCompilation) {
-            AndroidPluginIntegration.registerGeneratedJavaSources(
+            AndroidPluginIntegration.registerGeneratedSources(
                 project = project,
                 kotlinCompilation = kotlinCompilation,
                 kspTaskProvider = kspTaskProvider as TaskProvider<KspTaskJvm>,
                 javaOutputDir = javaOutputDir,
+                kotlinOutputDir = kotlinOutputDir,
                 classOutputDir = classOutputDir,
                 resourcesOutputDir = project.files(resourceOutputDir)
             )

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -165,7 +165,7 @@ class SourceSetConfigurationsTest {
     }
 
     @Test
-    fun registerJavaSourcesToAndroid() {
+    fun registerGeneratedSourcesToAndroid() {
         testRule.setupAppAsAndroidApp()
         testRule.appModule.dependencies.addAll(
             listOf(
@@ -255,6 +255,21 @@ class SourceSetConfigurationsTest {
             ),
             SourceFolder(
                 "releaseUnitTest", "SRC:generated/ksp/releaseUnitTest/java"
+            ),
+            SourceFolder(
+                "debug", "SRC:generated/ksp/debug/kotlin"
+            ),
+            SourceFolder(
+                "release", "SRC:generated/ksp/release/kotlin"
+            ),
+            SourceFolder(
+                "debugAndroidTest", "SRC:generated/ksp/debugAndroidTest/kotlin"
+            ),
+            SourceFolder(
+                "debugUnitTest", "SRC:generated/ksp/debugUnitTest/kotlin"
+            ),
+            SourceFolder(
+                "releaseUnitTest", "SRC:generated/ksp/releaseUnitTest/kotlin"
             ),
             // TODO byte sources seems to be overridden by tmp/kotlin-classes/debug
             //  assert them as well once fixed


### PR DESCRIPTION
Register autogenerated kotlin source files to android plugin source set for IDE/AndriodStudio indexing