### PR TITLE
Use properties where possible in KspExtension

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -233,10 +233,16 @@ abstract class KspAATask @Inject constructor(
                     cfg.excludedProcessors.value(kspExtension.excludedProcessors)
 
                     cfg.incremental.value(
-                        project.providers.gradleProperty("ksp.incremental").orNull?.toBoolean() ?: true
+                        project.providers
+                            .gradleProperty("ksp.incremental")
+                            .map { it.toBoolean() }
+                            .orElse(true)
                     )
                     cfg.incrementalLog.value(
-                        project.providers.gradleProperty("ksp.incremental.log").orNull?.toBoolean() ?: false
+                        project.providers
+                            .gradleProperty("ksp.incremental.log")
+                            .map { it.toBoolean() }
+                            .orElse(false)
                     )
 
                     cfg.classpathStructure.from(getClassStructureFiles(project, cfg.libraries))

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -17,12 +17,12 @@
 
 package com.google.devtools.ksp.gradle
 
-import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.process.CommandLineArgumentProvider
+import javax.inject.Inject
 
 abstract class KspExtension @Inject constructor(project: Project) {
     internal val apOptions = project.objects.mapProperty(String::class.java, String::class.java)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -143,11 +143,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             options.add(
                 InternalSubpluginOption("projectBaseDir", project.project.projectDir.canonicalPath)
             )
-            options.add(
-                project.provider {
-                    SubpluginOption("allWarningsAsErrors", allWarningsAsErrors.toString())
-                }
-            )
+            options.add(allWarningsAsErrors.map { SubpluginOption("allWarningsAsErrors", it.toString()) })
             // Turn this on by default to work KT-30172 around. It is off by default in the compiler plugin.
             options.add(
                 project.providers.gradleProperty("ksp.return.ok.on.error")
@@ -166,6 +162,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             options.addAll(
                 kspExtension.apOptions.map { apOptions ->
                     apOptions.map { (k, v) -> SubpluginOption("apoption", "$k=$v") }
+                }
+            )
+            options.add(
+                kspExtension.excludedProcessors.map {
+                    SubpluginOption("excludedProcessors", it.joinToString(":"))
                 }
             )
             options.add(


### PR DESCRIPTION
This PR converts all internal things in KspExtension to be properties instead of lists and maps. This will ensure that reads are deferred for as long as possible and will prevent forcing reads during configuration.

Unfortunately some properties cannot be changed without causing changes to the ABI. New properties could be introduced but the names would have to be different.

This partially fixes #1752