### PR TITLE
UPDATE_KOTLIN_VERSION: 2.1.0-dev-7621

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -56,12 +56,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformCommonCompilerOptionsH
 import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptions
 import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptionsDefault
 import org.jetbrains.kotlin.gradle.dsl.KotlinNativeCompilerOptionsHelper
-import org.jetbrains.kotlin.gradle.internal.ClassLoadersCachingBuildService
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilationInfo
-import org.jetbrains.kotlin.gradle.plugin.PropertiesProvider.Companion.kotlinPropertiesProvider
 import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
-import org.jetbrains.kotlin.gradle.targets.native.KonanPropertiesBuildService
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 import org.jetbrains.kotlin.gradle.tasks.Kotlin2JsCompile
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -169,7 +166,7 @@ class KotlinFactories {
                         from = compilerOptions,
                         into = kspTask.compilerOptions
                     )
-                    kspTask.produceUnpackedKlib.set(false)
+                    kspTask.produceUnpackagedKlib.set(false)
                     kspTask.onlyIf {
                         // KonanTarget is not properly serializable, hence we should check by name
                         // see https://youtrack.jetbrains.com/issue/KT-61657.
@@ -178,15 +175,6 @@ class KotlinFactories {
                             it.name == konanTargetName
                         }
                     }
-                    kspTask.kotlinCompilerArgumentsLogLevel
-                        .value(project.kotlinPropertiesProvider.kotlinCompilerArgumentsLogLevel)
-                        .finalizeValueOnRead()
-                    kspTask.konanPropertiesService
-                        .value(KonanPropertiesBuildService.registerIfAbsent(project))
-                        .disallowChanges()
-                    kspTask.classLoadersCachingService
-                        .value(ClassLoadersCachingBuildService.registerIfAbsent(project))
-                        .disallowChanges()
                 }
             }
         }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -81,7 +81,7 @@ class SourceSetConfigurationsTest {
             """
                 kotlin {
                     jvm { }
-                    android(name = "foo") { }
+                    androidTarget(name = "foo") { }
                     js(IR) { browser() }
                     androidNativeX86 { }
                     androidNativeX64(name = "bar") { }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.0-dev-5441
+kotlinBaseVersion=2.1.0-dev-7621
 agpBaseVersion=8.7.0
 intellijVersion=233.13135.103
 junitVersion=4.13.1


### PR DESCRIPTION
Only K1 and KGP is updated here. KSP2 is awaiting for the fix of [this regression](https://youtrack.jetbrains.com/issue/KT-72002/Analysis-API-psi-KaTypeParameterSymbol-for-default-Java-constructor-is-null) to come in the next Kotlin dev build.