### PR TITLE
fix reference element for unhandled types

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.analysis.api.annotations.KtNamedAnnotationValue
 import org.jetbrains.kotlin.analysis.api.components.buildClassType
 import org.jetbrains.kotlin.analysis.api.symbols.KtSymbolOrigin
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
 
 // TODO: implement a psi based version of annotation application.
 class KSAnnotationImpl private constructor(
@@ -44,7 +45,17 @@ class KSAnnotationImpl private constructor(
 
     override val annotationType: KSTypeReference by lazy {
         analyze {
-            KSTypeReferenceResolvedImpl.getCached(buildClassType(annotationApplication.classId!!))
+            if (annotationApplication.psi is KtAnnotationEntry) {
+                KSTypeReferenceImpl.getCached(
+                    (annotationApplication.psi as KtAnnotationEntry).typeReference!!,
+                    parent = this@KSAnnotationImpl
+                )
+            } else {
+                KSTypeReferenceResolvedImpl.getCached(
+                    buildClassType(annotationApplication.classId!!),
+                    parent = this@KSAnnotationImpl
+                )
+            }
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -16,7 +16,6 @@
  */
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.common.IdKeyPair
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.impl.recordLookup
@@ -32,6 +31,7 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
 import org.jetbrains.kotlin.analysis.api.annotations.annotations
 import org.jetbrains.kotlin.analysis.api.types.KtType
+import org.jetbrains.kotlin.psi.KtDynamicType
 import org.jetbrains.kotlin.psi.KtNullableType
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtUserType
@@ -57,11 +57,9 @@ class KSTypeReferenceImpl(
         while (typeElement is KtNullableType)
             typeElement = typeElement.innerType
         when (typeElement) {
-            // is KtFunctionType -> KSCallableReferenceImpl.getCached(typeElement)
             is KtUserType -> KSClassifierReferenceImpl.getCached(typeElement, this)
-            // is KtDynamicType -> KSDynamicReferenceImpl.getCached(this)
-            // is KtIntersectionType -> KSDefNonNullReferenceImpl.getCached(typeElement)
-            else -> throw IllegalStateException("Unexpected type element ${typeElement?.javaClass}, $ExceptionMessage")
+            is KtDynamicType -> KSDynamicReferenceImpl.getCached(this)
+            else -> (resolve() as KSTypeImpl).type.toClassifierReference(this)
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSClassifierReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSClassifierReferenceResolvedImpl.kt
@@ -46,7 +46,9 @@ class KSClassifierReferenceResolvedImpl private constructor(
         get() = parent?.location ?: NonExistLocation
 
     override fun toString(): String {
-        return referencedName()
+        return referencedName() + if (typeArguments.isNotEmpty()) "<${
+        typeArguments.map { it.toString() }.joinToString(", ")
+        }>" else ""
     }
 }
 

--- a/kotlin-analysis-api/testData/parent.kt
+++ b/kotlin-analysis-api/testData/parent.kt
@@ -48,8 +48,8 @@
 // parent of synthetic constructor for B: B
 // parent of RGB: (RGB..RGB?)
 // parent of (RGB..RGB?): INVARIANT (RGB..RGB?)
-// parent of INVARIANT (RGB..RGB?): Enum
-// parent of Enum: Enum<(RGB..RGB?)>
+// parent of INVARIANT (RGB..RGB?): Enum<INVARIANT (RGB..RGB?)>
+// parent of Enum<INVARIANT (RGB..RGB?)>: Enum<(RGB..RGB?)>
 // parent of Enum<(RGB..RGB?)>: RGB
 // parent of RGB: File: B.java
 // parent of R: RGB
@@ -95,11 +95,11 @@
 // parent of synthetic constructor for Anno: Anno
 // parent of Int: Int
 // parent of Int: INVARIANT Int
-// parent of INVARIANT Int: Map
+// parent of INVARIANT Int: Map<INVARIANT Int, INVARIANT T>
 // parent of T: T
 // parent of T: INVARIANT T
-// parent of INVARIANT T: Map
-// parent of Map: Map<Int, T>
+// parent of INVARIANT T: Map<INVARIANT Int, INVARIANT T>
+// parent of Map<INVARIANT Int, INVARIANT T>: Map<Int, T>
 // parent of Map<Int, T>: Alias
 // parent of Any?: T
 // parent of T: File: a.kt
@@ -149,8 +149,8 @@
 // parent of synthetic constructor for InnerClass: InnerClass
 // parent of CMYK: CMYK
 // parent of CMYK: INVARIANT CMYK
-// parent of INVARIANT CMYK: Enum
-// parent of Enum: Enum<CMYK>
+// parent of INVARIANT CMYK: Enum<INVARIANT CMYK>
+// parent of Enum<INVARIANT CMYK>: Enum<CMYK>
 // parent of Enum<CMYK>: CMYK
 // parent of CMYK: File: a.kt
 // parent of CMYK: synthetic constructor for CMYK
@@ -171,8 +171,8 @@
 // parent of entries: CMYK
 // parent of YUV: YUV
 // parent of YUV: INVARIANT YUV
-// parent of INVARIANT YUV: Enum
-// parent of Enum: Enum<YUV>
+// parent of INVARIANT YUV: Enum<INVARIANT YUV>
+// parent of Enum<INVARIANT YUV>: Enum<YUV>
 // parent of Enum<YUV>: YUV
 // parent of YUV: null
 // parent of YUV: YUV
@@ -183,8 +183,8 @@
 // parent of V: YUV
 // parent of YUV: YUV
 // parent of YUV: INVARIANT YUV
-// parent of INVARIANT YUV: Array
-// parent of Array: Array<YUV>
+// parent of INVARIANT YUV: Array<INVARIANT YUV>
+// parent of Array<INVARIANT YUV>: Array<YUV>
 // parent of Array<YUV>: values
 // parent of values: YUV
 // parent of String: String
@@ -195,20 +195,20 @@
 // parent of valueOf: YUV
 // parent of YUV: YUV
 // parent of YUV: INVARIANT YUV
-// parent of INVARIANT YUV: EnumEntries
-// parent of EnumEntries: EnumEntries<YUV>
+// parent of INVARIANT YUV: EnumEntries<INVARIANT YUV>
+// parent of EnumEntries<INVARIANT YUV>: EnumEntries<YUV>
 // parent of EnumEntries<YUV>: entries
 // parent of YUV: YUV
 // parent of YUV: INVARIANT YUV
-// parent of INVARIANT YUV: EnumEntries
-// parent of EnumEntries: EnumEntries<YUV>
+// parent of INVARIANT YUV: EnumEntries<INVARIANT YUV>
+// parent of EnumEntries<INVARIANT YUV>: EnumEntries<YUV>
 // parent of EnumEntries<YUV>: entries.getter()
 // parent of entries.getter(): entries
 // parent of entries: YUV
 // parent of HSV: (HSV..HSV?)
 // parent of (HSV..HSV?): INVARIANT (HSV..HSV?)
-// parent of INVARIANT (HSV..HSV?): Enum
-// parent of Enum: Enum<(HSV..HSV?)>
+// parent of INVARIANT (HSV..HSV?): Enum<INVARIANT (HSV..HSV?)>
+// parent of Enum<INVARIANT (HSV..HSV?)>: Enum<(HSV..HSV?)>
 // parent of Enum<(HSV..HSV?)>: HSV
 // parent of HSV: File: HSV.class
 // parent of HSV: HSV

--- a/kotlin-analysis-api/testData/parent.kt
+++ b/kotlin-analysis-api/testData/parent.kt
@@ -78,14 +78,16 @@
 // parent of List<INVARIANT Int>: List<INVARIANT Int>
 // parent of List<INVARIANT Int>: topProp.getter()
 // parent of topProp.getter(): topProp
-// parent of Anno: null
+// parent of Anno: Anno
+// parent of Anno: @Anno
 // parent of @Anno: topProp
 // parent of topProp: File: a.kt
 // parent of T: T
 // parent of T: topFun
 // parent of Any?: T
 // parent of T: topFun
-// parent of Anno: null
+// parent of Anno: Anno
+// parent of Anno: @Anno
 // parent of @Anno: topFun
 // parent of topFun: File: a.kt
 // parent of Annotation: Annotation
@@ -108,7 +110,8 @@
 // parent of ITF: File: a.kt
 // parent of ITF: ITF
 // parent of ITF: topClass
-// parent of Anno: null
+// parent of Anno: Anno
+// parent of Anno: @Anno
 // parent of @Anno: topClass
 // parent of topClass: File: a.kt
 // parent of Int: Int

--- a/kotlin-analysis-api/testData/referenceElement.kt
+++ b/kotlin-analysis-api/testData/referenceElement.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Google LLC
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: ReferenceElementProcessor
+// EXPECTED:
+// KSClassifierReferenceImpl: Qualifier of B is A
+// KSClassifierReferenceImpl: Qualifier of C<INVARIANT Int> is A<INVARIANT String>
+// KSClassifierReferenceImpl: Qualifier of Int is null
+// KSClassifierReferenceImpl: Qualifier of String is null
+// KSClassifierReferenceDescriptorImpl: Qualifier of Int is null
+// KSClassifierReferenceDescriptorImpl: Qualifier of String is null
+// KSClassifierReferenceDescriptorImpl: Qualifier of Y is X
+// KSClassifierReferenceDescriptorImpl: Qualifier of Z<INVARIANT Int> is X<INVARIANT String>
+// KSDefNonNullReferenceImpl: Enclosed type of T
+// KSClassifierReferenceJavaImpl: Qualifier of Any is null
+// KSClassifierReferenceJavaImpl: Qualifier of Any is null
+// KSClassifierReferenceJavaImpl: Qualifier of Any is null
+// KSClassifierReferenceJavaImpl: Qualifier of Any is null
+// KSClassifierReferenceJavaImpl: Qualifier of Any is null
+// KSClassifierReferenceJavaImpl: Qualifier of H is J<INVARIANT (String..String?)>
+// KSClassifierReferenceJavaImpl: Qualifier of I is J
+// KSClassifierReferenceJavaImpl: Qualifier of String is null
+// END
+
+// MODULE: lib
+// FILE: lib.kt
+class X<T1> {
+    class Y
+    inner class Z<T2>
+}
+
+val z: X.Y = X.Y()
+val w: X<String>.Z<Int> = X<String>().Z<Int>()
+
+// MODULE: main(lib)
+// FILE: reference.kt
+class A<T1> {
+    class B
+    inner class C<T2>
+}
+
+class DefNonNull<T> {
+    val u: T & Any
+}
+
+val x: A.B = A.B()
+val y: A<String>.C<Int> = A<String>().C<Int>()
+
+// FILE: J.java
+class J<T> {
+    class H {
+    }
+
+    static class I {
+    }
+}
+
+class K {
+    J<String>.H x = null;
+    J.I z = null;
+}

--- a/kotlin-analysis-api/testData/referenceElement.kt
+++ b/kotlin-analysis-api/testData/referenceElement.kt
@@ -20,6 +20,8 @@
 // EXPECTED:
 // KSClassifierReferenceImpl: Qualifier of B is A
 // KSClassifierReferenceImpl: Qualifier of C<INVARIANT Int> is A<INVARIANT String>
+// KSClassifierReferenceImpl: Qualifier of ExampleAnnotation<INVARIANT ExampleParameter> is null
+// KSClassifierReferenceImpl: Qualifier of ExampleParameter is null
 // KSClassifierReferenceImpl: Qualifier of Int is null
 // KSClassifierReferenceImpl: Qualifier of String is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of Int is null
@@ -43,12 +45,16 @@ class X<T1> {
     class Y
     inner class Z<T2>
 }
+annotation class ExampleAnnotation<T>
+
+interface ExampleParameter
 
 val z: X.Y = X.Y()
 val w: X<String>.Z<Int> = X<String>().Z<Int>()
 
 // MODULE: main(lib)
 // FILE: reference.kt
+@ExampleAnnotation<ExampleParameter>
 class A<T1> {
     class B
     inner class C<T2>

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -529,11 +529,10 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../kotlin-analysis-api/testData/recordJavaSupertypes.kt")
     }
 
-    @Disabled
     @TestMetadata("referenceElement.kt")
     @Test
     fun testReferenceElement() {
-        runTest("../test-utils/testData/api/referenceElement.kt")
+        runTest("../kotlin-analysis-api/testData/referenceElement.kt")
     }
 
     @TestMetadata("replaceWithErrorTypeArgs.kt")

--- a/test-utils/testData/api/referenceElement.kt
+++ b/test-utils/testData/api/referenceElement.kt
@@ -20,6 +20,8 @@
 // EXPECTED:
 // KSClassifierReferenceImpl: Qualifier of B is A
 // KSClassifierReferenceImpl: Qualifier of C is A
+// KSClassifierReferenceImpl: Qualifier of ExampleAnnotation is null
+// KSClassifierReferenceImpl: Qualifier of ExampleParameter is null
 // KSClassifierReferenceImpl: Qualifier of Int is null
 // KSClassifierReferenceImpl: Qualifier of String is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of Int is null
@@ -42,12 +44,16 @@ class X<T1> {
     class Y
     inner class Z<T2>
 }
+annotation class ExampleAnnotation<T>
+
+interface ExampleParameter
 
 val z: X.Y = X.Y()
 val w: X<String>.Z<Int> = X<String>().Z<Int>()
 
 // MODULE: main(lib)
 // FILE: reference.kt
+@ExampleAnnotation<ExampleParameter>
 class A<T1> {
     class B
     inner class C<T2>


### PR DESCRIPTION
fallback to resolved types for creating reference element when the type is not supported in PSI element. Tests forked mainly due to behavior change in `toString()` implementation on the reference element, new behavior is more consistent and contains more information.