### PR TITLE
KSP2: clean up legacy incremental code

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -218,9 +218,6 @@ class KotlinSymbolProcessing(
                 if (kspConfig is KSPJvmConfig) {
                     roots.addAll(kspConfig.javaSourceRoots)
                 }
-                roots.forEach {
-                    it.mkdirs()
-                }
                 addSourceRoots(roots.map { it.toPath() })
             }.apply(::addModule)
 


### PR DESCRIPTION
which was an lefe-over when moving to IncrementalGlobalSearchScope.

It also causes a problem when users wire generated outputs to source sets.

Prevents #2230 