### PR TITLE
Downgrade to Kotlin 2.0.21

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -166,7 +166,7 @@ class KotlinFactories {
                         from = compilerOptions,
                         into = kspTask.compilerOptions
                     )
-                    kspTask.produceUnpackagedKlib.set(false)
+                    kspTask.produceUnpackedKlib.set(false)
                     kspTask.onlyIf {
                         // KonanTarget is not properly serializable, hence we should check by name
                         // see https://youtrack.jetbrains.com/issue/KT-61657.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -417,6 +417,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         }
 
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
+            kspTask.compilerOptions.useK2.value(false)
             val languageVersion = kotlinCompilation.compilerOptions.options.languageVersion
             val progressiveMode = kotlinCompilation.compilerOptions.options.progressiveMode
             kspTask.compilerOptions.languageVersion.value(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.20-dev-2637
+kotlinBaseVersion=2.0.21
 agpBaseVersion=7.3.1
 agpTestVersion=8.7.1
-intellijVersion=233.13135.128
+intellijVersion=233.13135.103
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2


### PR DESCRIPTION
on the freshly forked 1.0.28-release.