### PR TITLE
Add `excludedSources` to the KSP extension

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -166,16 +166,21 @@ abstract class KspAATask @Inject constructor(
                     cfg.moduleName.value(kotlinCompilation.defaultSourceSet.name)
                     val kotlinOutputDir = KspGradleSubplugin.getKspKotlinOutputDir(project, sourceSetName, target)
                     val javaOutputDir = KspGradleSubplugin.getKspJavaOutputDir(project, sourceSetName, target)
+                    val filteredTasks =
+                        kspExtension.excludedSources.buildDependencies.getDependencies(null).map { it.name }
                     kotlinCompilation.allKotlinSourceSetsObservable.forAll { sourceSet ->
                         val filtered = sourceSet.kotlin.srcDirs.filter {
-                            !kotlinOutputDir.isParentOf(it) && !javaOutputDir.isParentOf(it)
+                            !kotlinOutputDir.isParentOf(it) && !javaOutputDir.isParentOf(it) &&
+                                it !in kspExtension.excludedSources
                         }.map {
                             // @SkipWhenEmpty doesn't work well with File.
                             project.objects.fileTree().from(it)
                         }
                         cfg.sourceRoots.from(filtered)
                         cfg.javaSourceRoots.from(filtered)
-                        kspAATask.dependsOn(sourceSet.kotlin.nonSelfDeps(kspTaskName))
+                        kspAATask.dependsOn(
+                            sourceSet.kotlin.nonSelfDeps(kspTaskName).filter { it.name !in filteredTasks }
+                        )
                     }
                     if (kotlinCompilation is KotlinCommonCompilation) {
                         cfg.commonSourceRoots.from(kotlinCompilation.defaultSourceSet.kotlin)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -18,12 +18,17 @@
 package com.google.devtools.ksp.gradle
 
 import org.gradle.api.GradleException
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.process.CommandLineArgumentProvider
 
-open class KspExtension {
+abstract class KspExtension {
     internal val apOptions = mutableMapOf<String, String>()
     internal val commandLineArgumentProviders = mutableListOf<CommandLineArgumentProvider>()
     internal val excludedProcessors = mutableSetOf<String>()
+
+    // Specify sources that should be excluded from KSP.
+    // If you have a task that generates sources, you can call `ksp.excludedSources.from(task)`.
+    abstract val excludedSources: ConfigurableFileCollection
 
     open val arguments: Map<String, String> get() = apOptions.toMap()
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -318,13 +318,16 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                     )
                 }
             } else {
+                val filteredTasks =
+                    kspExtension.excludedSources.buildDependencies.getDependencies(null).map { it.name }
                 kotlinCompilation.allKotlinSourceSetsObservable.forAll { sourceSet ->
                     kspTask.setSource(
                         sourceSet.kotlin.srcDirs.filter {
-                            !kotlinOutputDir.isParentOf(it) && !javaOutputDir.isParentOf(it)
+                            !kotlinOutputDir.isParentOf(it) && !javaOutputDir.isParentOf(it) &&
+                                it !in kspExtension.excludedSources
                         }
                     )
-                    kspTask.dependsOn(sourceSet.kotlin.nonSelfDeps(kspTaskName))
+                    kspTask.dependsOn(sourceSet.kotlin.nonSelfDeps(kspTaskName).filter { it.name !in filteredTasks })
                 }
             }
 


### PR DESCRIPTION
This new property allows users to create a Gradle task that generates Kotlin code, which can
then get excluded by KSP's processing step.

This can help avoid circular Gradle dependency issues, such as in the case where KSP
generates an intermediate file (like a resource) which a Gradle plugin then consumes
and uses to generate its own source. Without this change, KSP would want to rerun
when the new source got generated, which upsets Gradle because it already ran.

The following is one example of using the `excludedSources` property:

```
val generateCodeTask = tasks.register("generateCodeTask") {
    val outputDir = project.layout.buildDirectory.dir("generated/src")
    outputs.dir(outputDir)

    doLast {
        /* ... generate code into outputDir ... */
    }
}

ksp.excludedSources.from(generateCodeTask)

kotlin {
    sourceSets.main {
        kotlin.srcDir(generateCodeTask)
    }
}
```

Bug #1791 