### PR TITLE
fix modifier calculation for synthetic members

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -213,7 +213,7 @@ fun KSPropertyDeclaration.isAbstract(): Boolean {
         (setter?.modifiers?.contains(Modifier.ABSTRACT) ?: true)
 }
 
-fun KSDeclaration.isOpen() = !this.isLocal() &&
+fun KSDeclaration.isOpen() = !this.isLocal() && !this.modifiers.contains(Modifier.FINAL) &&
     (
         (this as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE ||
             this.modifiers.contains(Modifier.OVERRIDE) ||

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -56,7 +56,7 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationS
     }
 
     override val modifiers: Set<Modifier> by lazy {
-        if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB) {
+        if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC) {
             when (ktDeclarationSymbol) {
                 is KtPropertySymbol -> ktDeclarationSymbol.toModifiers()
                 is KtClassOrObjectSymbol -> ktDeclarationSymbol.toModifiers()

--- a/kotlin-analysis-api/testData/visibilities.kt
+++ b/kotlin-analysis-api/testData/visibilities.kt
@@ -41,6 +41,7 @@
 // KtEnumWithVal: <init>: PRIVATE
 // KtEnumWithVal: values: PUBLIC
 // KtEnumWithVal: valueOf: PUBLIC
+// JavaAnnotation: value: PUBLIC
 // END
 
 // MODULE: lib
@@ -110,6 +111,11 @@ class C {
     protected int protectedFun() {
         return 1;
     }
+}
+
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    String value();
 }
 
 // FILE: Enum.java

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
@@ -51,6 +51,7 @@ class VisibilityProcessor : AbstractTestProcessor() {
         val javaEnum = resolver.getClassDeclarationByName("Enum")!!
         val kotlinEnum = resolver.getClassDeclarationByName("KtEnum")!!
         val kotlinEnumWithVal = resolver.getClassDeclarationByName("KtEnumWithVal")!!
+        val javaAnnotation = resolver.getClassDeclarationByName("JavaAnnotation")!!
         javaClass.declarations.filterIsInstance<KSPropertyDeclaration>().map {
             "${it.simpleName.asString()}: ${it.getVisibility()},visible in A, B, D: " +
                 "${it.isVisibleFrom(symbolA)}, ${it.isVisibleFrom(symbolB)}, ${it.isVisibleFrom(symbolD)}"
@@ -77,6 +78,9 @@ class VisibilityProcessor : AbstractTestProcessor() {
         }.forEach { results.add(it) }
         kotlinEnumWithVal.declarations.filterIsInstance<KSFunctionDeclaration>().map {
             "${kotlinEnumWithVal.simpleName.asString()}: ${it.simpleName.asString()}: ${it.getVisibility() }"
+        }.forEach { results.add(it) }
+        javaAnnotation.declarations.filterIsInstance<KSPropertyDeclaration>().map {
+            "${javaAnnotation.simpleName.asString()}: ${it.simpleName.asString()}: ${it.getVisibility() }"
         }.forEach { results.add(it) }
         return emptyList()
     }

--- a/test-utils/testData/api/visibilities.kt
+++ b/test-utils/testData/api/visibilities.kt
@@ -108,6 +108,11 @@ class C {
     }
 }
 
+
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    String value();
+}
 // FILE: Enum.java
 public enum Enum {
     Y,U,V;


### PR DESCRIPTION
test result is only modified for KSP2 for the reason that KSP2 treats Java annotation values as properties while KSP1 treats it as functions, therefore the test processor does not look into Java annotation values in KSP1.

One change to shared logic: `isOpen()` should always check for `FINAL` modifier first, this hasn't been an issue for KSP1 since certain synthetic members of data class (namely `componentX`) is not generated in KSP1, but ran into issue with KSP2 where the `OVERRIDE` modifier present in `componentX` take over the `isOpen` check.