### PR TITLE
Fix mapping of TypeAliasDescriptor to KsTypeAlias

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -1443,6 +1443,7 @@ fun MemberDescriptor.toKSDeclaration(): KSDeclaration =
             is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(this)
             is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(this)
             is PropertyDescriptor -> KSPropertyDeclarationDescriptorImpl.getCached(this)
+            is TypeAliasDescriptor -> KSTypeAliasDescriptorImpl.getCached(this)
             else -> throw IllegalStateException("Unknown expect/actual implementation")
         }
     }

--- a/test-utils/testData/api/getPackage.kt
+++ b/test-utils/testData/api/getPackage.kt
@@ -26,6 +26,7 @@
 // symbols from package lib2
 // lib2.Foo KOTLIN_LIB
 // lib2.a KOTLIN_LIB
+// lib2.FooTypeAlias KOTLIN_LIB
 // symbols from package main.test
 // main.test.KotlinMain KOTLIN
 // main.test.C JAVA
@@ -52,6 +53,8 @@ class Bar {}
 package lib2
 
 class Foo
+
+typealias FooTypeAlias = Foo
 
 val a = 0
 


### PR DESCRIPTION
Using `getDeclarationsFromPackage` fails if the package contains a compiled `typealias`:
```
java.lang.IllegalStateException: failed to analyze: java.lang.IllegalStateException: Unknown expect/actual implementation
	at org.jetbrains.kotlin.analyzer.AnalysisResult.throwIfError(AnalysisResult.kt:56)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFilesUsingStandardMode(GenerationUtils.kt:205)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFiles(GenerationUtils.kt:88)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFiles(GenerationUtils.kt:73)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFiles$default(GenerationUtils.kt:67)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFilesTo(GenerationUtils.kt:61)
	at com.google.devtools.ksp.test.AbstractKSPCompilerPluginTest.runTest(AbstractKSPCompilerPluginTest.kt:75)
	at com.google.devtools.ksp.testutils.AbstractKSPTest.runTest(AbstractKSPTest.kt:225)
	at com.google.devtools.ksp.test.KSPCompilerPluginTest.testGetPackage(KSPCompilerPluginTest.kt:249)
    ...
Caused by: java.lang.IllegalStateException: Unknown expect/actual implementation
	at com.google.devtools.ksp.processing.impl.ResolverImplKt.toKSDeclaration(ResolverImpl.kt:1447)
	at com.google.devtools.ksp.processing.impl.ResolverImpl$getDeclarationsFromPackage$1.invoke(ResolverImpl.kt:972)
	at com.google.devtools.ksp.processing.impl.ResolverImpl$getDeclarationsFromPackage$1.invoke(ResolverImpl.kt:972)
	at kotlin.sequences.TransformingSequence$iterator$1.next(Sequences.kt:210)
	at kotlin.sequences.FilteringSequence$iterator$1.calcNext(Sequences.kt:170)
	at kotlin.sequences.FilteringSequence$iterator$1.hasNext(Sequences.kt:194)
	at kotlin.sequences.FlatteningSequence$iterator$1.ensureItemIterator(Sequences.kt:307)
	at kotlin.sequences.FlatteningSequence$iterator$1.hasNext(Sequences.kt:303)
	at com.google.devtools.ksp.processor.GetPackageProcessor.addPackage(GetPackageProcessor.kt:31)
	at com.google.devtools.ksp.processor.GetPackageProcessor.process(GetPackageProcessor.kt:17)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$6$1.invoke(KotlinSymbolProcessingExtension.kt:293)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension$doAnalysis$6$1.invoke(KotlinSymbolProcessingExtension.kt:291)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.handleException(KotlinSymbolProcessingExtension.kt:396)
	at com.google.devtools.ksp.AbstractKotlinSymbolProcessingExtension.doAnalysis(KotlinSymbolProcessingExtension.kt:291)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(TopDownAnalyzerFacadeForJVM.kt:112)
	at org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration$default(TopDownAnalyzerFacadeForJVM.kt:77)
	at org.jetbrains.kotlin.resolve.lazy.JvmResolveUtil.analyze(JvmResolveUtil.kt:99)
	at org.jetbrains.kotlin.resolve.lazy.JvmResolveUtil.analyzeAndCheckForErrors(JvmResolveUtil.kt:66)
	at org.jetbrains.kotlin.codegen.GenerationUtils.compileFilesUsingStandardMode(GenerationUtils.kt:201)
	... 66 more
```

This fixes that issue and updates the `testGetPackage` test to cover the "`typealias` in library" case.