### PR TITLE
cherry-pick to 1.0.13: Add generated source set with new KGP API

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -555,7 +555,15 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             // No else; The cases should be exhaustive
         }
         kspGeneratedSourceSet.kotlin.srcDir(project.files(kotlinOutputDir, javaOutputDir).builtBy(kspTaskProvider))
-        kotlinCompilation.source(kspGeneratedSourceSet)
+        if (kotlinCompilation is KotlinCommonCompilation) {
+            // Do not make common source sets depend on generated source sets.
+            // They will be observed by downstreams and confuse processors.
+            kotlinCompileProvider.configure {
+                it.source(kspGeneratedSourceSet.kotlin)
+            }
+        } else {
+            kotlinCompilation.defaultSourceSet.dependsOn(kspGeneratedSourceSet)
+        }
         kotlinCompileProvider.configure { kotlinCompile ->
             when (kotlinCompile) {
                 is AbstractKotlinCompile<*> -> kotlinCompile.libraries.from(project.files(classOutputDir))


### PR DESCRIPTION
KotlinCompilation.source() is deprecated.

(cherry picked from commit fbeec1f5e5eeb74d16096f3fa8f983d2269d0ec1)