### PR TITLE
Expand inline classes before mapping to jvm types

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -759,17 +759,10 @@ class ResolverAAImpl(
             return if (this is KSTypeImpl) {
                 analyze {
                     val decl = (this@toSignature.declaration as? KSClassDeclaration)
-                    // special handling for single parameter inline value class
-                    // unwrap the underlying for jvm signature.
-                    if (
-                        decl != null &&
-                        (decl.modifiers.contains(Modifier.INLINE) || decl.modifiers.contains(Modifier.VALUE)) &&
-                        decl.primaryConstructor?.parameters?.size == 1
-                    ) {
-                        decl.primaryConstructor!!.parameters.single().type.resolve().toSignature()
-                    } else {
-                        this@toSignature.type.toSignature()
-                    }
+                    // Force inline value class to be unwrapped.
+                    // Do not remove until AA fixes this.
+                    decl?.primaryConstructor
+                    type.toSignature()
                 }
             } else {
                 "<ERROR>"
@@ -778,7 +771,7 @@ class ResolverAAImpl(
 
         return when (ksAnnotated) {
             is KSClassDeclaration -> analyze {
-                (ksAnnotated.asStarProjectedType() as KSTypeImpl).type.mapToJvmType().descriptor
+                (ksAnnotated.asStarProjectedType() as KSTypeImpl).toSignature()
             }
             is KSFunctionDeclarationImpl -> {
                 analyze {

--- a/kotlin-analysis-api/testData/signatureMapper.kt
+++ b/kotlin-analysis-api/testData/signatureMapper.kt
@@ -21,6 +21,7 @@
 // a: I
 // foo: ()Ljava/lang/String;
 // f: ()I
+// g: ()I
 // <init>: ()V
 // LJavaIntefaceWithVoid;
 // getVoid: ()Ljava/lang/Void;
@@ -47,7 +48,10 @@ class Cls {
 
     fun foo(): String { return "1" }
 
-    fun f(): MyInlineClass = 1
+    @JvmName("f")
+    fun f(): MyInlineClass = TODO()
+
+    fun g(): MyInlineClass = TODO()
 }
 
 // FILE: JavaIntefaceWithVoid.java

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 
 @KspExperimental
 class MapSignatureProcessor : AbstractTestProcessor() {
@@ -37,7 +38,16 @@ class MapSignatureProcessor : AbstractTestProcessor() {
             }.forEach { subject ->
                 result.add(resolver.mapToJvmSignature(subject)!!)
                 subject.declarations.forEach {
+                    if (it is KSFunctionDeclaration) {
+                        val decl = it.returnType!!.resolve().declaration
+                        println("before: ${it.simpleName.asString()}: ${resolver.mapToJvmSignature(decl)}")
+                    }
                     result.add(it.simpleName.asString() + ": " + resolver.mapToJvmSignature(it))
+                    if (it is KSFunctionDeclaration) {
+                        val decl = it.returnType!!.resolve().declaration
+                        println("after: ${it.simpleName.asString()}: ${resolver.mapToJvmSignature(decl)}")
+                    }
+
                 }
             }
         return emptyList()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -38,16 +38,16 @@ class MapSignatureProcessor : AbstractTestProcessor() {
             }.forEach { subject ->
                 result.add(resolver.mapToJvmSignature(subject)!!)
                 subject.declarations.forEach {
+                    var returnTypeSignature: String? = null
                     if (it is KSFunctionDeclaration) {
                         val decl = it.returnType!!.resolve().declaration
-                        println("before: ${it.simpleName.asString()}: ${resolver.mapToJvmSignature(decl)}")
+                        returnTypeSignature = resolver.mapToJvmSignature(decl)
                     }
                     result.add(it.simpleName.asString() + ": " + resolver.mapToJvmSignature(it))
                     if (it is KSFunctionDeclaration) {
                         val decl = it.returnType!!.resolve().declaration
-                        println("after: ${it.simpleName.asString()}: ${resolver.mapToJvmSignature(decl)}")
+                        assert(returnTypeSignature == resolver.mapToJvmSignature(decl))
                     }
-
                 }
             }
         return emptyList()

--- a/test-utils/testData/api/signatureMapper.kt
+++ b/test-utils/testData/api/signatureMapper.kt
@@ -21,6 +21,7 @@
 // a: I
 // foo: ()Ljava/lang/String;
 // f: ()I
+// g: ()I
 // <init>: ()V
 // LJavaIntefaceWithVoid;
 // getVoid: ()Ljava/lang/Void;
@@ -47,7 +48,10 @@ class Cls {
 
     fun foo(): String { return "1" }
 
-    fun f(): MyInlineClass = 1
+    @JvmName("f")
+    fun f(): MyInlineClass = TODO()
+
+    fun g(): MyInlineClass = TODO()
 }
 
 // FILE: JavaIntefaceWithVoid.java


### PR DESCRIPTION
by requesting AA to do so implicitly.

Fixes #2109 