### PR TITLE
Close ksp caches on exception and error

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -310,6 +310,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                         processor.process(resolver).filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
                 }?.let {
                     resolver.tearDown()
+                    incrementalContext.closeFiles()
                     return it
                 }
                 if (logger.hasError()) {
@@ -336,9 +337,11 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                     processor.onError()
                 }?.let {
                     resolver.tearDown()
+                    incrementalContext.closeFiles()
                     return it
                 }
             }
+            incrementalContext.closeFiles()
         } else {
             if (finished) {
                 processors.forEach { processor ->
@@ -346,6 +349,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                         processor.finish()
                     }?.let {
                         resolver.tearDown()
+                        incrementalContext.closeFiles()
                         return it
                     }
                 }
@@ -364,6 +368,8 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                         codeGenerator.outputs,
                         codeGenerator.sourceToOutputs
                     )
+                } else {
+                    incrementalContext.closeFiles()
                 }
             }
         }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -135,14 +135,9 @@ class KMPImplementedIT(val useKSP2: Boolean) {
         setup(shouldFail = true)
         gradleRunner.withArguments("compileKotlinJvm").buildAndFail()
 
-        // Triggers the caching issue
+        // Should not trigger the caching issue
         setup(shouldFail = false)
-        gradleRunner.withArguments("compileKotlinJvm")
-            .buildAndFail().let { result ->
-                println("OUTPUT START")
-                println(result.output)
-                Assert.assertTrue(result.output.contains("id-to-file.tab] is already registered"))
-            }
+        gradleRunner.withArguments("compileKotlinJvm").build()
     }
 
     @Test

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
@@ -1,0 +1,61 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class KotlinInjectIT(val useKSP2: Boolean) {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("kotlin-inject", useKSP2 = useKSP2)
+
+    @Test
+    fun triggerException() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val path = "workload/src/commonMain/kotlin/AppComponent.kt"
+        val file = File(project.root, path)
+
+        fun setup(shouldFail: Boolean) {
+            project.restore(path)
+
+            // kotlin-inject will complain that Component classes can't be private
+            if (shouldFail) {
+                file
+                    .apply {
+                        writeText(
+                            file.readText()
+                                .replace("abstract class AppComponent", "private abstract class AppComponent")
+                        )
+                    }
+            }
+        }
+
+        // Start the kotlin daemon?
+        setup(shouldFail = false)
+        gradleRunner.withArguments("compileKotlinJvm").build()
+
+        // Make a processor fail
+        setup(shouldFail = true)
+        gradleRunner.withArguments("compileKotlinJvm").buildAndFail()
+
+        // Triggers the caching issue
+        setup(shouldFail = false)
+        gradleRunner.withArguments("compileKotlinJvm")
+            .buildAndFail().let { result ->
+                println("OUTPUT START")
+                println(result.output)
+                Assert.assertTrue(result.output.contains("id-to-file.tab] is already registered"))
+            }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "KSP2={0}")
+        fun params() = listOf(arrayOf(true), arrayOf(false))
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
@@ -1,7 +1,6 @@
 package com.google.devtools.ksp.test
 
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -43,14 +42,9 @@ class KotlinInjectIT(val useKSP2: Boolean) {
         setup(shouldFail = true)
         gradleRunner.withArguments("compileKotlinJvm").buildAndFail()
 
-        // Triggers the caching issue
+        // Should not trigger the caching issue
         setup(shouldFail = false)
-        gradleRunner.withArguments("compileKotlinJvm")
-            .buildAndFail().let { result ->
-                println("OUTPUT START")
-                println(result.output)
-                Assert.assertTrue(result.output.contains("id-to-file.tab] is already registered"))
-            }
+        gradleRunner.withArguments("compileKotlinJvm").build()
     }
 
     companion object {

--- a/integration-tests/src/test/resources/kmp/annotations/src/commonMain/kotlin/com/example/TriggerExceptionAnnotation.kt
+++ b/integration-tests/src/test/resources/kmp/annotations/src/commonMain/kotlin/com/example/TriggerExceptionAnnotation.kt
@@ -1,0 +1,3 @@
+package com.example
+
+annotation class TriggerExceptionAnnotation

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TriggerExceptionProcessor.kt
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TriggerExceptionProcessor.kt
@@ -1,0 +1,35 @@
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.validate
+
+class TriggerExceptionProcessor(val codeGenerator: CodeGenerator, val logger: KSPLogger) : SymbolProcessor {
+    var invoked = false
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (invoked) {
+            return emptyList()
+        }
+        invoked = true
+
+        val symbols = resolver.getSymbolsWithAnnotation("com.example.TriggerExceptionAnnotation")
+        if (symbols.any()) {
+            logger.error("Exception triggered")
+            error("Exception triggered")
+        }
+
+        codeGenerator.createNewFile(
+            Dependencies(true),
+            "",
+            "NoTrigger",
+            "kt"
+        )
+
+        return emptyList()
+    }
+}
+
+class TriggerExceptionProvider : SymbolProcessorProvider {
+    override fun create(env: SymbolProcessorEnvironment): SymbolProcessor {
+        return TriggerExceptionProcessor(env.codeGenerator, env.logger)
+    }
+}

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,3 +1,5 @@
 TestProcessorProvider
 ValidateProcessorProvider
 ErrorProcessorProvider
+TriggerExceptionProvider
+

--- a/integration-tests/src/test/resources/kmp/workload/src/commonMain/kotlin/com/example/FooBar.kt
+++ b/integration-tests/src/test/resources/kmp/workload/src/commonMain/kotlin/com/example/FooBar.kt
@@ -1,0 +1,4 @@
+package com.example
+
+//@TriggerExceptionAnnotation
+class FooBar

--- a/integration-tests/src/test/resources/kotlin-inject/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-inject/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    kotlin("multiplatform") apply false
+}
+
+val testRepo: String by project
+allprojects {
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}

--- a/integration-tests/src/test/resources/kotlin-inject/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-inject/settings.gradle.kts
@@ -1,0 +1,20 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("multiplatform") version kotlinVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    }
+}
+
+rootProject.name = "hmpp"
+
+include(":workload")
+include(":test-processor")

--- a/integration-tests/src/test/resources/kotlin-inject/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-inject/workload/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    kotlin("multiplatform")
+    id("com.google.devtools.ksp")
+}
+
+version = "1.0-SNAPSHOT"
+
+kotlin {
+    jvm {
+        withJava()
+    }
+
+    sourceSets {
+        val commonMain by getting {
+            dependencies {
+                implementation("me.tatarka.inject:kotlin-inject-runtime:0.7.2")
+            }
+        }
+
+        val jvmMain by getting {
+        }
+    }
+}
+
+dependencies {
+    add("kspJvm", "me.tatarka.inject:kotlin-inject-compiler-ksp:0.7.2")
+}

--- a/integration-tests/src/test/resources/kotlin-inject/workload/src/commonMain/kotlin/AppComponent.kt
+++ b/integration-tests/src/test/resources/kotlin-inject/workload/src/commonMain/kotlin/AppComponent.kt
@@ -1,0 +1,8 @@
+@me.tatarka.inject.annotations.Component
+abstract class AppComponent {
+    abstract val repo: Repository
+
+}
+
+@me.tatarka.inject.annotations.Inject
+class Repository()

--- a/integration-tests/src/test/resources/kotlin-inject/workload/src/commonMain/kotlin/CommonMain.kt
+++ b/integration-tests/src/test/resources/kotlin-inject/workload/src/commonMain/kotlin/CommonMain.kt
@@ -1,0 +1,1 @@
+class CommonMain

--- a/integration-tests/src/test/resources/kotlin-inject/workload/src/jvmMain/kotlin/JvmMain.kt
+++ b/integration-tests/src/test/resources/kotlin-inject/workload/src/jvmMain/kotlin/JvmMain.kt
@@ -1,0 +1,1 @@
+class JvmMain

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -212,13 +212,13 @@ abstract class IncrementalContextBase(
     // Beware: no side-effects here; Caches should only be touched in updateCaches.
     fun calcDirtyFiles(ksFiles: List<KSFile>): Collection<KSFile> = closeFilesOnException {
         if (!isIncremental) {
-            return ksFiles
+            return@closeFilesOnException ksFiles
         }
 
         if (rebuild) {
             collectDefinedSymbols(ksFiles)
             logDirtyFiles(ksFiles, ksFiles)
-            return ksFiles
+            return@closeFilesOnException ksFiles
         }
 
         val newSyms = mutableSetOf<LookupSymbolWrapper>()
@@ -286,7 +286,7 @@ abstract class IncrementalContextBase(
             dirtyFilesByNewSyms,
             dirtyFilesBySealed
         )
-        return ksFiles.filter { it.relativeFile in dirtyFiles }
+        return@closeFilesOnException ksFiles.filter { it.relativeFile in dirtyFiles }
     }
 
     // Loop detection isn't needed because of overwritten checks in CodeGeneratorImpl
@@ -404,17 +404,21 @@ abstract class IncrementalContextBase(
         collectDefinedSymbols(newFiles)
     }
 
-    private inline fun <T> closeFilesOnException(f: () -> T): T {
+    fun <T> closeFilesOnException(f: () -> T): T {
         try {
             return f()
         } catch (e: Exception) {
-            symbolsMap.flush()
-            sealedMap.flush()
-            symbolLookupCache.close()
-            classLookupCache.close()
-            sourceToOutputsMap.flush()
+            closeFiles()
             throw e
         }
+    }
+
+    fun closeFiles() {
+        symbolsMap.flush()
+        sealedMap.flush()
+        symbolLookupCache.close()
+        classLookupCache.close()
+        sourceToOutputsMap.flush()
     }
 
     // TODO: add a wildcard for outputs with no source and get rid of the outputs parameter.
@@ -424,7 +428,7 @@ abstract class IncrementalContextBase(
         sourceToOutputs: Map<File, Set<File>>,
     ) = closeFilesOnException {
         if (!isIncremental)
-            return
+            return@closeFilesOnException
 
         cachesUpToDateFile.delete()
         assert(!cachesUpToDateFile.exists())

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -548,9 +548,11 @@ class KotlinSymbolProcessing(
                 ResolverAAImpl.instance.propertyAsMemberOfCache = mutableMapOf()
 
                 processors.forEach {
-                    deferredSymbols[it] =
-                        it.process(resolver).filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
-                            .filterIsInstance<Deferrable>().mapNotNull(Deferrable::defer)
+                    incrementalContext.closeFilesOnException {
+                        deferredSymbols[it] =
+                            it.process(resolver).filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
+                                .filterIsInstance<Deferrable>().mapNotNull(Deferrable::defer)
+                    }
                     if (!deferredSymbols.containsKey(it) || deferredSymbols[it]!!.isEmpty()) {
                         deferredSymbols.remove(it)
                     }
@@ -591,6 +593,8 @@ class KotlinSymbolProcessing(
                     codeGenerator.outputs,
                     codeGenerator.sourceToOutputs
                 )
+            } else {
+                incrementalContext.closeFiles()
             }
 
             dropCaches()


### PR DESCRIPTION
Previously, LookupCache doesn't need to be explicitly closed. With newer intellij dependencies that comes with Kotlin 2.0.20 it becomes a problem.

Test cases are contributed by @asapha

Fixes #2072 