### PR TITLE
Revert "1.0.19 release: Downgrade Kotlin to 2.0.0-Beta4"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.0-Beta4
+kotlinBaseVersion=2.0.0-dev-15455
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -268,7 +268,6 @@ class PlaygroundIT(val useKSP2: Boolean) {
 
     @Test
     fun testVersions() {
-        Assume.assumeFalse(useKSP2)
         val kotlinCompile = "org.jetbrains.kotlin.gradle.tasks.KotlinCompile"
         val buildFile = File(project.root, "workload/build.gradle.kts")
         buildFile.appendText("\ntasks.withType<$kotlinCompile> {")
@@ -336,7 +335,6 @@ class PlaygroundIT(val useKSP2: Boolean) {
 
     @Test
     fun testProjectExtensionCompilerOptions() {
-        Assume.assumeFalse(useKSP2)
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
         val properties = File(project.root, "gradle.properties")
         properties.writeText(

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 
-@Disabled
 @Execution(ExecutionMode.SAME_THREAD)
 @DisabledOnOs(OS.WINDOWS)
 class KSPAATest : AbstractKSPAATest() {


### PR DESCRIPTION
Reverts google/ksp#1765

Merged into the wrong branch.