### PR TITLE
KSP2 embeddable: rename javax.annotation

### DIFF
--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -48,6 +48,7 @@ val prefixesToRelocate = listOf(
     "it.unimi.dsi.",
     "javaslang.",
     "javax.inject.",
+    "javax.annotation.",
     "kotlinx.collections.immutable.",
     "kotlinx.coroutines.",
     "org.apache.log4j.",


### PR DESCRIPTION
which is introduced by newer Guava as a transitive dependency. It is not exposed to callers and therefore safe to rename.