### PR TITLE
Add args from `CommandLineArgumentProvider` as separate `apoption` instead of joined.

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -142,11 +142,12 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 options += SubpluginOption("apoption", "${it.key}=${it.value}")
             }
             commandLineArgumentProviders.get().forEach {
-                val argument = it.asArguments().joinToString("")
-                if (!argument.matches(Regex("\\S+=\\S+"))) {
-                    throw IllegalArgumentException("KSP apoption does not match \\S+=\\S+: $argument")
+                it.asArguments().forEach { argument ->
+                    if (!argument.matches(Regex("\\S+=\\S+"))) {
+                        throw IllegalArgumentException("KSP apoption does not match \\S+=\\S+: $argument")
+                    }
+                    options += SubpluginOption("apoption", argument)
                 }
-                options += SubpluginOption("apoption", argument)
             }
             return options
         }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -183,7 +183,8 @@ class GradleCompilationTest {
 
                     override fun asArguments(): Iterable<String> {
                         return listOf(
-                            "room.schemaLocation=${'$'}{outputDir.path}"
+                            "room.schemaLocation=${'$'}{outputDir.path}",
+                            "room.generateKotlin=true"
                         )
                     }
                 }
@@ -201,6 +202,7 @@ class GradleCompilationTest {
         val pattern1 = Regex.escape("apoption=room.schemaLocation=")
         val pattern2 = Regex.escape("${testRule.appModule.moduleRoot}/schemas")
         assertThat(result.output).containsMatch("$pattern1\\S*$pattern2")
+        assertThat(result.output).contains("apoption=room.generateKotlin=true")
         val schemasFolder = testRule.appModule.moduleRoot.resolve("schemas")
         assertThat(result.task(":app:kspDebugKotlin")!!.outcome).isEquivalentAccordingToCompareTo(TaskOutcome.SUCCESS)
         assertThat(schemasFolder.exists()).isTrue()


### PR DESCRIPTION
Fixes https://github.com/google/ksp/issues/1218