### PR TITLE
Keep timestamps when copying from java shadows

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -469,7 +469,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                     roundDir.walkTopDown().forEach {
                         val dst = File(options.javaOutputDir, File(it.path).toRelativeString(roundDir))
                         if (dst.isFile || !dst.exists()) {
-                            it.copyTo(dst)
+                            copyWithTimestamp(it, dst, false)
                         }
                     }
                 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
@@ -37,6 +37,9 @@ class OutputDepsIt {
 
     val src2Output = mapOf(
         "workload/src/main/java/p1/J1.java" to setOf(
+            "java/p1/J1Generated.java",
+            "java/p1/K1Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/J1Generated.kt",
             "kotlin/p1/K1Generated.kt",
             "kotlin/p1/K2Generated.kt",
@@ -44,11 +47,15 @@ class OutputDepsIt {
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/java/p1/J2.java" to setOf(
+            "java/p1/J2Generated.java",
             "kotlin/p1/J2Generated.kt",
             "resources/p1.Anno1.log",
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/kotlin/p1/K1.kt" to setOf(
+            "java/p1/J1Generated.java",
+            "java/p1/K1Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/J1Generated.kt",
             "kotlin/p1/K1Generated.kt",
             "kotlin/p1/K2Generated.kt",
@@ -56,6 +63,9 @@ class OutputDepsIt {
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/kotlin/p1/K2.kt" to setOf(
+            "java/p1/J1Generated.java",
+            "java/p1/K1Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/J1Generated.kt",
             "kotlin/p1/K1Generated.kt",
             "kotlin/p1/K2Generated.kt",
@@ -66,6 +76,11 @@ class OutputDepsIt {
 
     val deletedSrc2Output = listOf(
         "workload/src/main/java/p1/J1.java" to listOf(
+            "java/p1/Anno1Generated.java",
+            "java/p1/Anno2Generated.java",
+            "java/p1/J2Generated.java",
+            "java/p1/K1Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/Anno1Generated.kt",
             "kotlin/p1/Anno2Generated.kt",
             "kotlin/p1/J2Generated.kt",
@@ -75,6 +90,10 @@ class OutputDepsIt {
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/java/p1/J2.java" to listOf(
+            "java/p1/Anno1Generated.java",
+            "java/p1/Anno2Generated.java",
+            "java/p1/K1Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/Anno1Generated.kt",
             "kotlin/p1/Anno2Generated.kt",
             "kotlin/p1/K1Generated.kt",
@@ -83,6 +102,9 @@ class OutputDepsIt {
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/kotlin/p1/K1.kt" to listOf(
+            "java/p1/Anno1Generated.java",
+            "java/p1/Anno2Generated.java",
+            "java/p1/K2Generated.java",
             "kotlin/p1/Anno1Generated.kt",
             "kotlin/p1/Anno2Generated.kt",
             "kotlin/p1/K2Generated.kt",
@@ -90,6 +112,8 @@ class OutputDepsIt {
             "resources/p1.Anno2.log",
         ),
         "workload/src/main/kotlin/p1/K2.kt" to listOf(
+            "java/p1/Anno1Generated.java",
+            "java/p1/Anno2Generated.java",
             "kotlin/p1/Anno1Generated.kt",
             "kotlin/p1/Anno2Generated.kt",
             "resources/p1.Anno1.log",

--- a/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/output-deps/test-processor/src/main/kotlin/TestProcessor.kt
@@ -44,6 +44,12 @@ class TestProcessor : SymbolProcessor {
                         writer.write("private val unused = \"unused\"")
                     }
                 }
+            codeGenerator.createNewFile(Dependencies(false, file), file.packageName.asString(), outputBaseFN, "java")
+                .use { output ->
+                    OutputStreamWriter(output).use { writer ->
+                        writer.write("class $outputBaseFN {}")
+                    }
+                }
         }
         processed = true
         return emptyList()


### PR DESCRIPTION
so that it won't break build system's incremental mechanism.