### PR TITLE
Make originalAnnotations lazy

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -119,10 +119,12 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KtDeclarationS
     override val docString: String?
         get() = ktDeclarationSymbol.toDocString()
 
-    internal val originalAnnotations = if (ktDeclarationSymbol.psi is KtElement || ktDeclarationSymbol.psi == null) {
-        ktDeclarationSymbol.annotations(this)
-    } else {
-        (ktDeclarationSymbol.psi as PsiJvmModifiersOwner)
-            .annotations.map { KSAnnotationJavaImpl.getCached(it, this) }.asSequence()
+    internal val originalAnnotations: Sequence<KSAnnotation> by lazy {
+        if (ktDeclarationSymbol.psi is KtElement || ktDeclarationSymbol.psi == null) {
+            ktDeclarationSymbol.annotations(this)
+        } else {
+            (ktDeclarationSymbol.psi as PsiJvmModifiersOwner)
+                .annotations.map { KSAnnotationJavaImpl.getCached(it, this) }.asSequence()
+        }
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -43,7 +43,9 @@ abstract class KSPropertyAccessorImpl(
             .plus(findAnnotationFromUseSiteTarget())
     }
 
-    internal val originalAnnotations = ktPropertyAccessorSymbol.annotations(this)
+    internal val originalAnnotations: Sequence<KSAnnotation> by lazy {
+        ktPropertyAccessorSymbol.annotations(this)
+    }
 
     override val location: Location by lazy {
         ktPropertyAccessorSymbol.psi?.toLocation() ?: NonExistLocation


### PR DESCRIPTION
Otherwise all annotations are resolved unconditionally when we index KSFiles.