### PR TITLE
UPDATE_KOTLIN_VERSION: 2.0.20-dev-1634

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx2200m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.20-dev-715
+kotlinBaseVersion=2.0.20-dev-1634
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ junit5Version=5.8.2
 junitPlatformVersion=1.8.2
 googleTruthVersion=1.1
 
-aaKotlinBaseVersion=2.0.20-dev-715
+aaKotlinBaseVersion=2.0.20-dev-1634
 aaIntellijVersion=213.7172.25
 aaGuavaVersion=29.0-jre
 aaAsmVersion=9.0

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -164,7 +164,7 @@ class KotlinSymbolProcessing(
             )
 
         val application: Application = kotlinCoreProjectEnvironment.environment.application
-        val project: Project = kotlinCoreProjectEnvironment.project
+        val project: MockProject = kotlinCoreProjectEnvironment.project
         val configLanguageVersionSettings = compilerConfiguration[CommonConfigurationKeys.LANGUAGE_VERSION_SETTINGS]
 
         CoreApplicationEnvironment.registerExtensionPoint(
@@ -248,7 +248,6 @@ class KotlinSymbolProcessing(
         val libraryRoots = StandaloneProjectFactory.getAllBinaryRoots(modules, kotlinCoreProjectEnvironment)
         val createPackagePartProvider =
             StandaloneProjectFactory.createPackagePartsProvider(
-                project as MockProject,
                 libraryRoots,
             )
         registerProjectServices(
@@ -665,7 +664,6 @@ private fun reinitJavaFileManager(
         rootsIndex,
         listOf(
             StandaloneProjectFactory.createPackagePartsProvider(
-                project,
                 libraryRoots + jdkRoots,
                 LanguageVersionSettingsImpl(LanguageVersion.LATEST_STABLE, ApiVersion.LATEST)
             ).invoke(ProjectScope.getLibrariesScope(project))
@@ -704,8 +702,20 @@ fun String?.toKotlinVersion(): KotlinVersion {
 
 // Workaround for ShadowJar's minimize, whose configuration isn't very flexible.
 internal val DEAR_SHADOW_JAR_PLEASE_DO_NOT_REMOVE_THESE = listOf(
+    org.jetbrains.kotlin.analysis.api.impl.base.java.source.JavaElementSourceWithSmartPointerFactory::class.java,
+    org.jetbrains.kotlin.analysis.api.impl.base.references.HLApiReferenceProviderService::class.java,
+    org.jetbrains.kotlin.analysis.api.fir.KtFirAnalysisSessionProvider::class.java,
+    org.jetbrains.kotlin.analysis.api.fir.references.ReadWriteAccessCheckerFirImpl::class.java,
+    org.jetbrains.kotlin.analysis.api.standalone.base.providers.KotlinStandaloneDirectInheritorsProvider::class.java,
+    org.jetbrains.kotlin.analysis.low.level.api.fir.services.LLRealFirElementByPsiElementChooser::class.java,
+    org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionInvalidationService::class.java,
+    org.jetbrains.kotlin.analysis.low.level.api.fir.stubBased.deserialization.LLStubBasedLibrarySymbolProviderFactory::class.java,
+    org.jetbrains.kotlin.analysis.providers.impl.KotlinProjectMessageBusProvider::class.java,
+    org.jetbrains.kotlin.idea.references.KotlinFirReferenceContributor::class.java,
+    org.jetbrains.kotlin.light.classes.symbol.SymbolKotlinAsJavaSupport::class.java,
     org.jetbrains.kotlin.load.java.ErasedOverridabilityCondition::class.java,
     org.jetbrains.kotlin.load.java.FieldOverridabilityCondition::class.java,
+    org.jetbrains.kotlin.plugin.references.SimpleNameReferenceExtension::class.java,
     org.jetbrains.kotlin.serialization.deserialization.builtins.BuiltInsLoaderImpl::class.java,
     com.fasterxml.aalto.AaltoInputProperties::class.java,
     com.google.errorprone.annotations.CheckReturnValue::class.java,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -54,7 +54,7 @@ class KSValueParameterImpl private constructor(
             ((ktValueParameterSymbol as KtFirValueParameterSymbol).firSymbol.fir as? FirJavaValueParameter)?.let {
                 // can't get containing class for FirJavaValueParameter, using empty stack for now.
                 it.returnTypeRef =
-                    it.returnTypeRef.resolveIfJavaType(it.moduleData.session, JavaTypeParameterStack.EMPTY)
+                    it.returnTypeRef.resolveIfJavaType(it.moduleData.session, JavaTypeParameterStack.EMPTY, null)
             }
         }
         (ktValueParameterSymbol.psiIfSource() as? KtParameter)?.typeReference

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -461,7 +461,7 @@ internal fun KtValueParameterSymbol.getDefaultValue(): KtAnnotationValue? {
                     val symbolBuilder = it.builder
                     val expectedTypeRef = it.firSymbol.fir.returnTypeRef
                     val expression = defaultValue
-                        ?.toFirExpression(firSession, JavaTypeParameterStack.EMPTY, expectedTypeRef)
+                        ?.toFirExpression(firSession, JavaTypeParameterStack.EMPTY, expectedTypeRef, null)
                     expression?.let {
                         FirAnnotationValueConverter.toConstantValue(expression, symbolBuilder)
                     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspStandaloneDirectInheritorsProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspStandaloneDirectInheritorsProvider.kt
@@ -3,7 +3,6 @@ package com.google.devtools.ksp.standalone
 import com.intellij.openapi.project.Project
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.api.fir.utils.isSubClassOf
-import org.jetbrains.kotlin.analysis.api.standalone.base.providers.KotlinStandaloneDirectInheritorsProvider
 import org.jetbrains.kotlin.analysis.low.level.api.fir.LLFirInternals
 import org.jetbrains.kotlin.analysis.low.level.api.fir.sessions.LLFirSessionCache
 import org.jetbrains.kotlin.analysis.project.structure.KtDanglingFileModule
@@ -30,7 +29,7 @@ class KspStandaloneDirectInheritorsProvider(private val project: Project) : Kotl
             (KotlinDeclarationProviderFactory.getInstance(project) as? IncrementalKotlinDeclarationProviderFactory)
                 ?.staticFactory as? KotlinStaticDeclarationProviderFactory
             ) ?: error(
-            "`${KotlinStandaloneDirectInheritorsProvider::class.simpleName}" +
+            "KotlinStandaloneDirectInheritorsProvider" +
                 "` expects the following declaration provider factory to be" +
                 " registered: `${KotlinStaticDeclarationProviderFactory::class.simpleName}`"
         )


### PR DESCRIPTION
KSP1: nothing has changed besides Kotlin version.

KSP2
* Patch AA service registration XMLs.
* Keep entry points from XML.
* `KotlinStandaloneDirectInheritorsProvider` was moved to internal in AA.
