### PR TITLE
Fix ResolverAAImpl.asMemberOf

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -867,7 +867,7 @@ class ResolverAAImpl(
     internal fun computeAsMemberOf(function: KSFunctionDeclaration, containing: KSType): KSFunction {
         val propertyDeclaredIn = function.closestClassDeclaration()
             ?: throw IllegalArgumentException(
-                "Cannot call asMemberOf with a property that is not declared in a class or an interface"
+                "Cannot call asMemberOf with a function that is not declared in a class or an interface"
             )
         val key = function to containing
         return functionAsMemberOfCache.getOrPut(key) {
@@ -910,9 +910,7 @@ class ResolverAAImpl(
                             next = funcToSub.substitute(it)
                             cnt += 1
                         }
-                        funcToSub
-                    }.let {
-                        KSFunctionImpl(it)
+                        KSFunctionImpl(funcToSub, it)
                     }
                 }
             } else KSFunctionErrorImpl(function)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
@@ -22,29 +22,80 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.signatures.KaFunctionSignature
-import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.typeParameters
+import org.jetbrains.kotlin.analysis.api.types.KaSubstitutor
+import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
+import java.util.*
 
-class KSFunctionImpl(val ktFunctionLikeSymbol: KaFunctionSignature<KaFunctionSymbol>) : KSFunction {
+class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
+    val functionSignature: KaFunctionSignature<KaFunctionSymbol>,
+    private val substitutor: KaSubstitutor,
+) : KSFunction {
 
     override val returnType: KSType? by lazy {
-        ktFunctionLikeSymbol.returnType.let { KSTypeImpl.getCached(it) }
+        functionSignature.returnType.let { KSTypeImpl.getCached(it) }
     }
 
     override val parameterTypes: List<KSType?> by lazy {
-        ktFunctionLikeSymbol.valueParameters.map { it.returnType.let { KSTypeImpl.getCached(it) } }
+        functionSignature.valueParameters.map { it.returnType.let { KSTypeImpl.getCached(it) } }
     }
 
     @OptIn(KaExperimentalApi::class)
     override val typeParameters: List<KSTypeParameter> by lazy {
-        (ktFunctionLikeSymbol as? KaDeclarationSymbol)?.typeParameters?.map { KSTypeParameterImpl.getCached(it) }
-            ?: emptyList()
+        functionSignature.symbol.typeParameters.map { typeParam ->
+            val bounds = typeParam.upperBounds.ifNotEmpty {
+                map { bound ->
+                    // Substitude to a fixed point.
+                    var prev = bound
+                    var curr = substitutor.substitute(bound)
+                    val seen = mutableSetOf<Pair<KaType, KaType>>()
+                    while (prev != curr) {
+                        val pair = Pair(prev, curr)
+                        if (pair in seen) {
+                            val msg = "Recurrent substitution of bounds of $typeParam: $bound by $substitutor"
+                            throw IllegalStateException(msg)
+                        }
+                        seen.add(pair)
+                        prev = curr
+                        curr = substitutor.substitute(curr)
+                    }
+                    curr
+                }
+            }
+            KSTypeParameterImpl.getCached(typeParam, bounds)
+        }
     }
 
     override val extensionReceiverType: KSType? by lazy {
-        ktFunctionLikeSymbol.receiverType?.let { KSTypeImpl.getCached(it) }
+        functionSignature.receiverType?.let { KSTypeImpl.getCached(it) }
     }
 
     override val isError: Boolean = false
+
+    private val cachedHashCode by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        Objects.hash(
+            returnType ?: 0,
+            parameterTypes,
+            typeParameters,
+            extensionReceiverType ?: 0
+        )
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as KSFunctionImpl
+
+        if (returnType != other.returnType) return false
+        if (parameterTypes != other.parameterTypes) return false
+        if (typeParameters != other.typeParameters) return false
+        if (extensionReceiverType != other.extensionReceiverType) return false
+
+        return true
+    }
+
+    override fun hashCode() = cachedHashCode
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -24,14 +24,20 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeParameterSymbol
+import org.jetbrains.kotlin.analysis.api.types.KaType
 
-class KSTypeParameterImpl private constructor(internal val ktTypeParameterSymbol: KaTypeParameterSymbol) :
+class KSTypeParameterImpl private constructor(
+    internal val ktTypeParameterSymbol: KaTypeParameterSymbol,
+    private val boundsSubstitued: List<KaType>?
+) :
     KSTypeParameter,
     AbstractKSDeclarationImpl(ktTypeParameterSymbol),
     KSExpectActual by KSExpectActualImpl(ktTypeParameterSymbol) {
-    companion object : KSObjectCache<KaTypeParameterSymbol, KSTypeParameterImpl>() {
-        fun getCached(ktTypeParameterSymbol: KaTypeParameterSymbol) =
-            cache.getOrPut(ktTypeParameterSymbol) { KSTypeParameterImpl(ktTypeParameterSymbol) }
+    companion object : KSObjectCache<Pair<KaTypeParameterSymbol, List<KaType>?>, KSTypeParameterImpl>() {
+        fun getCached(ktTypeParameterSymbol: KaTypeParameterSymbol, bounds: List<KaType>? = null) =
+            cache.getOrPut(Pair(ktTypeParameterSymbol, bounds)) {
+                KSTypeParameterImpl(ktTypeParameterSymbol, bounds)
+            }
     }
 
     override val name: KSName by lazy {
@@ -49,7 +55,9 @@ class KSTypeParameterImpl private constructor(internal val ktTypeParameterSymbol
     override val isReified: Boolean = ktTypeParameterSymbol.isReified
 
     override val bounds: Sequence<KSTypeReference> by lazy {
-        ktTypeParameterSymbol.upperBounds.asSequence().mapIndexed { index, type ->
+        boundsSubstitued?.mapIndexed { index, type ->
+            KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
+        }?.asSequence() ?: ktTypeParameterSymbol.upperBounds.asSequence().mapIndexed { index, type ->
             KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
         }.ifEmpty {
             sequenceOf(

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -614,8 +614,9 @@ internal fun fillInDeepSubstitutor(context: KaType, substitutorBuilder: KaSubsti
     if (parameters.size != arguments.size) {
         throw IllegalStateException("invalid substitution for $context")
     }
-    parameters.zip(arguments).forEach {
-        substitutorBuilder.substitution(it.first, it.second.type ?: it.first.upperBounds.first())
+    parameters.zip(arguments).forEach { (param, projection) ->
+        val arg = projection.type ?: param.upperBounds.firstOrNull() ?: analyze { useSiteSession.builtinTypes.any }
+        substitutorBuilder.substitution(param, arg)
     }
     (context.symbol as? KaClassSymbol)?.superTypes?.forEach {
         fillInDeepSubstitutor(it, substitutorBuilder)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -138,11 +138,10 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/annotationWithJavaTypeValue.kt")
     }
 
-    @Disabled
     @TestMetadata("asMemberOf.kt")
     @Test
     fun testAsMemberOf() {
-        runTest("../test-utils/testData/api/asMemberOf.kt")
+        runTest("../kotlin-analysis-api/testData/asMemberOf.kt")
     }
 
     @TestMetadata("backingFields.kt")

--- a/kotlin-analysis-api/testData/asMemberOf.kt
+++ b/kotlin-analysis-api/testData/asMemberOf.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: AsMemberOfProcessor
+// EXPECTED:
+// Child1!!
+// intType: kotlin.Int!!
+// baseTypeArg1: kotlin.Int!!
+// baseTypeArg2: kotlin.String?
+// typePair: kotlin.Pair!!<kotlin.String?, kotlin.Int!!>
+// errorType: <ERROR TYPE: NonExistType>!!
+// extensionProperty: kotlin.String?
+// returnInt: () -> kotlin.Int!!
+// returnArg1: () -> kotlin.Int!!
+// returnArg1Nullable: () -> kotlin.Int?
+// returnArg2: () -> kotlin.String?
+// returnArg2Nullable: () -> kotlin.String?
+// receiveArgs: (kotlin.Int?, kotlin.Int!!, kotlin.String?) -> kotlin.Unit!!
+// receiveArgsPair: (kotlin.Pair!!<kotlin.Int!!, kotlin.String?>, kotlin.Pair?<kotlin.Int?, kotlin.String?>) -> kotlin.Unit!!
+// functionArgType: <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.String?
+// functionArgTypeWithBounds: <in T: kotlin.Int!!>(Base.functionArgTypeWithBounds.T?) -> kotlin.String?
+// extensionFunction: kotlin.Int!!.() -> kotlin.Int?
+// Child2!!<no-type>
+// intType: kotlin.Int!!
+// baseTypeArg1: kotlin.Any!!
+// baseTypeArg2: kotlin.Any?
+// typePair: kotlin.Pair!!<kotlin.Any?, kotlin.Any!!>
+// errorType: <ERROR TYPE: NonExistType>!!
+// extensionProperty: kotlin.Any?
+// returnInt: () -> kotlin.Int!!
+// returnArg1: () -> kotlin.Any!!
+// returnArg1Nullable: () -> kotlin.Any?
+// returnArg2: () -> kotlin.Any?
+// returnArg2Nullable: () -> kotlin.Any?
+// receiveArgs: (kotlin.Int?, kotlin.Any!!, kotlin.Any?) -> kotlin.Unit!!
+// receiveArgsPair: (kotlin.Pair!!<kotlin.Any!!, kotlin.Any?>, kotlin.Pair?<kotlin.Any?, kotlin.Any?>) -> kotlin.Unit!!
+// functionArgType: <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.Any?
+// functionArgTypeWithBounds: <in T: kotlin.Any!!>(Base.functionArgTypeWithBounds.T?) -> kotlin.Any?
+// extensionFunction: kotlin.Any!!.() -> kotlin.Any?
+// Child2!!<kotlin.String!!>
+// intType: kotlin.Int!!
+// baseTypeArg1: kotlin.String!!
+// baseTypeArg2: kotlin.String?
+// typePair: kotlin.Pair!!<kotlin.String?, kotlin.String!!>
+// errorType: <ERROR TYPE: NonExistType>!!
+// extensionProperty: kotlin.String?
+// returnInt: () -> kotlin.Int!!
+// returnArg1: () -> kotlin.String!!
+// returnArg1Nullable: () -> kotlin.String?
+// returnArg2: () -> kotlin.String?
+// returnArg2Nullable: () -> kotlin.String?
+// receiveArgs: (kotlin.Int?, kotlin.String!!, kotlin.String?) -> kotlin.Unit!!
+// receiveArgsPair: (kotlin.Pair!!<kotlin.String!!, kotlin.String?>, kotlin.Pair?<kotlin.String?, kotlin.String?>) -> kotlin.Unit!!
+// functionArgType: <BaseTypeArg1: kotlin.Any?>(Base.functionArgType.BaseTypeArg1?) -> kotlin.String?
+// functionArgTypeWithBounds: <in T: kotlin.String!!>(Base.functionArgTypeWithBounds.T?) -> kotlin.String?
+// extensionFunction: kotlin.String!!.() -> kotlin.String?
+// NotAChild!!
+// intType: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `intType` (Base)
+// baseTypeArg1: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `baseTypeArg1` (Base)
+// baseTypeArg2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `baseTypeArg2` (Base)
+// typePair: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `typePair` (Base)
+// errorType: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `errorType` (Base)
+// extensionProperty: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `extensionProperty` (Base)
+// returnInt: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnInt` (Base)
+// returnArg1: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1` (Base)
+// returnArg1Nullable: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg1Nullable` (Base)
+// returnArg2: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg2` (Base)
+// returnArg2Nullable: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `returnArg2Nullable` (Base)
+// receiveArgs: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `receiveArgs` (Base)
+// receiveArgsPair: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `receiveArgsPair` (Base)
+// functionArgType: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `functionArgType` (Base)
+// functionArgTypeWithBounds: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `functionArgTypeWithBounds` (Base)
+// extensionFunction: java.lang.IllegalArgumentException: NotAChild is not a sub type of the class/interface that contains `extensionFunction` (Base)
+// List#get
+// listOfStrings: (kotlin.Int!!) -> kotlin.String!!
+// setOfStrings: java.lang.IllegalArgumentException: Set<String> is not a sub type of the class/interface that contains `get` (List)
+// Set#contains
+// listOfStrings: java.lang.IllegalArgumentException: List<String> is not a sub type of the class/interface that contains `contains` (Set)
+// setOfStrings: (kotlin.String!!) -> kotlin.Boolean!!
+// JavaChild1!!
+// intType: kotlin.Int!!
+// typeArg1: kotlin.String
+// typeArg2: kotlin.Int
+// errorType: (<ERROR TYPE: NonExist>..<ERROR TYPE: NonExist>?)
+// returnArg1: () -> kotlin.Int
+// receiveArgs: (kotlin.String, kotlin.Int, kotlin.Int!!) -> kotlin.Unit!!
+// methodArgType: <BaseTypeArg1: kotlin.Any>(JavaBase.methodArgType.BaseTypeArg1, kotlin.Int) -> kotlin.Unit!!
+// methodArgTypeWithBounds: <T: kotlin.String>(JavaBase.methodArgTypeWithBounds.T) -> kotlin.Unit!!
+// fileLevelFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
+// fileLevelExtensionFunction: java.lang.IllegalArgumentException: Cannot call asMemberOf with a function that is not declared in a class or an interface
+// fileLevelProperty: java.lang.IllegalArgumentException: Cannot call asMemberOf with a property that is not declared in a class or an interface
+// errorType: java.lang.IllegalArgumentException: <ERROR TYPE: NonExistingType> is not a sub type of the class/interface that contains `get` (List)
+// expected comparison failures
+// () -> kotlin.Int!!
+// () -> kotlin.Int!!
+// (kotlin.Int!!) -> kotlin.Unit!!
+// Baz!!<kotlin.Long!!, kotlin.Number!!>
+// END
+// FILE: Input.kt
+open class Base<BaseTypeArg1, BaseTypeArg2> {
+    val intType: Int = 0
+    val baseTypeArg1: BaseTypeArg1 = TODO()
+    val baseTypeArg2: BaseTypeArg2 = TODO()
+    val typePair: Pair<BaseTypeArg2, BaseTypeArg1>  = TODO()
+    val errorType: NonExistType = TODO()
+    fun returnInt():Int = TODO()
+    fun returnArg1(): BaseTypeArg1 = TODO()
+    fun returnArg1Nullable(): BaseTypeArg1? = TODO()
+    fun returnArg2(): BaseTypeArg2 = TODO()
+    fun returnArg2Nullable(): BaseTypeArg2? = TODO()
+    fun receiveArgs(intArg:Int?, arg1: BaseTypeArg1, arg2:BaseTypeArg2):Unit = TODO()
+    fun receiveArgsPair(
+        pairs: Pair<BaseTypeArg1, BaseTypeArg2>,
+        pairNullable: Pair<BaseTypeArg1?, BaseTypeArg2?>?,
+    ):Unit = TODO()
+    // intentional type argument name conflict here to ensure it does not get replaced by mistake
+    fun <BaseTypeArg1> functionArgType(t:BaseTypeArg1?): BaseTypeArg2 = TODO()
+    fun <in T: BaseTypeArg1> functionArgTypeWithBounds(t:T?): BaseTypeArg2 = TODO()
+    fun BaseTypeArg1.extensionFunction():BaseTypeArg1? = TODO()
+    val BaseTypeArg2.extensionProperty:BaseTypeArg2? = TODO()
+}
+
+open class Child1 : Base<Int, String?>() {
+}
+
+open class Child2<ChildTypeArg1> : Base<ChildTypeArg1, ChildTypeArg1?>() {
+}
+
+class NotAChild
+val child2WithString: Child2<String> = TODO()
+val listOfStrings: List<String> = TODO()
+val setOfStrings: Set<String> = TODO()
+
+fun <T>List<T>.fileLevelExtensionFunction():Unit = TODO()
+fun <T>fileLevelFunction():Unit = TODO()
+val fileLevelProperty:Int = 3
+val errorType: NonExistingType
+
+interface KotlinInterface {
+    val x:Int
+    var y:Int
+}
+
+interface Usage : Foo<Long, Integer> {
+    fun foo(param: Foo<Double, Integer>): Foo<String, Integer>
+}
+interface Foo<V1, V2: Integer> : Bar<Baz<V1, Number>, V2> {}
+interface Bar<U1, U2: Integer> : Baz<U1, U2> {}
+interface Baz<T1, T2: Number> {
+    fun method1(): T1
+    fun method2(): T2
+}
+
+// FILE: JavaInput.java
+class JavaBase<BaseTypeArg1, BaseTypeArg2> {
+    int intType;
+    BaseTypeArg1 typeArg1;
+    BaseTypeArg2 typeArg2;
+    NonExist errorType;
+    BaseTypeArg2 returnArg1() {
+        return null;
+    }
+    void receiveArgs(BaseTypeArg1 arg1, BaseTypeArg2 arg2, int intArg) {
+    }
+    <BaseTypeArg1> void methodArgType(BaseTypeArg1 arg1, BaseTypeArg2 arg2) {
+    }
+    <T extends BaseTypeArg1> void methodArgTypeWithBounds(T arg1) {
+    }
+}
+
+class JavaChild1 extends JavaBase<String, Integer> {
+}
+
+class JavaImpl implements KotlinInterface {
+    public int getX() {
+        return 1;
+    }
+    public int getY() {
+        return 1;
+    }
+    public void setY(int value) {
+    }
+}


### PR DESCRIPTION
1. Implement substitution of type parameters. Ideally they should be provided by AA.

2. Substitute to Any if the destination is star without bounds.

3. Fork the test case where nullabilities are incorrect in KSP1.

Fixes #1642 