### PR TITLE
Set Kotlin to 2.0.0-RC1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.0-dev-19480
+kotlinBaseVersion=2.0.0-RC1
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1


### PR DESCRIPTION
on the 1.0.21-release branch.