### PR TITLE
Allow spaces in commandLineArgumentProvider values

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -157,8 +157,8 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             )
             commandLineArgumentProviders.get().forEach {
                 it.asArguments().forEach { argument ->
-                    if (!argument.matches(Regex("\\S+=\\S+"))) {
-                        throw IllegalArgumentException("KSP apoption does not match \\S+=\\S+: $argument")
+                    if (!argument.matches(Regex("\\S+=.*\\S+.*"))) {
+                        throw IllegalArgumentException("KSP apoption does not match \\S+=.*\\S+.*: $argument")
                     }
                     options += InternalSubpluginOption("apoption", argument)
                 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -174,7 +174,7 @@ class GradleCompilationTest {
         testRule.appModule.buildFileAdditions.add(
             """
                 ksp {
-                    arg(Provider(project.layout.projectDirectory.dir("schemas").asFile))
+                    arg(Provider(project.layout.projectDirectory.dir("room schemas").asFile))
                 }
                 class Provider(roomOutputDir: File) : CommandLineArgumentProvider {
 
@@ -200,10 +200,10 @@ class GradleCompilationTest {
         )
         val result = testRule.runner().withArguments(":app:assembleDebug").build()
         val pattern1 = Regex.escape("apoption=room.schemaLocation=")
-        val pattern2 = Regex.escape("${testRule.appModule.moduleRoot}/schemas")
+        val pattern2 = Regex.escape("${testRule.appModule.moduleRoot}/room schemas")
         assertThat(result.output).containsMatch("$pattern1\\S*$pattern2")
         assertThat(result.output).contains("apoption=room.generateKotlin=true")
-        val schemasFolder = testRule.appModule.moduleRoot.resolve("schemas")
+        val schemasFolder = testRule.appModule.moduleRoot.resolve("room schemas")
         assertThat(result.task(":app:kspDebugKotlin")!!.outcome).isEquivalentAccordingToCompareTo(TaskOutcome.SUCCESS)
         assertThat(schemasFolder.exists()).isTrue()
         assertThat(schemasFolder.resolve("Database/1.json").exists()).isTrue()
@@ -234,7 +234,7 @@ class GradleCompilationTest {
         )
 
         val result = testRule.runner().withArguments(":app:assemble").buildAndFail()
-        assertThat(result.output).contains("KSP apoption does not match \\S+=\\S+: invalid")
+        assertThat(result.output).contains("KSP apoption does not match \\S+=.*\\S+.*: invalid")
     }
 
     @Test


### PR DESCRIPTION
A sample problem: https://github.com/android/nowinandroid/issues/604 

I think it's perfectly valid to have a space in a file path. But the current regex pattern explicitly does not allow spaces in command line arguments.

I looked in the git history for this formatting, but couldn't find a reason for such a restrictive pattern.