### PR TITLE
Incremental: Support top level callables in libs

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -61,6 +61,8 @@ package com.google.devtools.ksp.processing {
     method public void associate(@NonNull java.util.List<? extends com.google.devtools.ksp.symbol.KSFile> sources, @NonNull String packageName, @NonNull String fileName, @NonNull String extensionName = "kt");
     method public void associateByPath(@NonNull java.util.List<? extends com.google.devtools.ksp.symbol.KSFile> sources, @NonNull String path, @NonNull String extensionName = "kt");
     method public void associateWithClasses(@NonNull java.util.List<? extends com.google.devtools.ksp.symbol.KSClassDeclaration> classes, @NonNull String packageName, @NonNull String fileName, @NonNull String extensionName = "kt");
+    method public void associateWithFunctions(@NonNull java.util.List<? extends com.google.devtools.ksp.symbol.KSFunctionDeclaration> functions, @NonNull String packageName, @NonNull String fileName, @NonNull String extensionName = "kt");
+    method public void associateWithProperties(@NonNull java.util.List<? extends com.google.devtools.ksp.symbol.KSPropertyDeclaration> properties, @NonNull String packageName, @NonNull String fileName, @NonNull String extensionName = "kt");
     method @NonNull public java.io.OutputStream createNewFile(@NonNull com.google.devtools.ksp.processing.Dependencies dependencies, @NonNull String packageName, @NonNull String fileName, @NonNull String extensionName = "kt");
     method @NonNull public java.io.OutputStream createNewFileByPath(@NonNull com.google.devtools.ksp.processing.Dependencies dependencies, @NonNull String path, @NonNull String extensionName = "kt");
     method @NonNull public java.util.Collection<java.io.File> getGeneratedFile();
@@ -81,6 +83,13 @@ package com.google.devtools.ksp.processing {
   public static final class Dependencies.Companion {
     method @NonNull public com.google.devtools.ksp.processing.Dependencies getALL_FILES();
     property @NonNull public final com.google.devtools.ksp.processing.Dependencies ALL_FILES;
+  }
+
+  public enum ExitCode {
+    method @NonNull public static com.google.devtools.ksp.processing.ExitCode valueOf(String value) throws java.lang.IllegalArgumentException, java.lang.NullPointerException;
+    method @NonNull public static com.google.devtools.ksp.processing.ExitCode[] values();
+    enum_constant public static final com.google.devtools.ksp.processing.ExitCode OK;
+    enum_constant public static final com.google.devtools.ksp.processing.ExitCode PROCESSING_ERROR;
   }
 
   public interface JsPlatformInfo extends com.google.devtools.ksp.processing.PlatformInfo {

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/CodeGenerator.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/CodeGenerator.kt
@@ -138,6 +138,42 @@ interface CodeGenerator {
     )
 
     val generatedFile: Collection<File>
+
+    /**
+     * Associate [functions] to an output file.
+     *
+     * @param functions are [KSFunctionDeclaration]s from which this output is built. Only those that are obtained
+     *              directly from [Resolver] are required.
+     * @param packageName corresponds to the relative path of the generated file; using either '.'or '/' as separator.
+     * @param fileName file name
+     * @param extensionName If "kt" or "java", this file will participate in subsequent compilation.
+     *                      Otherwise its creation is only considered in incremental processing.
+     * @see [CodeGenerator] for more details.
+     */
+    fun associateWithFunctions(
+        functions: List<KSFunctionDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String = "kt"
+    )
+
+    /**
+     * Associate [properties] to an output file.
+     *
+     * @param properties are [KSPropertyDeclaration]s from which this output is built. Only those that are obtained
+     *              directly from [Resolver] are required.
+     * @param packageName corresponds to the relative path of the generated file; using either '.'or '/' as separator.
+     * @param fileName file name
+     * @param extensionName If "kt" or "java", this file will participate in subsequent compilation.
+     *                      Otherwise its creation is only considered in incremental processing.
+     * @see [CodeGenerator] for more details.
+     */
+    fun associateWithProperties(
+        properties: List<KSPropertyDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String = "kt"
+    )
 }
 
 /**

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/processing/impl/CodeGeneratorImpl.kt
@@ -22,6 +22,8 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
@@ -94,6 +96,42 @@ class CodeGeneratorImpl(
         val path = pathOf(packageName, fileName, extensionName)
         val files = classes.map {
             it.containingFile ?: NoSourceFile(projectBase, it.qualifiedName?.asString().toString())
+        }
+        associate(files, path, extensionToDirectory(extensionName))
+    }
+
+    // FIXME: associate with the containing FileKt.
+    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin metadata.
+    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of interest.
+    //
+    // This implementation associates anyChangesWildcard, which is an overkill.
+    override fun associateWithFunctions(
+        functions: List<KSFunctionDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String
+    ) {
+        val path = pathOf(packageName, fileName, extensionName)
+        val files = functions.map {
+            it.containingFile ?: anyChangesWildcard
+        }
+        associate(files, path, extensionToDirectory(extensionName))
+    }
+
+    // FIXME: associate with the containing FileKt.
+    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin metadata.
+    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of interest.
+    //
+    // This implementation associates anyChangesWildcard, which is an overkill.
+    override fun associateWithProperties(
+        properties: List<KSPropertyDeclaration>,
+        packageName: String,
+        fileName: String,
+        extensionName: String
+    ) {
+        val path = pathOf(packageName, fileName, extensionName)
+        val files = properties.map {
+            it.containingFile ?: anyChangesWildcard
         }
         associate(files, path, extensionToDirectory(extensionName))
     }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
@@ -79,7 +79,6 @@ class IncrementalCPIT(val useKSP2: Boolean) {
 
     val func2Dirty = listOf(
         "l1/src/main/kotlin/p1/TopFunc1.kt" to setOf(
-            "w: [ksp] p1/K3.kt",
             "w: [ksp] processing done",
         ),
     )
@@ -126,7 +125,6 @@ class IncrementalCPIT(val useKSP2: Boolean) {
 
     val prop2Dirty = listOf(
         "l1/src/main/kotlin/p1/TopProp1.kt" to setOf(
-            "w: [ksp] p1/K3.kt",
             "w: [ksp] processing done",
         ),
     )

--- a/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/TopFunc1.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/TopFunc1.kt
@@ -1,0 +1,3 @@
+package p1
+
+fun MyTopFunc1(): Int = 0

--- a/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/TopProp1.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/src/main/kotlin/p1/TopProp1.kt
@@ -1,0 +1,3 @@
+package p1
+
+val MyTopProp1: Int = 0

--- a/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
@@ -1,4 +1,6 @@
 import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getFunctionDeclarationsByName
+import com.google.devtools.ksp.getPropertyDeclarationByName
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
@@ -61,6 +63,18 @@ class Validator : SymbolProcessor {
         val l5 = resolver.getClassDeclarationByName("p1.L5")!!
         codeGenerator.createNewFile(Dependencies(false), "p1", "l5", "log")
         codeGenerator.associateWithClasses(listOf(l5), "p1", "l5", "log")
+
+        // create an output from MyTopFunc1, declared in TopFunc1.kt, and k3
+        val myTopFunc1 = resolver.getFunctionDeclarationsByName("p1.MyTopFunc1", true).single()
+        codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopFunc1", "log")
+        codeGenerator.associateWithFunctions(listOf(myTopFunc1), "p1", "MyTopFunc1", "log")
+        codeGenerator.associateWithClasses(listOf(k3), "p1", "MyTopFunc1", "log")
+
+        // create an output from MyTopFunc1, declared in TopFunc1.kt, and k3
+        val myTopProp1 = resolver.getPropertyDeclarationByName("p1.MyTopProp1", true)!!
+        codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopProp1", "log")
+        codeGenerator.associateWithProperties(listOf(myTopProp1), "p1", "MyTopProp1", "log")
+        codeGenerator.associateWithClasses(listOf(k3), "p1", "MyTopProp1", "log")
         logger.warn("processing done")
 
         processed = true

--- a/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/src/main/kotlin/Validator.kt
@@ -64,17 +64,15 @@ class Validator : SymbolProcessor {
         codeGenerator.createNewFile(Dependencies(false), "p1", "l5", "log")
         codeGenerator.associateWithClasses(listOf(l5), "p1", "l5", "log")
 
-        // create an output from MyTopFunc1, declared in TopFunc1.kt, and k3
+        // create an output from MyTopFunc1, declared in TopFunc1.kt
         val myTopFunc1 = resolver.getFunctionDeclarationsByName("p1.MyTopFunc1", true).single()
         codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopFunc1", "log")
         codeGenerator.associateWithFunctions(listOf(myTopFunc1), "p1", "MyTopFunc1", "log")
-        codeGenerator.associateWithClasses(listOf(k3), "p1", "MyTopFunc1", "log")
 
-        // create an output from MyTopFunc1, declared in TopFunc1.kt, and k3
+        // create an output from MyTopProp1, declared in TopFunc1.kt
         val myTopProp1 = resolver.getPropertyDeclarationByName("p1.MyTopProp1", true)!!
         codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopProp1", "log")
         codeGenerator.associateWithProperties(listOf(myTopProp1), "p1", "MyTopProp1", "log")
-        codeGenerator.associateWithClasses(listOf(k3), "p1", "MyTopProp1", "log")
         logger.warn("processing done")
 
         processed = true


### PR DESCRIPTION
by treating outputs of them sensitive to any changes. The granular way requires knowledge from the each backend and will be implemented in the future.