### PR TITLE
Avoid resolving classpaths eagerly

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -18,7 +18,6 @@
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
 
 package com.google.devtools.ksp.gradle
-
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileCollection
@@ -44,7 +43,18 @@ import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2MetadataCompilerArguments
-import org.jetbrains.kotlin.gradle.dsl.*
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptionsDefault
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompilerOptionsHelper
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptionsDefault
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptionsHelper
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformCommonCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformCommonCompilerOptionsDefault
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformCommonCompilerOptionsHelper
+import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptions
+import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptionsDefault
+import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptionsHelper
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilationInfo
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
@@ -155,10 +165,11 @@ class KotlinFactories {
                     )
 
                     kspTask.onlyIf {
-                        // kspTask.konanTarget.enabledOnCurrentHost
-                        // workaround for: https://github.com/google/ksp/issues/1522
+                        // KonanTarget is not properly serializable, hence we should check by name
+                        // see https://youtrack.jetbrains.com/issue/KT-61657.
+                        val konanTargetName = kspTask.konanTarget.name
                         HostManager().enabled.any {
-                            it.name == kspTask.konanTarget.name
+                            it.name == konanTargetName
                         }
                     }
                 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -802,13 +802,15 @@ internal fun Configuration.markResolvable(): Configuration = apply {
     isVisible = false
 }
 
-
+/**
+ * A [SubpluginOption] that returns the joined path for files in the given [configuration].
+ */
 internal class ClasspathFilesSubpluginOption(
     key: String,
     val configuration: Configuration
 ) : SubpluginOption(
     key = key,
-    lazyValue = lazy<String> {
+    lazyValue = lazy {
         val files = configuration.resolve()
         files.joinToString(File.pathSeparator) { it.normalize().absolutePath }
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -538,10 +538,16 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                             kspTask.compilerPluginOptions.addPluginArgument(kotlinCompileTask.compilerPluginOptions)
                         }
                         kspTask.commonSources.from(kotlinCompileTask.commonSources)
-                        kspTask.options.add(FilesSubpluginOption("apclasspath", processorClasspath.files.toList()))
-                        val kspOptions = kspTask.options.get().flatMap { listOf("-P", it.toArg()) }
-                        kspTask.compilerOptions.freeCompilerArgs.value(
-                            kspOptions + kotlinCompileTask.compilerOptions.freeCompilerArgs.get()
+                        kspTask.options.add(
+                            ClasspathFilesSubpluginOption("apclasspath", processorClasspath)
+                        )
+                        kspTask.compilerOptions.freeCompilerArgs.addAll(
+                            kspTask.options.map {
+                                it.flatMap { listOf("-P", it.toArg()) }
+                            }
+                        )
+                        kspTask.compilerOptions.freeCompilerArgs.addAll(
+                            kotlinCompileTask.compilerOptions.freeCompilerArgs
                         )
                         configureLanguageVersion(kspTask)
                         // Cannot use lambda; See below for details.
@@ -795,3 +801,15 @@ internal fun Configuration.markResolvable(): Configuration = apply {
     isCanBeConsumed = false
     isVisible = false
 }
+
+
+internal class ClasspathFilesSubpluginOption(
+    key: String,
+    val configuration: Configuration
+) : SubpluginOption(
+    key = key,
+    lazyValue = lazy<String> {
+        val files = configuration.resolve()
+        files.joinToString(File.pathSeparator) { it.normalize().absolutePath }
+    }
+)

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -153,7 +153,7 @@ class ProcessorClasspathConfigurationsTest {
         // trigger task creation. KSP should not resolve classpaths
         // at this step
         val buildResult = testRule.runner()
-            .withArguments(":app:tasks")
+            .withArguments(":app:tasks", "--all")
             .build()
         val taskNames = listOf(
             "kspKotlinJs",

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -16,6 +16,7 @@
  */
 package com.google.devtools.ksp.gradle
 
+import com.google.common.truth.Truth.assertThat
 import com.google.devtools.ksp.gradle.testing.KspIntegrationTestRule
 import org.junit.Rule
 import org.junit.Test
@@ -151,9 +152,19 @@ class ProcessorClasspathConfigurationsTest {
         )
         // trigger task creation. KSP should not resolve classpaths
         // at this step
-        testRule.runner()
+        val buildResult = testRule.runner()
             .withArguments(":app:tasks")
             .build()
+        val taskNames = listOf(
+            "kspKotlinJs",
+            "kspKotlinJvm",
+            "kspKotlinLinuxX64",
+        )
+        taskNames.forEach {
+            assertThat(
+                buildResult.output
+            ).contains(it)
+        }
     }
 
     @Test
@@ -183,8 +194,18 @@ class ProcessorClasspathConfigurationsTest {
         )
         // trigger task creation. KSP should not resolve arguments
         // at this step
-        testRule.runner()
-            .withArguments(":app:tasks")
+        val buildResult = testRule.runner()
+            .withArguments(":app:tasks", "--all")
             .build()
+        val taskNames = listOf(
+            "kspKotlinJs",
+            "kspKotlinJvm",
+            "kspKotlinLinuxX64",
+        )
+        taskNames.forEach {
+            assertThat(
+                buildResult.output
+            ).contains(it)
+        }
     }
 }


### PR DESCRIPTION
This PR update KspSubplugin to resolve arguments lazily and also adds a workaround for KonanTarget serialization problem.

These are the 3 issues fixed:

* FilesSubpluginOption: Calling `FilesSubpluginOption("apclasspath", processorClasspath.files.toList())` requires resolving that classpath at configuration time, where it may not necessarily be ready for resolution. Replaced it with a `FileCollectionSubpluginOption` that will resolve it lazily. 
* options.get: Ksp was calling `options.get` at configuration time, which again causes early resolution. Furthermore, it won't change if options are later changed, which is a problem. Changed it to use the provider API.
* configuration cache: KSP has a `task.onlyIf` block to check if the KonanTarget can be compiled on this machine. Unfortunately, KonanTarget has a bug which makes it not properly serializable. (https://youtrack.jetbrains.com/issue/KT-61657) . Changed the block to use the name instead.

Fixes: #1568 
Test: testConfigurationsAreNotResolvedAtConfigurationTime for classpath problem
Test: testArgumentsAreNotResolvedAtConfigurationTime for options.get at configuration time
Test: applicationCanAccessGeneratedCode_multiplatform_withConfigCache for the KonanTarget fix