### PR TITLE
Kotlin: Migrate from ChangedFiles to SourcesChanges

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -40,6 +40,7 @@ import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.ExecOperations
 import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
@@ -58,7 +59,6 @@ import org.jetbrains.kotlin.gradle.tasks.TaskOutputsBackup
 import org.jetbrains.kotlin.gradle.tasks.configuration.BaseKotlin2JsCompileConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KotlinCompileCommonConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KotlinCompileConfig
-import org.jetbrains.kotlin.incremental.ChangedFiles
 import java.io.File
 import java.nio.file.Paths
 import javax.inject.Inject
@@ -171,7 +171,7 @@ interface KspTask : Task {
     val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
 
     @get:Internal
-    val incrementalChangesTransformers: ListProperty<(ChangedFiles) -> List<SubpluginOption>>
+    val incrementalChangesTransformers: ListProperty<(SourcesChanges) -> List<SubpluginOption>>
 }
 
 @CacheableTask

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -34,6 +34,7 @@ import org.gradle.language.jvm.tasks.ProcessResources
 import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.LanguageVersion.Companion.LATEST_STABLE
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -56,7 +57,6 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.tasks.*
-import org.jetbrains.kotlin.incremental.ChangedFiles
 import org.jetbrains.kotlin.incremental.isJavaFile
 import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeAsciiOnly
@@ -661,7 +661,7 @@ internal fun getClassStructureFiles(
 // Reuse Kapt's infrastructure to compute affected names in classpath.
 // This is adapted from KaptTask.findClasspathChanges.
 internal fun findClasspathChanges(
-    changes: ChangedFiles,
+    changes: SourcesChanges,
     cacheDir: File,
     allDataFiles: Set<File>,
     libs: List<File>,
@@ -669,7 +669,8 @@ internal fun findClasspathChanges(
 ): KaptClasspathChanges {
     cacheDir.mkdirs()
 
-    val changedFiles = (changes as? ChangedFiles.Known)?.let { it.modified + it.removed }?.toSet() ?: allDataFiles
+    val changedFiles =
+        (changes as? SourcesChanges.Known)?.let { it.modifiedFiles + it.removedFiles }?.toSet() ?: allDataFiles
 
     val loadedPrevious = ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(cacheDir)
     val previousAndCurrentDataFiles = lazy { loadedPrevious.getAllDataFiles() + allDataFiles }
@@ -698,7 +699,7 @@ internal fun findClasspathChanges(
         )
 
     val classpathChanges = currentSnapshot.diff(previousSnapshot, changedFiles)
-    if (classpathChanges is KaptClasspathChanges.Unknown || changes is ChangedFiles.Unknown) {
+    if (classpathChanges is KaptClasspathChanges.Unknown || changes is SourcesChanges.Unknown) {
         cacheDir.deleteRecursively()
         cacheDir.mkdirs()
     }
@@ -707,11 +708,11 @@ internal fun findClasspathChanges(
     return classpathChanges
 }
 
-internal fun ChangedFiles.hasNonSourceChange(): Boolean {
-    if (this !is ChangedFiles.Known)
+internal fun SourcesChanges.hasNonSourceChange(): Boolean {
+    if (this !is SourcesChanges.Known)
         return true
 
-    return !(this.modified + this.removed).all {
+    return !(this.modifiedFiles + this.removedFiles).all {
         it.isKotlinFile(listOf("kt")) || it.isJavaFile()
     }
 }
@@ -726,13 +727,13 @@ fun KaptClasspathChanges.toSubpluginOptions(): List<SubpluginOption> {
     }
 }
 
-fun ChangedFiles.toSubpluginOptions(): List<SubpluginOption> {
-    return if (this is ChangedFiles.Known) {
+fun SourcesChanges.toSubpluginOptions(): List<SubpluginOption> {
+    return if (this is SourcesChanges.Known) {
         val options = mutableListOf<SubpluginOption>()
-        this.modified.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+        this.modifiedFiles.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
             options += SubpluginOption("knownModified", map { it.path }.joinToString(File.pathSeparator))
         }
-        this.removed.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+        this.removedFiles.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
             options += SubpluginOption("knownRemoved", map { it.path }.joinToString(File.pathSeparator))
         }
         options
@@ -749,7 +750,7 @@ internal fun createIncrementalChangesTransformer(
     classpathStructure: Provider<FileCollection>,
     libraries: Provider<FileCollection>,
     processorCP: Provider<FileCollection>,
-): (ChangedFiles) -> List<SubpluginOption> = { changedFiles ->
+): (SourcesChanges) -> List<SubpluginOption> = { changedFiles ->
     val options = mutableListOf<SubpluginOption>()
     val apClasspath = processorCP.get().files.toList()
     if (isKspIncremental) {


### PR DESCRIPTION
In `master` of Kotlin there's a massive change in KGP removing a lot of dependencies KGP -> Kotlin compiler modules (https://github.com/JetBrains/kotlin/compare/e68661fc0dbb2851feff227939a84c9eb0d65517...829e0675f4ebe163506c99b15611b3c64dfab026), removing many of them both from compilation classpath and runtime classpath. One of such changes affecting KSP is replacing `org.jetbrains.kotlin.incremental.ChangedFiles` by `org.jetbrains.kotlin.buildtools.api.SourcesChanges`. It's a similar hierarchy but located in another module which KGP depends on and will depend on. This PR restores compatibility with KGP.