### PR TITLE
Fix a dependency of integration-tests

### DIFF
--- a/docs/ksp2cmdline.md
+++ b/docs/ksp2cmdline.md
@@ -2,21 +2,22 @@
 
 KSP2 has 4 main classes, one for each platform: `KSPJvmMain`, `KSPJsMain`, `KSPNativeMain`, `KSPCommonMain`. They reside
 in the same jars from the
-[artifacts.zip](https://github.com/google/ksp/releases/download/2.0.0-1.0.21/artifacts.zip) in the
-[release page](https://github.com/google/ksp/releases/tag/2.0.0-1.0.21):
-* `symbol-processing-aa-2.0.0-1.0.21.jar`
+[artifacts.zip](https://github.com/google/ksp/releases/download/2.0.21-1.0.26/artifacts.zip) in the
+[release page](https://github.com/google/ksp/releases/tag/2.0.21-1.0.26):
+* `symbol-processing-aa-2.0.21-1.0.26.jar`
 
 and depend on:
-* `symbol-processing-common-deps-2.0.0-1.0.21.jar`
+* `symbol-processing-common-deps-2.0.21-1.0.26.jar`
 
 You’ll also need the Kotlin runtime:
-* `kotlin-stdlib-2.0.0.jar`
+* `kotlin-stdlib-2.0.21.jar`
+* `kotlinx-coroutines-core-jvm-1.6.4.jar`
 
 Taking `KSPJvmMain` for example,
 
 ```
 java -cp \
-kotlin-analysis-api-2.0.0-1.0.21.jar:common-deps-2.0.0-1.0.21.jar:symbol-processing-api-2.0.0-1.0.21.jar:kotlin-stdlib-2.0.0.jar \
+kotlin-analysis-api-2.0.21-1.0.26.jar:common-deps-2.0.21-1.0.26.jar:symbol-processing-api-2.0.21-1.0.26.jar:kotlin-stdlib-2.0.21.jar:kotlinx-coroutines-core-jvm-1.6.4.jar \
 com.google.devtools.ksp.cmdline.KSPJvmMain \
 -jvm-target 11 \
 -module-name=main \

--- a/docs/ksp2entrypoints.md
+++ b/docs/ksp2entrypoints.md
@@ -1,9 +1,10 @@
 # Calling KSP2 In Programs
 
 There are two flavors of KSP2 artifacts: `symbol-processing-aa` and `symbol-processing-aa-embeddable`. They are both
-uber jars that include almost all runtime dependencies except `kotlin-stdlib` and `symbol-processing-common-deps`.
-The `-embeddable` version is the regular version with all the runtime dependencies renamed, so that it can be used with
-a Kotlin compiler in the same classpath without name clash. When in doubt, use `symbol-processing-aa-embeddable`.
+uber jars that include almost all runtime dependencies except `kotlin-stdlib`, `kotlinx-coroutines` and
+`symbol-processing-common-deps`. The `-embeddable` version is the regular version with all the runtime dependencies
+renamed, so that it can be used with a Kotlin compiler in the same classpath without name clash. When in doubt, use
+`symbol-processing-aa-embeddable`.
 
 Calling KSP2 consists of just 4 steps:
 1. Load processors

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -4,6 +4,7 @@ import kotlin.math.max
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
 val agpTestVersion: String by project
+val aaCoroutinesVersion: String by project
 
 plugins {
     kotlin("jvm")
@@ -18,6 +19,7 @@ dependencies {
     testImplementation(project(":symbol-processing"))
     testImplementation(project(":symbol-processing-cmdline"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
 }
 
 fun Test.configureCommonSettings() {


### PR DESCRIPTION
This is a followup of unbundling kotlinx.coroutines, which needs to be explicitly included in the classpath.