### PR TITLE
Deprecate KspTask.commandLineArgumentProviders.

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -128,6 +128,7 @@ interface KspTask : Task {
     @get:Internal
     val options: ListProperty<SubpluginOption>
 
+    @Deprecated("KSP is going to use compilation tasks created by KGP and no longer support this property.")
     @get:Nested
     val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
 


### PR DESCRIPTION
KSP will delegate task creation to KGP and drop support of the per-task commandLineArgumentProviders.