### PR TITLE
Get language version from KotlinCompilation

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -400,7 +400,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
 
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
             kspTask.compilerOptions.useK2.value(false)
-            kspTask.compilerOptions.languageVersion.orNull?.let { version ->
+            kotlinCompilation.compilerOptions.options.languageVersion.orNull?.let { version ->
                 if (version >= KotlinVersion.KOTLIN_2_0) {
                     kspTask.compilerOptions.languageVersion.value(LANGUAGE_VERSION)
                 }


### PR DESCRIPTION
instead of relying on `AbstractKotlinCompileConfig`.