### PR TITLE
Fix test failures on Windows

### DIFF
--- a/buildSrc/src/main/kotlin/com/google/devtools/ksp/ApiCheck.kt
+++ b/buildSrc/src/main/kotlin/com/google/devtools/ksp/ApiCheck.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.tasks.JavaExec
+import java.io.File
 
 val API_BASE_FILE="api.base"
 
@@ -74,7 +75,7 @@ private fun JavaExec.configureCommonMetalavaArgs(
 }
 
 private fun Project.getCompileClasspath(): String =
-    configurations.findByName("compileClasspath")!!.files.map { it.absolutePath }.joinToString(":")
+    configurations.findByName("compileClasspath")!!.files.map { it.absolutePath }.joinToString(File.pathSeparator)
 
 private fun Project.getMetalavaConfiguration(): Configuration {
     return configurations.findByName("metalava") ?: configurations.create("metalava") {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -275,7 +275,7 @@ class GradleCompilationTest {
         )
         val result = testRule.runner().withDebug(true).withArguments(":app:assembleDebug").build()
         val pattern1 = Regex.escape("apoption=room.schemaLocation=")
-        val pattern2 = Regex.escape("${testRule.appModule.moduleRoot}/schemas-kspDebugKotlin")
+        val pattern2 = Regex.escape(testRule.appModule.moduleRoot.resolve("schemas-kspDebugKotlin").path)
         val pattern3 = Regex.escape("commandLine=[")
         assertThat(result.output).containsMatch("$pattern1\\S*$pattern2")
         assertThat(result.output).containsMatch("$pattern3\\S*$pattern2")


### PR DESCRIPTION
I ran into these failures while trying to build ksp on my Windows machine:

* `:api:checkApi` failed because of the wrong classpath separator, see https://www.baeldung.com/java-classpath-syntax and https://bugs.openjdk.org/browse/JDK-8262004
* `GradleCompilationTest.commandLineArgumentIsIncludedInApoptionsWhenAddedInKspTask` failed because the output had `\` where `/` was expected.