### PR TITLE
KSP2: let exceptions pop through to Gradle

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -320,7 +320,7 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
             KotlinSymbolProcessing(kspConfig).execute()
         } catch (e: Exception) {
             kspGradleLogger.exception(e)
-            KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR
+            throw e
         }
 
         if (exitCode != KotlinSymbolProcessing.ExitCode.OK) {


### PR DESCRIPTION
This leaves a better clue of what went wrong.