### PR TITLE
Declaration ordering

### DIFF
--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
@@ -2,6 +2,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
@@ -30,9 +31,10 @@ class DeclarationOrderProcessor : AbstractTestProcessor() {
                 }
             )
             result.addAll(
-                resolver.getDeclarationsInSourceOrder(klass).filterIsInstance<KSFunctionDeclaration>().map {
-                    it.toSignature(resolver)
-                }
+                resolver.getDeclarationsInSourceOrder(klass).filterIsInstance<KSFunctionDeclaration>()
+                    .filter { !it.isConstructor() }.map {
+                        it.toSignature(resolver)
+                    }
             )
         }
         return emptyList()

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -199,7 +199,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/declarationsInAccessor.kt")
     }
 
-    @Disabled
     @TestMetadata("declarationOrder.kt")
     @Test
     fun testDeclarationOrder() {

--- a/test-utils/testData/api/declarationOrder.kt
+++ b/test-utils/testData/api/declarationOrder.kt
@@ -35,7 +35,6 @@
 // overloaded:(I)Ljava/lang/String;
 // overloaded:()Ljava/lang/String;
 // overloaded:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-// <init>:()V
 // lib.JavaClass
 // b:Ljava/lang/String;
 // a:Ljava/lang/String;
@@ -44,7 +43,6 @@
 // overloaded:(I)V
 // overloaded:()V
 // overloaded:(Ljava/lang/String;Ljava/lang/String;)V
-// <init>:()V
 // KotlinClass
 // b:Ljava/lang/String;
 // a:Ljava/lang/String;
@@ -62,7 +60,6 @@
 // overloaded:(I)Ljava/lang/String;
 // overloaded:()Ljava/lang/String;
 // overloaded:(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
-// <init>:()V
 // JavaClass
 // b:Ljava/lang/String;
 // a:Ljava/lang/String;
@@ -71,7 +68,6 @@
 // overloaded:(I)V
 // overloaded:()V
 // overloaded:(Ljava/lang/String;Ljava/lang/String;)V
-// <init>:()V
 // END
 // MODULE: module1
 // FILE: lib/KotlinClass.kt


### PR DESCRIPTION
* Mostly copied logic from FE1.0, unfortunately coupled code with FE1.0 implementation
details needs to be rewritten and therefore can't be reused directly as common utils.
* Implemented basic getJvmName for unblocking declaration util implementation.
* Due to the library compilation mechanism difference in 2 frontends, FE1.0 tests generates different binaries than AA tests, which caused synthetic constructors being in difference location in the generated bytecode, and since their location are not standardized, ignore them in test results.