### PR TITLE
Add `mapJavaNameToKotlinMutable` API to Resolver.

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -167,6 +167,7 @@ package com.google.devtools.ksp.processing {
     method @NonNull public com.google.devtools.ksp.symbol.KSTypeArgument getTypeArgument(@NonNull com.google.devtools.ksp.symbol.KSTypeReference typeRef, @NonNull com.google.devtools.ksp.symbol.Variance variance);
     method @com.google.devtools.ksp.KspExperimental public boolean isJavaRawType(@NonNull com.google.devtools.ksp.symbol.KSType type);
     method @Nullable @com.google.devtools.ksp.KspExperimental public com.google.devtools.ksp.symbol.KSName mapJavaNameToKotlin(@NonNull com.google.devtools.ksp.symbol.KSName javaName);
+    method @Nullable @com.google.devtools.ksp.KspExperimental public com.google.devtools.ksp.symbol.KSName mapJavaNameToKotlinMutable(@NonNull com.google.devtools.ksp.symbol.KSName javaName);
     method @Nullable @com.google.devtools.ksp.KspExperimental public com.google.devtools.ksp.symbol.KSName mapKotlinNameToJava(@NonNull com.google.devtools.ksp.symbol.KSName kotlinName);
     method @Nullable @com.google.devtools.ksp.KspExperimental public String mapToJvmSignature(@NonNull com.google.devtools.ksp.symbol.KSDeclaration declaration);
     method public boolean overrides(@NonNull com.google.devtools.ksp.symbol.KSDeclaration overrider, @NonNull com.google.devtools.ksp.symbol.KSDeclaration overridee);

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/Resolver.kt
@@ -250,9 +250,29 @@ interface Resolver {
      *
      * @param javaName a Java class name
      * @return corresponding Kotlin class name or null
+     *
+     * @see mapJavaNameToKotlinMutable
      */
     @KspExperimental
     fun mapJavaNameToKotlin(javaName: KSName): KSName?
+
+    /**
+     * Returns the corresponding Kotlin class with the given Java class, choosing mutable counterpart if applicable.
+     *
+     * E.g.
+     * java.lang.String -> kotlin.String
+     * java.lang.Integer -> kotlin.Int
+     * java.util.List -> kotlin.MutableList
+     * java.util.Map.Entry -> kotlin.MutableMap.MutableEntry
+     * java.lang.Void -> null
+     *
+     * @param javaName a Java class name
+     * @return corresponding mutable Kotlin class name or null
+     *
+     * @see mapJavaNameToKotlin
+     */
+    @KspExperimental
+    fun mapJavaNameToKotlinMutable(javaName: KSName): KSName?
 
     /**
      * Returns the corresponding Java class with the given Kotlin class.

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1127,6 +1127,18 @@ class ResolverImpl(
         JavaToKotlinClassMap.mapJavaToKotlin(FqName(javaName.asString()))?.toKSName()
 
     @KspExperimental
+    override fun mapJavaNameToKotlinMutable(javaName: KSName): KSName? {
+        var name = mapJavaNameToKotlin(javaName)
+        if (name != null) {
+            val mutable = JavaToKotlinClassMap.readOnlyToMutable(FqNameUnsafe(name.asString()))
+            if (mutable != null) {
+                name = getKSNameFromString(mutable.asString())
+            }
+        }
+        return name
+    }
+
+    @KspExperimental
     override fun mapKotlinNameToJava(kotlinName: KSName): KSName? =
         JavaToKotlinClassMap.mapKotlinToJava(FqNameUnsafe(kotlinName.asString()))?.toKSName()
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -246,6 +246,10 @@ class ResolverAAImpl(
         TODO("Not yet implemented")
     }
 
+    override fun mapJavaNameToKotlinMutable(javaName: KSName): KSName? {
+        TODO("Not yet implemented")
+    }
+
     override fun mapKotlinNameToJava(kotlinName: KSName): KSName? {
         TODO("Not yet implemented")
     }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
@@ -34,7 +34,12 @@ open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
         "java.lang.String",
         "java.lang.Integer",
         "java.util.List",
+        "java.util.Map",
+        "java.util.Set",
         "java.util.Map.Entry",
+        "java.util.ListIterator",
+        "java.util.Iterator",
+        "java.lang.Iterable",
         "java.lang.Void",
     )
 
@@ -50,7 +55,14 @@ open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
             val k = resolver.mapJavaNameToKotlin(
                 resolver.getKSNameFromString(it)
             )?.asString()
-            results.add("$it -> $k")
+            val m = resolver.mapJavaNameToKotlinMutable(
+                resolver.getKSNameFromString(it)
+            )?.asString()
+            if (k == m) {
+                results.add("$it -> $k")
+            } else {
+                results.add("$it -> $k, $m")
+            }
         }
 
         kotlinClasses.forEach {

--- a/test-utils/testData/api/javaToKotlinMapper.kt
+++ b/test-utils/testData/api/javaToKotlinMapper.kt
@@ -20,8 +20,13 @@
 // EXPECTED:
 // java.lang.String -> kotlin.String
 // java.lang.Integer -> kotlin.Int
-// java.util.List -> kotlin.collections.List
-// java.util.Map.Entry -> kotlin.collections.Map.Entry
+// java.util.List -> kotlin.collections.List, kotlin.collections.MutableList
+// java.util.Map -> kotlin.collections.Map, kotlin.collections.MutableMap
+// java.util.Set -> kotlin.collections.Set, kotlin.collections.MutableSet
+// java.util.Map.Entry -> kotlin.collections.Map.Entry, kotlin.collections.MutableMap.MutableEntry
+// java.util.ListIterator -> kotlin.collections.ListIterator, kotlin.collections.MutableListIterator
+// java.util.Iterator -> kotlin.collections.Iterator, kotlin.collections.MutableIterator
+// java.lang.Iterable -> kotlin.collections.Iterable, kotlin.collections.MutableIterable
 // java.lang.Void -> null
 // kotlin.Throwable -> java.lang.Throwable
 // kotlin.Int -> java.lang.Integer


### PR DESCRIPTION
This new function is complementary to the `mapJavaNameToKotlin`, which returns immutable Kotlin platform types.
There was no conventional way to obtain mutable types based on Java ones.