### PR TITLE
AA: implement asMemberOf

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -394,6 +394,8 @@ class KotlinSymbolProcessing(
             reinitJavaFileManager(kotlinCoreProjectEnvironment, modules, psiFiles)
 
             ResolverAAImpl.ktModule = modules.single()
+            ResolverAAImpl.functionAsMemberOfCache = mutableMapOf()
+            ResolverAAImpl.propertyAsMemberOfCache = mutableMapOf()
             val localFileSystem = VirtualFileManager.getInstance().getFileSystem(StandardFileSystems.FILE_PROTOCOL)
             val javaRoots = kspConfig.javaSourceRoots + kspConfig.javaOutputDir
             // Get non-symbolic paths first

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -57,11 +57,11 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        TODO("Not yet implemented")
+        return KSTypeImpl.getCached(ktEnumEntrySymbol.returnType).replace(typeArguments)
     }
 
     override fun asStarProjectedType(): KSType {
-        TODO("Not yet implemented")
+        return KSTypeImpl.getCached(ktEnumEntrySymbol.returnType).starProjection()
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -18,9 +18,8 @@
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.KSObjectCache
-import com.google.devtools.ksp.isConstructor
-import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.*
+import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 import com.intellij.psi.PsiClass
@@ -104,7 +103,7 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     }
 
     override fun asMemberOf(containing: KSType): KSFunction {
-        TODO("Not yet implemented")
+        return ResolverAAImpl.instance.computeAsMemberOf(this, containing)
     }
 
     override val simpleName: KSName by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
@@ -1,0 +1,41 @@
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+
+class KSFunctionErrorImpl(
+    private val declaration: KSFunctionDeclaration
+) : KSFunction {
+    override val isError: Boolean = true
+
+    override val returnType: KSType = KSErrorType
+
+    override val parameterTypes: List<KSType?>
+        get() = declaration.parameters.map {
+            KSErrorType
+        }
+    override val typeParameters: List<KSTypeParameter>
+        get() = emptyList()
+
+    override val extensionReceiverType: KSType?
+        get() = declaration.extensionReceiver?.let {
+            KSErrorType
+        }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as KSFunctionErrorImpl
+
+        if (declaration != other.declaration) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return declaration.hashCode()
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.impl.symbol.kotlin
+
+import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import org.jetbrains.kotlin.analysis.api.signatures.KtFunctionLikeSignature
+import org.jetbrains.kotlin.analysis.api.symbols.KtDeclarationSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KtFunctionLikeSymbol
+
+class KSFunctionImpl(val ktFunctionLikeSymbol: KtFunctionLikeSignature<KtFunctionLikeSymbol>) : KSFunction {
+
+    override val returnType: KSType? by lazy {
+        ktFunctionLikeSymbol.returnType.let { KSTypeImpl.getCached(it) }
+    }
+
+    override val parameterTypes: List<KSType?> by lazy {
+        ktFunctionLikeSymbol.valueParameters.map { it.returnType.let { KSTypeImpl.getCached(it) } }
+    }
+
+    override val typeParameters: List<KSTypeParameter> by lazy {
+        (ktFunctionLikeSymbol as? KtDeclarationSymbol)?.typeParameters?.map { KSTypeParameterImpl.getCached(it) }
+            ?: emptyList()
+    }
+
+    override val extensionReceiverType: KSType? by lazy {
+        ktFunctionLikeSymbol.receiverType?.let { KSTypeImpl.getCached(it) }
+    }
+
+    override val isError: Boolean = false
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -122,7 +122,7 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     }
 
     override fun asMemberOf(containing: KSType): KSType {
-        TODO("Not yet implemented")
+        return ResolverAAImpl.instance.computeAsMemberOf(this, containing)
     }
 
     override val qualifiedName: KSName? by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -2,6 +2,7 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.symbols.KtJavaFieldSymbol
@@ -44,7 +45,7 @@ class KSPropertyDeclarationJavaImpl private constructor(private val ktJavaFieldS
     }
 
     override fun asMemberOf(containing: KSType): KSType {
-        TODO("Not yet implemented")
+        return ResolverAAImpl.instance.computeAsMemberOf(this, containing)
     }
 
     override val typeParameters: List<KSTypeParameter>

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -18,7 +18,9 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.KSObjectCache
+import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.impl.KSNameImpl
+import com.google.devtools.ksp.processing.impl.KSTypeReferenceSyntheticImpl
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.symbols.KtTypeParameterSymbol
 
@@ -48,6 +50,10 @@ class KSTypeParameterImpl private constructor(internal val ktTypeParameterSymbol
     override val bounds: Sequence<KSTypeReference> by lazy {
         ktTypeParameterSymbol.upperBounds.asSequence().mapIndexed { index, type ->
             KSTypeReferenceImpl.getCached(type, this@KSTypeParameterImpl, index)
+        }.ifEmpty {
+            sequenceOf(
+                KSTypeReferenceSyntheticImpl.getCached(ResolverAAImpl.instance.builtIns.anyType.makeNullable(), this)
+            )
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.fir.java.JavaTypeParameterStack
 import org.jetbrains.kotlin.fir.java.declarations.FirJavaValueParameter
 import org.jetbrains.kotlin.fir.java.resolveIfJavaType
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
+import org.jetbrains.kotlin.psi.KtParameter
 
 class KSValueParameterImpl private constructor(
     private val ktValueParameterSymbol: KtValueParameterSymbol,
@@ -63,16 +64,16 @@ class KSValueParameterImpl private constructor(
     }
 
     override val isNoInline: Boolean
-        get() = TODO("Not yet implemented")
+        get() = ktValueParameterSymbol.isNoinline
 
     override val isCrossInline: Boolean
-        get() = TODO("Not yet implemented")
+        get() = ktValueParameterSymbol.isCrossinline
 
     override val isVal: Boolean
-        get() = TODO("Not yet implemented")
+        get() = (ktValueParameterSymbol.psi as? KtParameter)?.let { it.hasValOrVar() && !it.isMutable } ?: false
 
     override val isVar: Boolean
-        get() = TODO("Not yet implemented")
+        get() = (ktValueParameterSymbol.psi as? KtParameter)?.let { it.hasValOrVar() && it.isMutable } ?: false
 
     override val hasDefault: Boolean by lazy {
         ktValueParameterSymbol.hasDefaultValue

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -277,7 +277,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/getPackage.kt")
     }
 
-    @Disabled
     @TestMetadata("getByName.kt")
     @Test
     fun testGetByName() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -408,11 +408,10 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/nestedAnnotations.kt")
     }
 
-    @Disabled
     @TestMetadata("nestedClassType.kt")
     @Test
     fun testNestedClassType() {
-        runTest("../test-utils/testData/api/nestedClassType.kt")
+        runTest("testData/nestedClassType.kt")
     }
 
     @TestMetadata("nullableTypes.kt")

--- a/kotlin-analysis-api/testData/nestedClassType.kt
+++ b/kotlin-analysis-api/testData/nestedClassType.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: NestedClassTypeProcessor
+// EXPECTED:
+// foo
+// @TypeAnno1
+// COVARIANT [@TypeAnno1] String
+// bar
+// , @TypeAnno2
+// CONTRAVARIANT Int,INVARIANT [@TypeAnno2] String
+// END
+
+// FILE: a.kt
+annotation class TypeAnno1
+annotation class TypeAnno2
+
+class Outer<T> {
+    inner class InnerGeneric<P>
+    inner class Inner
+}
+
+class G<T>
+
+class C {
+    val foo: Outer<out @TypeAnno1 String>.Inner
+    val bar: Outer<@TypeAnno2 String>.InnerGeneric<in Int>
+}


### PR DESCRIPTION
In this PR:
* implements asType and starProjectedType for enum entries
* fillup misc apis on value parameter
* implements getDeclarationByName APIs
* fork test data for nestedClassType test (new behavior seems more correct with type annotation included).
* implement asMemberOf
   * currently still not working: 
   * function substitution is not working with transitive parameters
   * type parameter boundaries not rendered with substitution
* add Any to unbounded type parameter