### PR TITLE
Fix various issues around Resolver.getJavaWildcard

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/binary/KSClassifierReferenceDescriptorImpl.kt
@@ -68,7 +68,7 @@ class KSClassifierReferenceDescriptorImpl private constructor(
     }
 
     override val typeArguments: List<KSTypeArgument> by lazy {
-        arguments.map { KSTypeArgumentDescriptorImpl.getCached(it, origin, this.parent) }
+        arguments.map { KSTypeArgumentDescriptorImpl.getCached(it, origin, this) }
     }
 
     override fun referencedName(): String {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -367,7 +367,7 @@ class ResolverAAImpl(
         if (type.isError)
             return reference
         val position = findRefPosition(ref)
-        val ktType = (type as KSTypeImpl).type
+        val ktType = (type as KSTypeImpl).type.fullyExpand()
         // cast to FIR internal needed due to missing support in AA for type mapping mode
         // and corresponding type mapping APIs.
         val coneType = (ktType as KaFirType).coneType

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -556,7 +556,7 @@ class ResolverAAImpl(
         fun checkAnnotated(annotated: KSAnnotated): Boolean {
             return annotated.annotations.any {
                 val kaType = (it.annotationType.resolve() as? KSTypeImpl)?.type ?: return@any false
-                kaType.toAbbreviatedType().symbol?.classId?.asFqNameString() == realAnnotationName
+                kaType.fullyExpand().symbol?.classId?.asFqNameString() == realAnnotationName
             }
         }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -162,7 +162,7 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
         get() = type is KaFunctionType && type.isSuspend
 
     override fun hashCode(): Int {
-        return type.toAbbreviatedType().hashCode()
+        return type.fullyExpand().hashCode()
     }
 
     override fun equals(other: Any?): Boolean {
@@ -179,8 +179,4 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
     }
 }
 
-internal fun KaType.toAbbreviatedType(): KaType =
-    when (val symbol = this.classifierSymbol()) {
-        is KaTypeAliasSymbol -> symbol.expandedType.toAbbreviatedType()
-        else -> this
-    }
+internal fun KaType.fullyExpand(): KaType = analyze { fullyExpandedType }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -158,7 +158,7 @@ internal fun KaType.render(inFunctionType: Boolean = false): String {
                         if (!inFunctionType) {
                             append("[typealias ${symbol.name.asString()}]")
                         } else {
-                            append(this@render.toAbbreviatedType().render(inFunctionType = true))
+                            append(this@render.fullyExpand().render(inFunctionType = true))
                         }
                     } else {
                         append(this@render.symbol.name?.asString())

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -711,7 +711,7 @@ internal fun getVarianceForWildcard(
     val projectionKind = if (projection is KaTypeArgumentWithVariance) {
         projection.variance
     } else {
-        Variance.INVARIANT
+        Variance.OUT_VARIANCE
     }
     val parameterVariance = parameter.variance
     if (parameterVariance == Variance.INVARIANT) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -739,13 +739,13 @@ internal fun getVarianceForWildcard(
 
 @OptIn(KaExperimentalApi::class)
 internal fun KaType.toWildcard(mode: TypeMappingMode): KaType {
-    val parameters = this.classifierSymbol()?.typeParameters ?: emptyList()
     val args = this.typeArguments()
     return analyze {
         when (this@toWildcard) {
             is KaClassType -> {
                 // TODO: missing annotations from original type.
-                buildClassType(this@toWildcard.expandedSymbol!!.tryResolveToTypePhase()) {
+                buildClassType(symbol.tryResolveToTypePhase()) {
+                    val parameters = symbol.typeParameters
                     parameters.zip(args).map { (param, arg) ->
                         val argMode = mode.updateFromAnnotations(arg.type)
                         val variance = getVarianceForWildcard(param, arg, argMode)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -256,11 +256,10 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/equals.kt")
     }
 
-    @Disabled
     @TestMetadata("equivalentJavaWildcards.kt")
     @Test
     fun testEquivalentJavaWildcards() {
-        runTest("../test-utils/testData/api/equivalentJavaWildcards.kt")
+        runTest("../kotlin-analysis-api/testData/equivalentJavaWildcards.kt")
     }
 
     @TestMetadata("errorTypes.kt")

--- a/kotlin-analysis-api/testData/equivalentJavaWildcards.kt
+++ b/kotlin-analysis-api/testData/equivalentJavaWildcards.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: EquivalentJavaWildcardProcessor
+// EXPECTED:
+// bar1 : [@JvmSuppressWildcards(true)] A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
+// bar2 : [@JvmSuppressWildcards(false)] A<X, X> -> A<in X, out X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmSuppressWildcards : JvmSuppressWildcards -> JvmSuppressWildcards
+// bar3 : [@JvmWildcard] A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// - @JvmWildcard : JvmWildcard -> JvmWildcard
+// p1 : A<in X, out X> -> A<X, X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
+// p1.getter() : A<in X, out X> -> A<X, X>
+// - CONTRAVARIANT X : X -> X
+// - COVARIANT X : X -> X
+// p2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// p2.getter() : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// p3 : A<*, *> -> A<Any?, Any?>
+// p3.getter() : A<*, *> -> A<Any?, Any?>
+// p4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// p4.getter() : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// p5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// p5.getter() : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// p6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// p6.getter() : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// p7 : B<*> -> B<out Any?>
+// p7.getter() : B<*> -> B<out Any?>
+// p8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// p8.getter() : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// v1 : A<X, X> -> A<in X, out X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// v2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// v3 : A<*, *> -> A<out Any?, out Any?>
+// v4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// v5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// v6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// v7 : B<*> -> B<out Any?>
+// v8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// foo : Unit -> Unit
+// r1 : A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// r2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// r3 : A<*, *> -> A<Any?, Any?>
+// r4 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// r5 : B<in X> -> B<in X>
+// - CONTRAVARIANT X : X -> X
+// r6 : B<out X> -> B<out X>
+// - COVARIANT X : X -> X
+// r7 : B<*> -> B<out Any?>
+// r8 : B<A<X, out Y>> -> B<A<X, Y>>
+// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<X, Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// X : Any -> Any
+// <init> : X -> X
+// Y : X -> X
+// <init> : Y -> Y
+// A : Any -> Any
+// T1 : Any? -> Any?
+// T2 : Any? -> Any?
+// <init> : A<*, *> -> A<Any?, Any?>
+// T1 : Any? -> Any?
+// T2 : Any? -> Any?
+// B : Any -> Any
+// T : Any? -> Any?
+// synthetic constructor for B : B<*> -> B<out Any?>
+// T : Any? -> Any?
+// C1 : A<X, X> -> A<X, X>
+// - INVARIANT X : X -> X
+// - INVARIANT X : X -> X
+// <init> : C1 -> C1
+// C2 : A<Any, Y> -> A<Any, Y>
+// - INVARIANT Any : Any -> Any
+// - INVARIANT Y : Y -> Y
+// <init> : C2 -> C2
+// C3 : B<X> -> B<X>
+// - INVARIANT X : X -> X
+// <init> : C3 -> C3
+// C4 : B<A<X, out Y>> -> B<A<in X, out Y>>
+// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<in X, out Y>
+// - - INVARIANT X : X -> X
+// - - COVARIANT Y : Y -> Y
+// <init> : C4 -> C4
+// END
+
+open class X()
+final class Y() : X()
+
+open class A<in T1, out T2>()
+open class B<T>
+
+// FIXME: should this annotation propagate to the return type?
+// @JvmSuppressWildcards(false)
+// fun bar(): A<X, X> = TODO()
+
+// A<X, X>
+fun bar1(): @JvmSuppressWildcards(true) A<X, X> = TODO()
+// A<? super X, ? extends X>
+fun bar2(): @JvmSuppressWildcards(false) A<X, X> = TODO()
+// A<X, X>
+fun bar3(): @JvmWildcard A<X, X> = TODO()
+
+// A<X, X>
+val p1: A<in X, out X> = TODO()
+// A<java.lang.Object, Y>
+val p2: A<Any, Y> = TODO()
+// A<?, ?>
+val p3: A<*, *> = TODO()
+// B<X>
+val p4: B<X> = TODO()
+// B<? super X>
+val p5: B<in X> = TODO()
+// B<? extends X>
+val p6: B<out X> = TODO()
+// B<?>
+val p7: B<*> = TODO()
+// B<A<X, Y>>
+val p8: B<A<X, out Y>>
+
+// void foo(A<? super X, ? extends X>, A<java.lang.Object, Y>, A<?, ?>, B<X>, B<? super X>, B<? extends X>, B<?>, B<A<X, Y>>);
+fun foo(
+    v1: A<X, X>,
+    v2: A<Any, Y>,
+    v3: A<*, *>,
+    v4: B<X>,
+    v5: B<in X>,
+    v6: B<out X>,
+    v7: B<*>,
+    v8: B<A<X, out Y>>,
+): Unit = Unit
+
+// A<X, X>
+fun r1(): A<X, X> = TODO()
+// A<java.lang.Object, Y>
+fun r2(): A<Any, Y> = TODO()
+// A<?, ?>
+fun r3(): A<*, *> = TODO()
+// B<X>
+fun r4(): B<X> = TODO()
+// B<? super X>
+fun r5(): B<in X> = TODO()
+// B<? extends X>
+fun r6(): B<out X> = TODO()
+// B<?>
+fun r7(): B<*> = TODO()
+// B<A<X, Y>>
+fun r8(): B<A<X, out Y>> = TODO()
+
+// extends A<X, X>
+class C1() : A<X, X>()
+// A<java.lang.Object, Y>
+class C2() : A<Any, Y>()
+// B<X>
+class C3() : B<X>()
+// B<A<? super X, ? extends Y>>
+class C4() : B<A<X, out Y>>()

--- a/kotlin-analysis-api/testData/javaWildcards2.kt
+++ b/kotlin-analysis-api/testData/javaWildcards2.kt
@@ -71,7 +71,7 @@
 // enumList : List<MyEnum>
 // jvmWildcard : List<out String>
 // suppressJvmWildcard : List<Number>
-// <init> : VarianceSubjectSuppressed<Any?>
+// <init> : VarianceSubjectSuppressed<out Any?>
 // R : Any?
 // END
 

--- a/test-utils/testData/api/equivalentJavaWildcards.kt
+++ b/test-utils/testData/api/equivalentJavaWildcards.kt
@@ -77,7 +77,7 @@
 // - - INVARIANT X : X -> X
 // - - COVARIANT Y : Y -> Y
 // p8.getter() : B<A<X, out Y>> -> B<A<X, Y>>
-// - INVARIANT A<X, out Y> : A<X, out Y> -> A<in X, Y>
+// - INVARIANT A<X, out Y> : A<X, out Y> -> A<X, Y>
 // - - INVARIANT X : X -> X
 // - - COVARIANT Y : Y -> Y
 // v1 : A<X, X> -> A<in X, out X>


### PR DESCRIPTION
1. number of type parameters and type arguments mismatch. #2265 
2. Some `out` variances are incorrectly optimized away. #2264 
3. Star-projected invariant parameter should become covariant.

and also
4. Fixed type expansion; previously some type parameters were not substituted.
5. KSP1: KSTypeArgument.parent should be KSClassifierReference, instead of KSTypeReference.

finally,
6. Enabled the remaining tests around Resolver.getJavaWildcard.