### PR TITLE
Set JVM target back to Java 8.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,12 +102,12 @@ subprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         configure<JavaPluginExtension> {
             toolchain.languageVersion.set(compileJavaVersion)
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
         }
         configure<KotlinJvmProjectExtension> {
             compilerOptions {
-                jvmTarget = JvmTarget.JVM_11
+                jvmTarget = JvmTarget.JVM_1_8
                 languageVersion.set(KotlinVersion.KOTLIN_1_9)
                 apiVersion.set(languageVersion)
             }

--- a/common-deps/build.gradle.kts
+++ b/common-deps/build.gradle.kts
@@ -5,7 +5,6 @@ description = "Kotlin Symbol Processor"
 val kotlinBaseVersion: String by project
 val junitVersion: String by project
 val googleTruthVersion: String by project
-val agpBaseVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -53,7 +53,7 @@ object AndroidPluginIntegration {
     private fun decorateAndroidExtension(project: Project, onSourceSet: (String) -> Unit) {
         val sourceSets = when (val androidExt = project.extensions.getByName("android")) {
             is BaseExtension -> androidExt.sourceSets
-            is CommonExtension<*, *, *, *, *, *> -> androidExt.sourceSets
+            is CommonExtension<*, *, *, *> -> androidExt.sourceSets
             else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
         }
         sourceSets.all {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
@@ -55,7 +55,7 @@ data class TestConfig(
     }
 
     val androidBaseVersion by lazy {
-        kspProjectProperties["agpBaseVersion"] as String
+        kspProjectProperties["agpTestVersion"] as String
     }
 
     val mavenRepoPath = mavenRepoDir.path.replace(File.separatorChar, '/')

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,8 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=2.1.20-dev-201
-agpBaseVersion=8.7.0
+agpBaseVersion=7.3.1
+agpTestVersion=8.7.1
 intellijVersion=233.13135.128
 junitVersion=4.13.1
 junit5Version=5.8.2

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -3,7 +3,7 @@ import kotlin.math.max
 
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
-val agpBaseVersion: String by project
+val agpTestVersion: String by project
 
 plugins {
     kotlin("jvm")
@@ -23,7 +23,7 @@ dependencies {
 fun Test.configureCommonSettings() {
     systemProperty("kotlinVersion", kotlinBaseVersion)
     systemProperty("kspVersion", version)
-    systemProperty("agpVersion", agpBaseVersion)
+    systemProperty("agpVersion", agpTestVersion)
     jvmArgumentProviders.add(
         RelativizingInternalPathProvider(
             "testRepo",


### PR DESCRIPTION
Newer AGP is only available with Java 11+ variants. Therefore:
* KSP is compiled with older AGP and targeting Java 8.
* Gradle tests and integration tests run with newer AGP.