### PR TITLE
Bump dokka to 1.7.20

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     kotlin("jvm")
     `maven-publish`
     signing
-    id("org.jetbrains.dokka") version ("1.4.32")
+    id("org.jetbrains.dokka") version ("1.7.20")
 }
 
 dependencies {

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -14,7 +14,7 @@ tasks.withType<KotlinCompile> {
 plugins {
     kotlin("jvm")
     id("org.jetbrains.intellij") version "0.6.4"
-    id("org.jetbrains.dokka") version ("1.4.32")
+    id("org.jetbrains.dokka") version ("1.7.20")
 }
 
 intellij {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ tasks.withType<KotlinCompile> {
 plugins {
     kotlin("jvm")
     id("org.jetbrains.intellij") version "0.6.4"
-    id("org.jetbrains.dokka") version ("1.4.32")
+    id("org.jetbrains.dokka") version ("1.7.20")
 }
 
 intellij {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
     id("java-gradle-plugin")
     `maven-publish`
     signing
-    id("org.jetbrains.dokka") version ("1.4.32")
+    id("org.jetbrains.dokka") version ("1.7.20")
 }
 
 dependencies {

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -8,7 +8,7 @@ val libsForTesting by configurations.creating
 plugins {
     kotlin("jvm")
     id("org.jetbrains.intellij") version "0.6.4"
-    id("org.jetbrains.dokka") version ("1.4.32")
+    id("org.jetbrains.dokka") version ("1.7.20")
 }
 
 intellij {


### PR DESCRIPTION
Fixes building with JDK 17.

Without this, my build fails with:

```
> Task :api:dokkaJavadoc
Initializing plugins
Dokka is performing: documentation for api
Validity check
Creating documentation models

ERROR: Exception while analyzing expression at (294,45) in /Users/mbonnin/git/ksp/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments: Exception while analyzing expression at (294,45) in /Users/mbonnin/git/ksp/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.logOrThrowException(ExpressionTypingVisitorDispatcher.java:246)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.lambda$getTypeInfo$0(ExpressionTypingVisitorDispatcher.java:224)
        at org.jetbrains.kotlin.util.PerformanceCounter.time(PerformanceCounter.kt:101)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.getTypeInfo(ExpressionTypingVisitorDispatcher.java:164)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.getTypeInfo(ExpressionTypingVisitorDispatcher.java:134)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.getTypeInfo(ExpressionTypingVisitorDispatcher.java:146)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingServices.getBodyExpressionType(ExpressionTypingServices.java:233)
        at org.jetbrains.kotlin.resolve.DescriptorResolver.lambda$inferReturnTypeFromExpressionBody$4(DescriptorResolver.java:1223)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
        at org.jetbrains.kotlin.types.DeferredType.getDelegate(DeferredType.java:107)
        at org.jetbrains.kotlin.types.WrappedType.getConstructor(KotlinType.kt:128)
        at org.jetbrains.dokka.base.translators.descriptors.DokkaDescriptorVisitor.toBound(DefaultDescriptorToDocumentableTranslator.kt:808)
        at org.jetbrains.dokka.base.translators.descriptors.DokkaDescriptorVisitor$visitFunctionDescriptor$2.invokeSuspend(DefaultDescriptorToDocumentableTranslator.kt:490)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:106)
        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
Caused by: java.lang.IllegalStateException: Could not read class: VirtualFile: /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home!/modules/java.base/java/lang/constant/ConstantDesc.class
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass.<init>(BinaryJavaClass.kt:120)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass.<init>(BinaryJavaClass.kt:34)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl.findClass(KotlinCliJavaFileManagerImpl.kt:118)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl.findClass(KotlinCliJavaFileManagerImpl.kt:87)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl$findClass$$inlined$synchronized$lambda$1.invoke(KotlinCliJavaFileManagerImpl.kt:116)
        at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl$findClass$$inlined$synchronized$lambda$1.invoke(KotlinCliJavaFileManagerImpl.kt:48)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.ClassifierResolutionContext.resolveClass(ClassifierResolutionContext.kt:58)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.ClassifierResolutionContext.resolveByInternalName$resolution_common_jvm(ClassifierResolutionContext.kt:99)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryClassSignatureParser$parseParameterizedClassRefSignature$1.invoke(BinaryClassSignatureParser.kt:146)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryClassSignatureParser$parseParameterizedClassRefSignature$1.invoke(BinaryClassSignatureParser.kt:146)
        at kotlin.UnsafeLazyImpl.getValue(Lazy.kt:81)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.PlainJavaClassifierType.getClassifierResolverResult(Types.kt:40)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.PlainJavaClassifierType.isRaw(Types.kt:45)
        at org.jetbrains.kotlin.load.java.lazy.types.JavaTypeResolver.transformJavaClassifierType(JavaTypeResolver.kt:97)
        at org.jetbrains.kotlin.load.java.lazy.types.JavaTypeResolver.transformJavaType(JavaTypeResolver.kt:53)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaClassDescriptor$LazyJavaClassTypeConstructor.computeSupertypes(LazyJavaClassDescriptor.kt:210)
        at org.jetbrains.kotlin.types.AbstractTypeConstructor$supertypes$1.invoke(AbstractTypeConstructor.kt:82)
        at org.jetbrains.kotlin.types.AbstractTypeConstructor$supertypes$1.invoke(AbstractTypeConstructor.kt:82)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValueWithPostCompute.invoke(LockBasedStorageManager.java:481)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValueWithPostCompute.invoke(LockBasedStorageManager.java:512)
        at org.jetbrains.kotlin.types.AbstractTypeConstructor.getSupertypes(AbstractTypeConstructor.kt:29)
        at org.jetbrains.kotlin.types.AbstractTypeConstructor.getSupertypes(AbstractTypeConstructor.kt:28)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaClassMemberScope.computeFunctionNames(LazyJavaClassMemberScope.kt:75)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaClassMemberScope.computeFunctionNames(LazyJavaClassMemberScope.kt:64)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaScope$functionNamesLazy$2.invoke(LazyJavaScope.kt:270)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaScope$functionNamesLazy$2.invoke(LazyJavaScope.kt:270)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
        at org.jetbrains.kotlin.storage.StorageKt.getValue(storage.kt:42)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaScope.getFunctionNamesLazy(LazyJavaScope.kt:270)
        at org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaScope.getFunctionNames(LazyJavaScope.kt:274)
        at org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsCustomizer.getFunctionsNames(JvmBuiltInsCustomizer.kt:162)
        at org.jetbrains.kotlin.builtins.jvm.JvmBuiltInsCustomizer.getFunctionsNames(JvmBuiltInsCustomizer.kt:50)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.getNonDeclaredFunctionNames(DeserializedClassDescriptor.kt:305)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation$functionNames$2.invoke(DeserializedMemberScope.kt:258)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation$functionNames$2.invoke(DeserializedMemberScope.kt:257)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedLazyValue.invoke(LockBasedStorageManager.java:408)
        at org.jetbrains.kotlin.storage.LockBasedStorageManager$LockBasedNotNullLazyValue.invoke(LockBasedStorageManager.java:527)
        at org.jetbrains.kotlin.storage.StorageKt.getValue(storage.kt:42)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.getFunctionNames(DeserializedMemberScope.kt:257)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedMemberScope$OptimizedImplementation.getContributedFunctions(DeserializedMemberScope.kt:328)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedMemberScope.getContributedFunctions(DeserializedMemberScope.kt:82)
        at org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassDescriptor$DeserializedClassMemberScope.getContributedFunctions(DeserializedClassDescriptor.kt:244)
        at org.jetbrains.kotlin.types.expressions.BasicExpressionTypingVisitor.findEqualsWithNullableAnyParameter(BasicExpressionTypingVisitor.java:1194)
        at org.jetbrains.kotlin.types.expressions.BasicExpressionTypingVisitor.visitEquality(BasicExpressionTypingVisitor.java:1145)
        at org.jetbrains.kotlin.types.expressions.BasicExpressionTypingVisitor.visitBinaryExpression(BasicExpressionTypingVisitor.java:1069)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.visitBinaryExpression(ExpressionTypingVisitorDispatcher.java:403)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher$ForDeclarations.visitBinaryExpression(ExpressionTypingVisitorDispatcher.java:46)
        at org.jetbrains.kotlin.psi.KtBinaryExpression.accept(KtBinaryExpression.java:35)
        at org.jetbrains.kotlin.types.expressions.ExpressionTypingVisitorDispatcher.lambda$getTypeInfo$0(ExpressionTypingVisitorDispatcher.java:175)
        ... 18 more
Caused by: java.lang.UnsupportedOperationException: PermittedSubclasses requires ASM9
        at org.jetbrains.org.objectweb.asm.ClassVisitor.visitPermittedSubclass(ClassVisitor.java:266)
        at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:684)
        at org.jetbrains.org.objectweb.asm.ClassReader.accept(ClassReader.java:402)
        at org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass.<init>(BinaryJavaClass.kt:115)
        ... 68 more
```