### PR TITLE
Handle AnnotationTarget.VALUE_PARAMETER for property declarations.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -123,7 +123,7 @@ internal fun KtAnnotated.filterUseSiteTargetAnnotations(): Sequence<KtAnnotation
     return this.annotationEntries.asSequence().filter { property ->
         property.useSiteTarget?.getAnnotationUseSiteTarget()?.let {
             it != AnnotationUseSiteTarget.PROPERTY_GETTER && it != AnnotationUseSiteTarget.PROPERTY_SETTER &&
-                it != AnnotationUseSiteTarget.SETTER_PARAMETER
+                it != AnnotationUseSiteTarget.SETTER_PARAMETER && it != AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER
         } ?: true
     }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -38,7 +38,17 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
 
     override val annotations: Sequence<KSAnnotation> by lazy {
         ktParameter.filterUseSiteTargetAnnotations().map { KSAnnotationImpl.getCached(it) }
-            .filter { it.useSiteTarget != AnnotationUseSiteTarget.PARAM }
+            .filterNot { valueParameterAnnotation ->
+                valueParameterAnnotation.useSiteTarget == AnnotationUseSiteTarget.PARAM ||
+                    valueParameterAnnotation.annotationType.resolve().declaration.annotations.any { metaAnnotation ->
+                        metaAnnotation.annotationType.resolve().declaration.qualifiedName
+                            ?.asString() == "kotlin.annotation.Target" &&
+                            (metaAnnotation.arguments.singleOrNull()?.value as? ArrayList<*>)?.any {
+                            (it as? KSType)?.declaration?.qualifiedName
+                                ?.asString() == "kotlin.annotation.AnnotationTarget.VALUE_PARAMETER"
+                        } ?: false
+                    }
+            }
     }
 
     override val parentDeclaration: KSDeclaration? by lazy {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -31,6 +31,7 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.impl.synthetic.KSTypeReferenceSyntheticImpl
 import com.google.devtools.ksp.symbol.impl.toLocation
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.lexer.KtTokens.CROSSINLINE_KEYWORD
 import org.jetbrains.kotlin.lexer.KtTokens.NOINLINE_KEYWORD
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -69,7 +70,13 @@ class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : K
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {
-        ktParameter.filterUseSiteTargetAnnotations().map { KSAnnotationImpl.getCached(it) }
+        ktParameter.annotationEntries.asSequence().filter { annotation ->
+            annotation.useSiteTarget?.getAnnotationUseSiteTarget()?.let {
+                it != AnnotationUseSiteTarget.PROPERTY_GETTER &&
+                    it != AnnotationUseSiteTarget.PROPERTY_SETTER &&
+                    it != AnnotationUseSiteTarget.SETTER_PARAMETER
+            } ?: true
+        }.map { KSAnnotationImpl.getCached(it) }
             .plus(this.findAnnotationFromUseSiteTarget()).memoized()
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
@@ -66,6 +66,7 @@ class KSValueArgumentImpl private constructor(
     private fun KtAnnotationValue.toValue(): Any? = when (this) {
         is KtArrayAnnotationValue -> this.values.map { it.toValue() }
         is KtAnnotationApplicationValue -> KSAnnotationImpl.getCached(this.annotationValue)
+        // TODO: Enum entry should return a type, use declaration as a placeholder.
         is KtEnumEntryAnnotationValue -> this.callableId?.classId?.let {
             analyze {
                 it.toKtClassSymbol()?.let {

--- a/test-utils/testData/api/annotationInDependencies.kt
+++ b/test-utils/testData/api/annotationInDependencies.kt
@@ -45,6 +45,7 @@
 // parameter param1 : annotations.ValueParameterTarget{[value = onParam1]}
 // parameter param2 : annotations.NoTargetAnnotation{[value = onParam2]}
 // parameter param2 : annotations.ValueParameterTarget{[value = onParam2]}
+// parameter propInConstructor : annotations.ValueParameterTarget{[value = propInConstructor]}
 // property prop : annotations.FieldTarget2{[value = field:]}
 // property prop : annotations.FieldTarget{[value = onProp]}
 // property prop : annotations.NoTargetAnnotation{[value = onProp]}
@@ -59,6 +60,7 @@
 // parameter constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
 // parameter constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
 // parameter constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
+// parameter constructorParam : annotations.ValueParameterTarget{[value = onConstructorParam]}
 // property constructorParam : annotations.FieldTarget2{[value = field:]}
 // property constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
 // property constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
@@ -108,7 +110,7 @@ package lib;
 import annotations.*;
 @NoTargetAnnotation("onClass")
 @ClassTarget("onClass")
-class KotlinClass {
+class KotlinClass(@ValueParameterTarget("propInConstructor") val propInConstructor: String ) {
     @NoTargetAnnotation("onProp")
     @FieldTarget("onProp")
     @PropertyTarget("onProp")
@@ -186,6 +188,7 @@ class DataClass(
     @get:PropertyGetterTarget("get:")
     @field:FieldTarget2("field:")
     @setparam:ValueParameterTarget("onConstructorParam")
+    @ValueParameterTarget("onConstructorParam")
     var constructorParam : String = ""
 )
 // FILE: main/JavaClassInModule2.java


### PR DESCRIPTION
This special handling is needed when an annotation has implicit use site
    target restriction declared at that annotations declaration site. This is
    only happening for properties declared in constructor parameter because in
    constructor parameter, the use site is value parameter which does not violate
    annotation target contract, and annotations gets carried over to its actual
    property, therefore need to read the annotation declaration and resolve for targets.

The logic is unfortunately, ugly, wonder if there is any utility functions to check it simpler.

fixes #1198 