### PR TITLE
Use symbol-processing-aa-embeddable in Gradle

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -144,7 +144,7 @@ tasks.named<Test>("test").configure {
     dependsOn(":common-deps:publishAllPublicationsToTestRepository")
     dependsOn(":gradle-plugin:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing:publishAllPublicationsToTestRepository")
-    dependsOn(":kotlin-analysis-api:publishAllPublicationsToTestRepository")
+    dependsOn(":symbol-processing-aa-embeddable:publishAllPublicationsToTestRepository")
 }
 
 abstract class WriteVersionSrcTask @Inject constructor(

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -31,7 +31,6 @@ tasks.withType<Test> {
     dependsOn(":common-deps:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing-cmdline:publishAllPublicationsToTestRepository")
-    dependsOn(":kotlin-analysis-api:publishAllPublicationsToTestRepository")
     dependsOn(":symbol-processing-aa-embeddable:publishAllPublicationsToTestRepository")
 
     // JDK_9 environment property is required.


### PR DESCRIPTION
isolatedClassloader only isolates KSP from Gradle classpath. Bundled classes in the KSP jar can still be seen by processors and pollute their classpath. Replacing symbol-processing-aa with
symbol-processing-aa-embeddable solves both issues.

Note that classloaders are still required for:
1. loading KSP2 when needed, so that KSP1 don't download the fat jar.
2. processors need to be re-loaded everytime, in case of improper uses of static variables and/or memory leak.