### PR TITLE
UPDATE_KOTLIN_VERSION: 2.1.0-Beta2

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -166,7 +166,7 @@ class KotlinFactories {
                         from = compilerOptions,
                         into = kspTask.compilerOptions
                     )
-                    kspTask.produceUnpackedKlib.set(false)
+                    kspTask.produceUnpackagedKlib.set(false)
                     kspTask.onlyIf {
                         // KonanTarget is not properly serializable, hence we should check by name
                         // see https://youtrack.jetbrains.com/issue/KT-61657.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -417,7 +417,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         }
 
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
-            kspTask.compilerOptions.useK2.value(false)
             val languageVersion = kotlinCompilation.compilerOptions.options.languageVersion
             val progressiveMode = kotlinCompilation.compilerOptions.options.progressiveMode
             kspTask.compilerOptions.languageVersion.value(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.21
+kotlinBaseVersion=2.1.0-Beta2
 agpBaseVersion=8.7.0
-intellijVersion=233.13135.103
+intellijVersion=233.13135.128
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2


### PR DESCRIPTION
This is similar to #2161, but in the opposite way. The corresponding change needed by the Kotlin version difference is 

```
-                    kspTask.produceUnpackedKlib.set(false)
+                    kspTask.produceUnpackagedKlib.set(false)
```