### PR TITLE
handle java types in subtype checking

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -86,9 +86,7 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
         if (that.isError || this.isError) {
             return false
         }
-        return analyze {
-            (that as? KSTypeImpl)?.type?.isSubTypeOf(type) == true
-        }
+        return type.isAssignableFrom((that as KSTypeImpl).type)
     }
 
     override fun isMutabilityFlexible(): Boolean {

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -331,7 +331,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/javaNonNullTypes.kt")
     }
 
-    @Disabled
     @TestMetadata("javaSubtype.kt")
     @Test
     fun testJavaSubtype() {


### PR DESCRIPTION
Sort of reimplementation of [FE1.0](https://github.com/google/ksp/blob/0e1aaaa141d14231fad106f021d81cd1c90f2a67/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/utils.kt#L515) but in a different way, major difference here is the handling of flexible types, analysis API doesn't provide a replace utility for flexible types so instead of creating flexible types with converted type arguments, comparing the bounds directly to workaround it.