### PR TITLE
include type arguments in reference elements's referencedName/toString

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassifierReferenceImpl.kt
@@ -47,7 +47,14 @@ class KSClassifierReferenceImpl private constructor(val ktUserType: KtUserType) 
     }
 
     override fun referencedName(): String {
-        return ktUserType.referencedName ?: ""
+        val typeArgs = typeArguments
+        return if (typeArgs.isEmpty()) {
+            ktUserType.referencedName ?: ""
+        } else {
+            ktUserType.referencedName + typeArgs.joinToString(prefix = "<", postfix = ">") {
+                it.type?.toString() ?: "*"
+            }
+        }
     }
 
     override val qualifier: KSClassifierReference? by lazy {

--- a/test-utils/testData/api/referenceElement.kt
+++ b/test-utils/testData/api/referenceElement.kt
@@ -19,7 +19,7 @@
 // TEST PROCESSOR: ReferenceElementProcessor
 // EXPECTED:
 // KSClassifierReferenceImpl: Qualifier of B is A
-// KSClassifierReferenceImpl: Qualifier of C is A
+// KSClassifierReferenceImpl: Qualifier of C<Int> is A<String>
 // KSClassifierReferenceImpl: Qualifier of Int is null
 // KSClassifierReferenceImpl: Qualifier of String is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of Int is null


### PR DESCRIPTION
Fixes #1200

This just feels like an oversight to me as the other impls do include them, but lmk!