### PR TITLE
Fix `:kotlin-analysis-api:shadowJar` failing on Windows

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -172,7 +172,7 @@ tasks.withType<ShadowJar>() {
                 args = listOf(
                     "--multi-release", "base",
                     "--missing-deps",
-                    "-cp", depJars.joinToString(":"), jarJar.path
+                    "-cp", depJars.joinToString(File.pathSeparator), jarJar.path
                 )
                 standardOutput = stdout
             }


### PR DESCRIPTION
This is similar to https://github.com/google/ksp/pull/1436.