### PR TITLE
fix java array argument variance

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -738,7 +738,16 @@ class ResolverImpl(
                     )
                     javaTypeParameterMap[typeParameterDescriptor] = psi
                 }
-                return getKSTypeCached(resolveJavaType(type.psi, type), type.element.typeArguments, type.annotations)
+                val resolved = getKSTypeCached(
+                    resolveJavaType(type.psi, type),
+                    type.element.typeArguments,
+                    type.annotations
+                )
+                return if (type.psi is PsiArrayType) {
+                    resolved
+                } else {
+                    resolved.replace(type.element.typeArguments)
+                }
             }
             else -> throw IllegalStateException("Unable to resolve type for $type, $ExceptionMessage")
         }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceJavaImpl.kt
@@ -98,7 +98,7 @@ class KSTypeReferenceJavaImpl private constructor(val psi: PsiType, override val
                 val componentType = ResolverImpl.instance!!.resolveJavaType(type.componentType, this)
                 if (type.componentType !is PsiPrimitiveType) {
                     KSClassifierReferenceDescriptorImpl.getCached(
-                        ResolverImpl.instance!!.module.builtIns.getArrayType(Variance.INVARIANT, componentType),
+                        ResolverImpl.instance!!.module.builtIns.getArrayType(Variance.OUT_VARIANCE, componentType),
                         origin,
                         this
                     )

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -531,6 +531,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("../test-utils/testData/api/typeAnnotation.kt")
     }
 
+    @TestMetadata("typeArgumentVariance.kt")
+    @Test
+    fun testTypeArgumentVariance() {
+        runTest("../test-utils/testData/api/typeArgumentVariance.kt")
+    }
+
     @TestMetadata("typeComposure.kt")
     @Test
     fun testTypeComposure() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeArgumentVarianceProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeArgumentVarianceProcessor.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class TypeArgumentVarianceProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val myClass = resolver.getClassDeclarationByName("MyClass")!!
+        val fieldDeclaration = myClass.getDeclaredProperties().single { it.simpleName.asString() == "field" }
+        result.add(fieldDeclaration.type.toString())
+        result.add(fieldDeclaration.type.element?.typeArguments?.single().toString())
+        result.add(fieldDeclaration.type.resolve().toString())
+        result.add(fieldDeclaration.type.resolve().arguments.single().toString())
+        return emptyList()
+    }
+}

--- a/test-utils/testData/api/parent.kt
+++ b/test-utils/testData/api/parent.kt
@@ -157,10 +157,10 @@
 // parent of G: RGB
 // parent of B: RGB
 // parent of RGB: RGB
-// parent of RGB: INVARIANT RGB
-// parent of INVARIANT RGB: Array<(RGB..RGB?)>
-// parent of Array<(RGB..RGB?)>: Array<(RGB..RGB?)>
-// parent of Array<(RGB..RGB?)>: values
+// parent of RGB: COVARIANT RGB
+// parent of COVARIANT RGB: Array<out (RGB..RGB?)>
+// parent of Array<out (RGB..RGB?)>: Array<out (RGB..RGB?)>
+// parent of Array<out (RGB..RGB?)>: values
 // parent of values: RGB
 // parent of String: String
 // parent of String: name

--- a/test-utils/testData/api/typeArgumentVariance.kt
+++ b/test-utils/testData/api/typeArgumentVariance.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: TypeArgumentVarianceProcessor
+// EXPECTED:
+// MyInterface<? extends String>
+// COVARIANT String
+// (MyInterface<out (String..String?)>..MyInterface<out (String..String?)>?)
+// COVARIANT String
+// END
+
+// FILE: a.kt
+interface MyInterface<out T>
+
+// FILE: MyClass.java
+public class MyClass {
+    MyInterface<? extends String> field;
+}


### PR DESCRIPTION
fixes #1456 

It is a little bit messed up regarding flexible type.

By Java specs, array should have a single variance of covariance for its type arguments. However, from kotlin compiler, the said type is resolved to a flexible type with a lower bound of invariant type argument and an upper bound of covariant type argument. It might make sense from kotlinc since invariant is more restrictive hence works for a lower bound. It is just that when compiler is dealing with `KoltinType.arguments`, it only looks at lower bound which causes trouble because the lowerbound argument of an array actually discarded the covariant part.

It might look to be better respect Java spec by making it lower bound covariant as well, but attempting to do that caused a lot of failures elsewhere and trying to work against compiler seems a bad idea, following kotlinc's result is easier to implement here. 

However it is still reasonable to add a special handling in reference element to reflect the covariant nature of array.