### PR TITLE
Set up jvm toolchain requirements for tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,4 +94,11 @@ subprojects {
         sourceCompatibility = JavaVersion.VERSION_1_8.toString()
         targetCompatibility = JavaVersion.VERSION_1_8.toString()
     }
+
+    tasks.withType<Test>().configureEach {
+        // Java 11 is required to run tests
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(11))
+        })
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -93,12 +93,28 @@ subprojects {
     tasks.withType<JavaCompile>().configureEach {
         sourceCompatibility = JavaVersion.VERSION_1_8.toString()
         targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        javaCompiler.set(
+            javaToolchains.compilerFor {
+                languageVersion.set(JavaLanguageVersion.of(11))
+            }
+        )
     }
 
     tasks.withType<Test>().configureEach {
         // Java 11 is required to run tests
-        javaLauncher.set(javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(11))
-        })
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(11))
+            }
+        )
+    }
+
+    tasks.withType<JavaExec>().configureEach {
+        // Java 11 is required to run
+        javaLauncher.set(
+            javaToolchains.launcherFor {
+                languageVersion.set(JavaLanguageVersion.of(11))
+            }
+        )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfil
 kotlinBaseVersion=1.9.20-dev-1095
 agpBaseVersion=7.0.0
 intellijVersion=213.7172.25
-junitVersion=4.12
+junitVersion=4.13.1
 googleTruthVersion=1.1
 compilerTestEnabled=false
 

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -21,4 +21,13 @@ tasks.named<Test>("test") {
     dependsOn(":gradle-plugin:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing-cmdline:publishAllPublicationsToTestRepository")
+
+    // JDK_9 environment property is required.
+    // To add a custom location (if not detected automatically) follow https://docs.gradle.org/current/userguide/toolchains.html#sec:custom_loc
+    if (System.getenv("JDK_9") == null) {
+        val launcher9 = javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(9))
+        }
+        environment["JDK_9"] = launcher9.map { it.metadata.installationPath }
+    }
 }


### PR DESCRIPTION
After loosing some time debugging why some tests were failing I noticed that tests require Java 11, with some in `:integration-tests:test` also require `JDK_9` to be set up and pointing to a Java 9 installation. These changes declare these requirements.

I also updated jUnit to latest jUnit 4 (4.13.1).