### PR TITLE
1.0.18 release: Downgrade Kotlin to 1.9.22

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSDeclarationDescriptorImpl.kt
@@ -20,10 +20,10 @@ package com.google.devtools.ksp.symbol.impl.binary
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.memoized
 import com.google.devtools.ksp.symbol.*
+import org.jetbrains.kotlin.backend.common.serialization.findPackage
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.descriptors.findPackage
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassDescriptor
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.parents
@@ -50,7 +50,7 @@ abstract class KSDeclarationDescriptorImpl(private val descriptor: DeclarationDe
             is ClassDescriptor -> KSClassDeclarationDescriptorImpl.getCached(containingDescriptor)
             is FunctionDescriptor -> KSFunctionDeclarationDescriptorImpl.getCached(containingDescriptor)
             else -> null
-        }
+        } as KSDeclaration?
     }
 
     override val parent: KSNode? by lazy {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -39,7 +39,6 @@ import org.gradle.process.CommandLineArgumentProvider
 import org.gradle.process.ExecOperations
 import org.gradle.work.InputChanges
 import org.gradle.workers.WorkerExecutor
-import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.cli.common.arguments.CommonCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JSCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
@@ -68,6 +67,7 @@ import org.jetbrains.kotlin.gradle.tasks.TaskOutputsBackup
 import org.jetbrains.kotlin.gradle.tasks.configuration.BaseKotlin2JsCompileConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KotlinCompileCommonConfig
 import org.jetbrains.kotlin.gradle.tasks.configuration.KotlinCompileConfig
+import org.jetbrains.kotlin.incremental.ChangedFiles
 import org.jetbrains.kotlin.konan.target.HostManager
 import java.io.File
 import java.nio.file.Paths
@@ -186,7 +186,7 @@ interface KspTask : Task {
     val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
 
     @get:Internal
-    val incrementalChangesTransformers: ListProperty<(SourcesChanges) -> List<SubpluginOption>>
+    val incrementalChangesTransformers: ListProperty<(ChangedFiles) -> List<SubpluginOption>>
 }
 
 @CacheableTask

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -36,7 +36,6 @@ import org.gradle.tooling.provider.model.ToolingModelBuilderRegistry
 import org.gradle.util.GradleVersion
 import org.gradle.work.ChangeType
 import org.gradle.work.InputChanges
-import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.CLASS_STRUCTURE_ARTIFACT_TYPE
@@ -57,6 +56,7 @@ import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
 import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.plugin.mpp.*
 import org.jetbrains.kotlin.gradle.tasks.*
+import org.jetbrains.kotlin.incremental.ChangedFiles
 import org.jetbrains.kotlin.incremental.isJavaFile
 import org.jetbrains.kotlin.incremental.isKotlinFile
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
@@ -661,7 +661,7 @@ internal fun getClassStructureFiles(
 // Reuse Kapt's infrastructure to compute affected names in classpath.
 // This is adapted from KaptTask.findClasspathChanges.
 internal fun findClasspathChanges(
-    changes: SourcesChanges,
+    changes: ChangedFiles,
     cacheDir: File,
     allDataFiles: Set<File>,
     libs: List<File>,
@@ -669,8 +669,7 @@ internal fun findClasspathChanges(
 ): KaptClasspathChanges {
     cacheDir.mkdirs()
 
-    val changedFiles =
-        (changes as? SourcesChanges.Known)?.let { it.modifiedFiles + it.removedFiles }?.toSet() ?: allDataFiles
+    val changedFiles = (changes as? ChangedFiles.Known)?.let { it.modified + it.removed }?.toSet() ?: allDataFiles
 
     val loadedPrevious = ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(cacheDir)
     val previousAndCurrentDataFiles = lazy { loadedPrevious.getAllDataFiles() + allDataFiles }
@@ -699,7 +698,7 @@ internal fun findClasspathChanges(
         )
 
     val classpathChanges = currentSnapshot.diff(previousSnapshot, changedFiles)
-    if (classpathChanges is KaptClasspathChanges.Unknown || changes is SourcesChanges.Unknown) {
+    if (classpathChanges is KaptClasspathChanges.Unknown || changes is ChangedFiles.Unknown) {
         cacheDir.deleteRecursively()
         cacheDir.mkdirs()
     }
@@ -708,11 +707,11 @@ internal fun findClasspathChanges(
     return classpathChanges
 }
 
-internal fun SourcesChanges.hasNonSourceChange(): Boolean {
-    if (this !is SourcesChanges.Known)
+internal fun ChangedFiles.hasNonSourceChange(): Boolean {
+    if (this !is ChangedFiles.Known)
         return true
 
-    return !(this.modifiedFiles + this.removedFiles).all {
+    return !(this.modified + this.removed).all {
         it.isKotlinFile(listOf("kt")) || it.isJavaFile()
     }
 }
@@ -727,13 +726,13 @@ fun KaptClasspathChanges.toSubpluginOptions(): List<SubpluginOption> {
     }
 }
 
-fun SourcesChanges.toSubpluginOptions(): List<SubpluginOption> {
-    return if (this is SourcesChanges.Known) {
+fun ChangedFiles.toSubpluginOptions(): List<SubpluginOption> {
+    return if (this is ChangedFiles.Known) {
         val options = mutableListOf<SubpluginOption>()
-        this.modifiedFiles.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+        this.modified.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
             options += SubpluginOption("knownModified", map { it.path }.joinToString(File.pathSeparator))
         }
-        this.removedFiles.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
+        this.removed.filter { it.isKotlinFile(listOf("kt")) || it.isJavaFile() }.ifNotEmpty {
             options += SubpluginOption("knownRemoved", map { it.path }.joinToString(File.pathSeparator))
         }
         options
@@ -750,7 +749,7 @@ internal fun createIncrementalChangesTransformer(
     classpathStructure: Provider<FileCollection>,
     libraries: Provider<FileCollection>,
     processorCP: Provider<FileCollection>,
-): (SourcesChanges) -> List<SubpluginOption> = { changedFiles ->
+): (ChangedFiles) -> List<SubpluginOption> = { changedFiles ->
     val options = mutableListOf<SubpluginOption>()
     val apClasspath = processorCP.get().files.toList()
     if (isKspIncremental) {
@@ -791,7 +790,7 @@ internal fun getCPChanges(
 ): List<String> {
     val apClasspath = processorCP.files.toList()
     val changedFiles = if (!inputChanges.isIncremental) {
-        SourcesChanges.Unknown
+        ChangedFiles.Unknown()
     } else {
         incrementalProps.fold(mutableListOf<File>() to mutableListOf<File>()) { (modified, removed), prop ->
             inputChanges.getFileChanges(prop).forEach {
@@ -803,7 +802,7 @@ internal fun getCPChanges(
             }
             modified to removed
         }.run {
-            SourcesChanges.Known(first, second)
+            ChangedFiles.Known(first, second)
         }
     }
     val classpathChanges = findClasspathChanges(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.0-Beta4
+kotlinBaseVersion=1.9.22
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
@@ -38,7 +38,6 @@ class KSPCmdLineOptionsIT(val useKSP2: Boolean) {
         }.maxByOrNull { it.lastModified() }!!
         val compilerArgs = mutableListOf(
             "-no-stdlib",
-            "-language-version", "1.9",
             "-Xplugin=${kspPluginJar.absolutePath}",
             "-Xplugin=${kspApiJar.absolutePath}",
             "-P", "plugin:$kspPluginId:apclasspath=${processorJar.absolutePath}",

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -223,6 +223,7 @@ class PlaygroundIT(val useKSP2: Boolean) {
             Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
             Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
         }
+        Assert.assertTrue(result.output.contains("w: Language version 2.0 is experimental"))
         project.restore(buildFile.path)
     }
 
@@ -262,6 +263,7 @@ class PlaygroundIT(val useKSP2: Boolean) {
             Assert.assertTrue(jarFile.getEntry("hello/HELLO.class").size > 0)
             Assert.assertTrue(jarFile.getEntry("com/example/AClassBuilder.class").size > 0)
         }
+        Assert.assertTrue(result.output.contains("w: Language version 2.0 is experimental"))
         project.restore(buildFile.path)
         project.restore(gradleProperties.path)
     }
@@ -302,12 +304,12 @@ class PlaygroundIT(val useKSP2: Boolean) {
         gradleRunner.withArguments("build").buildAndFail().let {
             Assert.assertEquals(TaskOutcome.SUCCESS, it.task(":workload:kspKotlin")?.outcome)
             Assert.assertEquals(TaskOutcome.FAILED, it.task(":workload:compileKotlin")?.outcome)
-            Assert.assertTrue("Unresolved reference 'AClassBuilder'" in it.output)
+            Assert.assertTrue("Unresolved reference: AClassBuilder" in it.output)
         }
         gradleRunner.withArguments("build").buildAndFail().let {
             Assert.assertEquals(TaskOutcome.UP_TO_DATE, it.task(":workload:kspKotlin")?.outcome)
             Assert.assertEquals(TaskOutcome.FAILED, it.task(":workload:compileKotlin")?.outcome)
-            Assert.assertTrue("Unresolved reference 'AClassBuilder'" in it.output)
+            Assert.assertTrue("Unresolved reference: AClassBuilder" in it.output)
         }
 
         project.restore("workload/build.gradle.kts")


### PR DESCRIPTION
Most of the update commits have no changes to compiler-plugin nor gradle-plugin and are skipped.