### PR TITLE
KSP2: update for all, not just initial dirty sources

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -372,6 +372,16 @@ class PlaygroundIT(val useKSP2: Boolean) {
         }
     }
 
+    @Test
+    fun testEmpty() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        File(project.root, "workload/src/main/java/Empty.kt").appendText("\n\n")
+        gradleRunner.withArguments("clean", "assemble", "-Pksp.incremental.log=false").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+    }
+
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "KSP2={0}")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -495,7 +495,6 @@ class KotlinSymbolProcessing(
             )
             var allDirtyKSFiles = incrementalContext.calcDirtyFiles(allKSFiles).toList()
             var newKSFiles = allDirtyKSFiles
-            val initialDirtySet = allDirtyKSFiles.toSet()
 
             val targetPlatform = ResolverAAImpl.ktModule.targetPlatform
             val symbolProcessorEnvironment = SymbolProcessorEnvironment(
@@ -589,7 +588,7 @@ class KotlinSymbolProcessing(
 
             if (!logger.hasError) {
                 incrementalContext.updateCachesAndOutputs(
-                    initialDirtySet,
+                    allDirtyKSFiles,
                     codeGenerator.outputs,
                     codeGenerator.sourceToOutputs
                 )


### PR DESCRIPTION
* Dirtiness didn't propagate across generated files previously.
* Also fixes the issue of using out-of-date PSIs when getting paths.
