### PR TITLE
Incremental: fix roots from getSealedSubclasses 

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -234,9 +234,7 @@ abstract class IncrementalContextBase(
             symbolLookupCache.get(it).map { File(it) }
         }
 
-        val dirtyFilesBySealed = sealedMap.keys.flatMap { sealedMap[it]!! }.flatMap {
-            symbolLookupCache.get(it).map { File(it) }
-        }
+        val dirtyFilesBySealed = sealedMap.keys
 
         // Calculate dirty files by dirty classes in CP.
         val dirtyFilesByCP = changedClasses.flatMap { fqn ->

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
@@ -2,7 +2,6 @@ package com.google.devtools.ksp.test
 
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
-import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -17,7 +16,6 @@ class GetSealedSubclassesIncIT(val useKSP2: Boolean) {
 
     @Test
     fun testGetSealedSubclassesInc() {
-        Assume.assumeFalse(useKSP2)
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         val expected2 = listOf(

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -736,6 +736,7 @@ fun String?.toKotlinVersion(): KotlinVersion {
 
 // Workaround for ShadowJar's minimize, whose configuration isn't very flexible.
 internal val DEAR_SHADOW_JAR_PLEASE_DO_NOT_REMOVE_THESE = listOf(
+    kotlinx.coroutines.debug.internal.DebugProbesImpl::class.java,
     org.jetbrains.kotlin.analysis.api.impl.base.java.source.JavaElementSourceWithSmartPointerFactory::class.java,
     org.jetbrains.kotlin.analysis.api.impl.base.references.HLApiReferenceProviderService::class.java,
     org.jetbrains.kotlin.analysis.api.fir.KtFirAnalysisSessionProvider::class.java,


### PR DESCRIPTION
by just including the files that contain the sealed class / interface.
Their subclasses will be invalidated during dirtiness propagation.