### PR TITLE
Add extension: excludeProcessor()

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
@@ -55,6 +55,8 @@ class KspOptions(
     val compilerVersion: KotlinVersion,
 
     val commonSources: List<File>,
+
+    val excludedProcessors: Set<String>,
 ) {
     class Builder {
         var projectBaseDir: File? = null
@@ -90,6 +92,8 @@ class KspOptions(
 
         var commonSources: MutableList<File> = mutableListOf()
 
+        var excludedProcessors: MutableSet<String> = mutableSetOf()
+
         fun build(): KspOptions {
             return KspOptions(
                 requireNotNull(projectBaseDir) { "A non-null projectBaseDir must be provided" },
@@ -116,6 +120,7 @@ class KspOptions(
                 apiVersion,
                 compilerVersion,
                 commonSources,
+                excludedProcessors,
             )
         }
     }
@@ -286,6 +291,14 @@ enum class KspCliOption(
         false,
         true
     ),
+
+    EXCLUDED_PROCESSORS_OPTION(
+        "excludedProcessors",
+        "<excludedProcessors>",
+        "exclude providers by fqn",
+        false,
+        true
+    ),
 }
 
 @Suppress("IMPLICIT_CAST_TO_ANY")
@@ -314,4 +327,5 @@ fun KspOptions.Builder.processOption(option: KspCliOption, value: String) = when
     KspCliOption.CHANGED_CLASSES_OPTION -> changedClasses.addAll(value.split(':'))
     KspCliOption.RETURN_OK_ON_ERROR_OPTION -> returnOkOnError = value.toBoolean()
     KspCliOption.COMMON_SOURCES_OPTION -> commonSources.addAll(value.split(File.pathSeparator).map { File(it) })
+    KspCliOption.EXCLUDED_PROCESSORS_OPTION -> excludedProcessors.addAll(value.split(":"))
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -81,7 +81,8 @@ class KotlinSymbolProcessingExtension(
                     URLClassLoader(processingClasspath.map { it.toURI().toURL() }.toTypedArray(), javaClass.classLoader)
 
                 ServiceLoaderLite.loadImplementations(SymbolProcessorProvider::class.java, classLoader).filter {
-                    options.processors.isEmpty() || it.javaClass.name in options.processors
+                    (options.processors.isEmpty() && it.javaClass.name !in options.excludedProcessors) ||
+                        it.javaClass.name in options.processors
                 }
             }
             if (providers.isEmpty()) {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -23,6 +23,7 @@ import org.gradle.process.CommandLineArgumentProvider
 open class KspExtension {
     internal val apOptions = mutableMapOf<String, String>()
     internal val commandLineArgumentProviders = mutableListOf<CommandLineArgumentProvider>()
+    internal val excludedProcessors = mutableSetOf<String>()
 
     open val arguments: Map<String, String> get() = apOptions.toMap()
 
@@ -47,4 +48,9 @@ open class KspExtension {
 
     // Treat all warning as errors.
     open var allWarningsAsErrors: Boolean = false
+
+    // Keep processor providers from being called. Providers will still be loaded if they're in classpath.
+    open fun excludeProcessor(fullyQualifiedName: String) {
+        excludedProcessors.add(fullyQualifiedName)
+    }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -150,6 +150,10 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             kspExtension.apOptions.forEach {
                 options += SubpluginOption("apoption", "${it.key}=${it.value}")
             }
+            options += SubpluginOption(
+                "excludedProcessors",
+                kspExtension.excludedProcessors.joinToString(":")
+            )
             commandLineArgumentProviders.get().forEach {
                 it.asArguments().forEach { argument ->
                     if (!argument.matches(Regex("\\S+=\\S+"))) {


### PR DESCRIPTION
Excluded providers won't be called, even if they are loaded from classpath. This makes it easier to write wrappers for processors.

Fixes #1234 