### PR TITLE
asMemberOf: substitude upper and lower bounds recursively

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -608,7 +608,11 @@ internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
 internal fun fillInDeepSubstitutor(context: KaType, substitutorBuilder: KaSubstitutorBuilder) {
     val unwrappedType = when (context) {
         is KaClassType -> context
-        is KaFlexibleType -> context.lowerBound as? KaClassType ?: return
+        is KaFlexibleType -> {
+            fillInDeepSubstitutor(context.upperBound, substitutorBuilder)
+            fillInDeepSubstitutor(context.lowerBound, substitutorBuilder)
+            return
+        }
         else -> return
     }
     val parameters = unwrappedType.symbol.typeParameters

--- a/kotlin-analysis-api/testData/asMemberOf.kt
+++ b/kotlin-analysis-api/testData/asMemberOf.kt
@@ -111,6 +111,21 @@
 // (kotlin.Int!!) -> kotlin.Unit!!
 // Baz!!<kotlin.Long!!, kotlin.Number!!>
 // END
+// MODULE: lib
+// FILE: Test.java
+package lib;
+import java.util.List;
+class Test {
+    List<String> f() {
+        throw new RuntimeException("stub");
+    }
+}
+// FILE: TestKt.kt
+package lib
+class TestKt {
+    fun f(): MutableList<String> = TODO()
+}
+// MODULE: main(lib)
 // FILE: Input.kt
 open class Base<BaseTypeArg1, BaseTypeArg2> {
     val intType: Int = 0
@@ -195,4 +210,17 @@ class JavaImpl implements KotlinInterface {
     }
     public void setY(int value) {
     }
+}
+// FILE: main/Test.java
+package main;
+import java.util.List;
+class Test {
+    List<String> f() {
+        throw new RuntimeException("stub");
+    }
+}
+// FILE: TestKt.kt
+package main
+class TestKt {
+    fun f(): MutableList<String> = TODO()
 }

--- a/kotlin-analysis-api/testData/asMemberOf.kt
+++ b/kotlin-analysis-api/testData/asMemberOf.kt
@@ -18,6 +18,18 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: AsMemberOfProcessor
 // EXPECTED:
+// main.Test: MutableIterator<(String..String?)>
+// main.Test: Iterator<(String..String?)>
+// main.Test: MutableIterator<(String..String?)>
+// lib.Test: MutableIterator<(String..String?)>
+// lib.Test: Iterator<(String..String?)>
+// lib.Test: MutableIterator<(String..String?)>
+// main.TestKt: MutableIterator<String>
+// main.TestKt: Iterator<String>
+// main.TestKt: MutableIterator<String>
+// lib.TestKt: MutableIterator<String>
+// lib.TestKt: Iterator<String>
+// lib.TestKt: MutableIterator<String>
 // Child1!!
 // intType: kotlin.Int!!
 // baseTypeArg1: kotlin.Int!!

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -16,6 +16,20 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
+
+        listOf("main.Test", "lib.Test", "main.TestKt", "lib.TestKt").forEach { clsName ->
+            resolver.getClassDeclarationByName(clsName)!!.let { cls ->
+                val listType = cls.getAllFunctions().single {it.simpleName.asString() == "f"}.returnType!!.resolve()
+                val listDecl = listType.declaration as KSClassDeclaration
+                val iterator = listDecl.getAllFunctions().single { it.simpleName.asString() == "iterator" }
+                println("$clsName: ${iterator.asMemberOf(listType).returnType}")
+                val listIterator = resolver.getClassDeclarationByName("kotlin.collections.List")!!.getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
+                println("$clsName: ${listIterator.asMemberOf(listType).returnType}")
+                val mutableListIterator = resolver.getClassDeclarationByName("kotlin.collections.MutableCollection")!!.getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
+                println("$clsName: ${mutableListIterator.asMemberOf(listType).returnType}")
+            }
+        }
+
         val base = resolver.getClassDeclarationByName("Base")!!
         val child1 = resolver.getClassDeclarationByName("Child1")!!
         addToResults(resolver, base, child1.asStarProjectedType())

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -19,14 +19,17 @@ class AsMemberOfProcessor : AbstractTestProcessor() {
 
         listOf("main.Test", "lib.Test", "main.TestKt", "lib.TestKt").forEach { clsName ->
             resolver.getClassDeclarationByName(clsName)!!.let { cls ->
-                val listType = cls.getAllFunctions().single {it.simpleName.asString() == "f"}.returnType!!.resolve()
+                val listType = cls.getAllFunctions().single { it.simpleName.asString() == "f" }.returnType!!.resolve()
                 val listDecl = listType.declaration as KSClassDeclaration
                 val iterator = listDecl.getAllFunctions().single { it.simpleName.asString() == "iterator" }
-                println("$clsName: ${iterator.asMemberOf(listType).returnType}")
-                val listIterator = resolver.getClassDeclarationByName("kotlin.collections.List")!!.getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
-                println("$clsName: ${listIterator.asMemberOf(listType).returnType}")
-                val mutableListIterator = resolver.getClassDeclarationByName("kotlin.collections.MutableCollection")!!.getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
-                println("$clsName: ${mutableListIterator.asMemberOf(listType).returnType}")
+                results.add("$clsName: ${iterator.asMemberOf(listType).returnType}")
+                val listIterator = resolver.getClassDeclarationByName("kotlin.collections.List")!!
+                    .getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
+                results.add("$clsName: ${listIterator.asMemberOf(listType).returnType}")
+                val mutableListIterator =
+                    resolver.getClassDeclarationByName("kotlin.collections.MutableCollection")!!
+                        .getDeclaredFunctions().single { it.simpleName.asString() == "iterator" }
+                results.add("$clsName: ${mutableListIterator.asMemberOf(listType).returnType}")
             }
         }
 

--- a/test-utils/testData/api/asMemberOf.kt
+++ b/test-utils/testData/api/asMemberOf.kt
@@ -112,6 +112,21 @@
 // (kotlin.Int!!) -> kotlin.Unit!!
 // Baz!!<kotlin.Long!!, kotlin.Number!!>
 // END
+// MODULE: lib
+// FILE: Test.java
+package lib;
+import java.util.List;
+class Test {
+    List<String> f() {
+        throw new RuntimeException("stub");
+    }
+}
+// FILE: TestKt.kt
+package lib
+class TestKt {
+    fun f(): MutableList<String> = TODO()
+}
+// MODULE: main(lib)
 // FILE: Input.kt
 open class Base<BaseTypeArg1, BaseTypeArg2> {
     val intType: Int = 0
@@ -196,4 +211,18 @@ class JavaImpl implements KotlinInterface {
     }
     public void setY(int value) {
     }
+}
+
+// FILE: main/Test.java
+package main;
+import java.util.List;
+class Test {
+    List<String> f() {
+        throw new RuntimeException("stub");
+    }
+}
+// FILE: TestKt.kt
+package main
+class TestKt {
+    fun f(): MutableList<String> = TODO()
 }

--- a/test-utils/testData/api/asMemberOf.kt
+++ b/test-utils/testData/api/asMemberOf.kt
@@ -18,6 +18,18 @@
 // WITH_RUNTIME
 // TEST PROCESSOR: AsMemberOfProcessor
 // EXPECTED:
+// main.Test: MutableIterator<(String..String?)>
+// main.Test: Iterator<(String..String?)>
+// main.Test: MutableIterator<(String..String?)>
+// lib.Test: MutableIterator<(String..String?)>
+// lib.Test: Iterator<(String..String?)>
+// lib.Test: MutableIterator<(String..String?)>
+// main.TestKt: MutableIterator<String>
+// main.TestKt: Iterator<String>
+// main.TestKt: MutableIterator<String>
+// lib.TestKt: MutableIterator<String>
+// lib.TestKt: Iterator<String>
+// lib.TestKt: MutableIterator<String>
 // Child1!!
 // intType: kotlin.Int!!
 // baseTypeArg1: kotlin.Int!!


### PR DESCRIPTION
for flexible types.

Fixes #2116 