### PR TITLE
Patch AA service files in renamed uber jar

### DIFF
--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -132,6 +132,7 @@ tasks.withType<ShadowJar> {
     }
     mergeServiceFiles()
     exclude("META-INF/compiler.version")
+    exclude("META-INF/*.kotlin_module")
 
     this.transform(AAServiceTransformer())
 


### PR DESCRIPTION
FQNs starting with `com.intellij` and `org.jetbrains.kotlin` need to be  prefixed by `ksp.`, like what ShadowJar does to classes.