### PR TITLE
Register processor classpath to Gradle

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -28,6 +28,7 @@ import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.ClasspathNormalizer
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.language.jvm.tasks.ProcessResources
@@ -313,6 +314,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 }
             )
             kspTask.inputs.property("apOptions", kspExtension.arguments)
+            kspTask.inputs.files(processorClasspath).withNormalizer(ClasspathNormalizer::class.java)
         }
 
         fun configureAsAbstractKotlinCompileTool(kspTask: AbstractKotlinCompileTool<*>) {

--- a/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    implementation(project(":validator"))
     testImplementation("junit:junit:4.12")
     ksp(project(":validator"))
     kspTest(project(":validator"))


### PR DESCRIPTION
KGP doesn't register FilesSubpluginOption nor InternalSubpluginOption.

Fixes #1308 