### PR TITLE
Ignore default annotation values for classes without found files

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -632,8 +632,9 @@ internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
                 val parentClass = this.getContainingKSSymbol()!!.findParentOfType<KSClassDeclaration>()
                 val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classIdIfNonLocal!!
                 val file = analyze {
-                    (fileManager.findClass(classId, analysisScope) as JavaClassImpl).virtualFile!!.contentsToByteArray()
-                }
+                    fileManager.findClass(classId, analysisScope)
+                        ?.let { javaClass -> (javaClass as JavaClassImpl).virtualFile!!.contentsToByteArray() }
+                } ?: return null
                 var defaultValue: JavaAnnotationArgument? = null
                 ClassReader(file).accept(
                     object : ClassVisitor(Opcodes.API_VERSION) {


### PR DESCRIPTION
Since the release of Kotlin 2, I have experienced issues with KSP in [mockative/mockative](https://github.com/mockative/mockative). I finally took the time to investigate if there's a way to resolve it, and it turns out the only issue remaining is this:

```
java.lang.NullPointerException
	at com.google.devtools.ksp.impl.symbol.kotlin.UtilKt.getDefaultValue(util.kt:692)
	at com.google.devtools.ksp.impl.symbol.kotlin.UtilKt.getDefaultValue(util.kt:657)
	at com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSAnnotationResolvedImpl$defaultArguments$2.invoke(KSAnnotationResolvedImpl.kt:92)
	at com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSAnnotationResolvedImpl$defaultArguments$2.invoke(KSAnnotationResolvedImpl.kt:66)
    ...
```

Caused by the following code in **utils.kt**:

```kotlin
val file = analyze {
    (fileManager.findClass(classId, analysisScope) as JavaClassImpl).virtualFile!!.contentsToByteArray()
}
```

Specifically, `findClass` returns `null` for the annotation `kotlin.annotation.Target`.

I haven't been able to identify what in Mockative causes this, as I receive the `NullPointerException` in the call to:

```kotlin
resolver.getSymbolsWithAnnotation(...)
```

By changing the call in **utils.kt** to return `null` if the class (and thus file) cannot be found, Mockative works once again. 

I see a similar change is being implemented in `1.0.26`, however I would it seems like that's targeting Kotlin 2.1, so I would love if we could include this change in a `2.0.21-1.0.26` release so users of Mockative can finally upgrade to Kotlin 2.