### PR TITLE
KSTypeArgumentResolvedImpl: use aliasing type

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.annotations
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.types.KaStarTypeProjection
+import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.KaTypeArgumentWithVariance
 import org.jetbrains.kotlin.analysis.api.types.KaTypeProjection
 
@@ -50,12 +51,16 @@ class KSTypeArgumentResolvedImpl private constructor(
         }
     }
 
+    private val kaType: KaType? by lazy {
+        ktTypeProjection.type?.abbreviation ?: ktTypeProjection.type
+    }
+
     override val type: KSTypeReference? by lazy {
-        ktTypeProjection.type?.let { KSTypeReferenceResolvedImpl.getCached(it, this@KSTypeArgumentResolvedImpl) }
+        kaType?.let { KSTypeReferenceResolvedImpl.getCached(it, this@KSTypeArgumentResolvedImpl) }
     }
 
     override val annotations: Sequence<KSAnnotation> by lazy {
-        ktTypeProjection.type?.annotations(this) ?: emptySequence()
+        kaType?.annotations(this) ?: emptySequence()
     }
 
     override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC

--- a/kotlin-analysis-api/testData/typeAlias.kt
+++ b/kotlin-analysis-api/testData/typeAlias.kt
@@ -31,6 +31,9 @@
 // myList_b_String : MyList_B_String = MyList_B<String> = MyList<R> = List<T>
 // myListOfAlias : MyListOfAlias = List<@JvmSuppressWildcards A>
 // myListOfAliasInLib : MyListOfAliasInLib = List<@JvmSuppressWildcards AInLib>
+// viewBinderProviders : Map<Class<BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>>
+// nested1 : MyList<ListOfInt> = List<T>
+// nested2 : List<ListOfInt>
 // END
 
 // MODULE: module1
@@ -65,3 +68,13 @@ val myList_String: MyList_String = TODO()
 val myList_b_String: MyList_B_String = TODO()
 val myListOfAlias: MyListOfAlias = TODO()
 val myListOfAliasInLib: MyListOfAliasInLib = TODO()
+
+interface BaseViewHolder
+interface SpaceshipEmbedModel
+interface Provider<T>
+interface ViewBinder<T1, T2>
+typealias BaseEmbedViewBinder = ViewBinder<out BaseViewHolder, out SpaceshipEmbedModel>
+
+val viewBinderProviders: Map<Class<out BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = TODO()
+val nested1: MyList<ListOfInt>
+val nested2: List<ListOfInt>

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -78,8 +78,12 @@ open class TypeAliasProcessor : AbstractTestProcessor() {
         append(declaration.simpleName.asString())
         if (arguments.isNotEmpty()) {
             append("<")
-            arguments.map {
-                it.type?.resolve()?.toSignature() ?: "<error>"
+            arguments.mapIndexed { i, arg ->
+                val s = arg.type?.resolve()?.toSignature() ?: "<error>"
+                if (i < arguments.size - 1)
+                    s + ", "
+                else
+                    s
             }.forEach(this::append)
             append(">")
         }

--- a/test-utils/testData/api/typeAlias.kt
+++ b/test-utils/testData/api/typeAlias.kt
@@ -31,6 +31,9 @@
 // myList_b_String : MyList_B_String = MyList_B<String> = MyList<R> = List<T>
 // myListOfAlias : MyListOfAlias = List<A>
 // myListOfAliasInLib : MyListOfAliasInLib = List<@JvmSuppressWildcards AInLib>
+// viewBinderProviders : Map<Class<BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>>
+// nested1 : MyList<ListOfInt> = List<T>
+// nested2 : List<ListOfInt>
 // END
 
 // MODULE: module1
@@ -66,3 +69,13 @@ val myList_b_String: MyList_B_String = TODO()
 // FIXME: type annotation is missing
 val myListOfAlias: MyListOfAlias = TODO()
 val myListOfAliasInLib: MyListOfAliasInLib = TODO()
+
+interface BaseViewHolder
+interface SpaceshipEmbedModel
+interface Provider<T>
+interface ViewBinder<T1, T2>
+typealias BaseEmbedViewBinder = ViewBinder<out BaseViewHolder, out SpaceshipEmbedModel>
+
+val viewBinderProviders: Map<Class<out BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = TODO()
+val nested1: MyList<ListOfInt>
+val nested2: List<ListOfInt>


### PR DESCRIPTION
instead of aliased type. This aligns with KSTypeReference.resolve() which doesn't expand typealiases.

Fixes #2088 