### PR TITLE
Incremental: Throw away results from clean inputs 

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/IncrementalUtil.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/IncrementalUtil.kt
@@ -60,10 +60,7 @@ class AnyChanges(baseDir: File) : KSVirtualFile(baseDir, "AnyChanges")
 /**
  * Used for classes from classpath, i.e., classes without source files.
  */
-class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, "NoSourceFile") {
-    override val fileName: String
-        get() = "<NoSourceFile for $fqn is a virtual file; DO NOT USE.>"
-}
+class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, "NoSourceFile for $fqn")
 
 // Copy recursively, including last-modified-time of file and its parent dirs.
 //

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PartialCleanIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PartialCleanIT.kt
@@ -1,0 +1,36 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class PartialCleanIT(useK2: Boolean) {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("partial-clean", "test-processor", useK2)
+
+    @Test
+    fun testWorkaroundForIncorrectlyMarkedInputs() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+        File(project.root, "workload/src/main/kotlin/com/example/Baz.kt").appendText(System.lineSeparator())
+        gradleRunner.withArguments("assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "K2={0}")
+        fun params() = listOf(arrayOf(true), arrayOf(false))
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/TemporaryTestProject.kt
@@ -37,8 +37,10 @@ class TemporaryTestProject(
         // Update `params` in test classses to enable / disable K2.
         appendProperty("ksp.useK2=$useK2")
 
-        // Uncomment this to debug compiler and compiler plugin.
-        // gradleProperties.appendText("\nsystemProp.kotlin.compiler.execution.strategy=in-process")
+        // To debug compiler and compiler plugin:
+        // 1. s/kotlin-compiler/kotlin-compiler-embeddable in integration-tests/build.gradle.kts, and
+        // 2. uncomment below
+        // appendProperty("kotlin.compiler.execution.strategy=in-process")
     }
 
     fun restore(file: String) {

--- a/integration-tests/src/test/resources/partial-clean/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/partial-clean/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,60 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import java.io.OutputStreamWriter
+
+class TestProcessor(
+    val codeGenerator: CodeGenerator,
+    val logger: KSPLogger
+) : SymbolProcessor {
+    // FIXME: use getSymbolsWithAnnotation after it is fixed.
+    var rounds = 0
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (rounds++ > 0)
+            return emptyList()
+        logger.warn("$rounds: ${resolver.getNewFiles().toList().sortedBy { it.fileName }}")
+
+        resolver.getAllFiles().singleOrNull { it.fileName == "Bar.kt" }?.let {
+            codeGenerator.createNewFile(
+                Dependencies(false, it),
+                "com.example",
+                "Bar1",
+                "kt"
+            ).use { output ->
+                OutputStreamWriter(output).use { writer ->
+                    writer.write("package com.example\n\n")
+                    writer.write("open class Bar1\n")
+                }
+            }
+        }
+
+        resolver.getAllFiles().single { it.fileName == "Baz.kt" }.let {
+            it.declarations.filterIsInstance<KSClassDeclaration>().single().let {
+                it.superTypes.mapNotNull {
+                    it.resolve().declaration.containingFile
+                }.single { it.fileName == "Bar.kt" }.let {
+                    codeGenerator.createNewFile(
+                        Dependencies(false, it),
+                        "com.example",
+                        "Bar2",
+                        "kt"
+                    ).use { output ->
+                        OutputStreamWriter(output).use { writer ->
+                            writer.write("package com.example\n\n")
+                            writer.write("open class Bar2\n")
+                        }
+                    }
+                }
+            }
+        }
+
+        return emptyList()
+    }
+}
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        environment: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return TestProcessor(environment.codeGenerator, environment.logger)
+    }
+}

--- a/integration-tests/src/test/resources/partial-clean/workload/src/main/kotlin/com/example/Bar.kt
+++ b/integration-tests/src/test/resources/partial-clean/workload/src/main/kotlin/com/example/Bar.kt
@@ -1,0 +1,3 @@
+package com.example
+
+open class Bar

--- a/integration-tests/src/test/resources/partial-clean/workload/src/main/kotlin/com/example/Baz.kt
+++ b/integration-tests/src/test/resources/partial-clean/workload/src/main/kotlin/com/example/Baz.kt
@@ -1,0 +1,6 @@
+package com.example
+
+class Baz : Bar()
+
+val bar1 = Bar1()
+val bar2 = Bar2()


### PR DESCRIPTION
One common misuse of incremental APIs is associating a non-root source,
instead of the ones obtained from root functions
(e.g., getSymbolsWithAnnotation), to an output. This non-root source can
be reached and reprocessed even when it is clean. Because it is clean,
it is not available via root functions. As a result, other outputs that
are solely based on it won't be re-generated and is deemed as removed.

Assuming that the processors are deterministic, we are throwing away
outputs from clean inputs, and recovering them from the backup as a
workaround for processors.

Fixes #1555 