### PR TITLE
UPDATE_KOTLIN_VERSION: 2.1.0-RC

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -166,7 +166,7 @@ class KotlinFactories {
                         from = compilerOptions,
                         into = kspTask.compilerOptions
                     )
-                    kspTask.produceUnpackedKlib.set(false)
+                    kspTask.produceUnpackagedKlib.set(false)
                     kspTask.onlyIf {
                         // KonanTarget is not properly serializable, hence we should check by name
                         // see https://youtrack.jetbrains.com/issue/KT-61657.

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -417,7 +417,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         }
 
         fun configureLanguageVersion(kspTask: KotlinCompilationTask<*>) {
-            kspTask.compilerOptions.useK2.value(false)
             val languageVersion = kotlinCompilation.compilerOptions.options.languageVersion
             val progressiveMode = kotlinCompilation.compilerOptions.options.progressiveMode
             kspTask.compilerOptions.languageVersion.value(

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.0.21
+kotlinBaseVersion=2.1.0-RC
 agpBaseVersion=7.3.1
 agpTestVersion=8.7.1
-intellijVersion=233.13135.103
+intellijVersion=233.13135.128
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2


### PR DESCRIPTION
(cherry picked from commit b9a5788105bbaab3c49ba4fb8a6487d19363351e)

This PR bumps the Kotlin version from 2.0.21 to 2.1.0-RC for the 1.0.28-release branch.