### PR TITLE
remove module name mangling workaround

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -421,7 +421,14 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                         configurePluginOptions(kspTask)
                         kspTask.compilerOptions.noJdk.value(kotlinCompileTask.compilerOptions.noJdk)
                         configureLanguageVersion(kspTask)
-                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.moduleName.map { "$it-ksp" })
+                        if (kspTask.classpathSnapshotProperties.useClasspathSnapshot.get() == false) {
+                            kspTask.compilerOptions.moduleName.convention(
+                                kotlinCompileTask.moduleName.map { "$it-ksp" }
+                            )
+                        } else {
+                            kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.moduleName)
+                        }
+
                         kspTask.moduleName.value(kotlinCompileTask.moduleName.get())
                         kspTask.destination.value(kspOutputDir)
 
@@ -456,7 +463,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                         kspTask.compilerOptions.freeCompilerArgs
                             .value(kotlinCompileTask.compilerOptions.freeCompilerArgs)
                         configureLanguageVersion(kspTask)
-                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.moduleName.map { "$it-ksp" })
+                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.moduleName)
 
                         kspTask.incrementalChangesTransformers.add(
                             createIncrementalChangesTransformer(
@@ -516,8 +523,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                                 classpathCfg + kotlinCompileTask.compilerPluginClasspath!!
                             kspTask.compilerPluginOptions.addPluginArgument(kotlinCompileTask.compilerPluginOptions)
                         }
-                        kspTask.compilerOptions.moduleName
-                            .convention(kotlinCompileTask.compilerOptions.moduleName.map { "$it-ksp" })
+                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.compilerOptions.moduleName)
                         kspTask.commonSources.from(kotlinCompileTask.commonSources)
                         kspTask.options.add(FilesSubpluginOption("apclasspath", processorClasspath.files.toList()))
                         val kspOptions = kspTask.options.get().flatMap { listOf("-P", it.toArg()) }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIncrementalIT.kt
@@ -30,11 +30,11 @@ class AndroidIncrementalIT {
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground")
 
-    @Test
-    fun testPlaygroundAndroid() {
+    private fun testWithExtraFlags(vararg extras: String) {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         gradleRunner.withArguments(
+            *extras,
             "clean", ":application:compileDebugKotlin", "--configuration-cache-problems=warn", "--debug", "--stacktrace"
         ).build().let { result ->
             Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:compileDebugKotlin")?.outcome)
@@ -51,6 +51,7 @@ class AndroidIncrementalIT {
         }
 
         gradleRunner.withArguments(
+            *extras,
             ":application:compileDebugKotlin", "--configuration-cache-problems=warn", "--debug", "--stacktrace"
         ).build().let { result ->
             Assert.assertEquals(
@@ -58,5 +59,15 @@ class AndroidIncrementalIT {
                 BuildResultFixture(result).compiledKotlinSources,
             )
         }
+    }
+
+    @Test
+    fun testPlaygroundAndroid() {
+        testWithExtraFlags()
+    }
+
+    @Test
+    fun testPlaygroundAndroidUseClasspathSnapshotFalse() {
+        testWithExtraFlags("-Pkotlin.incremental.useClasspathSnapshot=false")
     }
 }


### PR DESCRIPTION
per comment in #649 , as the [linking issue](https://youtrack.jetbrains.com/issue/KT-45777) has been fixed, we should be able to remove this name mangling logic now.