### PR TITLE
Introduce ksp.map.annotation.arguments.in.java

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/KspOptions.kt
@@ -57,6 +57,7 @@ class KspOptions(
     val commonSources: List<File>,
 
     val excludedProcessors: Set<String>,
+    val mapAnnotationArgumentsInJava: Boolean,
 ) {
     class Builder {
         var projectBaseDir: File? = null
@@ -93,6 +94,7 @@ class KspOptions(
         var commonSources: MutableList<File> = mutableListOf()
 
         var excludedProcessors: MutableSet<String> = mutableSetOf()
+        var mapAnnotationArgumentsInJava: Boolean = false
 
         fun build(): KspOptions {
             return KspOptions(
@@ -121,6 +123,7 @@ class KspOptions(
                 compilerVersion,
                 commonSources,
                 excludedProcessors,
+                mapAnnotationArgumentsInJava,
             )
         }
     }
@@ -299,6 +302,14 @@ enum class KspCliOption(
         false,
         true
     ),
+
+    MAP_ANNOTATION_ARGUMENTS_IN_JAVA_OPTION(
+        "mapAnnotationArgumentsInJava",
+        "<mapAnnotationArgumentsInJava>",
+        "Map types in annotation arguments in Java sources",
+        false,
+        false
+    ),
 }
 
 @Suppress("IMPLICIT_CAST_TO_ANY")
@@ -328,4 +339,5 @@ fun KspOptions.Builder.processOption(option: KspCliOption, value: String) = when
     KspCliOption.RETURN_OK_ON_ERROR_OPTION -> returnOkOnError = value.toBoolean()
     KspCliOption.COMMON_SOURCES_OPTION -> commonSources.addAll(value.split(File.pathSeparator).map { File(it) })
     KspCliOption.EXCLUDED_PROCESSORS_OPTION -> excludedProcessors.addAll(value.split(":"))
+    KspCliOption.MAP_ANNOTATION_ARGUMENTS_IN_JAVA_OPTION -> mapAnnotationArgumentsInJava = value.toBoolean()
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -156,6 +156,10 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 "excludedProcessors",
                 kspExtension.excludedProcessors.joinToString(":")
             )
+            options += SubpluginOption(
+                "mapAnnotationArgumentsInJava",
+                project.findProperty("ksp.map.annotation.arguments.in.java")?.toString() ?: "false"
+            )
             commandLineArgumentProviders.get().forEach {
                 it.asArguments().forEach { argument ->
                     if (!argument.matches(Regex("\\S+=\\S+"))) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MapAnnotationArgumentsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MapAnnotationArgumentsIT.kt
@@ -1,0 +1,40 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class MapAnnotationArgumentsIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("map-annotation-arguments", "test-processor")
+
+    val expectedErrors = listOf(
+        "e: [ksp] unboxedChar: Char != Character\n",
+        "e: [ksp] boxedChar: (Char..Char?) != Character\n",
+        "e: Error occurred in KSP, check log for detail\n",
+    )
+
+    @Test
+    fun testMapAnnotationArguments() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("assemble", "-Pksp.map.annotation.arguments.in.java=true").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        gradleRunner.withArguments("clean", "assemble", "--rerun-tasks").buildAndFail().let { result ->
+            Assert.assertEquals(TaskOutcome.FAILED, result.task(":workload:kspKotlin")?.outcome)
+            Assert.assertTrue(expectedErrors.all { it in result.output })
+        }
+
+        gradleRunner.withArguments("clean", "assemble", "-Pksp.map.annotation.arguments.in.java=false", "--rerun-tasks")
+            .buildAndFail().let { result ->
+                Assert.assertEquals(TaskOutcome.FAILED, result.task(":workload:kspKotlin")?.outcome)
+                Assert.assertTrue(expectedErrors.all { it in result.output })
+            }
+    }
+}

--- a/integration-tests/src/test/resources/map-annotation-arguments/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/map-annotation-arguments/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,36 @@
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
+    val expected = mapOf(
+        "unboxedChar" to "Char",
+        "boxedChar" to "(Char..Char?)",
+    )
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val j = resolver.getClassDeclarationByName("com.example.AnnotationTest")!!
+        j.annotations.forEach { annotation ->
+            annotation.arguments.forEach {
+                val key = it.name?.asString()
+                val value = it.value.toString()
+                if (expected[key] != value) {
+                    logger.error("$key: ${expected[key]} != $value")
+                }
+            }
+        }
+
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        environment: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return TestProcessor(environment.codeGenerator, environment.logger)
+    }
+}

--- a/integration-tests/src/test/resources/map-annotation-arguments/workload/src/main/java/com/example/AnnotationTest.java
+++ b/integration-tests/src/test/resources/map-annotation-arguments/workload/src/main/java/com/example/AnnotationTest.java
@@ -1,0 +1,8 @@
+package com.example;
+
+@JavaAnnotation(
+    unboxedChar = char.class,
+    boxedChar = Character.class
+)
+public class AnnotationTest {
+}

--- a/integration-tests/src/test/resources/map-annotation-arguments/workload/src/main/java/com/example/JavaAnnotation.java
+++ b/integration-tests/src/test/resources/map-annotation-arguments/workload/src/main/java/com/example/JavaAnnotation.java
@@ -1,0 +1,6 @@
+package com.example;
+
+public @interface JavaAnnotation {
+  Class unboxedChar();
+  Class boxedChar();
+}


### PR DESCRIPTION
which defaults to false. When enabled, annotation arguments are mapped to Kotlin types in Java source files.

The option will be flipped to true and deprecated in the future gradually.

fixes #870