### PR TITLE
Migrate away from AGP's legacy Variant API (1 of N)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -17,10 +17,13 @@
 package com.google.devtools.ksp.gradle
 
 import com.android.build.api.dsl.CommonExtension
+import com.android.build.api.variant.Component
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.SourceKind
+import com.google.devtools.ksp.gradle.KspConfigurations.Companion.getAndroidConfigurationName
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.internal.KaptTask
@@ -61,6 +64,64 @@ object AndroidPluginIntegration {
         return kotlinCompilation.androidVariant
             .sourceSets
             .map { it.name }
+    }
+
+    fun setUpKspClasspathsForAndroidVariants(project: Project) {
+        val androidComponents =
+            project.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
+                ?: return
+        androidComponents.onVariants { variant ->
+            val variantKspConfigurations = calculateAndroidKspConfigurations(variant, project)
+            val variantProcessorClasspath =
+                project.configurations
+                    .maybeCreate("ksp${variant.name}KotlinProcessorClasspath")
+                    .markResolvable()
+            variantProcessorClasspath.extendsFrom(*variantKspConfigurations.toTypedArray())
+            variant.nestedComponents.forEach { component ->
+                val nestedKspConfigurations = calculateAndroidKspConfigurations(component, project)
+                val nestedProcessorClasspath =
+                    project.configurations
+                        .maybeCreate("ksp${component.name}KotlinProcessorClasspath")
+                        .markResolvable()
+                nestedProcessorClasspath.extendsFrom(*nestedKspConfigurations.toTypedArray())
+            }
+        }
+    }
+
+    private fun calculateAndroidKspConfigurations(component: Component, project: Project): List<Configuration> =
+        calculateSourceSetNames(component)
+            .map { getAndroidConfigurationName(kotlinTarget = null, it) }
+            .mapNotNull { project.configurations.findByName(it) }
+            .filter { it.allDependencies.isNotEmpty() }
+
+    private fun calculateSourceSetNames(component: Component): List<String> {
+        val sourceSetNames = mutableSetOf<String>()
+        val sourceSetPrefix = when {
+            component.name.endsWith("UnitTest") -> "test"
+            component.name.endsWith("AndroidTest") -> "androidTest"
+            component.name.endsWith("TestFixtures") -> "testFixtures"
+            component.name.endsWith("ScreenshotTest") -> "screenshotTest"
+            else -> ""
+        }
+        if (sourceSetPrefix.isEmpty()) {
+            sourceSetNames.add("main")
+        } else {
+            sourceSetNames.add(sourceSetPrefix)
+        }
+        component.buildType?.also { sourceSetNames.add("$sourceSetPrefix$it") }
+        component.productFlavors.forEach { sourceSetNames.add("$sourceSetPrefix${it.second}") }
+        val combinedFlavors =
+            component.productFlavors.joinToString("") { it.second.replaceFirstChar { char -> char.uppercase() } }
+        sourceSetNames.add("$sourceSetPrefix$combinedFlavors".replaceFirstChar { it.lowercase() })
+        val variantSourceSetSuffix = when {
+            component.name.endsWith("UnitTest") -> component.name.removeSuffix("UnitTest")
+            component.name.endsWith("AndroidTest") -> component.name.removeSuffix("AndroidTest")
+            component.name.endsWith("TestFixtures") -> component.name.removeSuffix("TestFixtures")
+            component.name.endsWith("ScreenshotTest") -> component.name.removeSuffix("ScreenshotTest")
+            else -> component.name
+        }.replaceFirstChar { it.uppercase() }
+        sourceSetNames.add("$sourceSetPrefix$variantSourceSetSuffix".replaceFirstChar { it.lowercase() })
+        return sourceSetNames.toList()
     }
 
     /**
@@ -154,5 +215,28 @@ object AndroidPluginIntegration {
             classOutputDir,
             resourcesOutputDir
         )
+    }
+
+    /**
+     * Returns false for AGP versions 8.0.0 or higher.
+     *
+     * Returns true for older AGP versions or when AGP version cannot be determined.
+     */
+    val useLegacyVariantApi: Boolean by lazy {
+        val agpVersion = try {
+            val versionClass = Class.forName("com.android.Version")
+            val versionField = versionClass.getField("ANDROID_GRADLE_PLUGIN_VERSION")
+            versionField.get(null) as String
+        } catch (e: Exception) {
+            // AGP not applied or version field not found
+            null
+        }
+
+        // Fall back to using the legacy Variant API for now
+        if (agpVersion == null) {
+            return@lazy true
+        }
+        val agpMajorVersion = agpVersion.split(".").firstOrNull()?.toIntOrNull()
+        return@lazy agpMajorVersion == null || agpMajorVersion < 8
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -253,11 +253,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         val kotlinCompileProvider: TaskProvider<AbstractKotlinCompileTool<*>> =
             project.locateTask(kotlinCompilation.compileKotlinTaskName) ?: return project.provider { emptyList() }
         val kspExtension = project.extensions.getByType(KspExtension::class.java)
-        val kspConfigurations = kspConfigurations.find(kotlinCompilation)
-        val nonEmptyKspConfigurations = kspConfigurations.filter { it.allDependencies.isNotEmpty() }
-        if (nonEmptyKspConfigurations.isEmpty()) {
-            return project.provider { emptyList() }
-        }
         if (kotlinCompileProvider.name == "compileKotlinMetadata") {
             return project.provider { emptyList() }
         }
@@ -300,6 +295,8 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         assert(kotlinCompileProvider.name.startsWith("compile"))
         val kspTaskName = kotlinCompileProvider.name.replaceFirst("compile", "ksp")
 
+        val kspConfigurations = kspConfigurations.find(kotlinCompilation)
+        val nonEmptyKspConfigurations = kspConfigurations.filter { it.allDependencies.isNotEmpty() }
         val processorClasspath = project.configurations.maybeCreate("${kspTaskName}ProcessorClasspath")
             .extendsFrom(*nonEmptyKspConfigurations.toTypedArray()).markResolvable()
 


### PR DESCRIPTION
WIP - this change indicates that AGP needs to exposure source set names per variant (or similar).

This change migrates one usage of AGP's legacy Variant API to the new Variant API.

Test: ProcessorClasspathConfigurationsTest, AGP741IT