### PR TITLE
getDeclarationsInSourceOrder: use AA for companion objects

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -227,7 +227,7 @@ class KSPAATest : AbstractKSPAATest() {
     @TestMetadata("declarationOrder.kt")
     @Test
     fun testDeclarationOrder() {
-        runTest("../test-utils/testData/api/declarationOrder.kt")
+        runTest("../kotlin-analysis-api/testData/declarationOrder.kt")
     }
 
     @TestMetadata("declarationUtil.kt")

--- a/kotlin-analysis-api/testData/declarationOrder.kt
+++ b/kotlin-analysis-api/testData/declarationOrder.kt
@@ -87,9 +87,9 @@
 // lib.KotlinCompanion.Companion
 // companionObjectProperty:Ljava/lang/String;
 // companionObjectPropertyJvmStatic:Ljava/lang/String;
+// companionObjectPropertyJvmField:Ljava/lang/String;
 // companionObjectPropertyLateinit:Ljava/lang/String;
 // companionObjectPropertyConst:Ljava/lang/String;
-// companionObjectPropertyJvmField:Ljava/lang/String;
 // companionObjectFunction:(Ljava/lang/String;)V
 // companionObjectFunctionJvmStatic:(Ljava/lang/String;)V
 // equals:(Ljava/lang/Object;)Z

--- a/test-utils/testData/api/declarationOrder.kt
+++ b/test-utils/testData/api/declarationOrder.kt
@@ -31,6 +31,10 @@
 // noBackingVarB:Ljava/lang/String;
 // noBackingVarA:Ljava/lang/String;
 // noBackingVarC:Ljava/lang/String;
+// privateFun:()V
+// protectedFun:()V
+// internalFun:()V
+// publicFun:()V
 // overloaded:(Ljava/lang/String;)Ljava/lang/String;
 // overloaded:(I)Ljava/lang/String;
 // overloaded:()Ljava/lang/String;
@@ -56,6 +60,10 @@
 // noBackingVarB:Ljava/lang/String;
 // noBackingVarA:Ljava/lang/String;
 // noBackingVarC:Ljava/lang/String;
+// privateFun:()V
+// protectedFun:()V
+// internalFun:()V
+// publicFun:()V
 // overloaded:(Ljava/lang/String;)Ljava/lang/String;
 // overloaded:(I)Ljava/lang/String;
 // overloaded:()Ljava/lang/String;
@@ -98,6 +106,10 @@ class KotlinClass {
     var noBackingVarC: String
         get() = ""
         set(value) {}
+    private fun privateFun(): Unit = TODO()
+    protected fun protectedFun(): Unit = TODO()
+    internal fun internalFun(): Unit = TODO()
+    fun publicFun(): Unit = TODO()
     fun overloaded(x:String): String = TODO()
     fun overloaded(x:Int): String = TODO()
     fun overloaded(): String = TODO()
@@ -139,6 +151,10 @@ class KotlinClass {
     var noBackingVarC: String
         get() = ""
         set(value) {}
+    private fun privateFun(): Unit = TODO()
+    protected fun protectedFun(): Unit = TODO()
+    internal fun internalFun(): Unit = TODO()
+    fun publicFun(): Unit = TODO()
     fun overloaded(x:String): String = TODO()
     fun overloaded(x:Int): String = TODO()
     fun overloaded(): String = TODO()


### PR DESCRIPTION
Members of companion objects can be compiled into ContainingClass.class
and ContainingClass$Companion.class. Therefore, the total ordering is
not recoverable from class files only.

Note that AA doesn't preserve the ordering among functions, static functions, and fields.

KSP1's behavior is left unchanged.

Mitigates #1898.