### PR TITLE
UPDATE_KOTLIN_VERSION: 1.8.20-dev-2904

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -8,7 +8,7 @@ val signingPassword: String? by project
 val kotlinBaseVersion: String by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=all-compatibility"
+    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
 }
 
 plugins {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     kotlin("jvm")
 }
 
+kotlin {
+    jvmToolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 repositories {
     mavenCentral()
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -8,7 +8,7 @@ val kotlinBaseVersion: String by project
 val intellijVersion: String by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
+    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
 }
 
 plugins {

--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -11,7 +11,7 @@ val kotlinBaseVersion: String by project
 val libsForTesting by configurations.creating
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
+    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
 }
 
 plugins {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -52,7 +52,7 @@ import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.context.ProjectContext
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.load.java.components.FilesByFacadeFqNameIndexer
-import org.jetbrains.kotlin.platform.js.JsPlatform
+import org.jetbrains.kotlin.platform.JsPlatform
 import org.jetbrains.kotlin.platform.jvm.JdkPlatform
 import org.jetbrains.kotlin.platform.konan.NativePlatform
 import org.jetbrains.kotlin.psi.KtFile

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -10,7 +10,7 @@ val signingKey: String? by project
 val signingPassword: String? by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
+    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
 }
 
 plugins {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
@@ -50,8 +50,17 @@ class TestProject(
     fun writeFiles() {
         writeBuildFile()
         writeSettingsFile()
+        writeRootProperties()
         appModule.writeBuildFile()
         processorModule.writeBuildFile()
+    }
+
+    private fun writeRootProperties() {
+        val contents = """
+            
+            kotlin.jvm.target.validation.mode=warning
+        """.trimIndent()
+        rootDir.resolve("gradle.properties").appendText(contents)
     }
 
     private fun writeSettingsFile() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,11 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=1.8.20-dev-2036
+kotlinBaseVersion=1.8.20-dev-2904
 agpBaseVersion=7.0.0
 intellijVersion=203.8084.24
 junitVersion=4.12
 googleTruthVersion=1.1
 compilerTestEnabled=false
+
+kotlin.jvm.target.validation.mode=warning

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -23,6 +23,7 @@ class TemporaryTestProject(projectName: String, baseProject: String? = null) : T
         gradleProperties.appendText("\nagpVersion=$agpVersion")
         gradleProperties.appendText("\ntestRepo=$testRepo")
         gradleProperties.appendText("\norg.gradle.unsafe.configuration-cache=true")
+        gradleProperties.appendText("\nkotlin.jvm.target.validation.mode=warning")
         // Uncomment this to debug compiler and compiler plugin.
         // gradleProperties.appendText("\nsystemProp.kotlin.compiler.execution.strategy=in-process")
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
@@ -26,7 +26,7 @@ class KSCallableReferenceImpl private constructor(
         get() = KSTypeReferenceImpl.getCached(ktFunctionalType.returnType)
 
     override val typeArguments: List<KSTypeArgument>
-        get() = ktFunctionalType.typeArguments.map { KSTypeArgumentImpl.getCached(it, this) }
+        get() = ktFunctionalType.typeArguments().map { KSTypeArgumentImpl.getCached(it, this) }
 
     override val origin: Origin
         get() = parent.origin

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -19,7 +19,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
-import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
+import org.jetbrains.kotlin.analysis.api.KtStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.components.buildClassType
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
@@ -94,7 +94,7 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         return analyze {
             analysisSession.buildClassType(ktClassOrObjectSymbol) {
-                typeArguments.forEach { argument(it.toKtTypeArgument()) }
+                typeArguments.forEach { argument(it.toKtTypeProjection()) }
             }.let { KSTypeImpl.getCached(it) }
         }
     }
@@ -107,7 +107,7 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
                     while (current is KSClassDeclarationImpl) {
                         current.ktClassOrObjectSymbol.typeParameters.forEach {
                             argument(
-                                KtStarProjectionTypeArgument(
+                                KtStarTypeProjection(
                                     (current as KSClassDeclarationImpl).ktClassOrObjectSymbol.token
                                 )
                             )

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
@@ -27,7 +27,7 @@ class KSClassifierReferenceImpl private constructor(
     }
 
     override val typeArguments: List<KSTypeArgument> by lazy {
-        ktType.typeArguments.map { KSTypeArgumentImpl.getCached(it, this) }
+        ktType.typeArguments().map { KSTypeArgumentImpl.getCached(it, this) }
     }
 
     override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -20,6 +20,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
+import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.analysis.api.fir.symbols.KtFirFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
@@ -131,7 +132,8 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     }
 
     private fun isSyntheticConstructor(): Boolean {
-        return origin == Origin.SYNTHETIC || (origin == Origin.JAVA && ktFunctionSymbol.psi == null)
+        return origin == Origin.SYNTHETIC ||
+            (origin == Origin.JAVA && ktFunctionSymbol.psi == null || ktFunctionSymbol.psi is PsiClass)
     }
 
     override fun toString(): String {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -19,10 +19,12 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
+import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.analysis.api.annotations.KtAnnotationApplication
 import org.jetbrains.kotlin.analysis.api.annotations.annotations
 import org.jetbrains.kotlin.analysis.api.symbols.KtKotlinPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.receiverType
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 
 class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbol: KtPropertySymbol) :
@@ -41,11 +43,19 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     }
 
     override val getter: KSPropertyGetter? by lazy {
-        ktPropertySymbol.getter?.let { KSPropertyGetterImpl.getCached(this, it) }
+        if (ktPropertySymbol.psi is PsiClass) {
+            null
+        } else {
+            ktPropertySymbol.getter?.let { KSPropertyGetterImpl.getCached(this, it) }
+        }
     }
 
     override val setter: KSPropertySetter? by lazy {
-        ktPropertySymbol.setter?.let { KSPropertySetterImpl.getCached(this, it) }
+        if (ktPropertySymbol.psi is PsiClass) {
+            null
+        } else {
+            ktPropertySymbol.setter?.let { KSPropertySetterImpl.getCached(this, it) }
+        }
     }
 
     override val extensionReceiver: KSTypeReference? by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
@@ -27,22 +27,24 @@ import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
-import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
-import org.jetbrains.kotlin.analysis.api.KtTypeArgument
+import org.jetbrains.kotlin.analysis.api.KtStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.KtTypeArgumentWithVariance
+import org.jetbrains.kotlin.analysis.api.KtTypeProjection
 
-class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeArgument, override val parent: KSNode?) :
-    KSTypeArgument {
-    companion object : KSObjectCache<IdKeyPair<KtTypeArgument, KSNode?>, KSTypeArgumentImpl>() {
-        fun getCached(ktTypeArgument: KtTypeArgument, parent: KSNode? = null) =
-            cache.getOrPut(IdKeyPair(ktTypeArgument, parent)) { KSTypeArgumentImpl(ktTypeArgument, parent) }
+class KSTypeArgumentImpl private constructor(
+    private val ktTypeProjection: KtTypeProjection,
+    override val parent: KSNode?
+) : KSTypeArgument {
+    companion object : KSObjectCache<IdKeyPair<KtTypeProjection, KSNode?>, KSTypeArgumentImpl>() {
+        fun getCached(ktTypeProjection: KtTypeProjection, parent: KSNode? = null) =
+            cache.getOrPut(IdKeyPair(ktTypeProjection, parent)) { KSTypeArgumentImpl(ktTypeProjection, parent) }
     }
 
     override val variance: Variance by lazy {
-        when (ktTypeArgument) {
-            is KtStarProjectionTypeArgument -> Variance.STAR
+        when (ktTypeProjection) {
+            is KtStarTypeProjection -> Variance.STAR
             is KtTypeArgumentWithVariance -> {
-                when (ktTypeArgument.variance) {
+                when (ktTypeProjection.variance) {
                     org.jetbrains.kotlin.types.Variance.INVARIANT -> Variance.INVARIANT
                     org.jetbrains.kotlin.types.Variance.IN_VARIANCE -> Variance.CONTRAVARIANT
                     org.jetbrains.kotlin.types.Variance.OUT_VARIANCE -> Variance.COVARIANT
@@ -53,11 +55,11 @@ class KSTypeArgumentImpl private constructor(private val ktTypeArgument: KtTypeA
     }
 
     override val type: KSTypeReference? by lazy {
-        ktTypeArgument.type?.let { KSTypeReferenceImpl.getCached(it, this@KSTypeArgumentImpl) }
+        ktTypeProjection.type?.let { KSTypeReferenceImpl.getCached(it, this@KSTypeArgumentImpl) }
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {
-        ktTypeArgument.type?.annotations() ?: emptySequence()
+        ktTypeProjection.type?.annotations() ?: emptySequence()
     }
 
     override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -25,7 +25,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Nullability
-import org.jetbrains.kotlin.analysis.api.KtStarProjectionTypeArgument
+import org.jetbrains.kotlin.analysis.api.KtStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.annotations.KtAnnotationsList
 import org.jetbrains.kotlin.analysis.api.components.buildClassType
 import org.jetbrains.kotlin.analysis.api.symbols.*
@@ -69,7 +69,7 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
     }
 
     override val arguments: List<KSTypeArgument> by lazy {
-        (type as? KtNonErrorClassType)?.typeArguments?.map { KSTypeArgumentImpl.getCached(it) } ?: emptyList()
+        (type as? KtNonErrorClassType)?.typeArguments()?.map { KSTypeArgumentImpl.getCached(it) } ?: emptyList()
     }
 
     override val annotations: Sequence<KSAnnotation>
@@ -100,7 +100,7 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
     override fun replace(arguments: List<KSTypeArgument>): KSType {
         return analyze {
             analysisSession.buildClassType((type as KtNonErrorClassType).classSymbol) {
-                arguments.forEach { arg -> argument(arg.toKtTypeArgument()) }
+                arguments.forEach { arg -> argument(arg.toKtTypeProjection()) }
             }.let { getCached(it) }
         }
     }
@@ -108,8 +108,8 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
     override fun starProjection(): KSType {
         return analyze {
             analysisSession.buildClassType((type as KtNonErrorClassType).classSymbol) {
-                type.typeArguments.forEach {
-                    argument(KtStarProjectionTypeArgument(type.token))
+                type.typeArguments().forEach {
+                    argument(KtStarTypeProjection(type.token))
                 }
             }.let { getCached(it) }
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -50,7 +50,7 @@ class KSTypeReferenceImpl private constructor(
                     ktType.lowerBound as KtUsualClassType,
                     this@KSTypeReferenceImpl
                 )
-                is KtClassErrorType -> null
+                is KtErrorType -> null
                 is KtTypeParameterType -> null
                 else -> throw IllegalStateException("Unexpected type element ${ktType.javaClass}, $ExceptionMessage")
             }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -37,7 +37,11 @@ class KSValueParameterImpl private constructor(
     }
 
     override val name: KSName? by lazy {
-        KSNameImpl.getCached(ktValueParameterSymbol.name.asString())
+        if (origin == Origin.SYNTHETIC && parent is KSPropertySetter) {
+            KSNameImpl.getCached("<set-?>")
+        } else {
+            KSNameImpl.getCached(ktValueParameterSymbol.name.asString())
+        }
     }
 
     @OptIn(SymbolInternals::class)
@@ -80,7 +84,12 @@ class KSValueParameterImpl private constructor(
             ).plus(findAnnotationFromUseSiteTarget())
     }
     override val origin: Origin by lazy {
-        mapAAOrigin(ktValueParameterSymbol)
+        val symbolOrigin = mapAAOrigin(ktValueParameterSymbol)
+        if (symbolOrigin == Origin.KOTLIN && ktValueParameterSymbol.psi == null) {
+            Origin.SYNTHETIC
+        } else {
+            symbolOrigin
+        }
     }
 
     override val location: Location by lazy {

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -4,7 +4,7 @@ val kotlinBaseVersion: String by project
 val intellijVersion: String by project
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.freeCompilerArgs += "-Xjvm-default=compatibility"
+    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
 }
 plugins {
     kotlin("jvm")


### PR DESCRIPTION
changes involved:
* compiler has made `kotlin.jvm.target.validation.mode` default to error, set the flag explicitly to `warning`, but seems to not work for buildSrc, since KSP build requires JDK 11 for android tests, it is better to just change buildSrc to use JDK11.
* compiler is now built with `-Xjvm-default=all`, KSP need to adopt all other occurrences of jvm default build flag to ensure run time works.
* some adjustments in analysis API to align with upstream changes, namely changes in how inner type arguments and complete type arguments are handled, now `KtType` will only contain innerTypeArguments, therefore we need to look up the newly added `qualifiers` to get the complete list of type arguments.