### PR TITLE
AA: isJavaRawType, override checking and effectiveJavaModifiers

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/JvmUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/JvmUtils.kt
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.processing.impl
+package com.google.devtools.ksp
 
-internal val JVM_STATIC_ANNOTATION_FQN = "kotlin.jvm.JvmStatic"
-internal val JVM_DEFAULT_ANNOTATION_FQN = "kotlin.jvm.JvmDefault"
-internal val JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN = "kotlin.jvm.JvmDefaultWithoutCompatibility"
-internal val JVM_STRICTFP_ANNOTATION_FQN = "kotlin.jvm.Strictfp"
-internal val JVM_SYNCHRONIZED_ANNOTATION_FQN = "kotlin.jvm.Synchronized"
-internal val JVM_TRANSIENT_ANNOTATION_FQN = "kotlin.jvm.Transient"
-internal val JVM_VOLATILE_ANNOTATION_FQN = "kotlin.jvm.Volatile"
+val JVM_STATIC_ANNOTATION_FQN = "kotlin.jvm.JvmStatic"
+val JVM_DEFAULT_ANNOTATION_FQN = "kotlin.jvm.JvmDefault"
+val JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN = "kotlin.jvm.JvmDefaultWithoutCompatibility"
+val JVM_STRICTFP_ANNOTATION_FQN = "kotlin.jvm.Strictfp"
+val JVM_SYNCHRONIZED_ANNOTATION_FQN = "kotlin.jvm.Synchronized"
+val JVM_TRANSIENT_ANNOTATION_FQN = "kotlin.jvm.Transient"
+val JVM_VOLATILE_ANNOTATION_FQN = "kotlin.jvm.Volatile"

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 
 package com.google.devtools.ksp.impl
 
@@ -50,6 +51,7 @@ import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.impl.file.impl.JavaFileManager
+import org.jetbrains.kotlin.analysis.api.fir.types.KtFirType
 import org.jetbrains.kotlin.analysis.api.symbols.KtEnumEntrySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtFileSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
@@ -62,6 +64,7 @@ import org.jetbrains.kotlin.analysis.api.types.KtType
 import org.jetbrains.kotlin.analysis.project.structure.KtModule
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl
+import org.jetbrains.kotlin.fir.types.isRaw
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
@@ -332,7 +335,7 @@ class ResolverAAImpl(
     }
 
     override fun isJavaRawType(type: KSType): Boolean {
-        TODO("Not yet implemented")
+        return type is KSTypeImpl && (type.type as KtFirType).coneType.isRaw()
     }
 
     @KspExperimental

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -178,6 +178,8 @@ class ResolverAAImpl(
                     .flatMap { it.getPackageScope().getPackageSymbols { it.asString() == curName } }
                     .distinct()
             }
+            // Above steps forfeited root package, adding it back.
+            packages += analysisSession.ROOT_PACKAGE_SYMBOL
             packages.flatMap {
                 it.getPackageScope().getAllSymbols().distinct().mapNotNull { symbol ->
                     when (symbol) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -23,6 +23,7 @@ import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.KtStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.components.buildClassType
 import org.jetbrains.kotlin.analysis.api.symbols.*
+import org.jetbrains.kotlin.descriptors.java.JavaVisibilities
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 
 class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSymbol: KtClassOrObjectSymbol) :
@@ -161,7 +162,9 @@ internal fun KtClassOrObjectSymbol.toModifiers(): Set<Modifier> {
     val result = mutableSetOf<Modifier>()
     if (this is KtNamedClassOrObjectSymbol) {
         result.add(modality.toModifier())
-        result.add(visibility.toModifier())
+        if (visibility != JavaVisibilities.PackageVisibility) {
+            result.add(visibility.toModifier())
+        }
         if (isInline) {
             result.add(Modifier.INLINE)
         }
@@ -170,6 +173,9 @@ internal fun KtClassOrObjectSymbol.toModifiers(): Set<Modifier> {
         }
         if (isExternal) {
             result.add(Modifier.EXTERNAL)
+        }
+        if (isInner) {
+            result.add(Modifier.INNER)
         }
     }
     if (classKind == KtClassKind.ENUM_CLASS) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -22,6 +22,7 @@ import com.google.devtools.ksp.KSObjectCache
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiMethod
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolKind
 import org.jetbrains.kotlin.descriptors.Modality
@@ -86,10 +87,11 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     }
 
     override val simpleName: KSName by lazy {
-        if (ktFunctionSymbol is KtFunctionSymbol) {
-            KSNameImpl.getCached(ktFunctionSymbol.name.asString())
-        } else {
-            KSNameImpl.getCached("<init>")
+        when (ktFunctionSymbol) {
+            is KtFunctionSymbol -> KSNameImpl.getCached(ktFunctionSymbol.name.asString())
+            is KtPropertyAccessorSymbol -> KSNameImpl.getCached((ktFunctionSymbol.psi as PsiMethod).name)
+            is KtConstructorSymbol -> KSNameImpl.getCached("<init>")
+            else -> throw IllegalStateException("Unexpected function symbol type ${ktFunctionSymbol.javaClass}")
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -56,6 +56,13 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
             }.plus(
                 ktPropertySymbol.backingFieldSymbol?.annotations
                     ?.map { KSAnnotationImpl.getCached(it) } ?: emptyList()
+            ).plus(
+                if (ktPropertySymbol.isFromPrimaryConstructor) {
+                    (parentDeclaration as? KSClassDeclaration)?.primaryConstructor?.parameters
+                        ?.singleOrNull { it.name == simpleName }?.annotations ?: emptySequence()
+                } else {
+                    emptySequence()
+                }
             )
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -79,10 +79,7 @@ class KSValueParameterImpl private constructor(
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {
-        (
-            ktValueParameterSymbol.generatedPrimaryConstructorProperty?.annotations(this)
-                ?: ktValueParameterSymbol.annotations(this)
-            ).plus(findAnnotationFromUseSiteTarget())
+        ktValueParameterSymbol.annotations(this).plus(findAnnotationFromUseSiteTarget())
     }
     override val origin: Origin by lazy {
         val symbolOrigin = mapAAOrigin(ktValueParameterSymbol)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -40,6 +40,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.markers.KtSymbolWithMembers
 import org.jetbrains.kotlin.analysis.api.types.*
 import org.jetbrains.kotlin.descriptors.Modality
 import org.jetbrains.kotlin.descriptors.Visibilities
+import org.jetbrains.kotlin.descriptors.java.JavaVisibilities
 import org.jetbrains.kotlin.fir.java.JavaTypeParameterStack
 import org.jetbrains.kotlin.fir.java.toFirExpression
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
@@ -369,7 +370,8 @@ internal fun org.jetbrains.kotlin.descriptors.Visibility.toModifier(): Modifier 
         Visibilities.Public -> Modifier.PUBLIC
         Visibilities.Private -> Modifier.PRIVATE
         Visibilities.Internal -> Modifier.INTERNAL
-        Visibilities.Protected -> Modifier.PROTECTED
+        Visibilities.Protected, JavaVisibilities.ProtectedAndPackage, JavaVisibilities.ProtectedStaticVisibility ->
+            Modifier.PROTECTED
         else -> Modifier.PUBLIC
     }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -451,7 +451,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/platformDeclaration.kt")
     }
 
-    @Disabled
     @TestMetadata("rawTypes.kt")
     @Test
     fun testRawTypes() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -74,7 +74,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/annotationInDependencies.kt")
     }
 
-    @Disabled
     @TestMetadata("annotationOnConstructorParameter.kt")
     @Test
     fun testAnnotationOnConstructorParameter() {
@@ -328,11 +327,10 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/interfaceWithDefault.kt")
     }
 
-    @Disabled
     @TestMetadata("javaModifiers.kt")
     @Test
     fun testJavaModifiers() {
-        runTest("../test-utils/testData/api/javaModifiers.kt")
+        runTest("testData/javaModifiers.kt")
     }
 
     @TestMetadata("javaNonNullTypes.kt")

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2020 Google LLC
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,26 +34,26 @@
 // DependencyOuterJavaClass.DependencyNestedJavaClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterJavaClass.DependencyNestedJavaClass: OPEN PUBLIC : PUBLIC
 // DependencyOuterJavaClass.staticPackageProtectedField: FINAL JAVA_STATIC : FINAL JAVA_STATIC
-// DependencyOuterJavaClass.staticPackageProtectedMethod: JAVA_STATIC : JAVA_STATIC
+// DependencyOuterJavaClass.staticPackageProtectedMethod: FINAL JAVA_STATIC : FINAL JAVA_STATIC
 // DependencyOuterJavaClass.staticPrivateField: FINAL JAVA_STATIC PRIVATE : FINAL JAVA_STATIC PRIVATE
-// DependencyOuterJavaClass.staticPrivateMethod: JAVA_STATIC PRIVATE : JAVA_STATIC PRIVATE
+// DependencyOuterJavaClass.staticPrivateMethod: FINAL JAVA_STATIC PRIVATE : FINAL JAVA_STATIC PRIVATE
 // DependencyOuterJavaClass.staticProtectedField: FINAL JAVA_STATIC PROTECTED : FINAL JAVA_STATIC PROTECTED
-// DependencyOuterJavaClass.staticProtectedMethod: JAVA_STATIC PROTECTED : JAVA_STATIC PROTECTED
+// DependencyOuterJavaClass.staticProtectedMethod: FINAL JAVA_STATIC PROTECTED : FINAL JAVA_STATIC PROTECTED
 // DependencyOuterJavaClass.staticPublicField: FINAL JAVA_STATIC PUBLIC : FINAL JAVA_STATIC PUBLIC
-// DependencyOuterJavaClass.staticPublicMethod: JAVA_STATIC PUBLIC : JAVA_STATIC PUBLIC
-// DependencyOuterJavaClass.strictfpFun: JAVA_STRICT OPEN : JAVA_STRICT
-// DependencyOuterJavaClass.synchronizedFun: JAVA_SYNCHRONIZED OPEN : JAVA_SYNCHRONIZED
-// DependencyOuterJavaClass.transientField: FINAL JAVA_TRANSIENT : FINAL JAVA_TRANSIENT
-// DependencyOuterJavaClass.volatileField: FINAL JAVA_VOLATILE : FINAL JAVA_VOLATILE
+// DependencyOuterJavaClass.staticPublicMethod: FINAL JAVA_STATIC PUBLIC : FINAL JAVA_STATIC PUBLIC
+// DependencyOuterJavaClass.strictfpFun: OPEN : JAVA_STRICT
+// DependencyOuterJavaClass.synchronizedFun: OPEN : JAVA_SYNCHRONIZED
+// DependencyOuterJavaClass.transientField: OPEN : JAVA_TRANSIENT
+// DependencyOuterJavaClass.volatileField: OPEN : JAVA_VOLATILE
 // DependencyOuterJavaClass: OPEN PUBLIC : PUBLIC
 // DependencyOuterKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.<init>: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion.companionField: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.companionMethod: FINAL PUBLIC : FINAL PUBLIC
-// DependencyOuterKotlinClass.Companion.customJvmStaticCompanionField: FINAL PUBLIC : FINAL PUBLIC
-// DependencyOuterKotlinClass.Companion.customJvmStaticCompanionMethod: FINAL PUBLIC : FINAL PUBLIC
-// DependencyOuterKotlinClass.Companion.jvmStaticCompanionField: FINAL PUBLIC : FINAL PUBLIC
-// DependencyOuterKotlinClass.Companion.jvmStaticCompanionMethod: FINAL PUBLIC : FINAL PUBLIC
+// DependencyOuterKotlinClass.Companion.customJvmStaticCompanionField: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
+// DependencyOuterKotlinClass.Companion.customJvmStaticCompanionMethod: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
+// DependencyOuterKotlinClass.Companion.jvmStaticCompanionField: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
+// DependencyOuterKotlinClass.Companion.jvmStaticCompanionMethod: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
 // DependencyOuterKotlinClass.Companion.privateCompanionField: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.privateCompanionMethod: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion: FINAL PUBLIC : FINAL PUBLIC
@@ -86,8 +86,8 @@
 // OuterKotlinClass.Companion.companionMethod: : FINAL PUBLIC
 // OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL PUBLIC
 // OuterKotlinClass.Companion.customJvmStaticCompanionMethod: : FINAL PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL JAVA_STATIC PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL PUBLIC
 // OuterKotlinClass.Companion.privateCompanionField: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion.privateCompanionMethod: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion: : FINAL JAVA_STATIC PUBLIC

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
@@ -27,7 +27,7 @@ class JavaModifierProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
-        return results
+        return results.sorted()
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -61,11 +61,7 @@ class JavaModifierProcessor : AbstractTestProcessor() {
         @OptIn(KspExperimental::class)
         private fun KSDeclaration.toSignature(): String {
             val parent = parentDeclaration
-            val id = if (parent == null) {
-                ""
-            } else {
-                "${parent.simpleName.asString()}."
-            } + simpleName.asString()
+            val id = qualifiedName?.asString()
             val modifiersSignature = modifiers.map { it.toString() }.sorted().joinToString(" ")
             val extras = resolver.effectiveJavaModifiers(this).map { it.toString() }.sorted().joinToString(" ").trim()
             return "$id: $modifiersSignature".trim() + " : " + extras


### PR DESCRIPTION
* implement `isJavaRawType`
* implement override checking.
* implements Resolver.effectiveJavaModifiers
* assorted minor fixes around modifers and resolver APIs.

test for effective jvm modifiers are forked due to inconsistent behavior with FE1.0 and the new result from AA looks more right to me.