### PR TITLE
fix special class name resolution for class literal annotation value

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSAnnotationDescriptorImpl.kt
@@ -128,8 +128,10 @@ class KSAnnotationDescriptorImpl private constructor(
 }
 
 private fun ClassId.findKSClassDeclaration(): KSClassDeclaration? {
-    val ksName = KSNameImpl.getCached(this.asSingleFqName().asString().replace("$", "."))
-    return ResolverImpl.instance!!.getClassDeclarationByName(ksName)
+    return ResolverImpl.instance!!.getClassDeclarationByName(this.asSingleFqName().asString()) ?: run {
+        val ksName = KSNameImpl.getCached(asSingleFqName().asString().replace("$", "."))
+        ResolverImpl.instance!!.getClassDeclarationByName(ksName)
+    }
 }
 
 private fun ClassId.findKSType(): KSType? = findKSClassDeclaration()?.asStarProjectedType()

--- a/test-utils/testData/api/annotationValue_kt.kt
+++ b/test-utils/testData/api/annotationValue_kt.kt
@@ -19,6 +19,7 @@
 // TEST PROCESSOR: AnnotationArgumentProcessor
 // EXPECTED:
 // defaultInNested
+// SomeClass$WithDollarSign
 // Str
 // 42
 // Foo
@@ -49,6 +50,10 @@ class ThrowsClass {
 annotation class Foo(val s: Int) {
     annotation class Nested(val nestedDefault:String = "defaultInNested")
 }
+class `SomeClass$WithDollarSign`
+
+annotation class MyAnnotation(val clazz: KClass<*>)
+
 
 annotation class Bar(
     val argStr: String,
@@ -68,6 +73,7 @@ annotation class Bar(
 
 fun Fun() {
     @Foo.Nested
+    @MyAnnotation(`SomeClass$WithDollarSign`::class)
     @Bar(
         "Str",
         40 + 2,


### PR DESCRIPTION
Simply replace `$` in the fqname for local class purpose does not work for escaped special class names, hence do a resolution in first try and then fallback to replacing `$` for local class.