### PR TITLE
[WIP] Support analyzing context receivers

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSClassDeclaration.kt
@@ -74,4 +74,9 @@ interface KSClassDeclaration : KSDeclaration, KSDeclarationContainer {
      * @return A type with all type parameters applied with star projection.
      */
     fun asStarProjectedType(): KSType
+
+    /**
+     * The class may have context receivers at the class level, which affect all constructors
+     */
+    val contextReceivers: List<KSTypeReference>
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunction.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunction.kt
@@ -54,6 +54,13 @@ interface KSFunction {
     val extensionReceiverType: KSType?
 
     /**
+     * The context receiver types of the function
+     *
+     * @see KSFunctionDeclaration.contextReceivers
+     */
+    val contextReceiverTypes: List<KSType>
+
+    /**
      * True if the compiler couldn't resolve the function.
      */
     val isError: Boolean

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSFunctionDeclaration.kt
@@ -45,6 +45,11 @@ interface KSFunctionDeclaration : KSDeclaration, KSDeclarationContainer {
     val extensionReceiver: KSTypeReference?
 
     /**
+     * Context receivers of this function
+     */
+    val contextReceivers: List<KSTypeReference>
+
+    /**
      * Return type of this function.
      * Can be null if an error occurred during resolution.
      */

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -72,6 +72,10 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
 
     override fun getAllProperties(): Sequence<KSPropertyDeclaration> = descriptor.getAllProperties()
 
+    override val contextReceivers: List<KSTypeReference> by lazy {
+        descriptor.getAllContextReceivers(this)
+    }
+
     override val primaryConstructor: KSFunctionDeclaration? by lazy {
         descriptor.unsubstitutedPrimaryConstructor?.let { KSFunctionDeclarationDescriptorImpl.getCached(it) }
     }
@@ -188,6 +192,12 @@ internal fun ClassDescriptor.getAllProperties(): Sequence<KSPropertyDeclaration>
                 else -> KSPropertyDeclarationDescriptorImpl.getCached(it as PropertyDescriptor)
             }
         }
+}
+
+internal fun ClassDescriptor.getAllContextReceivers(node: KSNode): List<KSTypeReference> {
+    return contextReceivers.map {
+        KSTypeReferenceDescriptorImpl.getCached(it.type, origin, node)
+    }
 }
 
 internal fun ClassDescriptor.sealedSubclassesSequence(): Sequence<KSClassDeclaration> {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSFunctionDeclarationDescriptorImpl.kt
@@ -58,6 +58,12 @@ class KSFunctionDeclarationDescriptorImpl private constructor(val descriptor: Fu
         }
     }
 
+    override val contextReceivers: List<KSTypeReference> by lazy {
+        descriptor.contextReceiverParameters.map {
+            KSTypeReferenceDescriptorImpl.getCached(it.type, origin, this)
+        }
+    }
+
     override val functionKind: FunctionKind by lazy {
 
         when {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -105,6 +105,8 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
         return getKSTypeCached(descriptor!!.defaultType)
     }
 
+    override val contextReceivers: List<KSTypeReference> = emptyList()
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitClassDeclaration(this, data)
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -166,6 +166,8 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
         } ?: KSErrorType
     }
 
+    override val contextReceivers: List<KSTypeReference> = emptyList()
+
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         return visitor.visitClassDeclaration(this, data)
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSFunctionDeclarationJavaImpl.kt
@@ -61,6 +61,8 @@ class KSFunctionDeclarationJavaImpl private constructor(val psi: PsiMethod) :
 
     override val extensionReceiver: KSTypeReference? = null
 
+    override val contextReceivers: List<KSTypeReference> = emptyList()
+
     override val functionKind: FunctionKind = when {
         psi.hasModifier(JvmModifier.STATIC) -> FunctionKind.STATIC
         else -> FunctionKind.MEMBER

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.processing.impl.KSTypeReferenceSyntheticImpl
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.binary.getAllContextReceivers
 import com.google.devtools.ksp.symbol.impl.binary.getAllFunctions
 import com.google.devtools.ksp.symbol.impl.binary.getAllProperties
 import com.google.devtools.ksp.symbol.impl.binary.sealedSubclassesSequence
@@ -130,6 +131,10 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
 
     override fun asStarProjectedType(): KSType {
         return getKSTypeCached(descriptor.defaultType.replaceArgumentsWithStarProjections())
+    }
+
+    override val contextReceivers: List<KSTypeReference> by lazy {
+        descriptor.getAllContextReceivers(this)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionDeclarationImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.processing.impl.KSPCompilationError
 import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.impl.*
+import com.google.devtools.ksp.symbol.impl.binary.KSTypeReferenceDescriptorImpl
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtConstructor
@@ -75,6 +76,12 @@ class KSFunctionDeclarationImpl private constructor(val ktFunction: KtFunction) 
             KSTypeReferenceImpl.getCached(ktFunction.receiverTypeReference!!)
         } else {
             null
+        }
+    }
+
+    override val contextReceivers: List<KSTypeReference> by lazy {
+        ktFunction.contextReceivers.map {
+            KSTypeReferenceImpl.getCached(it.typeReference()!!)
         }
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
@@ -43,6 +43,11 @@ class KSFunctionErrorImpl(
             KSErrorType
         }
 
+    override val contextReceiverTypes: List<KSType>
+        get() = declaration.contextReceivers.let {
+            listOf(KSErrorType)
+        }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionImpl.kt
@@ -54,6 +54,12 @@ class KSFunctionImpl(val descriptor: CallableDescriptor) : KSFunction {
         descriptor.extensionReceiverParameter?.type?.let(::getKSTypeCached)
     }
 
+    override val contextReceiverTypes: List<KSType> by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        descriptor.contextReceiverParameters.map {
+            getKSTypeCached(it.type)
+        }
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -64,6 +70,7 @@ class KSFunctionImpl(val descriptor: CallableDescriptor) : KSFunction {
         if (parameterTypes != other.parameterTypes) return false
         if (typeParameters != other.typeParameters) return false
         if (extensionReceiverType != other.extensionReceiverType) return false
+        if (contextReceiverTypes != other.contextReceiverTypes) return false
 
         return true
     }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSConstructorSyntheticImpl.kt
@@ -39,6 +39,8 @@ class KSConstructorSyntheticImpl private constructor(val ksClassDeclaration: KSC
 
     override val extensionReceiver: KSTypeReference? = null
 
+    override val contextReceivers: List<KSTypeReference> = emptyList()
+
     override val parameters: List<KSValueParameter> = emptyList()
 
     override val functionKind: FunctionKind = FunctionKind.MEMBER

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
@@ -64,6 +64,8 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
         return ResolverImpl.instance!!.builtIns.nothingType
     }
 
+    override val contextReceivers: List<KSTypeReference> = emptyList()
+
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         return ResolverImpl.instance!!.builtIns.nothingType
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -62,6 +62,14 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
         }
     }
 
+    override val contextReceivers: List<KSTypeReference> by lazy {
+        analyze {
+            ktFunctionSymbol.contextReceivers.map {
+                KSTypeReferenceImpl.getCached(it.type, this@KSFunctionDeclarationImpl)
+            }
+        }
+    }
+
     override val returnType: KSTypeReference? by lazy {
         analyze {
             // Constructors

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -224,7 +224,12 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
         } else {
             ""
         }
-        return "$receiverSignature$paramTypesSignature($params) -> $returnType"
+        val contextSignature = if (contextReceiverTypes.isNotEmpty()) {
+            contextReceiverTypes.map { it.toSignature() }.joinToString(prefix = "context(", postfix = ") ", separator = ",")
+        } else {
+            ""
+        }
+        return "$contextSignature$receiverSignature$paramTypesSignature($params) -> $returnType"
     }
 
     private fun Nullability.toSignature() = when (this) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
@@ -56,8 +56,15 @@ class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
                     listOf("class: " + it.key.qualifiedName!!.asString()) + it.value
                 }
         }
-        fun KSFunctionDeclaration.toSignature(): String {
+        fun KSFunctionDeclaration.toSignature(classDeclaration: KSClassDeclaration): String {
+            val contextSignature = if (classDeclaration.contextReceivers.isNotEmpty()) {
+                classDeclaration.contextReceivers.map { it.resolve().declaration.qualifiedName?.asString() }
+                    .joinToString(prefix = " context(", postfix = ") ", separator = ",")
+            } else {
+                ""
+            }
             return this.simpleName.asString() +
+                contextSignature +
                 "(${this.parameters.map {
                     buildString {
                         append(it.type.resolve().declaration.qualifiedName?.asString())
@@ -74,7 +81,7 @@ class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
             val declarations = mutableListOf<String>()
             declarations.addAll(
                 classDeclaration.getConstructors().map {
-                    it.toSignature()
+                    it.toSignature(classDeclaration)
                 }.sorted()
             )
             // TODO add some assertions that if we go through he path of getDeclarations

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/testutils/AbstractKSPTest.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/testutils/AbstractKSPTest.kt
@@ -22,11 +22,18 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.TestDataFile
+import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
+import org.jetbrains.kotlin.cli.common.setupCommonArguments
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
+import org.jetbrains.kotlin.cli.jvm.setupJvmSpecificArguments
 import org.jetbrains.kotlin.codegen.GenerationUtils
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.test.ExecutionListenerBasedDisposableProvider
@@ -111,6 +118,10 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             this@globalDefaults.frontend = frontend
             targetPlatform = JvmPlatforms.defaultJvmPlatform
             dependencyKind = DependencyKind.Source
+            languageSettings {
+                // TODO: when would this be removed after they become stable, as it is version specific?
+                this.enable(LanguageFeature.ContextReceivers)
+            }
         }
         useConfigurators(
             ::CommonEnvironmentConfigurator,

--- a/test-utils/testData/api/asMemberOf.kt
+++ b/test-utils/testData/api/asMemberOf.kt
@@ -26,6 +26,7 @@
 // errorType: <Error>?
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
+// returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
 // returnArg1: () -> kotlin.Int!!
 // returnArg1Nullable: () -> kotlin.Int?
 // returnArg2: () -> kotlin.String?
@@ -43,6 +44,7 @@
 // errorType: <Error>?
 // extensionProperty: kotlin.Any?
 // returnInt: () -> kotlin.Int!!
+// returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
 // returnArg1: () -> kotlin.Any?
 // returnArg1Nullable: () -> kotlin.Any?
 // returnArg2: () -> kotlin.Any?
@@ -60,6 +62,7 @@
 // errorType: <Error>?
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
+// returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
 // returnArg1: () -> kotlin.String!!
 // returnArg1Nullable: () -> kotlin.String?
 // returnArg2: () -> kotlin.String?
@@ -77,6 +80,7 @@
 // errorType: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `errorType` (Base)
 // extensionProperty: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `extensionProperty` (Base)
 // returnInt: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt` (Base)
+// returnInt2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt2` (Base)
 // returnArg1: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1` (Base)
 // returnArg1Nullable: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1Nullable` (Base)
 // returnArg2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg2` (Base)
@@ -104,7 +108,7 @@
 // fileLevelFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
 // fileLevelExtensionFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
 // fileLevelProperty: java.lang.IllegalArgumentException: Cannot call asMemberOf with a property that is not declared in a class or an interface
-// errorType: (<Error>?) -> <Error>?
+// errorType: context(<Error>?) (<Error>?) -> <Error>?
 // expected comparison failures
 // <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.String?
 // () -> kotlin.Int!!
@@ -119,6 +123,10 @@ open class Base<BaseTypeArg1, BaseTypeArg2> {
     val typePair: Pair<BaseTypeArg2, BaseTypeArg1>  = TODO()
     val errorType: NonExistType = TODO()
     fun returnInt():Int = TODO()
+
+    context(Int, String)
+    fun returnInt2():Int = TODO()
+
     fun returnArg1(): BaseTypeArg1 = TODO()
     fun returnArg1Nullable(): BaseTypeArg1? = TODO()
     fun returnArg2(): BaseTypeArg2 = TODO()

--- a/test-utils/testData/api/asMemberOf.kt
+++ b/test-utils/testData/api/asMemberOf.kt
@@ -27,6 +27,8 @@
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
 // returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
+// returnInt3: context(kotlin.String!!) kotlin.Int!!.() -> kotlin.Int!!
+// returnInt4: kotlin.Int!!.() -> kotlin.Int!!
 // returnArg1: () -> kotlin.Int!!
 // returnArg1Nullable: () -> kotlin.Int?
 // returnArg2: () -> kotlin.String?
@@ -45,6 +47,8 @@
 // extensionProperty: kotlin.Any?
 // returnInt: () -> kotlin.Int!!
 // returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
+// returnInt3: context(kotlin.String!!) kotlin.Int!!.() -> kotlin.Int!!
+// returnInt4: kotlin.Int!!.() -> kotlin.Int!!
 // returnArg1: () -> kotlin.Any?
 // returnArg1Nullable: () -> kotlin.Any?
 // returnArg2: () -> kotlin.Any?
@@ -63,6 +67,8 @@
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
 // returnInt2: context(kotlin.Int!!,kotlin.String!!) () -> kotlin.Int!!
+// returnInt3: context(kotlin.String!!) kotlin.Int!!.() -> kotlin.Int!!
+// returnInt4: kotlin.Int!!.() -> kotlin.Int!!
 // returnArg1: () -> kotlin.String!!
 // returnArg1Nullable: () -> kotlin.String?
 // returnArg2: () -> kotlin.String?
@@ -81,6 +87,8 @@
 // extensionProperty: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `extensionProperty` (Base)
 // returnInt: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt` (Base)
 // returnInt2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt2` (Base)
+// returnInt3: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt3` (Base)
+// returnInt4: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt4` (Base)
 // returnArg1: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1` (Base)
 // returnArg1Nullable: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1Nullable` (Base)
 // returnArg2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg2` (Base)
@@ -126,6 +134,11 @@ open class Base<BaseTypeArg1, BaseTypeArg2> {
 
     context(Int, String)
     fun returnInt2():Int = TODO()
+
+    context(String)
+    fun Int.returnInt3():Int = TODO()
+
+    fun Int.returnInt4():Int = TODO()
 
     fun returnArg1(): BaseTypeArg1 = TODO()
     fun returnArg1Nullable(): BaseTypeArg1? = TODO()

--- a/test-utils/testData/api/constructorDeclarations.kt
+++ b/test-utils/testData/api/constructorDeclarations.kt
@@ -114,6 +114,28 @@
 // <init>(): KotlinClassWithCompanion
 // class: lib.KotlinClassWithCompanion
 // <init>(): lib.KotlinClassWithCompanion
+// class: KotlinClassWithContextAndExplicitConstructor
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): KotlinClassWithContextAndExplicitConstructor
+// class: lib.KotlinClassWithContextAndExplicitConstructor
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): lib.KotlinClassWithContextAndExplicitConstructor
+// class: KotlinClassWithContextAndExplicitEmptyConstructor
+// <init> context(kotlin.Int,kotlin.String) (): KotlinClassWithContextAndExplicitEmptyConstructor
+// class: lib.KotlinClassWithContextAndExplicitEmptyConstructor
+// <init> context(kotlin.Int,kotlin.String) (): lib.KotlinClassWithContextAndExplicitEmptyConstructor
+// class: KotlinClassWithContextAndMultipleConstructors
+// <init> context(kotlin.Int,kotlin.String) (): KotlinClassWithContextAndMultipleConstructors
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): KotlinClassWithContextAndMultipleConstructors
+// class: lib.KotlinClassWithContextAndMultipleConstructors
+// <init> context(kotlin.Int,kotlin.String) (): lib.KotlinClassWithContextAndMultipleConstructors
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): lib.KotlinClassWithContextAndMultipleConstructors
+// class: KotlinClassWithContextAndPrimaryConstructor
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): KotlinClassWithContextAndPrimaryConstructor
+// class: lib.KotlinClassWithContextAndPrimaryConstructor
+// <init> context(kotlin.Int,kotlin.String) (kotlin.Int): lib.KotlinClassWithContextAndPrimaryConstructor
+// class: KotlinClassWithContextWithoutExplicitConstructor
+// <init> context(kotlin.Int,kotlin.String) (): KotlinClassWithContextWithoutExplicitConstructor
+// class: lib.KotlinClassWithContextWithoutExplicitConstructor
+// <init> context(kotlin.Int,kotlin.String) (): lib.KotlinClassWithContextWithoutExplicitConstructor
 // class: KotlinClassWithExplicitConstructor
 // <init>(kotlin.Int): KotlinClassWithExplicitConstructor
 // class: lib.KotlinClassWithExplicitConstructor
@@ -229,6 +251,23 @@ class KotlinClassWithMultipleConstructors2(z:Float) {
     constructor(y:Int): this(0f) {}
     constructor(x: String) : this(0f) {}
 }
+context(Int, String)
+class KotlinClassWithContextWithoutExplicitConstructor {
+}
+context(kotlin.Int, kotlin.String)
+class KotlinClassWithContextAndExplicitEmptyConstructor() {}
+context(Int, String)
+class KotlinClassWithContextAndPrimaryConstructor(x:Int) {
+}
+context(Int, String)
+class KotlinClassWithContextAndExplicitConstructor {
+    constructor(x:Int) {}
+}
+context(Int, String)
+class KotlinClassWithContextAndMultipleConstructors {
+    constructor() {}
+    constructor(y:Int): this() {}
+}
 abstract class AbstractKotlinClassWithoutExplicitConstructor {
 }
 abstract class AbstractKotlinClassWithPrimaryConstructor(x:Int) {
@@ -317,6 +356,23 @@ class KotlinClassWithMultipleConstructors1 {
 class KotlinClassWithMultipleConstructors2(z:Float) {
     constructor(y:Int): this(0f) {}
     constructor(x: String) : this(0f) {}
+}
+context(Int, String)
+class KotlinClassWithContextWithoutExplicitConstructor {
+}
+context(Int, String)
+class KotlinClassWithContextAndExplicitEmptyConstructor() {}
+context(Int, String)
+class KotlinClassWithContextAndPrimaryConstructor(x:Int) {
+}
+context(Int, String)
+class KotlinClassWithContextAndExplicitConstructor {
+    constructor(x:Int) {}
+}
+context(Int, String)
+class KotlinClassWithContextAndMultipleConstructors {
+    constructor() {}
+    constructor(y:Int): this() {}
 }
 abstract class AbstractKotlinClassWithoutExplicitConstructor {
 }


### PR DESCRIPTION
Add analysis for context receivers (experimental up thought Kotlin 1.9 but should be final in Kotlin 2.0)

This basically clones code for extension receivers and adds support for context receivers in the same classes and interfaces.  The testing is mirroring the same level of support for extension receivers (which is minimally covered in tests).  

This is to address issue #1136 

TODO:

* [X] constructors with context receivers
* [ ] open questions below
* [ ] top level functions are not currently covered by tests for Extension Receiver nor for this new context receivers, should they be?


