### PR TITLE
Filter default arguments by name, not by index 

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -92,6 +92,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("../test-utils/testData/api/annotationValue_java.kt")
     }
 
+    @TestMetadata("annotationValue_java2.kt")
+    @Test
+    fun testAnnotationValue_java2() {
+        runTest("../test-utils/testData/api/annotationValue_java2.kt")
+    }
+
     @TestMetadata("annotationValue_kt.kt")
     @Test
     fun testAnnotationValue_kt() {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -90,9 +90,11 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
                 )
             }
             val presentValueArgumentNames = presentArgs.map { it.name?.asString() ?: "" }
-            presentArgs + defaultArguments.filterIndexed { idx, ksValueArgument ->
-                ksValueArgument.name?.asString() !in presentValueArgumentNames &&
-                    annotationConstructor?.valueParameters?.get(idx)?.hasDefaultValue == true
+            presentArgs + defaultArguments.filter { ksValueArgument ->
+                val name = ksValueArgument.name?.asString() ?: return@filter false
+                if (name in presentValueArgumentNames)
+                    return@filter false
+                annotationConstructor?.valueParameters?.any { it.name.asString() == name && it.hasDefaultValue } == true
             }
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -60,8 +60,11 @@ class KSAnnotationResolvedImpl private constructor(
             val annotationClass = annotationApplication.classId?.toKtClassSymbol()
             val annotationConstructor = annotationClass?.memberScope?.constructors?.singleOrNull()
             val params = annotationConstructor?.valueParameters
-            defaultArguments.filterIndexed { idx, arg ->
-                arg.name?.asString() !in presentNames && params?.get(idx)?.hasDefaultValue == true
+            defaultArguments.filter { arg ->
+                val name = arg.name?.asString() ?: return@filter false
+                if (name in presentNames)
+                    return@filter false
+                params?.any { it.name.asString() == name && it.hasDefaultValue } == true
             }
         }
         presentArgs + absentArgs

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -106,6 +106,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../kotlin-analysis-api/testData/annotationValue/annotationValue_java.kt")
     }
 
+    @TestMetadata("annotationValue_java2.kt")
+    @Test
+    fun testAnnotationValue_java2() {
+        runTest("../kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt")
+    }
+
     @TestMetadata("annotationValue_kt.kt")
     @Test
     fun testAnnotationValue_kt() {

--- a/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
+++ b/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
@@ -21,9 +21,12 @@
 // MyClass: MyAnnotation: stringParam = 2
 // MyClass: MyAnnotation: stringParam2 = 1
 // MyClass: MyAnnotation: stringArrayParam = [3, 5, 7]
-// MyClassInLib: MyAnnotation: stringParam = 2
-// MyClassInLib: MyAnnotation: stringParam2 = 1
-// MyClassInLib: MyAnnotation: stringArrayParam = [3, 5, 7]
+// MyClass: MyAnnotationInLib: stringParam = 2
+// MyClass: MyAnnotationInLib: stringParam2 = 1
+// MyClass: MyAnnotationInLib: stringArrayParam = [3, 5, 7]
+// MyClassInLib: MyAnnotationInLib: stringParam = 2
+// MyClassInLib: MyAnnotationInLib: stringParam2 = 1
+// MyClassInLib: MyAnnotationInLib: stringArrayParam = [3, 5, 7]
 // Str
 // 42
 // Foo
@@ -49,8 +52,8 @@
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.TYPE_USE})
-@interface MyAnnotation {
-    String stringParam() default "1";
+@interface MyAnnotationInLib {
+    String stringParam();
     String stringParam2() default "1";
     String[] stringArrayParam() default {"3", "5", "7"};
 }
@@ -61,7 +64,7 @@ import java.lang.annotation.Target;
 }
 
 interface MyInterface {}
-@MyAnnotation(stringParam = "2") class MyClassInLib implements MyInterface {}
+@MyAnnotationInLib(stringParam = "2") class MyClassInLib implements MyInterface {}
 
 // FILE: OtherAnnotation.java
 import java.lang.annotation.Retention;
@@ -80,7 +83,20 @@ annotation class KotlinAnnotationWithDefaults(val otherAnnotation: OtherAnnotati
 
 // MODULE: main(module1)
 // FILE: Test.java
-@MyAnnotation(stringParam = "2") class MyClass implements MyInterface {}
+@Target({ElementType.TYPE, ElementType.TYPE_USE})
+@interface MyAnnotation {
+    String stringParam();
+    String stringParam2() default "1";
+    String[] stringArrayParam() default {"3", "5", "7"};
+}
+
+@Target({ElementType.TYPE, ElementType.TYPE_USE})
+@interface MyAnnotation {
+    String stringParam();
+    String stringParam2() default "1";
+    String[] stringArrayParam() default {"3", "5", "7"};
+}
+@MyAnnotation(stringParam = "2") @MyAnnotationInLib(stringParam = "2")  class MyClass implements MyInterface {}
 
 // FILE: a.kt
 enum class RGB {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -28,8 +28,12 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         listOf("MyClass", "MyClassInLib").forEach { clsName ->
             resolver.getClassDeclarationByName(clsName)?.let { cls ->
-                cls.annotations.single().arguments.forEach {
-                    results.add("$clsName: ${it.name!!.asString()} = ${it.value}")
+                cls.annotations.forEach() { annotation ->
+                    annotation.arguments.forEach {
+                        results.add(
+                            "$clsName: ${annotation.shortName.asString()}: ${it.name!!.asString()} = ${it.value}"
+                        )
+                    }
                 }
             }
         }

--- a/test-utils/testData/api/annotationValue_java.kt
+++ b/test-utils/testData/api/annotationValue_java.kt
@@ -18,12 +18,12 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: AnnotationArgumentProcessor
 // EXPECTED:
-// MyClass: stringParam = 2
-// MyClass: stringParam2 = 1
-// MyClass: stringArrayParam = [3, 5, 7]
-// MyClassInLib: stringParam = 2
-// MyClassInLib: stringParam2 = 1
-// MyClassInLib: stringArrayParam = [3, 5, 7]
+// MyClass: MyAnnotation: stringParam = 2
+// MyClass: MyAnnotation: stringParam2 = 1
+// MyClass: MyAnnotation: stringArrayParam = [3, 5, 7]
+// MyClassInLib: MyAnnotation: stringParam = 2
+// MyClassInLib: MyAnnotation: stringParam2 = 1
+// MyClassInLib: MyAnnotation: stringArrayParam = [3, 5, 7]
 // Str
 // 42
 // Foo

--- a/test-utils/testData/api/annotationValue_java2.kt
+++ b/test-utils/testData/api/annotationValue_java2.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2023 Google LLC
- * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,12 @@
 // MyClass: MyAnnotation: stringParam = 2
 // MyClass: MyAnnotation: stringParam2 = 1
 // MyClass: MyAnnotation: stringArrayParam = [3, 5, 7]
-// MyClassInLib: MyAnnotation: stringParam = 2
-// MyClassInLib: MyAnnotation: stringParam2 = 1
-// MyClassInLib: MyAnnotation: stringArrayParam = [3, 5, 7]
+// MyClass: MyAnnotationInLib: stringParam = 2
+// MyClass: MyAnnotationInLib: stringParam2 = 1
+// MyClass: MyAnnotationInLib: stringArrayParam = [3, 5, 7]
+// MyClassInLib: MyAnnotationInLib: stringParam = 2
+// MyClassInLib: MyAnnotationInLib: stringParam2 = 1
+// MyClassInLib: MyAnnotationInLib: stringArrayParam = [3, 5, 7]
 // Str
 // 42
 // Foo
@@ -32,16 +35,12 @@
 // Array
 // @Foo
 // @Suppress
-// RGB.G
-// JavaEnum.ONE
+// G
+// ONE
 // 31
 // [warning1, warning 2]
 // Sub: [i:42]
 // TestJavaLib: OtherAnnotation
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
 // END
 // MODULE: module1
 // FILE: placeholder.kt
@@ -49,19 +48,13 @@
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 @Target({ElementType.TYPE, ElementType.TYPE_USE})
-@interface MyAnnotation {
-    String stringParam() default "1";
+@interface MyAnnotationInLib {
+    String stringParam();
     String stringParam2() default "1";
     String[] stringArrayParam() default {"3", "5", "7"};
 }
-
-@interface Default {
-    Class<?>[] value();
-    int value1();
-}
-
 interface MyInterface {}
-@MyAnnotation(stringParam = "2") class MyClassInLib implements MyInterface {}
+@MyAnnotationInLib(stringParam = "2") class MyClassInLib implements MyInterface {}
 
 // FILE: OtherAnnotation.java
 import java.lang.annotation.Retention;
@@ -75,14 +68,17 @@ public @interface JavaAnnotationWithDefaults {
     OtherAnnotation otherAnnotationVal() default @OtherAnnotation("def");
 }
 
-// FILE: KotlinAnnotationWithDefaults.kt
-annotation class KotlinAnnotationWithDefaults(val otherAnnotation: OtherAnnotation = OtherAnnotation("hij"))
-
 // MODULE: main(module1)
 // FILE: Test.java
-@MyAnnotation(stringParam = "2") class MyClass implements MyInterface {}
-
+@Target({ElementType.TYPE, ElementType.TYPE_USE})
+@interface MyAnnotation {
+    String stringParam();
+    String stringParam2() default "1";
+    String[] stringArrayParam() default {"3", "5", "7"};
+}
+@MyAnnotation(stringParam = "2") @MyAnnotationInLib(stringParam = "2") class MyClass implements MyInterface {}
 // FILE: a.kt
+
 enum class RGB {
     R, G, B
 }
@@ -110,17 +106,16 @@ class C {
 
 }
 // FILE: JavaAnnotated.java
-@Default
 @Bar(argStr = "Str",
     argInt = 40 + 2,
     argClsUser = Foo.class,
-        argClsLib = java.io.File.class,
-argClsLocal = Local.class, // intentional error type
-argClsArray = kotlin.Array.class,
-argAnnoUser = @Foo(s = 17),
-argAnnoLib = @Suppress(names = {"name1", "name2"}),
-argEnum = RGB.G,
-argJavaNum = JavaEnum.ONE)
+    argClsLib = java.io.File.class,
+    argClsLocal = Local.class, // intentional error type
+    argClsArray = kotlin.Array.class,
+    argAnnoUser = @Foo(s = 17),
+    argAnnoLib = @Suppress(names = {"name1", "name2"}),
+    argEnum = RGB.G,
+    argJavaNum = JavaEnum.ONE)
 public class JavaAnnotated {}
 
 // FILE: JavaEnum.java
@@ -144,18 +139,3 @@ class Sub implements @B(a = @A(i = 42)) Parent {}
 // FILE: TestJavaLib.java
 @JavaAnnotationWithDefaults
 class TestJavaLib {}
-
-// FILE: JavaAnnotationWithDefaultsInSource.java
-public @interface JavaAnnotationWithDefaultsInSource {
-    OtherAnnotation otherAnnotationVal() default @OtherAnnotation("def");
-}
-
-// FILE: KotlinAnnotationWithDefaults.kt
-annotation class KotlinAnnotationWithDefaultsInSource(val otherAnnotation: OtherAnnotation = OtherAnnotation("hij"))
-
-// FILE: KotlinClient.kt
-@JavaAnnotationWithDefaultsInSource
-@KotlinAnnotationWithDefaultsInSource
-@JavaAnnotationWithDefaults
-@KotlinAnnotationWithDefaults
-class TestNestedAnnotationDefaults


### PR DESCRIPTION
KSAnnotation.defaultArguments doesn't have arguments without defaults.
Therefore it can be shorter than KSAnnotation.arguments. Their indexes
may not match.

Fixes #2107 