### PR TITLE
Update utils.kt

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -73,15 +73,18 @@ fun Resolver.getPropertyDeclarationByName(name: String, includeTopLevel: Boolean
 /**
  * Find the containing file of a KSNode.
  * @return KSFile if the given KSNode has a containing file.
- * exmample of symbols without a containing file: symbols from class files, synthetic symbols created by user.
+ * example of symbols without a containing file: symbols from class files, synthetic symbols created by user.
  */
 val KSNode.containingFile: KSFile?
     get() {
-        var parent = this.parent
-        while (parent != null && parent !is KSFile) {
-            parent = parent.parent
+        var current: KSNode? = this.parent
+        while (current != null) {
+            if (current is KSFile) {
+                return current
+            }
+            current = current.parent
         }
-        return parent as? KSFile?
+        return null
     }
 
 /**


### PR DESCRIPTION
**Variable Naming:** Changed `parent` to `current` to better reflect its role in the loop. This makes it clearer that we are traversing up the hierarchy.

**Early Return:** Instead of casting `parent` to `KSFile?` at the end, we check if `current` is an instance of `KSFile` during each iteration. If it is, we return it immediately. This avoids unnecessary casting and enhances readability.

**Null Return:** The method now directly returns `null` when no containing file is found, which is more idiomatic in Kotlin.