### PR TITLE
fix annotation value array type on native&js target

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -378,7 +378,8 @@ private fun KSAnnotation.createInvocationHandler(clazz: Class<*>): InvocationHan
                                 val value = { result.asArray(method, clazz) }
                                 cache.getOrPut(Pair(method.returnType, value), value)
                             } else {
-                                throw IllegalStateException("unhandled value type, $ExceptionMessage")
+                                val value = { result }
+                                cache.getOrPut(Pair(method.returnType, value), value)
                             }
                         }
                         method.returnType.isEnum -> {


### PR DESCRIPTION
 on nativie & js target, when annotation value array type, `result` is `Array<*>`,  I tried removed the `throw`and save it.

fix #1487, #1503