### PR TITLE
Do not use compiler hard-coded use-site target

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -114,6 +114,11 @@ class KSAnnotationResolvedImpl private constructor(
     }
 
     override val useSiteTarget: AnnotationUseSiteTarget? by lazy {
+        // Do not use compiler hard-coded use-site target.
+        // FIXME: use origin after it is fixed.
+        if (parent?.origin == Origin.KOTLIN_LIB || parent?.origin == Origin.JAVA_LIB)
+            return@lazy null
+
         when (annotationApplication.useSiteTarget) {
             null -> null
             FILE -> AnnotationUseSiteTarget.FILE
@@ -128,6 +133,7 @@ class KSAnnotationResolvedImpl private constructor(
         }
     }
 
+    // FIXME: use parent.origin
     override val origin: Origin = Origin.KOTLIN_LIB
 
     override val location: Location by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -58,6 +58,7 @@ class KSTypeReferenceResolvedImpl private constructor(
     }
 
     override val element: KSReferenceElement? by lazy {
+        // FIXME: synthetic elements can have non-synthetic annotations via use-site targets
         if (parent == null || parent.origin == Origin.SYNTHETIC) {
             null
         } else {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ImplicitElementProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ImplicitElementProcessor.kt
@@ -20,6 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
@@ -89,6 +90,18 @@ class ImplicitElementProcessor : AbstractTestProcessor() {
         )
         val ImplictConstructorJava = resolver.getClassDeclarationByName("ImplictConstructorJava")!!
         result.add(ImplictConstructorJava.getConstructors().map { it.toString() }.joinToString(","))
+
+        listOf("Test", "lib.Test").forEach { clsName ->
+            resolver.getClassDeclarationByName(clsName)!!.let { cls ->
+                cls.getDeclaredProperties().single().let { annotated ->
+                    result.add(
+                        "$clsName, $annotated: ${annotated.annotations.toList().map {
+                            "${it.shortName.asString()}: ${ it.useSiteTarget }"
+                        }}"
+                    )
+                }
+            }
+        }
         return emptyList()
     }
 }

--- a/test-utils/testData/api/implicitElements.kt
+++ b/test-utils/testData/api/implicitElements.kt
@@ -33,7 +33,48 @@
 // GetAnno
 // <init>
 // synthetic constructor for ImplictConstructorJava
+// Test, p: [MyKotlinAnnotation: null, MyJavaAnnotation: null]
+// lib.Test, p: [MyKotlinAnnotation: null, MyJavaAnnotation: null]
 // END
+// MODULE: lib
+// FILE: lib/MyJavaAnnotation.java
+package lib;
+import static java.lang.annotation.ElementType.CONSTRUCTOR;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.MODULE;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({FIELD})
+public @interface MyJavaAnnotation {}
+
+// FILE: lib/MyKotlinAnnotation.kt
+package lib
+@Target(AnnotationTarget.PROPERTY)
+annotation class MyKotlinAnnotation
+
+// FILE: lib/Test.kt
+package lib
+class Test(
+    @MyKotlinAnnotation
+    @MyJavaAnnotation
+    val p: Int
+)
+
+// MODULE: main(lib)
+// FILE: Test.kt
+import lib.*
+class Test(
+    @MyKotlinAnnotation
+    @MyJavaAnnotation
+    val p: Int
+)
 // FILE: a.kt
 annotation class GetAnno
 annotation class SetAnno


### PR DESCRIPTION
K2 attaches PROPERTY/FIELD unconditionally when deserializing properties/fields in JvmBinaryAnnotationDeserializer.

They cannot be used to determine whether there is a use-site target, or the annotation is immediately on the property/element in the source.

fixes #1882 

ref: https://github.com/JetBrains/kotlin/blob/66ccc6ab3e6cade8a54f874bbed19535528efc96/compiler/fir/java/src/org/jetbrains/kotlin/fir/java/deserialization/JvmBinaryAnnotationDeserializer.kt#L114