### PR TITLE
Properly config and validate shadow jars

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -156,6 +156,7 @@ abstract class KspAATask @Inject constructor(
                     "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-common-deps:$KSP_VERSION"
                 ),
                 project.dependencies.create("org.jetbrains.intellij.deps:trove4j:1.0.20200330"),
+                project.dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:$KSP_KOTLIN_BASE_VERSION"),
             ).apply {
                 isTransitive = false
             }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -72,11 +72,10 @@ dependencies {
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
     compileOnly(project(":common-deps"))
 
-    compileOnly(project(":api"))
+    implementation(project(":api"))
     implementation(project(":common-util"))
 
     testImplementation(kotlin("stdlib", aaKotlinBaseVersion))
-    testImplementation(project(":api"))
 }
 
 sourceSets.main {
@@ -102,6 +101,10 @@ tasks.withType<org.gradle.jvm.tasks.Jar> {
 }
 
 tasks.withType<ShadowJar>() {
+    dependencies {
+        exclude(project(":api"))
+    }
+    exclude("kotlin/**")
     archiveClassifier.set("")
     minimize()
     mergeServiceFiles()


### PR DESCRIPTION
1. kotlin-stdlib was still included from transitive dependencies.
2. jar validation is now merged into `shadow`