### PR TITLE
Do not index classpath in declaration provider

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -370,12 +370,7 @@ class KotlinSymbolProcessing(
             project.getService(
                 KotlinDeclarationProviderFactory::class.java
             ) as IncrementalKotlinDeclarationProviderFactory
-            )
-            .update(
-                ktFiles,
-                StandaloneProjectFactory.getAllBinaryRoots(modules, kotlinCoreProjectEnvironment).map { it.file } +
-                    listOfNotNull(VirtualFileManager.getInstance().findFileByNioPath(kspConfig.classOutputDir.toPath()))
-            )
+            ).update(ktFiles)
         (
             project.getService(
                 KotlinPackageProviderFactory::class.java

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProvider.kt
@@ -1,7 +1,6 @@
 package com.google.devtools.ksp.standalone
 
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.project.structure.KtModule
 import org.jetbrains.kotlin.analysis.providers.KotlinDeclarationProvider
@@ -94,11 +93,9 @@ class IncrementalKotlinDeclarationProviderFactory(
         }
     }
 
-    fun update(files: Collection<KtFile>, moduleRoots: List<VirtualFile>) {
+    fun update(files: Collection<KtFile>) {
         this.files = files
-        this.staticFactory = KotlinStaticDeclarationProviderFactory(
-            project, files, sharedBinaryRoots = moduleRoots, shouldBuildStubsForBinaryLibraries = true
-        )
+        this.staticFactory = KotlinStaticDeclarationProviderFactory(project, files)
         provider?.let {
             it.del = createDelegateProvider()
         }


### PR DESCRIPTION
It was a workaround where symbol provider depended on declaration provider. It is no longer needed after KT-66689 was fixed.