### PR TITLE
fix: `NoClassDefFound` with `ksp.useKSP2=true`

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
         depSourceJars("$it:$aaKotlinBaseVersion:sources") { isTransitive = false }
     }
 
+    implementation("io.javaslang:javaslang:2.0.6")  // needed transitively for `kotlin-compiler-common-for-ide`
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
     implementation(kotlin("stdlib", aaKotlinBaseVersion))
 


### PR DESCRIPTION
Fixes and closes google/ksp#1665
