### PR TITLE
#1678 - Set overwrite flag on copyWithTimestamp based on if a file or not

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -490,7 +490,7 @@ abstract class AbstractKotlinSymbolProcessingExtension(
                     roundDir.walkTopDown().forEach {
                         val dst = File(options.javaOutputDir, File(it.path).toRelativeString(roundDir))
                         if (dst.isFile || !dst.exists()) {
-                            copyWithTimestamp(it, dst, false)
+                            copyWithTimestamp(it, dst, overwrite = dst.isFile)
                         }
                     }
                 }


### PR DESCRIPTION
This should fix the `FileAlreadyExistsException` from #1678, as called out by @jonamireh [here](https://github.com/google/ksp/issues/1678#issuecomment-2332157791). Ultimately this appears to be a symptom of a larger issue; If this fixes the repeated `FileAlreadyExistsException` thrown during rebuilds in the meantime, however, it would be a good bridge for maintaining developer velocity since this issue causes almost every build to require a manual rebuild (or, disabling incremental KSP builds) for the team that I work on.