### PR TITLE
Disable MultiplatformIT on Windows

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
@@ -20,6 +20,7 @@ class MultiplatformIT(useKSP2: Boolean) {
     @Test
     fun testJVM() {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("mac", ignoreCase = true))
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         val resultCleanBuild =


### PR DESCRIPTION
kotlinNpmInstall fails too often and has nothing to do with KSP.