### PR TITLE
Downgrade to Kotlin 2.0.21

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          ref: 1.0.26-release
+          ref: 1.0.27-release
   
       - name: merge commits from main to release branch
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,11 +4,11 @@ name: CI
 
 on:
   push:
-    branches: [ main, 1.0.26-release, 1.0.25-release ]
+    branches: [ main, '[0-9]+.[0-9]+.[0-9]+-release*' ]
   pull_request:
-    branches: [ main, 1.0.26-release, 1.0.25-release ]
+    branches: [ main, '[0-9]+.[0-9]+.[0-9]+-release*' ]
   workflow_dispatch:
-    branches: [ main, 1.0.26-release, 1.0.25-release ]
+    branches: [ main, '[0-9]+.[0-9]+.[0-9]+-release*' ]
 
 jobs:
   build-and-test:

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -166,7 +166,7 @@ class KotlinFactories {
                         from = compilerOptions,
                         into = kspTask.compilerOptions
                     )
-                    kspTask.produceUnpackagedKlib.set(false)
+                    kspTask.produceUnpackedKlib.set(false)
                     kspTask.onlyIf {
                         // KonanTarget is not properly serializable, hence we should check by name
                         // see https://youtrack.jetbrains.com/issue/KT-61657.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -417,6 +417,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         }
 
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
+            kspTask.compilerOptions.useK2.value(false)
             val languageVersion = kotlinCompilation.compilerOptions.options.languageVersion
             val progressiveMode = kotlinCompilation.compilerOptions.options.progressiveMode
             kspTask.compilerOptions.languageVersion.value(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.20-dev-201
+kotlinBaseVersion=2.0.21
 agpBaseVersion=8.7.0
-intellijVersion=233.13135.128
+intellijVersion=233.13135.103
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2


### PR DESCRIPTION
This is a pull request to the next, 1.0.27 release branch which is just branched from main. The Kotlin in KSP main branch is newer than the most recent stable release. Therefore, right after branching, we downgrade the Kotlin version to the most recent stable release.

The changes in this PR includes:
1. Kotlin and IntelliJ version changes in `gradle.properties`
2. Corresponding changes due to Kotlin version changes