### PR TITLE
Support AGP's built-in Kotlin compilation

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -53,7 +53,7 @@ object AndroidPluginIntegration {
     private fun decorateAndroidExtension(project: Project, onSourceSet: (String) -> Unit) {
         val sourceSets = when (val androidExt = project.extensions.getByName("android")) {
             is BaseExtension -> androidExt.sourceSets
-            is CommonExtension<*, *, *, *> -> androidExt.sourceSets
+            is CommonExtension<*, *, *, *, *, *> -> androidExt.sourceSets
             else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
         }
         sourceSets.all {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -399,4 +399,19 @@ class GradleCompilationTest {
 
         testRule.runner().withArguments().build()
     }
+
+    /**
+     * Regression test for b/362279380
+     */
+    @Test
+    fun androidGradlePluginBuiltInKotlin() {
+        testRule.setupAppAsAndroidApp(enableAgpBuiltInKotlinSupport = true)
+        testRule.appModule.dependencies.addAll(
+            listOf(
+                artifact(configuration = "ksp", "androidx.room:room-compiler:2.4.2"),
+                artifact(configuration = "kspTest", "androidx.room:room-compiler:2.4.2")
+            )
+        )
+        testRule.runner().withArguments(":app:assembleDebug").build()
+    }
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -92,16 +92,23 @@ class KspIntegrationTestRule(
 
     /**
      * Sets up the app module as an android app, adding necessary plugin dependencies, a manifest
-     * file and necessary gradle configuration.
+     * file and necessary gradle configuration. If [enableAgpBuiltInKotlinSupport] is true, enable AGP's built-in Kotlin
+     * support instead of applying the Kotlin Android Gradle plugin.
      */
-    fun setupAppAsAndroidApp() {
+    fun setupAppAsAndroidApp(enableAgpBuiltInKotlinSupport: Boolean = false) {
         testProject.appModule.plugins.addAll(
             listOf(
                 PluginDeclaration.id("com.android.application", testConfig.androidBaseVersion),
-                PluginDeclaration.kotlin("android", testConfig.kotlinBaseVersion),
                 PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion)
             )
         )
+        if (enableAgpBuiltInKotlinSupport) {
+            testProject.appModule
+                .plugins
+                .add(PluginDeclaration.id("com.android.experimental.built-in-kotlin", testConfig.androidBaseVersion))
+        } else {
+            testProject.appModule.plugins.add(PluginDeclaration.kotlin("android", testConfig.kotlinBaseVersion))
+        }
         addAndroidBoilerplate()
     }
 
@@ -126,10 +133,14 @@ class KspIntegrationTestRule(
             """
             android {
                 namespace = "com.example.kspandroidtestapp"
-                compileSdkVersion(31)
+                compileSdk = 31
                 defaultConfig {
-                    minSdkVersion(24)
+                    minSdk = 24
                 }
+            }
+            
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib:${testConfig.kotlinBaseVersion}")
             }
             """.trimIndent()
         )

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=2.1.0-dev-5441
-agpBaseVersion=8.0.2
+agpBaseVersion=8.7.0
 intellijVersion=233.13135.103
 junitVersion=4.13.1
 junit5Version=5.8.2

--- a/integration-tests/src/test/resources/android-view-binding/app/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-view-binding/app/build.gradle.kts
@@ -12,7 +12,7 @@ dependencies {
 android {
     namespace = "com.example.kspandroidtestapp"
     defaultConfig {
-        minSdkVersion(24)
+        minSdk = 24
     }
     compileSdk = 34
     buildFeatures { 

--- a/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
@@ -20,11 +20,11 @@ dependencies {
 
 android {
     namespace = "com.example.myapplication"
-    compileSdkVersion(34)
+    compileSdk = 34
     defaultConfig {
         applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
-        minSdkVersion(34)
-        targetSdkVersion(34)
+        minSdk = 34
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }

--- a/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
@@ -23,10 +23,10 @@ dependencies {
 
 android {
     namespace = "com.example.mylibrary"
-    compileSdkVersion(34)
+    compileSdk = 34
     defaultConfig {
-        minSdkVersion(34)
-        targetSdkVersion(34)
+        minSdk = 34
+        targetSdk = 34
     }
 }
 

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -23,11 +23,11 @@ dependencies {
 
 android {
     namespace = "com.example.myapplication"
-    compileSdkVersion(34)
+    compileSdk = 34
     defaultConfig {
         applicationId = "org.gradle.kotlin.dsl.samples.androidstudio"
-        minSdkVersion(34)
-        targetSdkVersion(34)
+        minSdk = 34
+        targetSdk = 34
         versionCode = 1
         versionName = "1.0"
     }


### PR DESCRIPTION
Previously, the sourceSet-specific KSP configurations (e.g., kspTest) weren't being created when AGP's built-in Kotlin compilation was enabled.

This change also increases the AGP version to 8.7.0-beta01 in order to test against a version of AGP with the built-in Kotlin support.

Bug: b/362279380
Test: GradleCompilationTest