### PR TITLE
Turn off -progressive when downgrading from K2

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -366,6 +366,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
             kspTask.compilerOptions.useK2.value(false)
             val languageVersion = kotlinCompilation.compilerOptions.options.languageVersion
+            val progressiveMode = kotlinCompilation.compilerOptions.options.progressiveMode
             kspTask.compilerOptions.languageVersion.value(
                 project.provider {
                     languageVersion.orNull?.let { version ->
@@ -375,6 +376,18 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                             version
                         }
                     } ?: KotlinVersion.KOTLIN_1_9
+                }
+            )
+
+            // Turn off progressive mode if we need to downgrade language version.
+            kspTask.compilerOptions.progressiveMode.value(
+                project.provider {
+                    val compileLangVer = languageVersion.orNull ?: KotlinVersion.DEFAULT
+                    if (compileLangVer >= KotlinVersion.KOTLIN_2_0) {
+                        false
+                    } else {
+                        progressiveMode.orNull
+                    }
                 }
             )
         }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -361,6 +361,24 @@ class PlaygroundIT(val useKSP2: Boolean) {
         project.restore(properties.path)
     }
 
+    @Test
+    fun testProgressiveMode() {
+        val buildFile = File(project.root, "workload/build.gradle.kts")
+        buildFile.appendText(
+            """
+            kotlin {
+                compilerOptions {
+                    allWarningsAsErrors.value(true)
+                    progressiveMode.value(true)
+               }
+            }
+            """.trimIndent()
+        )
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.0")
+        gradleRunner.withArguments("clean", "build").build()
+        project.restore(buildFile.path)
+    }
+
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "KSP2={0}")


### PR DESCRIPTION
Progressive mode should always be used with latest language version.

Fixes #1612 