### PR TITLE
Replace compiler's persistent maps with ours 

### DIFF
--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Kotlin Symbol Processing Util"
 
 val intellijVersion: String by project
 val junitVersion: String by project
+val kotlinBaseVersion: String by project
 
 tasks.withType<KotlinCompile> {
     compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
@@ -34,6 +35,7 @@ dependencies {
     }
 
     implementation(project(":api"))
+    implementation(kotlin("stdlib", kotlinBaseVersion))
     testImplementation("junit:junit:$junitVersion")
 }
 

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/PersistentMap.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/PersistentMap.kt
@@ -1,0 +1,85 @@
+package com.google.devtools.ksp
+
+import com.intellij.util.io.DataExternalizer
+import com.intellij.util.io.IOUtil
+import com.intellij.util.io.KeyDescriptor
+import com.intellij.util.io.PersistentHashMap
+import java.io.DataInput
+import java.io.DataInputStream
+import java.io.DataOutput
+import java.io.File
+
+abstract class PersistentMap<K, V>(
+    storageFile: File,
+    keyDescriptor: KeyDescriptor<K>,
+    dataExternalizer: DataExternalizer<V>
+) : PersistentHashMap<K, V>(
+    storageFile,
+    keyDescriptor,
+    dataExternalizer
+) {
+    val keys: Collection<K>
+        get() = mutableListOf<K>().also { list ->
+            this.processKeysWithExistingMapping { key -> list.add(key) }
+        }
+
+    operator fun set(key: K, value: V) = put(key, value)
+
+    fun clear() {
+        keys.forEach {
+            remove(it)
+        }
+    }
+
+    fun flush() = force()
+}
+
+object FileKeyDescriptor : KeyDescriptor<File> {
+    override fun read(input: DataInput): File {
+        return File(IOUtil.readString(input))
+    }
+
+    override fun save(output: DataOutput, value: File) {
+        IOUtil.writeString(value.path, output)
+    }
+
+    override fun getHashCode(value: File): Int = value.hashCode()
+
+    override fun isEqual(val1: File, val2: File): Boolean = val1 == val2
+}
+
+object FileExternalizer : DataExternalizer<File> {
+    override fun read(input: DataInput): File = File(IOUtil.readString(input))
+
+    override fun save(output: DataOutput, value: File) {
+        IOUtil.writeString(value.path, output)
+    }
+}
+
+class ListExternalizer<T>(
+    private val elementExternalizer: DataExternalizer<T>,
+) : DataExternalizer<List<T>> {
+
+    override fun save(output: DataOutput, value: List<T>) {
+        value.forEach { elementExternalizer.save(output, it) }
+    }
+
+    override fun read(input: DataInput): List<T> {
+        val result = mutableListOf<T>()
+        val stream = input as DataInputStream
+
+        while (stream.available() > 0) {
+            result.add(elementExternalizer.read(stream))
+        }
+
+        return result
+    }
+}
+
+class FileToFilesMap(
+    storageFile: File,
+) : PersistentMap<File, List<File>>(
+    storageFile,
+    FileKeyDescriptor,
+    ListExternalizer(FileExternalizer)
+)

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(project(":common-deps"))
     testImplementation(gradleApi())
     testImplementation(project(":api"))
-    testImplementation(project(":common-util"))
     testImplementation("junit:junit:$junitVersion")
     testImplementation("com.google.truth:truth:$googleTruthVersion")
     testImplementation(gradleTestKit())

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -14,7 +14,6 @@ dependencies {
     testImplementation(gradleTestKit())
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
     testImplementation(project(":api"))
-    testImplementation(project(":common-util"))
     testImplementation(project(":gradle-plugin"))
     testImplementation(project(":symbol-processing"))
     testImplementation(project(":symbol-processing-cmdline"))


### PR DESCRIPTION
With one left in TODO: `org.jetbrains.kotlin.incremental.LookupStorage`, which requires more works.