### PR TITLE
Sync compiler options from KotlinCompilation

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -84,6 +84,12 @@ class KotlinFactories {
                 // See [KotlinCompileConfig] in for details.
                 // FIXME: make it configurable in upstream or support useClasspathSnapshot == true, if possible.
                 kspTaskProvider.configure {
+                    val compilerOptions = kotlinCompilation.compilerOptions.options as KotlinJvmCompilerOptions
+                    KotlinJvmCompilerOptionsHelper.syncOptionsAsConvention(
+                        from = compilerOptions,
+                        into = it.compilerOptions
+                    )
+
                     if (it.classpathSnapshotProperties.useClasspathSnapshot.get()) {
                         it.classpathSnapshotProperties.classpath.from(project.provider { it.libraries })
                     }
@@ -100,6 +106,12 @@ class KotlinFactories {
                 BaseKotlin2JsCompileConfig<Kotlin2JsCompile>(KotlinCompilationInfo(kotlinCompilation))
                     .execute(kspTaskProvider as TaskProvider<Kotlin2JsCompile>)
                 kspTaskProvider.configure {
+                    val compilerOptions = kotlinCompilation.compilerOptions.options as KotlinJsCompilerOptions
+                    KotlinJsCompilerOptionsHelper.syncOptionsAsConvention(
+                        from = compilerOptions,
+                        into = it.compilerOptions
+                    )
+
                     it.incrementalJsKlib = false
                 }
             }
@@ -113,6 +125,15 @@ class KotlinFactories {
             return project.tasks.register(taskName, KspTaskMetadata::class.java).also { kspTaskProvider ->
                 KotlinCompileCommonConfig(KotlinCompilationInfo(kotlinCompilation))
                     .execute(kspTaskProvider as TaskProvider<KotlinCompileCommon>)
+
+                kspTaskProvider.configure {
+                    val compilerOptions =
+                        kotlinCompilation.compilerOptions.options as KotlinMultiplatformCommonCompilerOptions
+                    KotlinMultiplatformCommonCompilerOptionsHelper.syncOptionsAsConvention(
+                        from = compilerOptions,
+                        into = it.compilerOptions
+                    )
+                }
             }
         }
 
@@ -127,6 +148,12 @@ class KotlinFactories {
                 KotlinCompilationInfo(kotlinCompilation)
             ).apply {
                 configure { kspTask ->
+                    val compilerOptions = kotlinCompilation.compilerOptions.options as KotlinNativeCompilerOptions
+                    KotlinNativeCompilerOptionsHelper.syncOptionsAsConvention(
+                        from = compilerOptions,
+                        into = kspTask.compilerOptions
+                    )
+
                     kspTask.onlyIf {
                         kspTask.konanTarget.enabledOnCurrentHost
                     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -419,16 +419,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                         configureAsKspTask(kspTask, isIncremental)
                         configureAsAbstractKotlinCompileTool(kspTask as AbstractKotlinCompileTool<*>)
                         configurePluginOptions(kspTask)
-                        kspTask.compilerOptions.noJdk.value(kotlinCompileTask.compilerOptions.noJdk)
-                        kspTask.compilerOptions.jvmTarget.value(kotlinCompileTask.compilerOptions.jvmTarget)
-                        kspTask.compilerOptions.verbose.convention(kotlinCompilation.compilerOptions.options.verbose)
                         configureLanguageVersion(kspTask)
                         if (kspTask.classpathSnapshotProperties.useClasspathSnapshot.get() == false) {
                             kspTask.compilerOptions.moduleName.convention(
                                 kotlinCompileTask.compilerOptions.moduleName.map { "$it-ksp" }
                             )
-                        } else {
-                            kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.compilerOptions.moduleName)
                         }
 
                         kspTask.destination.value(kspOutputDir)
@@ -461,11 +456,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                         configureAsKspTask(kspTask, isIncremental)
                         configureAsAbstractKotlinCompileTool(kspTask as AbstractKotlinCompileTool<*>)
                         configurePluginOptions(kspTask)
-                        kspTask.compilerOptions.verbose.convention(kotlinCompilation.compilerOptions.options.verbose)
-                        kspTask.compilerOptions.freeCompilerArgs
-                            .value(kotlinCompileTask.compilerOptions.freeCompilerArgs)
                         configureLanguageVersion(kspTask)
-                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.moduleName)
 
                         kspTask.incrementalChangesTransformers.add(
                             createIncrementalChangesTransformer(
@@ -525,11 +516,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                                 classpathCfg + kotlinCompileTask.compilerPluginClasspath!!
                             kspTask.compilerPluginOptions.addPluginArgument(kotlinCompileTask.compilerPluginOptions)
                         }
-                        kspTask.compilerOptions.moduleName.convention(kotlinCompileTask.compilerOptions.moduleName)
                         kspTask.commonSources.from(kotlinCompileTask.commonSources)
                         kspTask.options.add(FilesSubpluginOption("apclasspath", processorClasspath.files.toList()))
                         val kspOptions = kspTask.options.get().flatMap { listOf("-P", it.toArg()) }
-                        kspTask.compilerOptions.verbose.convention(kotlinCompilation.compilerOptions.options.verbose)
                         kspTask.compilerOptions.freeCompilerArgs.value(
                             kspOptions + kotlinCompileTask.compilerOptions.freeCompilerArgs.get()
                         )


### PR DESCRIPTION
instead of copying them one by one.