### PR TITLE
KSP2: fix module names for Android builds

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -154,7 +154,12 @@ abstract class KspAATask @Inject constructor(
                 kspAATask.kspClasspath.from(kspAADepCfg)
                 kspAATask.kspConfig.let { cfg ->
                     cfg.processorClasspath.from(processorClasspath)
-                    cfg.moduleName.value(project.name)
+                    // Ref: https://github.com/JetBrains/kotlin/blob/6535f86dfe36effeba976802ebd56a5a56071f45/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt#L92
+                    val moduleName = when (val compilationName = kotlinCompilation.name) {
+                        KotlinCompilation.MAIN_COMPILATION_NAME -> project.name
+                        else -> "${project.name}_$compilationName"
+                    }
+                    cfg.moduleName.value(moduleName)
                     val kotlinOutputDir = KspGradleSubplugin.getKspKotlinOutputDir(project, sourceSetName, target)
                     val javaOutputDir = KspGradleSubplugin.getKspJavaOutputDir(project, sourceSetName, target)
                     val filteredTasks =

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -32,6 +32,9 @@ class AndroidIT(useKSP2: Boolean) {
             assert("-keep class com.example.AClassBuilder { *; }" in configurationText) {
                 "Merged configuration did not contain generated proguard rules!\n$configurationText"
             }
+            val outputs = result.output.lines()
+            assert("w: [ksp] [workload_debug] Mangled name for internalFun: internalFun\$workload_debug" in outputs)
+            assert("w: [ksp] [workload_release] Mangled name for internalFun: internalFun\$workload_release" in outputs)
         }
     }
 

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/TestProcessor.kt
@@ -1,5 +1,6 @@
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.containingFile
+import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.*
 import com.google.devtools.ksp.symbol.*
 import java.io.OutputStream
@@ -48,6 +49,14 @@ class TestProcessor : SymbolProcessor {
         for (file in files) {
             emit("TestProcessor: processing ${file.fileName}", "")
             file.accept(visitor, "")
+        }
+
+        resolver.getClassDeclarationByName("com.example.AClass")?.let { aClass ->
+            aClass.declarations.single { it.simpleName.asString() == "internalFun" }.let { internalFun ->
+                val internalName = resolver.getJvmName(internalFun as KSFunctionDeclaration)
+                val moduleName = resolver.getModuleName().asString()
+                logger.warn("[$moduleName] Mangled name for internalFun: $internalName")
+            }
         }
         invoked = true
         return emptyList()

--- a/integration-tests/src/test/resources/playground/workload/src/main/java/com/example/AClass.kt
+++ b/integration-tests/src/test/resources/playground/workload/src/main/java/com/example/AClass.kt
@@ -14,4 +14,6 @@ class AClass(private val a: Int, val b: String, val c: Double, val d: HELLO) {
     class innerClass<T : HELLO>
 
     val generic = innerClass<HELLO>()
+
+    internal fun internalFun(): Int = 0
 }


### PR DESCRIPTION
by mimicking the rules from KGP.

fixes #2180 