### PR TITLE
UPDATE_KOTLIN_VERSION: 2.0.20-RC

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
@@ -59,7 +59,8 @@ class RecordJavaAsMemberOfProcessor : AbstractTestProcessor() {
         }
         m.forEach { symbol, files ->
             files.filter { it.endsWith(".java") }.sorted().forEach {
-                results.add("$symbol: $it")
+                val fn = it.substringAfterLast("java-sources/")
+                results.add("$symbol: $fn")
             }
         }
         return emptyList()

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
@@ -47,7 +47,8 @@ class RecordJavaGetAllMembersProcessor : AbstractTestProcessor() {
         }
         m.forEach { symbol, files ->
             files.filter { it.endsWith(".java") }.sorted().forEach {
-                results.add("$symbol: $it")
+                val fn = it.substringAfterLast("java-sources/")
+                results.add("$symbol: $fn")
             }
         }
         return emptyList()

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
@@ -64,7 +64,8 @@ class RecordJavaOverridesProcessor : AbstractTestProcessor() {
         }
         m.forEach { symbol, files ->
             files.filter { it.endsWith(".java") }.sorted().forEach {
-                results.add("$symbol: $it")
+                val fn = it.substringAfterLast("java-sources/")
+                results.add("$symbol: $fn")
             }
         }
         return emptyList()

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
@@ -43,7 +43,8 @@ class RecordJavaProcessor : AbstractTestProcessor() {
         }
         m.forEach { symbol, files ->
             files.filter { it.endsWith(".java") }.sorted().forEach {
-                results.add("$symbol: $it")
+                val fn = it.substringAfterLast("java-sources/")
+                results.add("$symbol: $fn")
             }
         }
         return emptyList()

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
@@ -44,7 +44,8 @@ class RecordJavaSupertypesProcessor : AbstractTestProcessor() {
         }
         m.forEach { symbol, files ->
             files.filter { it.endsWith(".java") }.sorted().forEach {
-                results.add("$symbol: $it")
+                val fn = it.substringAfterLast("java-sources/")
+                results.add("$symbol: $fn")
             }
         }
         return emptyList()

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPCompilerPluginTest.kt
@@ -9,7 +9,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
+import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
 import org.jetbrains.kotlin.codegen.GenerationUtils
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.languageVersionSettings
@@ -18,7 +18,6 @@ import org.jetbrains.kotlin.test.model.FrontendKinds
 import org.jetbrains.kotlin.test.model.TestModule
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.compilerConfigurationProvider
-import org.jetbrains.kotlin.test.services.javaFiles
 import java.io.File
 
 abstract class AbstractKSPCompilerPluginTest : AbstractKSPTest(FrontendKinds.ClassicFrontend) {
@@ -31,10 +30,6 @@ abstract class AbstractKSPCompilerPluginTest : AbstractKSPTest(FrontendKinds.Cla
         val compilerConfiguration = testServices.compilerConfigurationProvider.getCompilerConfiguration(mainModule)
         compilerConfiguration.put(CommonConfigurationKeys.MODULE_NAME, mainModule.name)
         compilerConfiguration.put(CommonConfigurationKeys.LOOKUP_TRACKER, DualLookupTracker())
-        if (!mainModule.javaFiles.isEmpty()) {
-            mainModule.writeJavaFiles()
-            compilerConfiguration.addJavaSourceRoot(mainModule.javaDir)
-        }
 
         // TODO: other platforms
         val kotlinCoreEnvironment = KotlinCoreEnvironment.createForTests(
@@ -55,9 +50,7 @@ abstract class AbstractKSPCompilerPluginTest : AbstractKSPTest(FrontendKinds.Cla
         val analysisExtension =
             KotlinSymbolProcessingExtension(
                 KspOptions.Builder().apply {
-                    if (!mainModule.javaFiles.isEmpty()) {
-                        javaSourceRoots.add(mainModule.javaDir)
-                    }
+                    javaSourceRoots.addAll(compilerConfiguration.javaSourceRoots.map { File(it) })
                     classOutputDir = File(testRoot, "kspTest/classes/main")
                     javaOutputDir = File(testRoot, "kspTest/src/main/java")
                     kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -128,8 +128,6 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
         defaultDirectives {
             +JvmEnvironmentConfigurationDirectives.FULL_JDK
             JvmEnvironmentConfigurationDirectives.JVM_TARGET with JvmTarget.DEFAULT
-            // SourceFileProviderImpl doesn't group files by module. Let's load them manually.
-            +JvmEnvironmentConfigurationDirectives.SKIP_JAVA_SOURCES
             +ConfigurationDirectives.WITH_STDLIB
             +LanguageSettingsDirectives.ALLOW_KOTLIN_PACKAGE
         }
@@ -198,6 +196,10 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             path,
             testConfiguration.directives,
         )
+        val dependencyProvider = DependencyProviderImpl(testServices, moduleStructure.modules)
+        testServices.registerDependencyProvider(dependencyProvider)
+        testServices.register(TestModuleStructure::class, moduleStructure)
+
         val mainModule = moduleStructure.modules.last()
         val libModules = moduleStructure.modules.dropLast(1)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.10-RC
+kotlinBaseVersion=2.0.20-dev-2651
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.20-dev-4579
+kotlinBaseVersion=2.0.20-dev-6501
 agpBaseVersion=7.2.0
-intellijVersion=213.7172.25
+intellijVersion=233.13135.103
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.20-dev-3728
+kotlinBaseVersion=2.0.20-dev-4579
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.0
+kotlinBaseVersion=2.0.10-RC
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.20-dev-2651
+kotlinBaseVersion=2.0.20-dev-3728
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.10-RC2
+kotlinBaseVersion=2.0.0
 agpBaseVersion=7.2.0
 intellijVersion=213.7172.25
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.20-dev-6501
+kotlinBaseVersion=2.0.20-RC
 agpBaseVersion=7.2.0
 intellijVersion=233.13135.103
 junitVersion=4.13.1

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -22,6 +22,7 @@ import com.google.devtools.ksp.impl.KotlinSymbolProcessing
 import com.google.devtools.ksp.processing.KSPJvmConfig
 import com.google.devtools.ksp.processor.AbstractTestProcessor
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
+import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.jvmModularRoots
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
@@ -34,7 +35,6 @@ import org.jetbrains.kotlin.test.services.JUnit5Assertions
 import org.jetbrains.kotlin.test.services.TestServices
 import org.jetbrains.kotlin.test.services.compilerConfigurationProvider
 import org.jetbrains.kotlin.test.services.isKtFile
-import org.jetbrains.kotlin.test.services.javaFiles
 import org.jetbrains.kotlin.test.util.KtTestUtil
 import org.jetbrains.kotlin.utils.PathUtil
 import java.io.ByteArrayOutputStream
@@ -111,18 +111,13 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
         // Therefore, this doesn't work:
         //  val ktFiles = mainModule.loadKtFiles(kotlinCoreEnvironment.project)
         mainModule.writeKtFiles()
-        if (!mainModule.javaFiles.isEmpty()) {
-            mainModule.writeJavaFiles()
-        }
 
         val testRoot = mainModule.testRoot
 
         val kspConfig = KSPJvmConfig.Builder().apply {
             moduleName = mainModule.name
             sourceRoots = listOf(mainModule.kotlinSrc)
-            if (!mainModule.javaFiles.isEmpty()) {
-                javaSourceRoots = listOf(mainModule.javaDir)
-            }
+            javaSourceRoots = compilerConfiguration.javaSourceRoots.map { File(it) }.toList()
             jdkHome = compilerConfiguration.get(JVMConfigurationKeys.JDK_HOME)
             jvmTarget = compilerConfiguration.get(JVMConfigurationKeys.JVM_TARGET)!!.description
             languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString

--- a/kotlin-analysis-api/testData/recordJavaAnnotationTypes.kt
+++ b/kotlin-analysis-api/testData/recordJavaAnnotationTypes.kt
@@ -18,14 +18,14 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaProcessor
 // EXPECTED:
-// kotlin.Annotation: javaSrc/p1/J.java
-// kotlin.Any: javaSrc/p1/J.java
-// kotlin.collections.List: javaSrc/p1/J.java
-// kotlin.collections.MutableList: javaSrc/p1/J.java
-// p1.Anno: javaSrc/p1/J.java
-// p1.Bnno: javaSrc/p1/J.java
-// p1.J: javaSrc/p1/J.java
-// p1.K: javaSrc/p1/J.java
+// kotlin.Annotation: main/p1/J.java
+// kotlin.Any: main/p1/J.java
+// kotlin.collections.List: main/p1/J.java
+// kotlin.collections.MutableList: main/p1/J.java
+// p1.Anno: main/p1/J.java
+// p1.Bnno: main/p1/J.java
+// p1.J: main/p1/J.java
+// p1.K: main/p1/J.java
 // END
 
 // FILE: p1/J.java

--- a/kotlin-analysis-api/testData/recordJavaAsMemberOf.kt
+++ b/kotlin-analysis-api/testData/recordJavaAsMemberOf.kt
@@ -18,14 +18,14 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaAsMemberOfProcessor
 // EXPECTED:
-// kotlin.Any: javaSrc/p1/B.java
-// p1.A: javaSrc/p1/B.java
-// p1.B: javaSrc/p1/A.java
-// p1.C: javaSrc/p1/A.java
-// p1.C: javaSrc/p1/B.java
-// p1.D: javaSrc/p1/A.java
-// p1.D: javaSrc/p1/B.java
-// p1.E: javaSrc/p1/B.java
+// kotlin.Any: main/p1/B.java
+// p1.A: main/p1/B.java
+// p1.B: main/p1/A.java
+// p1.C: main/p1/A.java
+// p1.C: main/p1/B.java
+// p1.D: main/p1/A.java
+// p1.D: main/p1/B.java
+// p1.E: main/p1/B.java
 // END
 
 // FILE: p1/A.java

--- a/kotlin-analysis-api/testData/recordJavaGetAllMembers.kt
+++ b/kotlin-analysis-api/testData/recordJavaGetAllMembers.kt
@@ -18,14 +18,14 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaGetAllMembersProcessor
 // EXPECTED:
-// p1.B: javaSrc/p1/B.java
-// p1.C: javaSrc/p1/B.java
-// p1.C: javaSrc/p1/C.java
-// p1.D: javaSrc/p1/C.java
-// p1.R2: javaSrc/p1/B.java
-// p1.R3: javaSrc/p1/C.java
-// p1.V2: javaSrc/p1/B.java
-// p1.V3: javaSrc/p1/C.java
+// p1.B: main/p1/B.java
+// p1.C: main/p1/B.java
+// p1.C: main/p1/C.java
+// p1.D: main/p1/C.java
+// p1.R2: main/p1/B.java
+// p1.R3: main/p1/C.java
+// p1.V2: main/p1/B.java
+// p1.V3: main/p1/C.java
 // END
 
 // FILE: p1/A.kt

--- a/kotlin-analysis-api/testData/recordJavaOverrides.kt
+++ b/kotlin-analysis-api/testData/recordJavaOverrides.kt
@@ -18,16 +18,16 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaOverridesProcessor
 // EXPECTED:
-// p1.B: javaSrc/p1/A.java
-// p1.C: javaSrc/p1/B.java
-// p1.R1: javaSrc/p1/A.java
-// p1.R1: javaSrc/p1/C.java
-// p1.R2: javaSrc/p1/A.java
-// p1.R2: javaSrc/p1/C.java
-// p1.V1: javaSrc/p1/A.java
-// p1.V1: javaSrc/p1/C.java
-// p1.V2: javaSrc/p1/A.java
-// p1.V2: javaSrc/p1/C.java
+// p1.B: main/p1/A.java
+// p1.C: main/p1/B.java
+// p1.R1: main/p1/A.java
+// p1.R1: main/p1/C.java
+// p1.R2: main/p1/A.java
+// p1.R2: main/p1/C.java
+// p1.V1: main/p1/A.java
+// p1.V1: main/p1/C.java
+// p1.V2: main/p1/A.java
+// p1.V2: main/p1/C.java
 // END
 
 // FILE: p1/A.java

--- a/kotlin-analysis-api/testData/recordJavaResolutions.kt
+++ b/kotlin-analysis-api/testData/recordJavaResolutions.kt
@@ -18,30 +18,30 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaProcessor
 // EXPECTED:
-// kotlin.Any: javaSrc/p1/J1.java
-// kotlin.Any: javaSrc/p1/J2.java
-// kotlin.Any: javaSrc/p1/TestJ2J.java
-// kotlin.Any: javaSrc/p1/TestJ2K.java
-// kotlin.Any: javaSrc/p2/J2.java
-// kotlin.Any: javaSrc/p3/J1.java
-// kotlin.Any: javaSrc/p3/J2.java
-// kotlin.Any: javaSrc/p3/J3.java
-// p1.J1: javaSrc/p1/J1.java
-// p1.J1: javaSrc/p1/TestJ2J.java
-// p1.J2: javaSrc/p1/J2.java
-// p1.J3: javaSrc/p1/TestJ2J.java
-// p1.K1: javaSrc/p1/TestJ2K.java
-// p1.K3: javaSrc/p1/TestJ2K.java
-// p1.TestJ2J: javaSrc/p1/TestJ2J.java
-// p1.TestJ2K: javaSrc/p1/TestJ2K.java
-// p2.J2: javaSrc/p1/TestJ2J.java
-// p2.J2: javaSrc/p2/J2.java
-// p2.K2: javaSrc/p1/TestJ2K.java
-// p3.J1: javaSrc/p3/J1.java
-// p3.J2: javaSrc/p3/J2.java
-// p3.J3: javaSrc/p1/TestJ2J.java
-// p3.J3: javaSrc/p3/J3.java
-// p3.K3: javaSrc/p1/TestJ2K.java
+// kotlin.Any: main/p1/J1.java
+// kotlin.Any: main/p1/J2.java
+// kotlin.Any: main/p1/TestJ2J.java
+// kotlin.Any: main/p1/TestJ2K.java
+// kotlin.Any: main/p2/J2.java
+// kotlin.Any: main/p3/J1.java
+// kotlin.Any: main/p3/J2.java
+// kotlin.Any: main/p3/J3.java
+// p1.J1: main/p1/J1.java
+// p1.J1: main/p1/TestJ2J.java
+// p1.J2: main/p1/J2.java
+// p1.J3: main/p1/TestJ2J.java
+// p1.K1: main/p1/TestJ2K.java
+// p1.K3: main/p1/TestJ2K.java
+// p1.TestJ2J: main/p1/TestJ2J.java
+// p1.TestJ2K: main/p1/TestJ2K.java
+// p2.J2: main/p1/TestJ2J.java
+// p2.J2: main/p2/J2.java
+// p2.K2: main/p1/TestJ2K.java
+// p3.J1: main/p3/J1.java
+// p3.J2: main/p3/J2.java
+// p3.J3: main/p1/TestJ2J.java
+// p3.J3: main/p3/J3.java
+// p3.K3: main/p1/TestJ2K.java
 // END
 
 // FILE: p1/TestJ2K.java

--- a/kotlin-analysis-api/testData/recordJavaSupertypes.kt
+++ b/kotlin-analysis-api/testData/recordJavaSupertypes.kt
@@ -18,14 +18,14 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaSupertypesProcessor
 // EXPECTED:
-// <anonymous>.A: javaSrc/A.java
-// <anonymous>.B: javaSrc/A.java
-// <anonymous>.C: javaSrc/A.java
-// <anonymous>.C: javaSrc/C.java
-// <anonymous>.D: javaSrc/C.java
-// <anonymous>.D: javaSrc/D.java
-// kotlin.Any: javaSrc/C.java
-// kotlin.Any: javaSrc/D.java
+// <anonymous>.A: main/A.java
+// <anonymous>.B: main/A.java
+// <anonymous>.C: main/A.java
+// <anonymous>.C: main/C.java
+// <anonymous>.D: main/C.java
+// <anonymous>.D: main/D.java
+// kotlin.Any: main/C.java
+// kotlin.Any: main/D.java
 // END
 
 // FILE: A.java

--- a/test-utils/testData/api/recordJavaAnnotationTypes.kt
+++ b/test-utils/testData/api/recordJavaAnnotationTypes.kt
@@ -18,10 +18,10 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaProcessor
 // EXPECTED:
-// java.util.List: javaSrc/p1/J.java
-// p1.Anno: javaSrc/p1/J.java
-// p1.Bnno: javaSrc/p1/J.java
-// p1.K: javaSrc/p1/J.java
+// java.util.List: main/p1/J.java
+// p1.Anno: main/p1/J.java
+// p1.Bnno: main/p1/J.java
+// p1.K: main/p1/J.java
 // END
 
 // FILE: p1/J.java

--- a/test-utils/testData/api/recordJavaAsMemberOf.kt
+++ b/test-utils/testData/api/recordJavaAsMemberOf.kt
@@ -18,12 +18,12 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaAsMemberOfProcessor
 // EXPECTED:
-// p1.A: javaSrc/p1/B.java
-// p1.B: javaSrc/p1/A.java
-// p1.C: javaSrc/p1/B.java
-// p1.D: javaSrc/p1/A.java
-// p1.D: javaSrc/p1/B.java
-// p1.E: javaSrc/p1/B.java
+// p1.A: main/p1/B.java
+// p1.B: main/p1/A.java
+// p1.C: main/p1/B.java
+// p1.D: main/p1/A.java
+// p1.D: main/p1/B.java
+// p1.E: main/p1/B.java
 // END
 
 // FILE: p1/A.java

--- a/test-utils/testData/api/recordJavaGetAllMembers.kt
+++ b/test-utils/testData/api/recordJavaGetAllMembers.kt
@@ -18,12 +18,12 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaGetAllMembersProcessor
 // EXPECTED:
-// p1.C: javaSrc/p1/B.java
-// p1.D: javaSrc/p1/C.java
-// p1.R2: javaSrc/p1/B.java
-// p1.R3: javaSrc/p1/C.java
-// p1.V2: javaSrc/p1/B.java
-// p1.V3: javaSrc/p1/C.java
+// p1.C: main/p1/B.java
+// p1.D: main/p1/C.java
+// p1.R2: main/p1/B.java
+// p1.R3: main/p1/C.java
+// p1.V2: main/p1/B.java
+// p1.V3: main/p1/C.java
 // END
 
 // FILE: p1/A.kt

--- a/test-utils/testData/api/recordJavaOverrides.kt
+++ b/test-utils/testData/api/recordJavaOverrides.kt
@@ -18,16 +18,16 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaOverridesProcessor
 // EXPECTED:
-// p1.B: javaSrc/p1/A.java
-// p1.C: javaSrc/p1/B.java
-// p1.R1: javaSrc/p1/A.java
-// p1.R1: javaSrc/p1/C.java
-// p1.R2: javaSrc/p1/A.java
-// p1.R2: javaSrc/p1/C.java
-// p1.V1: javaSrc/p1/A.java
-// p1.V1: javaSrc/p1/C.java
-// p1.V2: javaSrc/p1/A.java
-// p1.V2: javaSrc/p1/C.java
+// p1.B: main/p1/A.java
+// p1.C: main/p1/B.java
+// p1.R1: main/p1/A.java
+// p1.R1: main/p1/C.java
+// p1.R2: main/p1/A.java
+// p1.R2: main/p1/C.java
+// p1.V1: main/p1/A.java
+// p1.V1: main/p1/C.java
+// p1.V2: main/p1/A.java
+// p1.V2: main/p1/C.java
 // END
 
 // FILE: p1/A.java

--- a/test-utils/testData/api/recordJavaResolutions.kt
+++ b/test-utils/testData/api/recordJavaResolutions.kt
@@ -18,14 +18,14 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaProcessor
 // EXPECTED:
-// p1.J1: javaSrc/p1/TestJ2J.java
-// p1.J3: javaSrc/p1/TestJ2J.java
-// p1.K1: javaSrc/p1/TestJ2K.java
-// p1.K3: javaSrc/p1/TestJ2K.java
-// p2.J2: javaSrc/p1/TestJ2J.java
-// p2.K2: javaSrc/p1/TestJ2K.java
-// p3.J3: javaSrc/p1/TestJ2J.java
-// p3.K3: javaSrc/p1/TestJ2K.java
+// p1.J1: main/p1/TestJ2J.java
+// p1.J3: main/p1/TestJ2J.java
+// p1.K1: main/p1/TestJ2K.java
+// p1.K3: main/p1/TestJ2K.java
+// p2.J2: main/p1/TestJ2J.java
+// p2.K2: main/p1/TestJ2K.java
+// p3.J3: main/p1/TestJ2J.java
+// p3.K3: main/p1/TestJ2K.java
 // END
 
 // FILE: p1/TestJ2K.java

--- a/test-utils/testData/api/recordJavaSupertypes.kt
+++ b/test-utils/testData/api/recordJavaSupertypes.kt
@@ -18,10 +18,10 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: RecordJavaSupertypesProcessor
 // EXPECTED:
-// <anonymous>.A: javaSrc/A.java
-// <anonymous>.B: javaSrc/A.java
-// <anonymous>.C: javaSrc/A.java
-// <anonymous>.D: javaSrc/C.java
+// <anonymous>.A: main/A.java
+// <anonymous>.B: main/A.java
+// <anonymous>.C: main/A.java
+// <anonymous>.D: main/C.java
 // END
 
 // FILE: A.java


### PR DESCRIPTION
Rewind and reapply Kotlin version changes on the 1.0.24-release branch. It won't be necessary from 1.0.25-release on.