### PR TITLE
include library roots in declaration provider init

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -378,7 +378,12 @@ class KotlinSymbolProcessing(
             project.getService(
                 KotlinDeclarationProviderFactory::class.java
             ) as IncrementalKotlinDeclarationProviderFactory
-            ).update(ktFiles)
+            )
+            .update(
+                ktFiles,
+                StandaloneProjectFactory.getAllBinaryRoots(modules, kotlinCoreProjectEnvironment).map { it.file } +
+                    listOfNotNull(VirtualFileManager.getInstance().findFileByNioPath(kspConfig.classOutputDir.toPath()))
+            )
         (
             project.getService(
                 KotlinPackageProviderFactory::class.java

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProvider.kt
@@ -1,6 +1,7 @@
 package com.google.devtools.ksp.standalone
 
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.project.structure.KtModule
 import org.jetbrains.kotlin.analysis.providers.KotlinDeclarationProvider
@@ -93,9 +94,9 @@ class IncrementalKotlinDeclarationProviderFactory(
         }
     }
 
-    fun update(files: Collection<KtFile>) {
+    fun update(files: Collection<KtFile>, moduleRoots: List<VirtualFile>) {
         this.files = files
-        this.staticFactory = KotlinStaticDeclarationProviderFactory(project, files)
+        this.staticFactory = KotlinStaticDeclarationProviderFactory(project, files, additionalRoots = moduleRoots)
         provider?.let {
             it.del = createDelegateProvider()
         }

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -161,7 +161,6 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/companion.kt")
     }
 
-    @Disabled
     @TestMetadata("constProperties.kt")
     @Test
     fun testConstProperties() {


### PR DESCRIPTION
This should address indexing for top level callables.
`additionalRoots` is used for indexing during initialization.