### PR TITLE
Cherry-pick updates to persistent maps

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/PersistentMap.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/PersistentMap.kt
@@ -1,0 +1,85 @@
+package com.google.devtools.ksp
+
+import com.intellij.util.io.DataExternalizer
+import com.intellij.util.io.IOUtil
+import com.intellij.util.io.KeyDescriptor
+import com.intellij.util.io.PersistentHashMap
+import java.io.DataInput
+import java.io.DataInputStream
+import java.io.DataOutput
+import java.io.File
+
+abstract class PersistentMap<K, V>(
+    storageFile: File,
+    keyDescriptor: KeyDescriptor<K>,
+    dataExternalizer: DataExternalizer<V>
+) : PersistentHashMap<K, V>(
+    storageFile,
+    keyDescriptor,
+    dataExternalizer
+) {
+    val keys: Collection<K>
+        get() = mutableListOf<K>().also { list ->
+            this.processKeysWithExistingMapping { key -> list.add(key) }
+        }
+
+    operator fun set(key: K, value: V) = put(key, value)
+
+    fun clear() {
+        keys.forEach {
+            remove(it)
+        }
+    }
+
+    fun flush() = force()
+}
+
+object FileKeyDescriptor : KeyDescriptor<File> {
+    override fun read(input: DataInput): File {
+        return File(IOUtil.readString(input))
+    }
+
+    override fun save(output: DataOutput, value: File) {
+        IOUtil.writeString(value.path, output)
+    }
+
+    override fun getHashCode(value: File): Int = value.hashCode()
+
+    override fun isEqual(val1: File, val2: File): Boolean = val1 == val2
+}
+
+object FileExternalizer : DataExternalizer<File> {
+    override fun read(input: DataInput): File = File(IOUtil.readString(input))
+
+    override fun save(output: DataOutput, value: File) {
+        IOUtil.writeString(value.path, output)
+    }
+}
+
+class ListExternalizer<T>(
+    private val elementExternalizer: DataExternalizer<T>,
+) : DataExternalizer<List<T>> {
+
+    override fun save(output: DataOutput, value: List<T>) {
+        value.forEach { elementExternalizer.save(output, it) }
+    }
+
+    override fun read(input: DataInput): List<T> {
+        val result = mutableListOf<T>()
+        val stream = input as DataInputStream
+
+        while (stream.available() > 0) {
+            result.add(elementExternalizer.read(stream))
+        }
+
+        return result
+    }
+}
+
+class FileToFilesMap(
+    storageFile: File,
+) : PersistentMap<File, List<File>>(
+    storageFile,
+    FileKeyDescriptor,
+    ListExternalizer(FileExternalizer)
+)

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/Incremental.kt
@@ -36,9 +36,7 @@ import org.jetbrains.kotlin.incremental.*
 import org.jetbrains.kotlin.incremental.components.LookupTracker
 import org.jetbrains.kotlin.incremental.components.Position
 import org.jetbrains.kotlin.incremental.components.ScopeKind
-import org.jetbrains.kotlin.incremental.storage.AppendableBasicMap
-import org.jetbrains.kotlin.incremental.storage.AppendableDataExternalizer
-import org.jetbrains.kotlin.incremental.storage.CollectionExternalizer
+import org.jetbrains.kotlin.incremental.storage.AppendableAbstractBasicMap
 import org.jetbrains.kotlin.incremental.storage.FileToPathConverter
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperclassesWithoutAny
 import org.jetbrains.kotlin.types.KotlinType
@@ -51,44 +49,19 @@ import java.util.*
 abstract class PersistentMap<K : Comparable<K>, V>(
     storageFile: File,
     keyDescriptor: KeyDescriptor<K>,
-    valueExternalizer: AppendableDataExternalizer<V>,
+    valueExternalizer: DataExternalizer<V>,
     icContext: IncrementalCompilationContext,
-) : AppendableBasicMap<K, V>(storageFile, keyDescriptor, valueExternalizer, icContext) {
-    abstract operator fun get(key: K): V?
-    abstract operator fun set(key: K, value: V)
-    abstract fun remove(key: K)
-}
+) : AppendableAbstractBasicMap<K, V, Collection<V>>(storageFile, keyDescriptor, valueExternalizer, icContext)
 
 class FileToSymbolsMap(
     storageFile: File,
     icContext: IncrementalCompilationContext
-) : PersistentMap<File, Collection<LookupSymbol>>(
+) : PersistentMap<File, LookupSymbol>(
     storageFile,
     FileKeyDescriptor,
-    CollectionExternalizer(LookupSymbolExternalizer, { HashSet() }),
+    LookupSymbolExternalizer,
     icContext,
-) {
-    override fun dumpKey(key: File): String = key.toString()
-
-    override fun dumpValue(value: Collection<LookupSymbol>): String = value.toString()
-
-    fun add(file: File, symbol: LookupSymbol) {
-        storage.append(file, listOf(symbol))
-    }
-
-    override operator fun get(key: File): Collection<LookupSymbol>? = storage[key]
-
-    override operator fun set(key: File, symbols: Collection<LookupSymbol>) {
-        storage[key] = symbols
-    }
-
-    override fun remove(key: File) {
-        storage.remove(key)
-    }
-
-    val keys: Collection<File>
-        get() = storage.keys
-}
+)
 
 object FileKeyDescriptor : KeyDescriptor<File> {
     override fun read(input: DataInput): File {
@@ -124,30 +97,16 @@ object FileExternalizer : DataExternalizer<File> {
 class FileToFilesMap(
     storageFile: File,
     icContext: IncrementalCompilationContext
-) : PersistentMap<File, Collection<File>>(
+) : PersistentMap<File, File>(
     storageFile,
     FileKeyDescriptor,
-    CollectionExternalizer(FileExternalizer, { HashSet() }),
+    FileExternalizer,
     icContext,
 ) {
-
-    override operator fun get(key: File): Collection<File>? = storage[key]
-
-    override operator fun set(key: File, value: Collection<File>) {
-        storage[key] = value
-    }
-
     override fun dumpKey(key: File): String = key.path
 
     override fun dumpValue(value: Collection<File>) =
         value.dumpCollection()
-
-    override fun remove(key: File) {
-        storage.remove(key)
-    }
-
-    val keys: Collection<File>
-        get() = storage.keys
 }
 
 object symbolCollector : KSDefaultVisitor<(LookupSymbol) -> Unit, Unit>() {
@@ -452,7 +411,7 @@ class IncrementalContext(
 
         logSourceToOutputs(outputs, sourceToOutputs)
 
-        sourceToOutputsMap.flush(false)
+        sourceToOutputsMap.flush()
     }
 
     private fun updateOutputs(outputs: Set<File>, cleanOutputs: Collection<File>) {
@@ -494,14 +453,14 @@ class IncrementalContext(
         updateLookupCache(dirtyFiles)
 
         // Update symbolsMap
-        fun <K : Comparable<K>, V> update(m: PersistentMap<K, Collection<V>>, u: MultiMap<K, V>) {
+        fun <K : Comparable<K>, V> update(m: PersistentMap<K, V>, u: MultiMap<K, V>) {
             // Update symbol caches from modified files.
             u.keySet().forEach {
                 m.set(it, u[it].toSet())
             }
         }
 
-        fun <K : Comparable<K>, V> remove(m: PersistentMap<K, Collection<V>>, removedKeys: Collection<K>) {
+        fun <K : Comparable<K>, V> remove(m: PersistentMap<K, V>, removedKeys: Collection<K>) {
             // Remove symbol caches from removed files.
             removedKeys.forEach {
                 m.remove(it)
@@ -515,15 +474,15 @@ class IncrementalContext(
             update(symbolsMap, updatedSymbols)
             remove(symbolsMap, removed)
         } else {
-            symbolsMap.clean()
+            symbolsMap.clear()
             update(symbolsMap, updatedSymbols)
 
-            sealedMap.clean()
+            sealedMap.clear()
             update(sealedMap, updatedSealed)
         }
-        symbolsMap.flush(false)
+        symbolsMap.flush()
         symbolsMap.close()
-        sealedMap.flush(false)
+        sealedMap.flush()
         sealedMap.close()
     }
 


### PR DESCRIPTION
Note that d44ad7d has two prerequisites that were parts of compiler bumps: 4e408831 and 36751997. The relevant changes were manually picked in 87c3929. Later compiler bumps in this branch can be done reverting d104f84f and 87c3929, and then picking 4e408831, 36751997 and d44ad7d.