### PR TITLE
Update KSNameImpl.kt

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/KSNameImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/KSNameImpl.kt
@@ -13,10 +13,12 @@ class KSNameImpl private constructor(val name: String) : KSName {
     }
 
     override fun getQualifier(): String {
-        return name.split(".").dropLast(1).joinToString(".")
+        val lastIndex = name.lastIndexOf('.')
+        return if (lastIndex != -1) name.substring(0, lastIndex) else ""
     }
 
     override fun getShortName(): String {
-        return name.split(".").last()
+        val lastIndex = name.lastIndexOf('.')
+        return if (lastIndex != -1) name.substring(lastIndex + 1) else name
     }
 }


### PR DESCRIPTION
**Using lastIndexOf**:
Instead of splitting the string into an array and then joining it back together, we find the index of the last period (.) in the string using lastIndexOf. This is more efficient as it avoids unnecessary array creation.

**Using substring**:
If a period is found (lastIndex != -1), we use substring to extract everything before the last period. This is a direct operation on the string and avoids the overhead of creating an intermediate list.

**Handling Edge Cases**:
If there is no period in the string, we return an empty string. This ensures that our function behaves predictably regardless of input.