### PR TITLE
Allow enabling KSP2 per module

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -17,14 +17,24 @@
 
 package com.google.devtools.ksp.gradle
 
+import com.google.devtools.ksp.KspExperimental
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.process.CommandLineArgumentProvider
 import javax.inject.Inject
 
 abstract class KspExtension @Inject constructor(project: Project) {
+    /**
+     * Enables or disables KSP 2, defaults to the `ksp.useKsp2` gradle property or `false` if that's not set.
+     *
+     * This API is temporary and will be removed once KSP1 is removed.
+     */
+    @KspExperimental
+    abstract val useKsp2: Property<Boolean>
+
     internal val apOptions = project.objects.mapProperty(String::class.java, String::class.java)
     internal val commandLineArgumentProviders = project.objects.listProperty(CommandLineArgumentProvider::class.java)
         .also { it.finalizeValueOnRead() }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -387,4 +387,17 @@ class GradleCompilationTest {
         assertThat(result.output).contains("HAS LIBRARY: ")
         assertThat(result.output).doesNotContain("app/build/generated/ksp/main/classes")
     }
+
+    @Test
+    fun changingKsp2AtRuntime() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.buildFileAdditions.add(
+            """
+                @OptIn(com.google.devtools.ksp.KspExperimental::class)
+                ksp { useKsp2.set(true) }
+            """.trimIndent()
+        )
+
+        testRule.runner().withArguments().build()
+    }
 }


### PR DESCRIPTION
With the change in #2034 a side effect was that KSP2 had to be enabled per Gradle project, not per module.

With this change a DSL property has been added to handle this.