### PR TITLE
AA: reference element rework

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -107,7 +107,8 @@ class KotlinSymbolProcessing(
             ktFiles.map {
                 analyze { it.getFileSymbol() }
             },
-            javaFiles
+            options,
+            project
         )
         ResolverAAImpl.instance = resolver
         processors.forEach { it.process(resolver) }
@@ -119,7 +120,7 @@ fun main(args: Array<String>) {
     val commandLineProcessor = KSPCommandLineProcessor(compilerConfiguration)
     val logger = CommandLineKSPLogger()
 
-    val analysisSession = buildStandaloneAnalysisAPISession {
+    val analysisSession = buildStandaloneAnalysisAPISession(withPsiDeclarationFromBinaryModuleProvider = true) {
         buildKtModuleProviderByCompilerConfiguration(compilerConfiguration)
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
@@ -8,10 +8,10 @@ import org.jetbrains.kotlin.analysis.api.types.KtType
 
 class KSCallableReferenceImpl private constructor(
     private val ktFunctionalType: KtFunctionalType,
-    override val parent: KSNode
+    override val parent: KSNode?
 ) : KSCallableReference {
-    companion object : KSObjectCache<IdKeyPair<KtType, KSNode>, KSCallableReference>() {
-        fun getCached(ktFunctionalType: KtFunctionalType, parent: KSNode): KSCallableReference =
+    companion object : KSObjectCache<IdKeyPair<KtType, KSNode?>, KSCallableReference>() {
+        fun getCached(ktFunctionalType: KtFunctionalType, parent: KSNode?): KSCallableReference =
             cache.getOrPut(IdKeyPair(ktFunctionalType, parent)) { KSCallableReferenceImpl(ktFunctionalType, parent) }
     }
     override val receiverType: KSTypeReference?
@@ -29,8 +29,8 @@ class KSCallableReferenceImpl private constructor(
         get() = ktFunctionalType.typeArguments().map { KSTypeArgumentImpl.getCached(it, this) }
 
     override val origin: Origin
-        get() = parent.origin
+        get() = parent?.origin ?: Origin.SYNTHETIC
 
     override val location: Location
-        get() = parent.location
+        get() = parent?.location ?: NonExistLocation
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDefNonNullReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDefNonNullReferenceImpl.kt
@@ -1,0 +1,27 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.IdKeyPair
+import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.symbol.*
+import org.jetbrains.kotlin.analysis.api.types.KtDefinitelyNotNullType
+
+class KSDefNonNullReferenceImpl private constructor(
+    val ktDefinitelyNotNullType: KtDefinitelyNotNullType,
+    override val parent: KSTypeReference?
+) : KSDefNonNullReference {
+    companion object : KSObjectCache<IdKeyPair<KtDefinitelyNotNullType, KSTypeReference?>, KSDefNonNullReference>() {
+        fun getCached(ktType: KtDefinitelyNotNullType, parent: KSTypeReference?) =
+            KSDefNonNullReferenceImpl.cache
+                .getOrPut(IdKeyPair(ktType, parent)) { KSDefNonNullReferenceImpl(ktType, parent) }
+    }
+    override val enclosedType: KSClassifierReference by lazy {
+        ktDefinitelyNotNullType.original.toClassifierReference(parent) as KSClassifierReference
+    }
+    override val typeArguments: List<KSTypeArgument>
+        get() = emptyList()
+
+    override val origin: Origin = Origin.KOTLIN
+
+    override val location: Location
+        get() = parent?.location ?: NonExistLocation
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
@@ -3,7 +3,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
 
-class KSDynamicReferenceImpl private constructor(override val parent: KSNode?) : KSDynamicReference {
+class KSDynamicReferenceImpl private constructor(override val parent: KSNode) : KSDynamicReference {
     companion object : KSObjectCache<KSTypeReference, KSDynamicReferenceImpl>() {
         fun getCached(parent: KSTypeReference) = cache.getOrPut(parent) { KSDynamicReferenceImpl(parent) }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -22,15 +22,9 @@ import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 import com.intellij.psi.PsiClass
-import org.jetbrains.kotlin.analysis.api.fir.symbols.KtFirFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
 import org.jetbrains.kotlin.descriptors.Modality
-import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
-import org.jetbrains.kotlin.fir.java.declarations.FirJavaMethod
-import org.jetbrains.kotlin.fir.java.resolveIfJavaType
-import org.jetbrains.kotlin.fir.resolve.getContainingClass
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 
@@ -68,19 +62,7 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
         }
     }
 
-    @OptIn(SymbolInternals::class)
     override val returnType: KSTypeReference? by lazy {
-        // FIXME: temporary workaround before upstream fixes java type refs.
-        if (origin == Origin.JAVA) {
-            if (ktFunctionSymbol is KtFirFunctionSymbol) {
-                (ktFunctionSymbol.firSymbol.fir as? FirJavaMethod)?.also {
-                    it.returnTypeRef = it.returnTypeRef.resolveIfJavaType(
-                        it.moduleData.session,
-                        (it.getContainingClass(it.moduleData.session) as FirJavaClass).javaTypeParameterStack
-                    )
-                }
-            }
-        }
         analyze {
             // Constructors
             if (ktFunctionSymbol is KtConstructorSymbol) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -98,7 +98,9 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     }
 
     override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached("${parentDeclaration?.qualifiedName?.asString()}.${this.simpleName.asString()}")
+        val name = ktPropertySymbol.callableIdIfNonLocal?.asSingleFqName()?.asString()
+            ?: ("${parentDeclaration?.qualifiedName?.asString()}.${this.simpleName.asString()}")
+        KSNameImpl.getCached(name)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -4,13 +4,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
-import org.jetbrains.kotlin.analysis.api.fir.symbols.KtFirJavaFieldSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtJavaFieldSymbol
-import org.jetbrains.kotlin.fir.java.declarations.FirJavaClass
-import org.jetbrains.kotlin.fir.java.declarations.FirJavaField
-import org.jetbrains.kotlin.fir.java.resolveIfJavaType
-import org.jetbrains.kotlin.fir.resolve.getContainingClass
-import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 
 class KSPropertyDeclarationJavaImpl private constructor(private val ktJavaFieldSymbol: KtJavaFieldSymbol) :
     KSPropertyDeclaration,
@@ -29,15 +23,7 @@ class KSPropertyDeclarationJavaImpl private constructor(private val ktJavaFieldS
     override val extensionReceiver: KSTypeReference?
         get() = null
 
-    @OptIn(SymbolInternals::class)
     override val type: KSTypeReference by lazy {
-        // FIXME: temporary workaround before upstream fixes java type refs.
-        ((ktJavaFieldSymbol as KtFirJavaFieldSymbol).firSymbol.fir as FirJavaField).also {
-            it.returnTypeRef = it.returnTypeRef.resolveIfJavaType(
-                it.moduleData.session,
-                (it.getContainingClass(it.moduleData.session) as FirJavaClass).javaTypeParameterStack
-            )
-        }
         KSTypeReferenceImpl.getCached(ktJavaFieldSymbol.returnType, this@KSPropertyDeclarationJavaImpl)
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -62,10 +62,10 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
     }
 
     override val nullability: Nullability by lazy {
-        if (type.nullability == KtTypeNullability.NON_NULLABLE) {
-            Nullability.NOT_NULL
-        } else {
-            Nullability.NULLABLE
+        when {
+            type is KtFlexibleType && type.lowerBound.nullability != type.upperBound.nullability -> Nullability.PLATFORM
+            analyze { type.canBeNull } -> Nullability.NULLABLE
+            else -> Nullability.NOT_NULL
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -17,7 +17,6 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.IdKeyTriple
 import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.symbol.*
@@ -42,18 +41,7 @@ class KSTypeReferenceImpl private constructor(
         if (parent == null || parent.origin == Origin.SYNTHETIC) {
             null
         } else {
-            when (ktType) {
-                is KtFunctionalType -> KSCallableReferenceImpl.getCached(ktType, this@KSTypeReferenceImpl)
-                is KtDynamicType -> KSDynamicReferenceImpl.getCached(this@KSTypeReferenceImpl)
-                is KtUsualClassType -> KSClassifierReferenceImpl.getCached(ktType, this@KSTypeReferenceImpl)
-                is KtFlexibleType -> KSClassifierReferenceImpl.getCached(
-                    ktType.lowerBound as KtUsualClassType,
-                    this@KSTypeReferenceImpl
-                )
-                is KtErrorType -> null
-                is KtTypeParameterType -> null
-                else -> throw IllegalStateException("Unexpected type element ${ktType.javaClass}, $ExceptionMessage")
-            }
+            ktType.toClassifierReference(this)
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -49,7 +49,7 @@ class KSValueParameterImpl private constructor(
     override val type: KSTypeReference by lazy {
         // FIXME: temporary workaround before upstream fixes java type refs.
         if (origin == Origin.JAVA || origin == Origin.JAVA_LIB) {
-            ((ktValueParameterSymbol as KtFirValueParameterSymbol).firSymbol.fir as FirJavaValueParameter).also {
+            ((ktValueParameterSymbol as KtFirValueParameterSymbol).firSymbol.fir as? FirJavaValueParameter)?.let {
                 // can't get containing class for FirJavaValueParameter, using empty stack for now.
                 it.returnTypeRef =
                     it.returnTypeRef.resolveIfJavaType(it.moduleData.session, JavaTypeParameterStack.EMPTY)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
@@ -142,7 +142,7 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             cachesDir = File(testRoot, "kspTest/kspCaches")
             kspOutputDir = File(testRoot, "kspTest")
         }.build()
-        val analysisSession = buildStandaloneAnalysisAPISession {
+        val analysisSession = buildStandaloneAnalysisAPISession(withPsiDeclarationFromBinaryModuleProvider = true) {
             buildKtModuleProviderByCompilerConfiguration(compilerConfiguration)
         }
         val ksp = KotlinSymbolProcessing(

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -329,7 +329,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/javaModifiers.kt")
     }
 
-    @Disabled
     @TestMetadata("javaNonNullTypes.kt")
     @Test
     fun testJavaNonNullTypes() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -304,7 +304,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/implicitPropertyAccessors.kt")
     }
 
-    @Disabled
     @TestMetadata("inheritedTypeAlias.kt")
     @Test
     fun testInheritedTypeAlias() {
@@ -356,7 +355,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/javaTypes.kt")
     }
 
-    @Disabled
     @TestMetadata("javaTypes2.kt")
     @Test
     fun testJavaTypes2() {


### PR DESCRIPTION
* reimplement reference element to align with upstream's change to `KtType.qualifiers`
* Support def non null types in reference element
   *  tested for symbols from source, symbols from binaries blocked due to get top level callables not working for libraries.
* some other minor fixes.
