### PR TITLE
Replace ':' with File.pathSeparator in command line arguments

### DIFF
--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
@@ -474,13 +474,13 @@ fun parseFile(arg: String): File {
 fun <T> parseList(arg: String, transform: (String) -> T): List<T> {
     if (arg.length > 0 && arg[0] == '-')
         throw IllegalArgumentException("expecting a List but got $arg")
-    return arg.split(':').map { transform(it) }
+    return arg.split(File.pathSeparatorChar).map { transform(it) }
 }
 
 fun <T> parseMap(arg: String, transform: (String) -> T): Map<String, T> {
     if (arg.length > 0 && arg[0] == '-')
         throw IllegalArgumentException("expecting a Map but got $arg")
-    return arg.split(':').map {
+    return arg.split(File.pathSeparatorChar).map {
         val (k, v) = it.split('=')
         k to transform(v)
     }.toMap()

--- a/common-deps/src/test/kotlin/com/google/devtools/ksp/CommandLineArgParserTest.kt
+++ b/common-deps/src/test/kotlin/com/google/devtools/ksp/CommandLineArgParserTest.kt
@@ -9,9 +9,10 @@ import java.io.File
 class CommandLineArgParserTest {
     @Test
     fun testJvm() {
+        val sep = File.pathSeparator
         val args = arrayListOf<String>(
             "-module-name=MyModule",
-            "-source-roots", "/path/to/A:/path/to/B",
+            "-source-roots", "/path/to/A$sep/path/to/B",
             "/path/to/processorA.jar",
             "-kotlin-output-dir=/path/to/output/kotlin",
             "-java-output-dir=/path/to/output/java",
@@ -23,7 +24,7 @@ class CommandLineArgParserTest {
             "-project-base-dir", "/path/to/base",
             "-output-base-dir", "/path/to/output",
             "-caches-dir", "/path/to/caches",
-            "/path/to/processorB.jar:rel/to/processorC.jar",
+            "/path/to/processorB.jar${sep}rel/to/processorC.jar",
         ).toTypedArray()
         val (config, classpath) = kspJvmArgParser(args)
         Assert.assertEquals(

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -28,8 +28,8 @@ internal fun printHelpMsg(optionsList: String) {
     println(optionsList)
     println("where:")
     println(" * is required")
-    println(" List is colon separated. E.g., arg1:arg2:arg3")
-    println(" Map is in the form key1=value1:key2=value2")
+    println(" List is <path-separator> separated. E.g., arg1:arg2:arg3 on Linux/Mac, or arg1;arg2;arg3 on Windows")
+    println(" Map is in the form key1=value1:key2=value2 on Linux/Mac or key1=value1;key2=value2 on Windows")
 }
 
 internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSPConfig, List<String>>) {


### PR DESCRIPTION
':' is a valid character in path on Windows.

Fixes #2046 