### PR TITLE
Introduce SymbolProcessorEnvironment.kspVersion

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -83,6 +83,13 @@ package com.google.devtools.ksp.processing {
     property @NonNull public final com.google.devtools.ksp.processing.Dependencies ALL_FILES;
   }
 
+  public enum ExitCode {
+    method @NonNull public static com.google.devtools.ksp.processing.ExitCode valueOf(String value) throws java.lang.IllegalArgumentException, java.lang.NullPointerException;
+    method @NonNull public static com.google.devtools.ksp.processing.ExitCode[] values();
+    enum_constant public static final com.google.devtools.ksp.processing.ExitCode OK;
+    enum_constant public static final com.google.devtools.ksp.processing.ExitCode PROCESSING_ERROR;
+  }
+
   public interface JsPlatformInfo extends com.google.devtools.ksp.processing.PlatformInfo {
   }
 
@@ -187,10 +194,12 @@ package com.google.devtools.ksp.processing {
   public final class SymbolProcessorEnvironment {
     ctor public SymbolProcessorEnvironment(@NonNull java.util.Map<java.lang.String,java.lang.String> options, @NonNull kotlin.KotlinVersion kotlinVersion, @NonNull com.google.devtools.ksp.processing.CodeGenerator codeGenerator, @NonNull com.google.devtools.ksp.processing.KSPLogger logger);
     ctor public SymbolProcessorEnvironment(@NonNull java.util.Map<java.lang.String,java.lang.String> options, @NonNull kotlin.KotlinVersion kotlinVersion, @NonNull com.google.devtools.ksp.processing.CodeGenerator codeGenerator, @NonNull com.google.devtools.ksp.processing.KSPLogger logger, @NonNull kotlin.KotlinVersion apiVersion, @NonNull kotlin.KotlinVersion compilerVersion, @NonNull java.util.List<? extends com.google.devtools.ksp.processing.PlatformInfo> platforms);
+    ctor public SymbolProcessorEnvironment(@NonNull java.util.Map<java.lang.String,java.lang.String> options, @NonNull kotlin.KotlinVersion kotlinVersion, @NonNull com.google.devtools.ksp.processing.CodeGenerator codeGenerator, @NonNull com.google.devtools.ksp.processing.KSPLogger logger, @NonNull kotlin.KotlinVersion apiVersion, @NonNull kotlin.KotlinVersion compilerVersion, @NonNull java.util.List<? extends com.google.devtools.ksp.processing.PlatformInfo> platforms, @NonNull kotlin.KotlinVersion kspVersion);
     method @NonNull public kotlin.KotlinVersion getApiVersion();
     method @NonNull public com.google.devtools.ksp.processing.CodeGenerator getCodeGenerator();
     method @NonNull public kotlin.KotlinVersion getCompilerVersion();
     method @NonNull public kotlin.KotlinVersion getKotlinVersion();
+    method @NonNull public kotlin.KotlinVersion getKspVersion();
     method @NonNull public com.google.devtools.ksp.processing.KSPLogger getLogger();
     method @NonNull public java.util.Map<java.lang.String,java.lang.String> getOptions();
     method @NonNull public java.util.List<com.google.devtools.ksp.processing.PlatformInfo> getPlatforms();
@@ -198,6 +207,7 @@ package com.google.devtools.ksp.processing {
     property @NonNull public final com.google.devtools.ksp.processing.CodeGenerator codeGenerator;
     property @NonNull public final kotlin.KotlinVersion compilerVersion;
     property @NonNull public final kotlin.KotlinVersion kotlinVersion;
+    property @NonNull public final kotlin.KotlinVersion kspVersion;
     property @NonNull public final com.google.devtools.ksp.processing.KSPLogger logger;
     property @NonNull public final java.util.Map<java.lang.String,java.lang.String> options;
     property @NonNull public final java.util.List<com.google.devtools.ksp.processing.PlatformInfo> platforms;

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
@@ -54,6 +54,11 @@ class SymbolProcessorEnvironment(
      * There can be multiple platforms in a metadata compilation.
      */
     val platforms: List<PlatformInfo>,
+
+    /**
+     * KSP version
+     */
+    val kspVersion: KotlinVersion,
 ) {
     // For compatibility with KSP 1.0.2 and earlier
     constructor(
@@ -68,6 +73,26 @@ class SymbolProcessorEnvironment(
         logger,
         kotlinVersion,
         kotlinVersion,
-        emptyList()
+        emptyList(),
+        KotlinVersion(1, 0)
+    )
+
+    constructor(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger,
+        apiVersion: KotlinVersion,
+        compilerVersion: KotlinVersion,
+        platforms: List<PlatformInfo>,
+    ) : this(
+        options,
+        kotlinVersion,
+        codeGenerator,
+        logger,
+        apiVersion,
+        compilerVersion,
+        platforms,
+        KotlinVersion(1, 0)
     )
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -282,7 +282,8 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                             logger,
                             options.apiVersion,
                             options.compilerVersion,
-                            findTargetInfos(options.languageVersionSettings, module)
+                            findTargetInfos(options.languageVersionSettings, module),
+                            KotlinVersion(1, 0),
                         )
                     )
                 }?.let { analysisResult ->

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -284,6 +284,8 @@ class PlaygroundIT(val useKSP2: Boolean) {
                 // In case KSP 1 and KSP 2 uses different compiler versions, ignore this test for KSP 2 for now.
                 Assert.assertTrue(result.output.contains("compiler version: $kotlinVersion"))
             }
+            val expectedKspVersion = if (useKSP2) "2.0" else "1.0"
+            Assert.assertTrue(result.output.contains("ksp version: $expectedKspVersion"))
         }
         project.restore(buildFile.path)
     }

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
@@ -278,6 +278,7 @@ class TestProcessorProvider2 : SymbolProcessorProvider {
             env.logger.warn("language version: ${env.kotlinVersion}")
             env.logger.warn("api version: ${env.apiVersion}")
             env.logger.warn("compiler version: ${env.compilerVersion}")
+            env.logger.warn("ksp version: ${env.kspVersion}")
             env.platforms.filterIsInstance<JvmPlatformInfo>().single().let {
                 env.logger.warn("platform: $it")
                 env.logger.warn("jvm default mode: ${it.jvmDefaultMode}")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -498,7 +498,8 @@ class KotlinSymbolProcessing(
             logger,
             kspConfig.apiVersion.toKotlinVersion(),
             KotlinCompilerVersion.getVersion().toKotlinVersion(),
-            targetPlatform.getPlatformInfo(kspConfig)
+            targetPlatform.getPlatformInfo(kspConfig),
+            KotlinVersion(2, 0)
         )
 
         // Load and instantiate processsors


### PR DESCRIPTION
To be consistent with apiVersion, only major.minor is used. patch is ignored.

TODO: automatically update after KSP 1 is deprecated.