### PR TITLE
Check and add missing dependencies

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -128,7 +128,9 @@ tasks.withType<ShadowJar>() {
     }
     exclude("kotlin/**")
     archiveClassifier.set("")
-    minimize()
+    minimize {
+        exclude(dependency("org.lz4:lz4-java:.*"))
+    }
     mergeServiceFiles()
 
     doLast {

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     ) {
         isTransitive = false
     }
+    implementation("org.jetbrains:annotations:24.1.0")
 
     compileOnly(project(":common-deps"))
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -705,6 +705,16 @@ internal val DEAR_SHADOW_JAR_PLEASE_DO_NOT_REMOVE_THESE = listOf(
     org.jetbrains.kotlin.load.java.ErasedOverridabilityCondition::class.java,
     org.jetbrains.kotlin.load.java.FieldOverridabilityCondition::class.java,
     org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInsLoaderImpl::class.java,
+    com.fasterxml.aalto.AaltoInputProperties::class.java,
+    com.google.errorprone.annotations.CheckReturnValue::class.java,
+    com.intellij.openapi.application.JetBrainsProtocolHandler::class.java,
+    com.intellij.openapi.editor.impl.EditorDocumentPriorities::class.java,
+    com.intellij.psi.tree.ChildRoleBase::class.java,
+    com.intellij.util.xmlb.Constants::class.java,
+    com.intellij.xml.CommonXmlStrings::class.java,
+    javax.annotation.ParametersAreNonnullByDefault::class.java,
+    org.codehaus.stax2.XMLInputFactory2::class.java,
+    org.codehaus.stax2.XMLStreamProperties::class.java,
 )
 
 fun TargetPlatform.getPlatformInfo(kspConfig: KSPConfig): List<PlatformInfo> =


### PR DESCRIPTION
1. warn on missing dependencies when building KSP2 uber jar.
2. Add org.jetbrains:annotations
3. do not minimize lz4-java, where some of the classes are loaded by reflection
4. keep more classes by naming them explicitly