### PR TITLE
map java types to kotlin types when parsing annotation class referece values

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -461,7 +461,11 @@ internal fun KtValueParameterSymbol.getDefaultValue(): KtAnnotationValue? {
         if (this is FirAnnotation) {
             return KtAnnotationApplicationValue(
                 KtAnnotationApplicationWithArgumentsInfo(
-                    ClassId.fromString((annotationTypeRef.coneType as? ConeLookupTagBasedType)?.lookupTag.toString()),
+                    JavaToKotlinClassMap.mapJavaToKotlinIncludingClassMapping(
+                        ClassId.fromString(
+                            (annotationTypeRef.coneType as? ConeLookupTagBasedType)?.lookupTag.toString()
+                        ).asSingleFqName()
+                    ),
                     null,
                     null,
                     emptyList(),
@@ -484,8 +488,9 @@ internal fun KtValueParameterSymbol.getDefaultValue(): KtAnnotationValue? {
             }
 
             if (coneType is ConeClassLikeType && coneType !is ConeErrorType) {
-                val classId = coneType.lookupTag.classId
-                val type = builder.typeBuilder.buildKtType(coneType)
+                val classId = JavaToKotlinClassMap
+                    .mapJavaToKotlinIncludingClassMapping(coneType.lookupTag.classId.asSingleFqName())
+                val type = builder.typeBuilder.buildKtType(coneType).convertToKotlinType()
                 KtKClassAnnotationValue(type, classId, null, token)
             } else {
                 null

--- a/kotlin-analysis-api/testData/annotationValue/defaultKClassValue.kt
+++ b/kotlin-analysis-api/testData/annotationValue/defaultKClassValue.kt
@@ -1,0 +1,20 @@
+// TEST PROCESSOR: DefaultKClassValueProcessor
+// EXPECTED:
+// kotlin.String
+// kotlin.String
+// kotlin.String
+// kotlin.Int
+// END
+// MODULE: lib1
+// FILE: lib1.kt
+annotation class ExampleAnnotation(val value: kotlin.reflect.KClass<*> = java.lang.String::class)
+
+// MODULE: main(lib1)
+// FILE: a.kt
+
+@ExampleAnnotation(String::class)
+class Example
+
+@ExampleAnnotation(Int::class)
+class Example2
+

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DefaultKClassValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DefaultKClassValueProcessor.kt
@@ -1,0 +1,28 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeImpl
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class DefaultKClassValueProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val example1 = resolver.getClassDeclarationByName("Example")!!.annotations.first()
+        val example2 = resolver.getClassDeclarationByName("Example2")!!.annotations.first()
+        val arg1 = (example1.arguments.single().value as KSTypeImpl).declaration.qualifiedName!!
+        val defaultArg1 = (example1.defaultArguments.single().value as KSTypeImpl).declaration.qualifiedName!!
+        results.add(defaultArg1.asString())
+        results.add(arg1.asString())
+        val arg2 = (example2.arguments.single().value as KSTypeImpl).declaration.qualifiedName!!
+        val defaultArg2 = (example2.defaultArguments.single().value as KSTypeImpl).declaration.qualifiedName!!
+        results.add(defaultArg2.asString())
+        results.add(arg2.asString())
+        return emptyList()
+    }
+}

--- a/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/test-utils/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -83,6 +83,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/annotationWithArbitraryClassValue.kt")
     }
 
+    @TestMetadata("defaultKClassValue.kt")
+    @Test
+    fun testAnnotationValue_defaultKClassValue() {
+        runTest("../kotlin-analysis-api/testData/annotationValue/defaultKClassValue.kt")
+    }
+
     @TestMetadata("annotationValue_java.kt")
     @Test
     fun testAnnotationValue_java() {


### PR DESCRIPTION
fixes #1948 