### PR TITLE
Fix ThreadLocal memory leaks in KSObjectCacheManager

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSObjectCacheManager.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSObjectCacheManager.kt
@@ -28,7 +28,10 @@ class KSObjectCacheManager {
             get() = caches_prop.get()
 
         fun register(cache: KSObjectCache<*, *>) = caches.add(cache)
-        fun clear() = caches.forEach { it.clear() }
+        fun clear() {
+            caches.forEach { it.clear() }
+            caches_prop.remove()
+        }
     }
 }
 
@@ -44,5 +47,8 @@ abstract class KSObjectCache<K, V> {
             return cache_prop.get()
         }
 
-    open fun clear() = cache.clear()
+    open fun clear() {
+        cache.clear()
+        cache_prop.remove()
+    }
 }


### PR DESCRIPTION
Potentially fixes #2073, however unable to test against the [project that reproduced the issue](https://github.com/android/nowinandroid). I checked the other occurrences of ThreadLocal and the one mentioned in KSObjectCacheManager is the only one which seems it needs specific clearing and is clearly a culprit due to various users providing heap dumps across multiple JDK versions.