### PR TITLE
Java shadow dir: handle absolute paths

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -467,7 +467,10 @@ abstract class AbstractKotlinSymbolProcessingExtension(
             javaShadowBase.listFiles()?.forEach { roundDir ->
                 if (roundDir.exists() && roundDir.isDirectory()) {
                     roundDir.walkTopDown().forEach {
-                        it.copyTo(File(options.javaOutputDir, it.path))
+                        val dst = File(options.javaOutputDir, File(it.path).toRelativeString(roundDir))
+                        if (dst.isFile || !dst.exists()) {
+                            it.copyTo(dst)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
They may appear on platforms other than Gradle.

TEST=on other platforms