### PR TITLE
multiple-round: implement incremental providers

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/analysisapi/providers/IncrementalKotlinDeclarationProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/analysisapi/providers/IncrementalKotlinDeclarationProvider.kt
@@ -1,0 +1,105 @@
+package com.google.devtools.ksp.analysisapi.providers
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.analysis.project.structure.KtModule
+import org.jetbrains.kotlin.analysis.providers.KotlinDeclarationProvider
+import org.jetbrains.kotlin.analysis.providers.KotlinDeclarationProviderFactory
+import org.jetbrains.kotlin.analysis.providers.impl.KotlinStaticDeclarationProviderFactory
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtClassLikeDeclaration
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtScript
+import org.jetbrains.kotlin.psi.KtTypeAlias
+
+class IncrementalKotlinDeclarationProvider(var del: KotlinDeclarationProvider) : KotlinDeclarationProvider() {
+    override fun computePackageSetWithTopLevelCallableDeclarations(): Set<String> {
+        return del.computePackageSetWithTopLevelCallableDeclarations()
+    }
+
+    override fun findFilesForFacade(facadeFqName: FqName): Collection<KtFile> {
+        return del.findFilesForFacade(facadeFqName)
+    }
+
+    override fun findFilesForFacadeByPackage(packageFqName: FqName): Collection<KtFile> {
+        return del.findFilesForFacadeByPackage(packageFqName)
+    }
+
+    override fun findFilesForScript(scriptFqName: FqName): Collection<KtScript> {
+        return del.findFilesForScript(scriptFqName)
+    }
+
+    override fun findInternalFilesForFacade(facadeFqName: FqName): Collection<KtFile> {
+        return del.findInternalFilesForFacade(facadeFqName)
+    }
+
+    override fun getAllClassesByClassId(classId: ClassId): Collection<KtClassOrObject> {
+        return del.getAllClassesByClassId(classId)
+    }
+
+    override fun getAllTypeAliasesByClassId(classId: ClassId): Collection<KtTypeAlias> {
+        return del.getAllTypeAliasesByClassId(classId)
+    }
+
+    override fun getClassLikeDeclarationByClassId(classId: ClassId): KtClassLikeDeclaration? {
+        return del.getClassLikeDeclarationByClassId(classId)
+    }
+
+    override fun getTopLevelCallableFiles(callableId: CallableId): Collection<KtFile> {
+        return del.getTopLevelCallableFiles(callableId)
+    }
+
+    override fun getTopLevelCallableNamesInPackage(packageFqName: FqName): Set<Name> {
+        return del.getTopLevelCallableNamesInPackage(packageFqName)
+    }
+
+    override fun getTopLevelFunctions(callableId: CallableId): Collection<KtNamedFunction> {
+        return del.getTopLevelFunctions(callableId)
+    }
+
+    override fun getTopLevelKotlinClassLikeDeclarationNamesInPackage(packageFqName: FqName): Set<Name> {
+        return del.getTopLevelKotlinClassLikeDeclarationNamesInPackage(packageFqName)
+    }
+
+    override fun getTopLevelProperties(callableId: CallableId): Collection<KtProperty> {
+        return del.getTopLevelProperties(callableId)
+    }
+}
+
+class IncrementalKotlinDeclarationProviderFactory(
+    private val project: Project,
+) : KotlinDeclarationProviderFactory() {
+    private var provider: IncrementalKotlinDeclarationProvider? = null
+    private lateinit var scope: GlobalSearchScope
+    private var contextualModule: KtModule? = null
+    private var files: Collection<KtFile> = emptyList()
+
+    override fun createDeclarationProvider(
+        scope: GlobalSearchScope,
+        contextualModule: KtModule?
+    ): KotlinDeclarationProvider {
+        this.scope = scope
+        this.contextualModule = contextualModule
+        return IncrementalKotlinDeclarationProvider(createDelegateProvider()).also {
+            provider = it
+        }
+    }
+
+    fun update(files: Collection<KtFile>) {
+        this.files = files
+        provider?.let {
+            it.del = createDelegateProvider()
+        }
+    }
+
+    private fun createDelegateProvider(): KotlinDeclarationProvider {
+        val staticFactory = KotlinStaticDeclarationProviderFactory(project, files)
+        return staticFactory.createDeclarationProvider(scope, contextualModule)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/analysisapi/providers/IncrementalKotlinPackageProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/analysisapi/providers/IncrementalKotlinPackageProvider.kt
@@ -1,0 +1,72 @@
+package com.google.devtools.ksp.analysisapi.providers
+
+import com.intellij.openapi.project.Project
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.analysis.providers.KotlinPackageProvider
+import org.jetbrains.kotlin.analysis.providers.KotlinPackageProviderFactory
+import org.jetbrains.kotlin.analysis.providers.impl.KotlinStaticPackageProviderFactory
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.platform.TargetPlatform
+import org.jetbrains.kotlin.psi.KtFile
+
+class IncrementalKotlinPackageProvider(var del: KotlinPackageProvider) : KotlinPackageProvider() {
+    override fun doesKotlinOnlyPackageExist(packageFqName: FqName): Boolean {
+        return del.doesKotlinOnlyPackageExist(packageFqName)
+    }
+
+    override fun doesPackageExist(packageFqName: FqName, platform: TargetPlatform): Boolean {
+        return del.doesPackageExist(packageFqName, platform)
+    }
+
+    override fun doesPlatformSpecificPackageExist(packageFqName: FqName, platform: TargetPlatform): Boolean {
+        return del.doesPlatformSpecificPackageExist(packageFqName, platform)
+    }
+
+    override fun getKotlinOnlySubPackagesFqNames(packageFqName: FqName, nameFilter: (Name) -> Boolean): Set<Name> {
+        return del.getKotlinOnlySubPackagesFqNames(packageFqName, nameFilter)
+    }
+
+    override fun getPlatformSpecificSubPackagesFqNames(
+        packageFqName: FqName,
+        platform: TargetPlatform,
+        nameFilter: (Name) -> Boolean
+    ): Set<Name> {
+        return del.getPlatformSpecificSubPackagesFqNames(packageFqName, platform, nameFilter)
+    }
+
+    override fun getSubPackageFqNames(
+        packageFqName: FqName,
+        platform: TargetPlatform,
+        nameFilter: (Name) -> Boolean
+    ): Set<Name> {
+        return del.getSubPackageFqNames(packageFqName, platform, nameFilter)
+    }
+}
+
+class IncrementalKotlinPackageProviderFactory(
+    private val project: Project,
+) : KotlinPackageProviderFactory() {
+    private var provider: IncrementalKotlinPackageProvider? = null
+    private lateinit var scope: GlobalSearchScope
+    private var files: Collection<KtFile> = emptyList()
+
+    override fun createPackageProvider(searchScope: GlobalSearchScope): KotlinPackageProvider {
+        this.scope = searchScope
+        return IncrementalKotlinPackageProvider(createDelegateProvider()).also {
+            provider = it
+        }
+    }
+
+    fun update(files: Collection<KtFile>) {
+        this.files = files
+        provider?.let {
+            it.del = createDelegateProvider()
+        }
+    }
+
+    private fun createDelegateProvider(): KotlinPackageProvider {
+        val staticFactory = KotlinStaticPackageProviderFactory(project, files)
+        return staticFactory.createPackageProvider(scope)
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -87,7 +87,6 @@ import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.org.objectweb.asm.Opcodes
-import java.io.File
 import java.nio.file.Files
 
 @OptIn(KspExperimental::class)
@@ -322,29 +321,8 @@ class ResolverAAImpl(
                         else -> null
                     }
                 }
-            }.plus(javaPackageToClassMap.getOrDefault(packageName, emptyList()).asSequence()).asSequence()
+            }.asSequence()
         }
-    }
-
-    private val javaPackageToClassMap: Map<String, List<KSDeclaration>> by lazy {
-        val packageToClassMapping = mutableMapOf<String, List<KSDeclaration>>()
-        ksFiles
-            .filter { file ->
-                file.origin == Origin.JAVA &&
-                    kspConfig.javaSourceRoots.any { root ->
-                        file.filePath.startsWith(root.absolutePath) &&
-                            file.filePath.substringAfter(root.absolutePath)
-                            .dropLastWhile { c -> c != File.separatorChar }.dropLast(1).drop(1)
-                            .replace(File.separatorChar, '.') == file.packageName.asString()
-                    }
-            }
-            .forEach {
-                packageToClassMapping.put(
-                    it.packageName.asString(),
-                    packageToClassMapping.getOrDefault(it.packageName.asString(), emptyList()).plus(it.declarations)
-                )
-            }
-        packageToClassMapping
     }
 
     override fun getDeclarationsInSourceOrder(container: KSDeclarationContainer): Sequence<KSDeclaration> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -635,4 +635,10 @@ class KSPAATest : AbstractKSPAATest() {
     fun testVisibilities() {
         runTest("../test-utils/testData/api/visibilities.kt")
     }
+
+    @TestMetadata("multipleround.kt")
+    @Test
+    fun testMultipleround() {
+        runTest("../test-utils/testData/api/multipleround.kt")
+    }
 }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
@@ -24,9 +24,10 @@ import com.google.devtools.ksp.symbol.*
 
 class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
     val visitor = ConstructorsVisitor()
+    lateinit var result: List<String>
 
     override fun toResult(): List<String> {
-        return visitor.toResult()
+        return result
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -39,6 +40,7 @@ class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
                 .getClassDeclarationByName("lib.${it.simpleName.asString()}")
                 ?.accept(visitor, Unit)
         }
+        result = visitor.toResult()
         return emptyList()
     }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
@@ -42,6 +42,9 @@ class MultipleroundProcessor : AbstractTestProcessor() {
         result.add("Round $round:")
         check("K")
         check("J")
+        val newFiles = resolver.getNewFiles().map { it.fileName }.toSet()
+        val allFiles = resolver.getAllFiles().map { it.fileName }
+        result.add(allFiles.map { if (it in newFiles) "+$it" else it }.sorted().joinToString())
 
         round++
         return emptyList()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
@@ -1,0 +1,56 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class MultipleroundProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+    override fun toResult(): List<String> {
+        return result
+    }
+
+    var round = 0
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        fun gen(cls: String, ext: String) {
+            env.codeGenerator.createNewFile(Dependencies(false), "com.example", cls, ext).use {
+                it.write("package com.example;".toByteArray())
+                it.write("interface $cls {}".toByteArray())
+            }
+        }
+
+        when (round) {
+            0 -> gen("I0", "kt")
+            1 -> gen("I1", "java")
+            2 -> gen("I2", "kt")
+            3 -> gen("I3", "java")
+            4 -> gen("I4", "kt")
+            5 -> gen("I5", "java")
+        }
+
+        fun check(cls: String) {
+            resolver.getClassDeclarationByName(resolver.getKSNameFromString(cls))?.let { c ->
+                result.add(
+                    "${c.simpleName.asString()} : " +
+                        c.superTypes.map { it.resolve().declaration.simpleName.asString() }.joinToString()
+                )
+            }
+        }
+
+        result.add("Round $round:")
+        check("K")
+        check("J")
+
+        round++
+        return emptyList()
+    }
+
+    lateinit var env: SymbolProcessorEnvironment
+
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        env = environment
+        return this
+    }
+}

--- a/test-utils/testData/api/multipleround.kt
+++ b/test-utils/testData/api/multipleround.kt
@@ -20,24 +20,31 @@
 // Round 0:
 // K : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
 // J : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
+// +J.java, +K.kt
 // Round 1:
 // K : I0, <Error>, <Error>, <Error>, <Error>, <Error>
 // J : I0, <Error>, <Error>, <Error>, <Error>, <Error>
+// +I0.kt, J.java, K.kt
 // Round 2:
 // K : I0, I1, <Error>, <Error>, <Error>, <Error>
 // J : I0, I1, <Error>, <Error>, <Error>, <Error>
+// +I1.java, I0.kt, J.java, K.kt
 // Round 3:
 // K : I0, I1, I2, <Error>, <Error>, <Error>
 // J : I0, I1, I2, <Error>, <Error>, <Error>
+// +I2.kt, I0.kt, I1.java, J.java, K.kt
 // Round 4:
 // K : I0, I1, I2, I3, <Error>, <Error>
 // J : I0, I1, I2, I3, <Error>, <Error>
+// +I3.java, I0.kt, I1.java, I2.kt, J.java, K.kt
 // Round 5:
 // K : I0, I1, I2, I3, I4, <Error>
 // J : I0, I1, I2, I3, I4, <Error>
+// +I4.kt, I0.kt, I1.java, I2.kt, I3.java, J.java, K.kt
 // Round 6:
 // K : I0, I1, I2, I3, I4, I5
 // J : I0, I1, I2, I3, I4, I5
+// +I5.java, I0.kt, I1.java, I2.kt, I3.java, I4.kt, J.java, K.kt
 // END
 
 // FILE: K.kt

--- a/test-utils/testData/api/multipleround.kt
+++ b/test-utils/testData/api/multipleround.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: MultipleroundProcessor
+// EXPECTED:
+// Round 0:
+// K : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
+// J : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
+// Round 1:
+// K : I0, <Error>, <Error>, <Error>, <Error>, <Error>
+// J : I0, <Error>, <Error>, <Error>, <Error>, <Error>
+// Round 2:
+// K : I0, I1, <Error>, <Error>, <Error>, <Error>
+// J : I0, I1, <Error>, <Error>, <Error>, <Error>
+// Round 3:
+// K : I0, I1, I2, <Error>, <Error>, <Error>
+// J : I0, I1, I2, <Error>, <Error>, <Error>
+// Round 4:
+// K : I0, I1, I2, I3, <Error>, <Error>
+// J : I0, I1, I2, I3, <Error>, <Error>
+// Round 5:
+// K : I0, I1, I2, I3, I4, <Error>
+// J : I0, I1, I2, I3, I4, <Error>
+// Round 6:
+// K : I0, I1, I2, I3, I4, I5
+// J : I0, I1, I2, I3, I4, I5
+// END
+
+// FILE: K.kt
+import com.example.*
+
+class K : I0, I1, I2, I3, I4, I5
+
+// FILE: J.java
+import com.example.*;
+
+class J implements I0, I1, I2, I3, I4, I5 {
+
+}


### PR DESCRIPTION
and replace StandaloneAnalysisAPISessionBuilder, which hides KotlinCoreProjectEnvironment, which is needed to update KotlinCliJavaFileManagerImpl for new files.