### PR TITLE
use correct overridee check for properties declared in constructors.

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationParameterImpl.kt
@@ -91,9 +91,8 @@ class KSPropertyDeclarationParameterImpl private constructor(val ktParameter: Kt
     override fun isDelegated(): Boolean = false
 
     override fun findOverridee(): KSPropertyDeclaration? {
-        return ResolverImpl.instance!!.resolvePropertyDeclaration(this)?.original?.overriddenDescriptors
-            ?.singleOrNull { it.overriddenDescriptors.isEmpty() }
-            ?.toKSPropertyDeclaration()
+        return ResolverImpl.instance!!.resolvePropertyDeclaration(this)?.original
+            ?.findClosestOverridee()?.toKSPropertyDeclaration()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -42,6 +42,7 @@ class OverrideeProcessor : AbstractTestProcessor() {
         logSubject(resolver, "JavaAccessorImpl")
         logSubject(resolver, "JavaAnno")
         logSubject(resolver, "JavaAnnos")
+        logSubject(resolver, "PrimaryConstructorOverride")
         return emptyList()
     }
 

--- a/test-utils/testData/api/overridee.kt
+++ b/test-utils/testData/api/overridee.kt
@@ -89,6 +89,9 @@
 // JavaAnno.intParam() -> null
 // JavaAnnos:
 // JavaAnnos.value() -> null
+// PrimaryConstructorOverride:
+// PrimaryConstructorOverride.x -> KtInterfaceWithProperty.x
+// PrimaryConstructorOverride.y -> KtInterfaceWithProperty.y
 // END
 // MODULE: lib
 // FILE: lib.kt
@@ -149,6 +152,12 @@ class NoOverride(val propInParam: Int) {
 interface KtInterfaceWithProperty {
     val x:Int
     var y:Int
+}
+
+interface Intermediate: KtInterfaceWithProperty
+
+class PrimaryConstructorOverride(override val x: Int): Intermediate {
+    override val y: Int = 1
 }
 
 abstract class GrandBase {


### PR DESCRIPTION
fixes #1182

The issue has been observed before in other implementations, somehow the fix missed `KSPropertyDeclarationParameterImpl`