### PR TITLE
#1232: Include type hint into KSErrorType.

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/ErrorTypeUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/ErrorTypeUtils.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.common
+
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeArgument
+
+inline fun <E> errorTypeOnInconsistentArguments(
+    arguments: List<KSTypeArgument>,
+    placeholdersProvider: () -> List<KSTypeArgument>,
+    withCorrectedArguments: (corrected: List<KSTypeArgument>) -> KSType,
+    errorType: (name: String, message: String) -> E,
+): E? {
+    if (arguments.isNotEmpty()) {
+        val placeholders = placeholdersProvider()
+        val diff = arguments.size - placeholders.size
+        if (diff > 0) {
+            val wouldBeType = withCorrectedArguments(arguments.dropLast(diff))
+            return errorType(wouldBeType.toString(), "Unexpected extra $diff type argument(s)")
+        } else if (diff < 0) {
+            val wouldBeType = withCorrectedArguments(arguments + placeholders.drop(arguments.size))
+            return errorType(wouldBeType.toString(), "Missing ${-diff} type argument(s)")
+        }
+    }
+    return null
+}

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -153,7 +153,7 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     override fun asType(typeArguments: List<KSTypeArgument>): KSType =
         descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
             getKSTypeCached(it, typeArguments)
-        } ?: KSErrorType
+        } ?: KSErrorType()
 
     override fun asStarProjectedType(): KSType {
         return getKSTypeCached(descriptor.defaultType.replaceArgumentsWithStarProjections())

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassDeclarationDescriptorImpl.kt
@@ -151,9 +151,7 @@ class KSClassDeclarationDescriptorImpl private constructor(val descriptor: Class
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType =
-        descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
-            getKSTypeCached(it, typeArguments)
-        } ?: KSErrorType()
+        descriptor.defaultType.replaceTypeArguments(typeArguments)
 
     override fun asStarProjectedType(): KSType {
         return getKSTypeCached(descriptor.defaultType.replaceArgumentsWithStarProjections())

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.symbol.impl.java
 
+import com.google.devtools.ksp.common.errorTypeOnInconsistentArguments
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.toKSModifiers
 import com.google.devtools.ksp.processing.impl.KSObjectCache
@@ -96,8 +97,10 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
 
     // Enum can't have type parameters.
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        if (typeArguments.isNotEmpty())
-            return KSErrorType()
+        errorTypeOnInconsistentArguments(
+            arguments = typeArguments, placeholdersProvider = ::emptyList,
+            withCorrectedArguments = ::asType, errorType = ::KSErrorType,
+        )?.let { error -> return error }
         return asStarProjectedType()
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaEnumEntryImpl.kt
@@ -97,7 +97,7 @@ class KSClassDeclarationJavaEnumEntryImpl private constructor(val psi: PsiEnumCo
     // Enum can't have type parameters.
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         if (typeArguments.isNotEmpty())
-            return KSErrorType
+            return KSErrorType()
         return asStarProjectedType()
     }
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -153,17 +153,13 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return descriptor?.let {
-            it.defaultType.replaceTypeArguments(typeArguments)?.let {
-                getKSTypeCached(it, typeArguments)
-            }
-        } ?: KSErrorType()
+        return descriptor?.defaultType?.replaceTypeArguments(typeArguments) ?: KSErrorType(psi.qualifiedName)
     }
 
     override fun asStarProjectedType(): KSType {
         return descriptor?.let {
             getKSTypeCached(it.defaultType.replaceArgumentsWithStarProjections())
-        } ?: KSErrorType()
+        } ?: KSErrorType(psi.qualifiedName)
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSClassDeclarationJavaImpl.kt
@@ -157,13 +157,13 @@ class KSClassDeclarationJavaImpl private constructor(val psi: PsiClass) :
             it.defaultType.replaceTypeArguments(typeArguments)?.let {
                 getKSTypeCached(it, typeArguments)
             }
-        } ?: KSErrorType
+        } ?: KSErrorType()
     }
 
     override fun asStarProjectedType(): KSType {
         return descriptor?.let {
             getKSTypeCached(it.defaultType.replaceArgumentsWithStarProjections())
-        } ?: KSErrorType
+        } ?: KSErrorType()
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/java/KSTypeReferenceLiteJavaImpl.kt
@@ -47,13 +47,14 @@ class KSTypeReferenceLiteJavaImpl private constructor(val psiElement: PsiElement
     val type: KSType by lazy {
         when (psiElement) {
             is PsiAnnotation -> {
-                val psiClass = psiElement.nameReferenceElement!!.resolve() as? PsiClass
+                val nameReferenceElement = psiElement.nameReferenceElement!!
+                val psiClass = nameReferenceElement.resolve() as? PsiClass
                 psiClass?.let {
                     (psiElement.containingFile as? PsiJavaFile)?.let {
                         ResolverImpl.instance!!.incrementalContext.recordLookup(it, psiClass.qualifiedName!!)
                     }
                     KSClassDeclarationJavaImpl.getCached(psiClass).asStarProjectedType()
-                } ?: KSErrorType
+                } ?: KSErrorType(nameReferenceElement.text)
             }
             is PsiMethod -> {
                 KSClassDeclarationJavaImpl.getCached(psiElement.containingClass!!).asStarProjectedType()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -122,9 +122,7 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
-            getKSTypeCached(it, typeArguments)
-        } ?: KSErrorType()
+        return descriptor.defaultType.replaceTypeArguments(typeArguments)
     }
 
     override fun asStarProjectedType(): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSClassDeclarationImpl.kt
@@ -124,7 +124,7 @@ class KSClassDeclarationImpl private constructor(val ktClassOrObject: KtClassOrO
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         return descriptor.defaultType.replaceTypeArguments(typeArguments)?.let {
             getKSTypeCached(it, typeArguments)
-        } ?: KSErrorType
+        } ?: KSErrorType()
     }
 
     override fun asStarProjectedType(): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSErrorType.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSErrorType.kt
@@ -25,8 +25,12 @@ import org.jetbrains.kotlin.types.error.ErrorType
 import org.jetbrains.kotlin.types.error.ErrorTypeKind
 
 class KSErrorType(
-    val nameHint: String? = null,
+    val nameHint: String?,
 ) : KSType {
+    constructor(name: String, message: String?) : this(
+        nameHint = listOfNotNull(name, message).takeIf { it.isNotEmpty() }?.joinToString(" % ")
+    )
+
     override val annotations: Sequence<KSAnnotation>
         get() = emptySequence()
 

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSFunctionErrorImpl.kt
@@ -29,18 +29,19 @@ class KSFunctionErrorImpl(
 ) : KSFunction {
     override val isError: Boolean = true
 
-    override val returnType: KSType = KSErrorType
+    override val returnType: KSType
+        get() = KSErrorType.fromReferenceBestEffort(declaration.returnType)
 
     override val parameterTypes: List<KSType?>
         get() = declaration.parameters.map {
-            KSErrorType
+            KSErrorType.fromReferenceBestEffort(it.type)
         }
     override val typeParameters: List<KSTypeParameter>
         get() = emptyList()
 
     override val extensionReceiverType: KSType?
         get() = declaration.extensionReceiver?.let {
-            KSErrorType
+            KSErrorType.fromReferenceBestEffort(it)
         }
 
     override fun equals(other: Any?): Boolean {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -97,7 +97,7 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
             KSTypeReferenceDeferredImpl.getCached(this) {
                 val desc = propertyDescriptor as? VariableDescriptorWithAccessors
                 if (desc == null) {
-                    KSErrorType()
+                    KSErrorType(null /* no info available */)
                 } else {
                     getKSTypeCached(desc.type)
                 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSPropertyDeclarationImpl.kt
@@ -97,7 +97,7 @@ class KSPropertyDeclarationImpl private constructor(val ktProperty: KtProperty) 
             KSTypeReferenceDeferredImpl.getCached(this) {
                 val desc = propertyDescriptor as? VariableDescriptorWithAccessors
                 if (desc == null) {
-                    KSErrorType
+                    KSErrorType()
                 } else {
                     getKSTypeCached(desc.type)
                 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -97,7 +97,7 @@ class KSTypeImpl private constructor(
     override fun replace(arguments: List<KSTypeArgument>): KSType {
         return kotlinType.replaceTypeArguments(arguments)?.let {
             getKSTypeCached(it, arguments, annotations)
-        } ?: KSErrorType
+        } ?: KSErrorType()
     }
 
     override fun starProjection(): KSType {
@@ -136,10 +136,12 @@ fun getKSTypeCached(
     ksTypeArguments: List<KSTypeArgument>? = null,
     annotations: Sequence<KSAnnotation> = sequenceOf()
 ): KSType {
-    return if (kotlinType.isError ||
-        kotlinType.constructor.declarationDescriptor is NotFoundClasses.MockClassDescriptor
-    ) {
-        KSErrorType
+    if (kotlinType.isError) {
+        return KSErrorType.fromKtErrorType(kotlinType)
+    }
+    val descriptor = kotlinType.constructor.declarationDescriptor
+    return if (descriptor is NotFoundClasses.MockClassDescriptor) {
+        KSErrorType(descriptor.name.asString())
     } else {
         KSTypeImpl.getCached(
             kotlinType,

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSTypeImpl.kt
@@ -95,9 +95,7 @@ class KSTypeImpl private constructor(
     }
 
     override fun replace(arguments: List<KSTypeArgument>): KSType {
-        return kotlinType.replaceTypeArguments(arguments)?.let {
-            getKSTypeCached(it, arguments, annotations)
-        } ?: KSErrorType()
+        return kotlinType.replaceTypeArguments(arguments, annotations)
     }
 
     override fun starProjection(): KSType {

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -112,7 +112,7 @@ class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : K
 
     override val type: KSTypeReference by lazy {
         ktParameter.typeReference?.let { KSTypeReferenceImpl.getCached(it) }
-            ?: findPropertyForAccessor()?.type ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType, this)
+            ?: findPropertyForAccessor()?.type ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType(), this)
     }
 
     override val hasDefault: Boolean = ktParameter.hasDefaultValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSValueParameterImpl.kt
@@ -112,7 +112,8 @@ class KSValueParameterImpl private constructor(val ktParameter: KtParameter) : K
 
     override val type: KSTypeReference by lazy {
         ktParameter.typeReference?.let { KSTypeReferenceImpl.getCached(it) }
-            ?: findPropertyForAccessor()?.type ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType(), this)
+            ?: findPropertyForAccessor()?.type
+            ?: KSTypeReferenceSyntheticImpl.getCached(KSErrorType(null /* no info available */), this)
     }
 
     override val hasDefault: Boolean = ktParameter.hasDefaultValue()

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/synthetic/KSErrorTypeClassDeclaration.kt
@@ -18,54 +18,73 @@
 package com.google.devtools.ksp.symbol.impl.synthetic
 
 import com.google.devtools.ksp.common.impl.KSNameImpl
-import com.google.devtools.ksp.processing.impl.ResolverImpl
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.impl.kotlin.KSErrorType
 
-object KSErrorTypeClassDeclaration : KSClassDeclaration {
-    override val annotations: Sequence<KSAnnotation> = emptySequence()
+class KSErrorTypeClassDeclaration(
+    private val type: KSErrorType,
+) : KSClassDeclaration {
+    override val annotations: Sequence<KSAnnotation>
+        get() = emptySequence()
 
-    override val classKind: ClassKind = ClassKind.CLASS
+    override val classKind: ClassKind
+        get() = ClassKind.CLASS
 
-    override val containingFile: KSFile? = null
+    override val containingFile: KSFile?
+        get() = null
 
-    override val declarations: Sequence<KSDeclaration> = emptySequence()
+    override val declarations: Sequence<KSDeclaration>
+        get() = emptySequence()
 
-    override val isActual: Boolean = false
+    override val isActual: Boolean
+        get() = false
 
-    override val isExpect: Boolean = false
+    override val isExpect: Boolean
+        get() = false
 
-    override val isCompanionObject: Boolean = false
+    override val isCompanionObject: Boolean
+        get() = false
 
-    override val location: Location = NonExistLocation
+    override val location: Location
+        get() = NonExistLocation
 
-    override val parent: KSNode? = null
+    override val parent: KSNode?
+        get() = null
 
-    override val modifiers: Set<Modifier> = emptySet()
+    override val modifiers: Set<Modifier>
+        get() = emptySet()
 
-    override val origin: Origin = Origin.SYNTHETIC
+    override val origin: Origin
+        get() = Origin.SYNTHETIC
 
-    override val packageName: KSName = KSNameImpl.getCached("")
+    override val packageName: KSName
+        get() = KSNameImpl.getCached("")
 
-    override val parentDeclaration: KSDeclaration? = null
+    override val parentDeclaration: KSDeclaration?
+        get() = null
 
-    override val primaryConstructor: KSFunctionDeclaration? = null
+    override val primaryConstructor: KSFunctionDeclaration?
+        get() = null
 
-    override val qualifiedName: KSName? = null
+    override val qualifiedName: KSName?
+        get() = null
 
-    override val simpleName: KSName = KSNameImpl.getCached("<Error>")
+    override val simpleName: KSName = KSNameImpl.getCached(type.toString())
 
-    override val superTypes: Sequence<KSTypeReference> = emptySequence()
+    override val superTypes: Sequence<KSTypeReference>
+        get() = emptySequence()
 
-    override val typeParameters: List<KSTypeParameter> = emptyList()
+    override val typeParameters: List<KSTypeParameter>
+        get() = emptyList()
 
     override fun getSealedSubclasses(): Sequence<KSClassDeclaration> = emptySequence()
 
     override fun asStarProjectedType(): KSType {
-        return ResolverImpl.instance!!.builtIns.nothingType
+        return type
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return ResolverImpl.instance!!.builtIns.nothingType
+        return type
     }
 
     override fun findActuals(): Sequence<KSDeclaration> {
@@ -89,8 +108,15 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
     }
 
     override fun toString(): String {
-        return "Error type synthetic declaration"
+        return simpleName.asString()
     }
 
-    override val docString = null
+    override fun equals(other: Any?): Boolean {
+        return this === other || other is KSErrorTypeClassDeclaration && other.type == type
+    }
+
+    override fun hashCode(): Int = type.hashCode()
+
+    override val docString
+        get() = null
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -416,14 +416,14 @@ class ResolverAAImpl(
             }.updateFromParents(ref)
         }
         return analyze {
-            ktType.toWildcard(mode)?.let {
+            ktType.toWildcard(mode).let {
                 var candidate: KtType = it
                 for (i in indexes.reversed()) {
                     candidate = candidate.typeArguments()[i].type!!
                 }
                 KSTypeReferenceSyntheticImpl.getCached(KSTypeImpl.getCached(candidate), null)
             }
-        } ?: reference
+        }
     }
 
     override fun getJvmCheckedException(accessor: KSPropertyAccessor): Sequence<KSType> {
@@ -832,7 +832,7 @@ class ResolverAAImpl(
                     }
                 }
             } else {
-                KSErrorType
+                return if (resolved.isError) resolved else KSErrorType(resolved.toString())
             }
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -179,18 +179,19 @@ fun calcValue(value: PsiAnnotationMemberValue?): Any? {
         is PsiPrimitiveType -> {
             result.boxedTypeName?.let {
                 ResolverAAImpl.instance
-                    .getClassDeclarationByName(result.boxedTypeName!!)?.asStarProjectedType() ?: KSErrorType
-            }
+                    .getClassDeclarationByName(it)?.asStarProjectedType()
+            } ?: KSErrorType(result.boxedTypeName)
         }
         is PsiArrayType -> {
             val componentType = when (val component = result.componentType) {
-                is PsiPrimitiveType -> component.boxedTypeName?.let {
+                is PsiPrimitiveType -> component.boxedTypeName?.let { boxedTypeName ->
                     ResolverAAImpl.instance
-                        .getClassDeclarationByName(component.boxedTypeName!!)?.asStarProjectedType()
-                } ?: KSErrorType
+                        .getClassDeclarationByName(boxedTypeName)?.asStarProjectedType()
+                } ?: KSErrorType(component.boxedTypeName)
                 else -> {
                     ResolverAAImpl.instance
-                        .getClassDeclarationByName(component.canonicalText)?.asStarProjectedType() ?: KSErrorType
+                        .getClassDeclarationByName(component.canonicalText)?.asStarProjectedType()
+                        ?: KSErrorType(component.canonicalText)
                 }
             }
             val componentTypeRef = ResolverAAImpl.instance.createKSTypeReferenceFromKSType(componentType)
@@ -200,7 +201,8 @@ fun calcValue(value: PsiAnnotationMemberValue?): Any? {
         }
         is PsiType -> {
             ResolverAAImpl.instance
-                .getClassDeclarationByName(result.canonicalText)?.asStarProjectedType() ?: KSErrorType
+                .getClassDeclarationByName(result.canonicalText)?.asStarProjectedType()
+                ?: KSErrorType(result.canonicalText)
         }
         is PsiLiteralValue -> {
             result.value

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -125,7 +125,7 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         if (typeArguments.isNotEmpty() && typeArguments.size != asStarProjectedType().arguments.size) {
-            return KSErrorType
+            return KSErrorType()
         }
         return analyze {
             if (typeArguments.isEmpty()) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
@@ -19,8 +19,12 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.symbol.*
 
 class KSErrorType(
-    private val hint: String? = null,
+    private val hint: String?,
 ) : KSType {
+    constructor(name: String, message: String?) : this(
+        hint = listOfNotNull(name, message).takeIf { it.isNotEmpty() }?.joinToString(" % ")
+    )
+
     override val declaration: KSDeclaration
         get() = KSErrorTypeClassDeclaration(this)
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
@@ -114,7 +114,7 @@ class KSErrorTypeClassDeclaration(
         return this === other || other is KSErrorTypeClassDeclaration && other.type == type
     }
 
-    override fun hashCode(): Int = type.hashCode()
+    override fun hashCode(): Int = type.hashCode() * 2
 
     override val docString
         get() = null

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
@@ -18,54 +18,72 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.impl.KSNameImpl
-import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.symbol.*
 
-object KSErrorTypeClassDeclaration : KSClassDeclaration {
-    override val annotations: Sequence<KSAnnotation> = emptySequence()
+class KSErrorTypeClassDeclaration(
+    private val type: KSType,
+) : KSClassDeclaration {
+    override val annotations: Sequence<KSAnnotation>
+        get() = emptySequence()
 
-    override val classKind: ClassKind = ClassKind.CLASS
+    override val classKind: ClassKind
+        get() = ClassKind.CLASS
 
-    override val containingFile: KSFile? = null
+    override val containingFile: KSFile?
+        get() = null
 
-    override val declarations: Sequence<KSDeclaration> = emptySequence()
+    override val declarations: Sequence<KSDeclaration>
+        get() = emptySequence()
 
-    override val isActual: Boolean = false
+    override val isActual: Boolean
+        get() = false
 
-    override val isExpect: Boolean = false
+    override val isExpect: Boolean
+        get() = false
 
-    override val isCompanionObject: Boolean = false
+    override val isCompanionObject: Boolean
+        get() = false
 
-    override val location: Location = NonExistLocation
+    override val location: Location
+        get() = NonExistLocation
 
-    override val parent: KSNode? = null
+    override val parent: KSNode?
+        get() = null
 
-    override val modifiers: Set<Modifier> = emptySet()
+    override val modifiers: Set<Modifier>
+        get() = emptySet()
 
-    override val origin: Origin = Origin.SYNTHETIC
+    override val origin: Origin
+        get() = Origin.SYNTHETIC
 
-    override val packageName: KSName = KSNameImpl.getCached("")
+    override val packageName: KSName
+        get() = KSNameImpl.getCached("")
 
-    override val parentDeclaration: KSDeclaration? = null
+    override val parentDeclaration: KSDeclaration?
+        get() = null
 
-    override val primaryConstructor: KSFunctionDeclaration? = null
+    override val primaryConstructor: KSFunctionDeclaration?
+        get() = null
 
-    override val qualifiedName: KSName? = null
+    override val qualifiedName: KSName?
+        get() = null
 
-    override val simpleName: KSName = KSNameImpl.getCached("<Error>")
+    override val simpleName: KSName = KSNameImpl.getCached(type.toString())
 
-    override val superTypes: Sequence<KSTypeReference> = emptySequence()
+    override val superTypes: Sequence<KSTypeReference>
+        get() = emptySequence()
 
-    override val typeParameters: List<KSTypeParameter> = emptyList()
+    override val typeParameters: List<KSTypeParameter>
+        get() = emptyList()
 
     override fun getSealedSubclasses(): Sequence<KSClassDeclaration> = emptySequence()
 
     override fun asStarProjectedType(): KSType {
-        return ResolverAAImpl.instance.builtIns.nothingType
+        return type
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
-        return ResolverAAImpl.instance.builtIns.nothingType
+        return type
     }
 
     override fun findActuals(): Sequence<KSDeclaration> {
@@ -89,8 +107,15 @@ object KSErrorTypeClassDeclaration : KSClassDeclaration {
     }
 
     override fun toString(): String {
-        return "Error type synthetic declaration"
+        return simpleName.asString()
     }
 
-    override val docString = null
+    override fun equals(other: Any?): Boolean {
+        return this === other || other is KSErrorTypeClassDeclaration && other.type == type
+    }
+
+    override fun hashCode(): Int = type.hashCode()
+
+    override val docString
+        get() = null
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
@@ -10,18 +10,19 @@ class KSFunctionErrorImpl(
 ) : KSFunction {
     override val isError: Boolean = true
 
-    override val returnType: KSType = KSErrorType
+    override val returnType: KSType
+        get() = KSErrorType.fromReferenceBestEffort(declaration.returnType)
 
     override val parameterTypes: List<KSType?>
         get() = declaration.parameters.map {
-            KSErrorType
+            KSErrorType.fromReferenceBestEffort(it.type)
         }
     override val typeParameters: List<KSTypeParameter>
         get() = emptyList()
 
     override val extensionReceiverType: KSType?
         get() = declaration.extensionReceiver?.let {
-            KSErrorType
+            KSErrorType.fromReferenceBestEffort(it)
         }
 
     override fun equals(other: Any?): Boolean {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -51,11 +51,11 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
                     }
                 }
                 is KtTypeParameterType -> KSTypeParameterImpl.getCached(symbol)
-                is KtClassErrorType -> KSErrorTypeClassDeclaration
+                is KtClassErrorType -> KSErrorTypeClassDeclaration(this@KSTypeImpl)
                 is KtFlexibleType ->
                     type.lowerBoundIfFlexible().toDeclaration()
                 is KtDefinitelyNotNullType -> this@toDeclaration.original.toDeclaration()
-                else -> KSErrorTypeClassDeclaration
+                else -> KSErrorTypeClassDeclaration(this@KSTypeImpl)
             }
         }
     }
@@ -110,12 +110,12 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
     }
 
     override fun replace(arguments: List<KSTypeArgument>): KSType {
-        return type.replace(arguments.map { it.toKtTypeProjection() })?.let { getCached(it) } ?: KSErrorType
+        return type.replace(arguments.map { it.toKtTypeProjection() })?.let { getCached(it) } ?: KSErrorType()
     }
 
     override fun starProjection(): KSType {
         return type.replace(List(type.typeArguments().size) { KtStarTypeProjection(type.token) })
-            ?.let { getCached(it) } ?: KSErrorType
+            ?.let { getCached(it) } ?: KSErrorType()
     }
 
     override fun makeNullable(): KSType {
@@ -134,7 +134,7 @@ class KSTypeImpl private constructor(internal val type: KtType) : KSType {
         get() = type.nullability == KtTypeNullability.NULLABLE
 
     override val isError: Boolean
-        get() = type is KtClassErrorType
+        get() = type is KtErrorType
 
     override val isFunctionType: Boolean
         get() = type is KtFunctionalType && !type.isSuspend

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
@@ -55,6 +55,45 @@ class KSValueArgumentImpl private constructor(
     override fun toString(): String {
         return "${name?.asString() ?: ""}:$value"
     }
+//
+//    private fun KtAnnotationValue.toValue(): Any? = when (this) {
+//        is KtArrayAnnotationValue -> this.values.map { it.toValue() }
+//        is KtAnnotationApplicationValue -> KSAnnotationImpl.getCached(this.annotationValue)
+//        // TODO: Enum entry should return a type, use declaration as a placeholder.
+//        is KtEnumEntryAnnotationValue -> this.callableId?.classId?.let {
+//            analyze {
+//                it.toKtClassSymbol()?.let {
+//                    it.declarations().filterIsInstance<KSClassDeclarationEnumEntryImpl>().singleOrNull {
+//                        it.simpleName.asString() == this@toValue.callableId?.callableName?.asString()
+//                    }
+//                }
+//            }
+//        } ?: KSErrorType(callableId?.toString())
+//        is KtKClassAnnotationValue -> {
+//            val classDeclaration = when (this) {
+//                is KtKClassAnnotationValue.KtNonLocalKClassAnnotationValue -> analyze {
+//                    (this@toValue.classId.toKtClassSymbol())?.let { KSClassDeclarationImpl.getCached(it) }
+//                }
+//                is KtKClassAnnotationValue.KtLocalKClassAnnotationValue -> analyze {
+//                    this@toValue.ktClass.getNamedClassOrObjectSymbol()?.let {
+//                        KSClassDeclarationImpl.getCached(it)
+//                    }
+//                }
+//                is KtKClassAnnotationValue.KtErrorClassAnnotationValue -> null
+//            }
+//            classDeclaration?.asStarProjectedType() ?: KSErrorType(
+//                when (this) {
+//                    is KtKClassAnnotationValue.KtErrorClassAnnotationValue -> unresolvedQualifierName
+//                    is KtKClassAnnotationValue.KtLocalKClassAnnotationValue -> ktClass.run {
+//                        fqName?.asString() ?: name
+//                    }
+//                    is KtKClassAnnotationValue.KtNonLocalKClassAnnotationValue -> classId.asFqNameString()
+//                } ?: sourcePsi?.text
+//            )
+//        }
+//        is KtConstantAnnotationValue -> this.constantValue.value
+//        is KtUnsupportedAnnotationValue -> null
+//    }
 
     override fun defer(): Restorable = Restorable { getCached(namedAnnotationValue, origin) }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -22,14 +22,11 @@ import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.impl.recordLookup
 import com.google.devtools.ksp.impl.symbol.kotlin.Deferrable
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
-import com.google.devtools.ksp.impl.symbol.kotlin.KSErrorType
 import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeParameterImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.analyze
 import com.google.devtools.ksp.impl.symbol.kotlin.annotations
-import com.google.devtools.ksp.impl.symbol.kotlin.classifierSymbol
-import com.google.devtools.ksp.impl.symbol.kotlin.getNameHint
 import com.google.devtools.ksp.impl.symbol.kotlin.render
 import com.google.devtools.ksp.impl.symbol.kotlin.toClassifierReference
 import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
@@ -61,22 +58,7 @@ class KSTypeReferenceResolvedImpl private constructor(
 
     override fun resolve(): KSType {
         analyze { recordLookup(ktType, parent) }
-        // TODO: non exist type returns KtNonErrorClassType, check upstream for KtClassErrorType usage.
-        return if (
-            analyze {
-                ktType is KtClassErrorType || (ktType.classifierSymbol() == null)
-            }
-        ) {
-            KSErrorType(
-                when (ktType) {
-                    is KtClassErrorType -> ktType.getNameHint()
-                    is KtTypeErrorType -> null // No info available
-                    else -> ktType.render()
-                }
-            )
-        } else {
-            KSTypeImpl.getCached(ktType)
-        }
+        return KSTypeImpl.getCached(ktType)
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -29,6 +29,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.analyze
 import com.google.devtools.ksp.impl.symbol.kotlin.annotations
 import com.google.devtools.ksp.impl.symbol.kotlin.classifierSymbol
+import com.google.devtools.ksp.impl.symbol.kotlin.getNameHint
 import com.google.devtools.ksp.impl.symbol.kotlin.render
 import com.google.devtools.ksp.impl.symbol.kotlin.toClassifierReference
 import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
@@ -66,7 +67,13 @@ class KSTypeReferenceResolvedImpl private constructor(
                 ktType is KtClassErrorType || (ktType.classifierSymbol() == null)
             }
         ) {
-            KSErrorType
+            KSErrorType(
+                when (ktType) {
+                    is KtClassErrorType -> ktType.getNameHint()
+                    is KtTypeErrorType -> null // No info available
+                    else -> ktType.render()
+                }
+            )
         } else {
             KSTypeImpl.getCached(ktType)
         }

--- a/kotlin-analysis-api/testData/annotationValue/java.kt
+++ b/kotlin-analysis-api/testData/annotationValue/java.kt
@@ -30,7 +30,7 @@
 // 42
 // Foo
 // File
-// Error type synthetic declaration
+// <ERROR TYPE: Local>
 // Array
 // @Foo
 // @Suppress

--- a/kotlin-analysis-api/testData/annotationValue/kotlin.kt
+++ b/kotlin-analysis-api/testData/annotationValue/kotlin.kt
@@ -30,8 +30,8 @@
 // File
 // Local
 // Array
-// Error type synthetic declaration
-// [<ERROR TYPE>, Foo]
+// <ERROR TYPE: Missing>
+// [<ERROR TYPE: Missing>, Foo]
 // @Foo
 // @Suppress
 // RGB.G

--- a/kotlin-analysis-api/testData/replaceWithErrorTypeArgs.kt
+++ b/kotlin-analysis-api/testData/replaceWithErrorTypeArgs.kt
@@ -19,24 +19,24 @@
 // TEST PROCESSOR: ReplaceWithErrorTypeArgsProcessor
 // EXPECTED:
 // KS.star.replace([INVARIANT Int, INVARIANT String]): KS<Int, String>
-// KS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): KS<<ERROR TYPE>, <ERROR TYPE>>
+// KS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): KS<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // KS.asType([INVARIANT Int, INVARIANT String]): KS<Int, String>
-// KS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): KS<<ERROR TYPE>, <ERROR TYPE>>
+// KS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): KS<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // KS.asType(emptyList()): KS<T1, T2>
 // KL.star.replace([INVARIANT Int, INVARIANT String]): KL<Int, String>
-// KL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): KL<<ERROR TYPE>, <ERROR TYPE>>
+// KL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): KL<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // KL.asType([INVARIANT Int, INVARIANT String]): KL<Int, String>
-// KL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): KL<<ERROR TYPE>, <ERROR TYPE>>
+// KL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): KL<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // KL.asType(emptyList()): KL<T1, T2>
 // JS.star.replace([INVARIANT Int, INVARIANT String]): JS<Int, String>
-// JS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): JS<<ERROR TYPE>, <ERROR TYPE>>
+// JS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): JS<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // JS.asType([INVARIANT Int, INVARIANT String]): JS<Int, String>
-// JS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): JS<<ERROR TYPE>, <ERROR TYPE>>
+// JS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): JS<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // JS.asType(emptyList()): JS<T1, T2>
 // JL.star.replace([INVARIANT Int, INVARIANT String]): JL<Int, String>
-// JL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): JL<<ERROR TYPE>, <ERROR TYPE>>
+// JL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): JL<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // JL.asType([INVARIANT Int, INVARIANT String]): JL<Int, String>
-// JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): JL<<ERROR TYPE>, <ERROR TYPE>>
+// JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): JL<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // JL.asType(emptyList()): JL<T1, T2>
 // KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
 // KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>

--- a/kotlin-analysis-api/testData/replaceWithErrorTypeArgs.kt
+++ b/kotlin-analysis-api/testData/replaceWithErrorTypeArgs.kt
@@ -38,65 +38,65 @@
 // JL.asType([INVARIANT Int, INVARIANT String]): JL<Int, String>
 // JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): JL<<ERROR TYPE: NotExist1>, <ERROR TYPE: NotExist2>>
 // JL.asType(emptyList()): JL<T1, T2>
-// KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KS1<Int> % Unexpected extra 1 type argument(s)>
+// KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KS1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
+// KS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KS1<Int> % Unexpected extra 1 type argument(s)>
+// KS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KS1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
 // KS1.asType(emptyList()): KS1<T>
-// KL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KL1<Int> % Unexpected extra 1 type argument(s)>
+// KL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KL1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
+// KL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KL1<Int> % Unexpected extra 1 type argument(s)>
+// KL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KL1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
 // KL1.asType(emptyList()): KL1<T>
-// JS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JS1<Int> % Unexpected extra 1 type argument(s)>
+// JS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JS1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
+// JS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JS1<Int> % Unexpected extra 1 type argument(s)>
+// JS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JS1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
 // JS1.asType(emptyList()): JS1<T>
-// JL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JL1<Int> % Unexpected extra 1 type argument(s)>
+// JL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JL1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
+// JL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JL1<Int> % Unexpected extra 1 type argument(s)>
+// JL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JL1<<ERROR TYPE: NotExist1>> % Unexpected extra 1 type argument(s)>
 // JL1.asType(emptyList()): JL1<T>
-// JSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
 // JSE.asType(emptyList()): JSE
-// JSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
 // JSE.E.asType(emptyList()): JSE
-// JLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
 // JLE.asType(emptyList()): JLE
-// JLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
 // JLE.E.asType(emptyList()): JLE
-// KSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
 // KSE.asType(emptyList()): KSE
-// KSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
 // KSE.E.asType(emptyList()): KSE
-// KLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
 // KLE.asType(emptyList()): KLE
-// KLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
 // KLE.E.asType(emptyList()): KLE
 // default type:A
 // flexible type star:T

--- a/test-utils/testData/api/annotationValue_java.kt
+++ b/test-utils/testData/api/annotationValue_java.kt
@@ -28,7 +28,7 @@
 // 42
 // Foo
 // File
-// Error type synthetic declaration
+// <ERROR TYPE: Local>
 // Array
 // @Foo
 // @Suppress

--- a/test-utils/testData/api/annotationValue_kt.kt
+++ b/test-utils/testData/api/annotationValue_kt.kt
@@ -26,8 +26,8 @@
 // File
 // Local
 // Array
-// Error type synthetic declaration
-// [<ERROR TYPE>, Foo]
+// <ERROR TYPE: Missing>
+// [<ERROR TYPE: Missing>, Foo]
 // @Foo
 // @Suppress
 // G

--- a/test-utils/testData/api/asMemberOf.kt
+++ b/test-utils/testData/api/asMemberOf.kt
@@ -23,7 +23,7 @@
 // baseTypeArg1: kotlin.Int!!
 // baseTypeArg2: kotlin.String?
 // typePair: kotlin.Pair!!<kotlin.String?, kotlin.Int!!>
-// errorType: <Error>?
+// errorType: <ERROR TYPE: NonExistType>?
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
 // returnArg1: () -> kotlin.Int!!
@@ -40,7 +40,7 @@
 // baseTypeArg1: kotlin.Any?
 // baseTypeArg2: kotlin.Any?
 // typePair: kotlin.Pair!!<kotlin.Any?, kotlin.Any?>
-// errorType: <Error>?
+// errorType: <ERROR TYPE: NonExistType>?
 // extensionProperty: kotlin.Any?
 // returnInt: () -> kotlin.Int!!
 // returnArg1: () -> kotlin.Any?
@@ -57,7 +57,7 @@
 // baseTypeArg1: kotlin.String!!
 // baseTypeArg2: kotlin.String?
 // typePair: kotlin.Pair!!<kotlin.String?, kotlin.String!!>
-// errorType: <Error>?
+// errorType: <ERROR TYPE: NonExistType>?
 // extensionProperty: kotlin.String?
 // returnInt: () -> kotlin.Int!!
 // returnArg1: () -> kotlin.String!!
@@ -96,7 +96,7 @@
 // intType: kotlin.Int!!
 // typeArg1: kotlin.String
 // typeArg2: kotlin.Int
-// errorType: <Error>?
+// errorType: <ERROR TYPE: NonExist>?
 // returnArg1: () -> kotlin.Int
 // receiveArgs: (kotlin.String, kotlin.Int, kotlin.Int!!) -> kotlin.Unit!!
 // methodArgType: <BaseTypeArg1: kotlin.Any>(JavaBase.methodArgType.BaseTypeArg1, kotlin.Int) -> kotlin.Unit!!
@@ -104,7 +104,7 @@
 // fileLevelFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
 // fileLevelExtensionFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
 // fileLevelProperty: java.lang.IllegalArgumentException: Cannot call asMemberOf with a property that is not declared in a class or an interface
-// errorType: (<Error>?) -> <Error>?
+// errorType: (<ERROR TYPE: Int>?) -> <ERROR TYPE: E>?
 // expected comparison failures
 // <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.String?
 // () -> kotlin.Int!!

--- a/test-utils/testData/api/multipleround.kt
+++ b/test-utils/testData/api/multipleround.kt
@@ -18,28 +18,28 @@
 // TEST PROCESSOR: MultipleroundProcessor
 // EXPECTED:
 // Round 0:
-// K : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
-// J : <Error>, <Error>, <Error>, <Error>, <Error>, <Error>
+// K : <ERROR TYPE: I0>, <ERROR TYPE: I1>, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
+// J : <ERROR TYPE: I0>, <ERROR TYPE: I1>, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
 // +J.java, +K.kt
 // Round 1:
-// K : I0, <Error>, <Error>, <Error>, <Error>, <Error>
-// J : I0, <Error>, <Error>, <Error>, <Error>, <Error>
+// K : I0, <ERROR TYPE: I1>, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
+// J : I0, <ERROR TYPE: I1>, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
 // +I0.kt, J.java, K.kt
 // Round 2:
-// K : I0, I1, <Error>, <Error>, <Error>, <Error>
-// J : I0, I1, <Error>, <Error>, <Error>, <Error>
+// K : I0, I1, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
+// J : I0, I1, <ERROR TYPE: I2>, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
 // +I1.java, I0.kt, J.java, K.kt
 // Round 3:
-// K : I0, I1, I2, <Error>, <Error>, <Error>
-// J : I0, I1, I2, <Error>, <Error>, <Error>
+// K : I0, I1, I2, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
+// J : I0, I1, I2, <ERROR TYPE: I3>, <ERROR TYPE: I4>, <ERROR TYPE: I5>
 // +I2.kt, I0.kt, I1.java, J.java, K.kt
 // Round 4:
-// K : I0, I1, I2, I3, <Error>, <Error>
-// J : I0, I1, I2, I3, <Error>, <Error>
+// K : I0, I1, I2, I3, <ERROR TYPE: I4>, <ERROR TYPE: I5>
+// J : I0, I1, I2, I3, <ERROR TYPE: I4>, <ERROR TYPE: I5>
 // +I3.java, I0.kt, I1.java, I2.kt, J.java, K.kt
 // Round 5:
-// K : I0, I1, I2, I3, I4, <Error>
-// J : I0, I1, I2, I3, I4, <Error>
+// K : I0, I1, I2, I3, I4, <ERROR TYPE: I5>
+// J : I0, I1, I2, I3, I4, <ERROR TYPE: I5>
 // +I4.kt, I0.kt, I1.java, I2.kt, I3.java, J.java, K.kt
 // Round 6:
 // K : I0, I1, I2, I3, I4, I5

--- a/test-utils/testData/api/parameterTypes.kt
+++ b/test-utils/testData/api/parameterTypes.kt
@@ -18,9 +18,9 @@
 // TEST PROCESSOR: ParameterTypeProcessor
 // EXPECTED:
 // a: Int
-// b: <ERROR TYPE>
+// b: <ERROR TYPE: NonExist>
 // c: <ERROR TYPE>
-// errorValue: <ERROR TYPE>
+// errorValue: <ERROR TYPE: ErrorType>
 // v: String
 // value: Int
 // END

--- a/test-utils/testData/api/replaceWithErrorTypeArgs.kt
+++ b/test-utils/testData/api/replaceWithErrorTypeArgs.kt
@@ -19,84 +19,84 @@
 // TEST PROCESSOR: ReplaceWithErrorTypeArgsProcessor
 // EXPECTED:
 // KS.star.replace([INVARIANT Int, INVARIANT String]): KS<Int, String>
-// KS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // KS.asType([INVARIANT Int, INVARIANT String]): KS<Int, String>
-// KS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // KS.asType(emptyList()): KS<T1, T2>
 // KL.star.replace([INVARIANT Int, INVARIANT String]): KL<Int, String>
-// KL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // KL.asType([INVARIANT Int, INVARIANT String]): KL<Int, String>
-// KL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // KL.asType(emptyList()): KL<T1, T2>
 // JS.star.replace([INVARIANT Int, INVARIANT String]): JS<Int, String>
-// JS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // JS.asType([INVARIANT Int, INVARIANT String]): JS<Int, String>
-// JS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // JS.asType(emptyList()): JS<T1, T2>
 // JL.star.replace([INVARIANT Int, INVARIANT String]): JL<Int, String>
-// JL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // JL.asType([INVARIANT Int, INVARIANT String]): JL<Int, String>
-// JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: NotExist1>
 // JL.asType(emptyList()): JL<T1, T2>
-// KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KS1<Int> % Unexpected extra 1 type argument(s)>
+// KS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
+// KS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KS1<Int> % Unexpected extra 1 type argument(s)>
+// KS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
 // KS1.asType(emptyList()): KS1<T>
-// KL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KL1<Int> % Unexpected extra 1 type argument(s)>
+// KL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
+// KL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KL1<Int> % Unexpected extra 1 type argument(s)>
+// KL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
 // KL1.asType(emptyList()): KL1<T>
-// JS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JS1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JS1<Int> % Unexpected extra 1 type argument(s)>
+// JS1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
+// JS1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JS1<Int> % Unexpected extra 1 type argument(s)>
+// JS1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
 // JS1.asType(emptyList()): JS1<T>
-// JL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JL1.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JL1<Int> % Unexpected extra 1 type argument(s)>
+// JL1.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
+// JL1.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JL1<Int> % Unexpected extra 1 type argument(s)>
+// JL1.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: <ERROR TYPE: NotExist1> % Unexpected extra 1 type argument(s)>
 // JL1.asType(emptyList()): JL1<T>
-// JSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
+// JSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE % Unexpected extra 2 type argument(s)>
 // JSE.asType(emptyList()): JSE
-// JSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE.E % Unexpected extra 2 type argument(s)>
+// JSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE.E % Unexpected extra 2 type argument(s)>
+// JSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JSE.E % Unexpected extra 2 type argument(s)>
+// JSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JSE.E % Unexpected extra 2 type argument(s)>
 // JSE.E.asType(emptyList()): JSE.E
-// JLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
+// JLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE % Unexpected extra 2 type argument(s)>
 // JLE.asType(emptyList()): JLE
-// JLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// JLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// JLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// JLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE.E % Unexpected extra 2 type argument(s)>
+// JLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE.E % Unexpected extra 2 type argument(s)>
+// JLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: JLE.E % Unexpected extra 2 type argument(s)>
+// JLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: JLE.E % Unexpected extra 2 type argument(s)>
 // JLE.E.asType(emptyList()): JLE.E
-// KSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
+// KSE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KSE % Unexpected extra 2 type argument(s)>
 // KSE.asType(emptyList()): KSE
-// KSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KSE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: E % Unexpected extra 2 type argument(s)>
+// KSE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: E % Unexpected extra 2 type argument(s)>
+// KSE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: E % Unexpected extra 2 type argument(s)>
+// KSE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: E % Unexpected extra 2 type argument(s)>
 // KSE.E.asType(emptyList()): E
-// KLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
+// KLE.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE % Unexpected extra 2 type argument(s)>
 // KLE.asType(emptyList()): KLE
-// KLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
-// KLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE>
-// KLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE>
+// KLE.E.star.replace([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE.E % Unexpected extra 2 type argument(s)>
+// KLE.E.star.replace([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE.E % Unexpected extra 2 type argument(s)>
+// KLE.E.asType([INVARIANT Int, INVARIANT String]): <ERROR TYPE: KLE.E % Unexpected extra 2 type argument(s)>
+// KLE.E.asType([INVARIANT NotExist1, INVARIANT NotExist2]): <ERROR TYPE: KLE.E % Unexpected extra 2 type argument(s)>
 // KLE.E.asType(emptyList()): KLE.E
 // default type:A
 // flexible type star:(T..T?)


### PR DESCRIPTION
This CL makes `KSErrorType` a class with a string
"hint", that by convention should be a "simpleName" of an unresolved type.

`KSErrorTypeClassDeclaration` is also no longer a singleton and references a corresponding `KSErrorType`.

The implementation consists of extracting the available info on the unresolved type on the best effort basis.

Resolves #1232

## Changes for the clients

- if `isError` is true for a `type`, then the `toString()` for the `type` will "likely" return a meaningful value in a format of `"<ERROR TYPE: SomeSimpleName>"`, of `<ERROR TYPE>` (as before) if no info was available.
- `KSErrorType` and their synthetic declarations will now be separate instances.

-------------------

This is the first iteration; if API changes are needed and/or other issues are uncovered, I'm ready to work on them. If my approach to solving the original issue is presumed to be OK, I may write more tests for error types in addition to the existing ones.