### PR TITLE
Fix circular dependency with KAPT

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -85,7 +85,7 @@ object AndroidPluginIntegration {
             val filteredSources = Callable {
                 val destinationProperty = (kaptProvider?.get() as? KaptTask)?.destinationDir
                 val dir = destinationProperty?.get()?.asFile
-                sources.filter { dir?.isParentOf(it.dir) == false }
+                sources.filter { dir?.isParentOf(it.dir) != true }
             }
             when (task) {
                 is KspTaskJvm -> {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KaptKspTest.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KaptKspTest.kt
@@ -1,0 +1,45 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class KaptKspTest(useKSP2: Boolean) {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("android-view-binding", "playground", useKSP2)
+
+    @Test
+    fun testPlaygroundAndroid() {
+        val buildFile = File(project.root, "app/build.gradle.kts")
+        val content = buildFile.readText()
+        val newContent = content.replace("kotlin(\"android\")", "kotlin(\"android\")\n kotlin(\"kapt\")\n")
+        buildFile.writeText(newContent)
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(
+            "clean",
+            ":app:testDebugUnitTest",
+            "--configuration-cache-problems=warn",
+            "--info",
+            "--stacktrace"
+        ).build().let { result ->
+            val output = result.output.lines()
+            val kspTask = output.filter { it.contains(":app:kspDebugKotlin") }
+            val kaptTask = output.filter { it.contains(":app:kaptDebugKotlin") }
+            Assert.assertTrue(kspTask.isNotEmpty())
+            Assert.assertTrue(kaptTask.isNotEmpty())
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "KSP2={0}")
+        fun params() = listOf(arrayOf(true), arrayOf(false))
+    }
+}


### PR DESCRIPTION
This is a workaround for KAPT and KSP work together. 
kotlinCompilation.androidVariant.getSourceFolders(SourceKind.JAVA) is the place both kapt and ksp put result to in order to be available for Kotlin compiler. Still, it causes circular dependency of Gradle tasks like:
```
:app:kaptDebugUnitTestKotlin
\--- :app:kaptGenerateStubsDebugUnitTestKotlin
     \--- :app:kspDebugUnitTestKotlin
          \--- :app:kaptDebugUnitTestKotlin (*)
```
Fix filters out generated KAPT folder to be input of KSP task.
Unfortunately, there is no API that allow to parallelize such Kotlin preprocessors.