### PR TITLE
Generate Java to a new root in each round

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -29,7 +29,7 @@ import java.io.OutputStream
 
 class CodeGeneratorImpl(
     private val classDir: File,
-    private val javaDir: File,
+    private val javaDir: () -> File,
     private val kotlinDir: File,
     private val resourcesDir: File,
     private val projectBase: File,
@@ -101,7 +101,7 @@ class CodeGeneratorImpl(
     private fun extensionToDirectory(extensionName: String): File {
         return when (extensionName) {
             "class" -> classDir
-            "java" -> javaDir
+            "java" -> javaDir()
             "kt" -> kotlinDir
             else -> resourcesDir
         }

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -112,8 +112,7 @@ class CodeGeneratorImpl(
         if (!isWithinBaseDir(baseDir, file)) {
             throw IllegalStateException("requested path is outside the bounds of the required directory")
         }
-        val absolutePath = file.absolutePath
-        if (absolutePath in fileMap) {
+        if (path in fileMap) {
             throw FileAlreadyExistsException(file)
         }
         val parentFile = file.parentFile
@@ -121,7 +120,7 @@ class CodeGeneratorImpl(
             throw IllegalStateException("failed to make parent directories.")
         }
         file.writeText("")
-        fileMap[absolutePath] = file
+        fileMap[path] = file
         val sources = if (dependencies.isAllSources) {
             allSources + anyChangesWildcard
         } else {
@@ -132,8 +131,8 @@ class CodeGeneratorImpl(
             }
         }
         associate(sources, file)
-        fileOutputStreamMap[absolutePath] = fileMap[absolutePath]!!.outputStream()
-        return fileOutputStreamMap[absolutePath]!!
+        fileOutputStreamMap[path] = fileMap[path]!!.outputStream()
+        return fileOutputStreamMap[path]!!
     }
 
     private fun isWithinBaseDir(baseDir: File, file: File): Boolean {

--- a/common-util/src/test/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImplTest.kt
+++ b/common-util/src/test/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImplTest.kt
@@ -26,7 +26,7 @@ class CodeGeneratorImplTest {
         resourcesDir.mkdir()
         codeGenerator = CodeGeneratorImpl(
             classesDir,
-            javaDir,
+            { javaDir },
             kotlinDir,
             resourcesDir,
             baseDir,

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -22,7 +22,6 @@ import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.memoized
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.processing.impl.workaroundForNested
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
 import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
@@ -75,7 +74,7 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
 
     // Could the resolution ever fail?
     private val descriptor: ClassDescriptor? by lazy {
-        ResolverImpl.instance!!.moduleClassResolver.resolveClass(JavaClassImpl(psi).apply { workaroundForNested() })
+        ResolverImpl.instance!!.moduleClassResolver.resolveClass(JavaClassImpl(psi))
     }
 
     // TODO in 1.5 + jvmTarget 15, will we return Java permitted types?

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt
@@ -20,7 +20,6 @@ import com.google.devtools.ksp.BinaryClassInfoCache
 import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.impl.ResolverImpl
-import com.google.devtools.ksp.processing.impl.workaroundForNested
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.symbol.impl.binary.KSClassDeclarationDescriptorImpl
@@ -231,9 +230,9 @@ internal inline fun <reified T : CallableMemberDescriptor> T.findClosestOverride
 
 internal fun ModuleClassResolver.resolveContainingClass(psiMethod: PsiMethod): ClassDescriptor? {
     return if (psiMethod.isConstructor) {
-        resolveClass(JavaConstructorImpl(psiMethod).containingClass.apply { workaroundForNested() })
+        resolveClass(JavaConstructorImpl(psiMethod).containingClass)
     } else {
-        resolveClass(JavaMethodImpl(psiMethod).containingClass.apply { workaroundForNested() })
+        resolveClass(JavaMethodImpl(psiMethod).containingClass)
     }
 }
 

--- a/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,58 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+import java.io.OutputStream
+
+fun OutputStream.appendText(str: String) {
+    this.write(str.toByteArray())
+}
+
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger,
+) : SymbolProcessor {
+    var round = 0
+
+    fun chk(decl: KSClassDeclaration) {
+        val t = decl.asStarProjectedType()
+        val v = decl.validate()
+        logger.warn("ROUND $round: ${decl.qualifiedName?.asString()}: $t: $v")
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (round > 0) {
+            resolver.getNewFiles().forEach {
+                it.declarations.filterIsInstance<KSClassDeclaration>().forEach {
+                    chk(it)
+                    it.declarations.filterIsInstance<KSClassDeclaration>().forEach {
+                        if (it.packageName.asString() == "cached.index") {
+                            if (!it.validate()) {
+                                throw Exception("Invalid class: ${it.qualifiedName?.asString()}")
+                            }
+                            chk(it)
+                        }
+                    }
+                }
+            }
+        }
+        if (round < 5) {
+            codeGenerator.createNewFile(Dependencies(false), "cached.index", "O$round", "java").use {
+                it.appendText("package cached.index;\n")
+                it.appendText("public class O$round {\n")
+                it.appendText("  public static class N$round {\n")
+                it.appendText("  }\n")
+                it.appendText("}\n")
+            }
+            round += 1
+        }
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        environment: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return TestProcessor(environment.codeGenerator, environment.logger)
+    }
+}

--- a/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/javaNestedClass/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,1 +1,2 @@
 ValidateProcessorProvider
+TestProcessorProvider

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -70,7 +70,7 @@ class KotlinSymbolProcessing(
         val anyChangesWildcard = AnyChanges(options.projectBaseDir)
         codeGenerator = CodeGeneratorImpl(
             options.classOutputDir,
-            options.javaOutputDir,
+            { options.javaOutputDir },
             options.kotlinOutputDir,
             options.resourceOutputDir,
             options.projectBaseDir,


### PR DESCRIPTION
and copy them back into options.javaOutputDir after processing finished.
This works a stale-cache issue in the compiler for nested classes
around.

See #1434 for details.