### PR TITLE
Don't drop caches before finish/onError

### DIFF
--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
@@ -5,6 +5,8 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.validate
 
 class MultipleroundProcessor : AbstractTestProcessor() {
     val result = mutableListOf<String>()
@@ -46,8 +48,18 @@ class MultipleroundProcessor : AbstractTestProcessor() {
         val allFiles = resolver.getAllFiles().map { it.fileName }
         result.add(allFiles.map { if (it in newFiles) "+$it" else it }.sorted().joinToString())
 
+        filesFromLastRound = resolver.getAllFiles()
         round++
         return emptyList()
+    }
+
+    lateinit var filesFromLastRound: Sequence<KSFile>
+
+    override fun finish() {
+        val allFiles = filesFromLastRound.map { it.fileName }.joinToString(", ")
+        result.add("Finish: $allFiles")
+        assert(filesFromLastRound.all { it.validate() })
+        super.finish()
     }
 
     lateinit var env: SymbolProcessorEnvironment

--- a/test-utils/testData/api/multipleround.kt
+++ b/test-utils/testData/api/multipleround.kt
@@ -45,6 +45,7 @@
 // K : I0, I1, I2, I3, I4, I5
 // J : I0, I1, I2, I3, I4, I5
 // +I5.java, I0.kt, I1.java, I2.kt, I3.java, I4.kt, J.java, K.kt
+// Finish: K.kt, J.java, I0.kt, I1.java, I2.kt, I3.java, I4.kt, I5.java
 // END
 
 // FILE: K.kt


### PR DESCRIPTION
This is a temporary workaround for Room. The proper solution is providing `Processor.finish(resolver: Resolver)` and `Processor.onError(resolver: Resolver)` after KSP1 is deprecated.