### PR TITLE
Copy javadoc and sources in publishing tasks

### DIFF
--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -224,14 +224,16 @@ tasks {
         from(copyDeps)
         filter { it.replaceWithKsp() }
     }
-
-    withType<PublishToMavenRepository> { dependsOn("signShadowPublication") }
-    withType<PublishToMavenLocal> { dependsOn("signShadowPublication") }
+    val javadocJar by creating(Jar::class) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        archiveClassifier.set("javadoc")
+        from(project(":kotlin-analysis-api").tasks["dokkaJavadocJar"])
+    }
 
     publish {
         dependsOn(shadowJar)
         dependsOn(sourcesJar)
-        dependsOn(project(":kotlin-analysis-api").tasks["dokkaJavadocJar"])
+        dependsOn(javadocJar)
     }
 }
 
@@ -239,7 +241,7 @@ publishing {
     publications {
         create<MavenPublication>("shadow") {
             artifactId = "symbol-processing-aa-embeddable"
-            artifact(project(":kotlin-analysis-api").tasks["dokkaJavadocJar"])
+            artifact(tasks["javadocJar"])
             artifact(tasks["sourcesJar"])
             artifact(tasks["shadowJar"])
             pom {

--- a/symbol-processing-cmdline/build.gradle.kts
+++ b/symbol-processing-cmdline/build.gradle.kts
@@ -34,10 +34,20 @@ tasks.withType<ShadowJar>() {
 }
 
 tasks {
+    val sourcesJar by creating(Jar::class) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        archiveClassifier.set("sources")
+        from(project(":kotlin-analysis-api").sourceSets.main.get().allSource)
+    }
+    val javadocJar by creating(Jar::class) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        archiveClassifier.set("javadoc")
+        from(project(":compiler-plugin").tasks["dokkaJavadocJar"])
+    }
     publish {
         dependsOn(shadowJar)
-        dependsOn(project(":compiler-plugin").tasks["dokkaJavadocJar"])
-        dependsOn(project(":compiler-plugin").tasks["sourcesJar"])
+        dependsOn(javadocJar)
+        dependsOn(sourcesJar)
     }
 }
 
@@ -45,9 +55,9 @@ publishing {
     publications {
         create<MavenPublication>("shadow") {
             artifactId = "symbol-processing-cmdline"
+            artifact(tasks["javadocJar"])
+            artifact(tasks["sourcesJar"])
             artifact(tasks["shadowJar"])
-            artifact(project(":compiler-plugin").tasks["dokkaJavadocJar"])
-            artifact(project(":compiler-plugin").tasks["sourcesJar"])
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing-cmdline")
                 description.set("Symbol processing for K/N and command line")

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -35,10 +35,20 @@ tasks.withType<ShadowJar> {
 }
 
 tasks {
+    val sourcesJar by creating(Jar::class) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        archiveClassifier.set("sources")
+        from(project(":kotlin-analysis-api").sourceSets.main.get().allSource)
+    }
+    val javadocJar by creating(Jar::class) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        archiveClassifier.set("javadoc")
+        from(project(":compiler-plugin").tasks["dokkaJavadocJar"])
+    }
     publish {
         dependsOn(shadowJar)
-        dependsOn(project(":compiler-plugin").tasks["dokkaJavadocJar"])
-        dependsOn(project(":compiler-plugin").tasks["sourcesJar"])
+        dependsOn(javadocJar)
+        dependsOn(sourcesJar)
     }
 }
 
@@ -46,8 +56,8 @@ publishing {
     publications {
         create<MavenPublication>("shadow") {
             artifactId = "symbol-processing"
-            artifact(project(":compiler-plugin").tasks["dokkaJavadocJar"])
-            artifact(project(":compiler-plugin").tasks["sourcesJar"])
+            artifact(tasks["javadocJar"])
+            artifact(tasks["sourcesJar"])
             artifact(tasks["shadowJar"])
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing")


### PR DESCRIPTION
so that signing doesn't happen in-place and introduce dangling artifacts.