### PR TITLE
AA java refs workaround

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -36,7 +36,9 @@ import org.jetbrains.kotlin.analysis.api.symbols.markers.KtNamedSymbol
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 
 abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationSymbol) : KSDeclaration {
-    override val origin: Origin = mapAAOrigin(ktDeclarationSymbol.origin)
+    override val origin: Origin by lazy {
+        mapAAOrigin(ktDeclarationSymbol)
+    }
 
     override val location: Location by lazy {
         ktDeclarationSymbol.psi.toLocation()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -143,6 +143,14 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
             this.simpleName.asString()
         }
     }
+
+    override val docString: String? by lazy {
+        if (isSyntheticConstructor()) {
+            parentDeclaration?.docString
+        } else {
+            super.docString
+        }
+    }
 }
 
 internal fun KtFunctionLikeSymbol.toModifiers(): Set<Modifier> {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -58,7 +58,7 @@ abstract class KSPropertyAccessorImpl(
     }
 
     override val origin: Origin by lazy {
-        val symbolOrigin = mapAAOrigin(ktPropertyAccessorSymbol.origin)
+        val symbolOrigin = mapAAOrigin(ktPropertyAccessorSymbol)
         if (symbolOrigin == Origin.KOTLIN && ktPropertyAccessorSymbol.psi == null) {
             Origin.SYNTHETIC
         } else {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -43,7 +43,7 @@ class KSValueParameterImpl private constructor(
     @OptIn(SymbolInternals::class)
     override val type: KSTypeReference by lazy {
         // FIXME: temporary workaround before upstream fixes java type refs.
-        if (origin == Origin.JAVA) {
+        if (origin == Origin.JAVA || origin == Origin.JAVA_LIB) {
             ((ktValueParameterSymbol as KtFirValueParameterSymbol).firSymbol.fir as FirJavaValueParameter).also {
                 // can't get containing class for FirJavaValueParameter, using empty stack for now.
                 it.returnTypeRef =
@@ -80,7 +80,7 @@ class KSValueParameterImpl private constructor(
             ).plus(findAnnotationFromUseSiteTarget())
     }
     override val origin: Origin by lazy {
-        mapAAOrigin(ktValueParameterSymbol.origin)
+        mapAAOrigin(ktValueParameterSymbol)
     }
 
     override val location: Location by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -56,9 +56,14 @@ internal val ktSymbolOriginToOrigin = mapOf(
     KtSymbolOrigin.SUBSTITUTION_OVERRIDE to Origin.JAVA_LIB
 )
 
-internal fun mapAAOrigin(ktSymbolOrigin: KtSymbolOrigin): Origin {
-    return ktSymbolOriginToOrigin[ktSymbolOrigin]
-        ?: throw IllegalStateException("unhandled origin ${ktSymbolOrigin.name}")
+internal fun mapAAOrigin(ktSymbol: KtSymbol): Origin {
+    val symbolOrigin = ktSymbolOriginToOrigin[ktSymbol.origin]
+        ?: throw IllegalStateException("unhandled origin ${ktSymbol.origin.name}")
+    return if (symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true) {
+        Origin.JAVA_LIB
+    } else {
+        symbolOrigin
+    }
 }
 
 internal fun KtAnnotationApplication.render(): String {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -395,7 +395,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/mangledNames.kt")
     }
 
-    @Disabled
     @TestMetadata("multipleModules.kt")
     @Test
     fun testMultipleModules() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -219,7 +219,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/declared.kt")
     }
 
-    @Disabled
     @TestMetadata("docString.kt")
     @Test
     fun testDocString() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -175,14 +175,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/constProperties.kt")
     }
 
-    @Disabled
     @TestMetadata("constructorDeclarations.kt")
     @Test
     fun testConstructorDeclarations() {
         runTest("../test-utils/testData/api/constructorDeclarations.kt")
     }
 
-    @Disabled
     @TestMetadata("crossModuleTypeAlias.kt")
     @Test
     fun testCrossModuleTypeAlias() {
@@ -574,7 +572,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/varianceTypeCheck.kt")
     }
 
-    @Disabled
     @TestMetadata("validateTypes.kt")
     @Test
     fun testValidateTypes() {


### PR DESCRIPTION
In FIR java types are first resolved to `JavaTypeRef` which is incompatible with `FirResolvedTypeRef` used in `FirCallableSymbol.returnType` whichj is in turn used by AA for getting symbol return types.

In FIR, java symbols are constructed to default be in last FIR resolve phase, therefore trying a workaround where we manually convert the java type refs `o` resolved type refs with internal functions from fir.java module should be safe for KSP.

Using this workaround before upstream fixes this issue