### PR TITLE
Marking command line arguments options as InternalSubpluginOptions

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -161,7 +161,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                     if (!argument.matches(Regex("\\S+=\\S+"))) {
                         throw IllegalArgumentException("KSP apoption does not match \\S+=\\S+: $argument")
                     }
-                    options += SubpluginOption("apoption", argument)
+                    options += InternalSubpluginOption("apoption", argument)
                 }
             }
             return options


### PR DESCRIPTION
We described in https://github.com/google/ksp/issues/1359 a cache issue when using Ksp with the Room processor since version 1.8.10-1.0.9. 

After reviewing the code, we have noticed that since this version all the values of the internal property `options` are set as `CompilerPluginConfig` for the KspTasks.  
```kotlin
kspTask.pluginOptions.add(
                project.provider {
                    CompilerPluginConfig().apply {
                        (kspTask as KspTask).options.get().forEach {
                            addPluginArgument(KSP_PLUGIN_ID, it)
                        }
                    }
                }
            )
```
Later,  KGP will populate the inputs arguments like:
```kotlin
result["$subpluginId." + option.key + indexSuffix] = option.value
```
At this point, KGP doesn't know about the path sensitivity of the argument value producing different build cache keys:
<img width="1035" alt="Screenshot 2023-04-18 at 5 36 06 PM" src="https://user-images.githubusercontent.com/475733/232936207-73471072-ef08-4ca4-8f1b-5fa931e6d577.png">
(notice the argument `com.google.devtools.ksp.symbol-processing.apoption:room.schemaLocation`)

This PR updates the type of subplugin option for the CommandLineArgumentProviders as `InternalSubpluginOption` because this type of Subplugin does not track these values as inputs and they should instead already be tracked via the CommandLineArgumentProvider.

## Tests
Ksp 
https://ge.solutions-team.gradle.com/c/jeca5opi7c6lo/cfxcrcoqv7v46/task-inputs?cacheability=cacheable

Using `InternalSubpluginOption`
https://ge.solutions-team.gradle.com/c/sxmggqn6mwihu/3drfct4q2zqqk/task-inputs?cacheability=cacheable

