### PR TITLE
Handle errors and call SymbolProcessor.onError()

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/AbstractKSPAATest.kt
@@ -142,8 +142,10 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             cachesDir = File(testRoot, "kspTest/kspCaches")
             outputBaseDir = File(testRoot, "kspTest")
         }.build()
-        val ksp = KotlinSymbolProcessing(kspConfig)
-        ksp.execute()
+        val exitCode = KotlinSymbolProcessing(kspConfig).execute()
+        if (exitCode != KotlinSymbolProcessing.ExitCode.OK) {
+            return listOf("KSP FAILED WITH EXIT CODE: ${exitCode.name}") + testProcessor.toResult()
+        }
         return testProcessor.toResult()
     }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/impl/test/KSPAATest.kt
@@ -659,4 +659,10 @@ class KSPAATest : AbstractKSPAATest() {
     fun testDeferredTypeRefs() {
         runTest("../test-utils/testData/api/deferredTypeRefs.kt")
     }
+
+    @TestMetadata("exitCode.kt")
+    @Test
+    fun testExitCode() {
+        runTest("../test-utils/testData/api/exitCode.kt")
+    }
 }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ExitCodeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ExitCodeProcessor.kt
@@ -1,0 +1,25 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class ExitCodeProcessor : AbstractTestProcessor() {
+    override fun toResult(): List<String> = emptyList()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (resolver.getNewFiles().single().fileName == "PrintError.kt") {
+            env.logger.error("An error")
+        }
+
+        return emptyList()
+    }
+
+    lateinit var env: SymbolProcessorEnvironment
+
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        env = environment
+        return this
+    }
+}

--- a/test-utils/testData/api/exitCode.kt
+++ b/test-utils/testData/api/exitCode.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: ExitCodeProcessor
+// EXPECTED:
+// KSP FAILED WITH EXIT CODE: PROCESSING_ERROR
+// END
+
+// FILE: PrintError.kt
+class PrintError


### PR DESCRIPTION
Most of the changes are refactoring to get rid of the hard to maintain `finished`, `initialized` flags.