### PR TITLE
Partially migrate KSP off AGP's legacy Variant API

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "Kotlin Symbol Processor"
@@ -126,6 +127,8 @@ java {
             resources.srcDir(testPropsOutDir)
         }
     }
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 tasks.named("compileTestKotlin").configure {
@@ -180,5 +183,8 @@ kotlin {
         main {
             kotlin.srcDir(writeVersionSrcTask)
         }
+    }
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
     }
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -300,7 +300,7 @@ class SourceSetConfigurationsTest(val useKSP2: Boolean) {
             it.startsWith("kapt") && !it.startsWith("kaptClasspath_")
         }
         val kspConfigurations = configurations.filter {
-            it.startsWith("ksp")
+            it.startsWith("ksp") && !it.endsWith("KotlinProcessorClasspath")
         }
         assertThat(kspConfigurations).containsExactlyElementsIn(
             kaptConfigurations.map {

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
@@ -55,7 +55,7 @@ data class TestConfig(
     }
 
     val androidBaseVersion by lazy {
-        kspProjectProperties["agpTestVersion"] as String
+        kspProjectProperties["agpBaseVersion"] as String
     }
 
     val mavenRepoPath = mavenRepoDir.path.replace(File.separatorChar, '/')

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,7 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=2.1.20-dev-8066
-agpBaseVersion=7.3.1
-agpTestVersion=8.7.1
+agpBaseVersion=8.10.0-alpha03
 intellijVersion=233.13135.128
 junitVersion=4.13.1
 junit5Version=5.8.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -1,9 +1,10 @@
 import com.google.devtools.ksp.RelativizingInternalPathProvider
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import kotlin.math.max
 
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
-val agpTestVersion: String by project
+val agpBaseVersion: String by project
 val aaCoroutinesVersion: String by project
 
 plugins {
@@ -25,7 +26,7 @@ dependencies {
 fun Test.configureCommonSettings() {
     systemProperty("kotlinVersion", kotlinBaseVersion)
     systemProperty("kspVersion", version)
-    systemProperty("agpVersion", agpTestVersion)
+    systemProperty("agpVersion", agpBaseVersion)
     jvmArgumentProviders.add(
         RelativizingInternalPathProvider(
             "testRepo",
@@ -68,4 +69,15 @@ tasks.named<Test>("test") {
 
     // Ensure that 'test' depends on 'compatibilityTest'
     dependsOn(agpCompatibilityTest)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP741IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP741IT.kt
@@ -41,6 +41,90 @@ class AGP741IT(useKSP2: Boolean) {
         }
     }
 
+    /**
+     * Similar to ProcessorClasspathConfigurationsTest.testConfigurationsForAndroidApp(), but we want to test with AGP
+     * version < 8.10.0 too because we use AGP's legacy Variant API in that case.
+     */
+    @Test
+    fun testConfigurationsForAndroidApp() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("7.6.3")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=7.4.1")
+        File(project.root, "workload/build.gradle.kts").appendText(
+            """
+                android {
+                    flavorDimensions += listOf("tier", "region")
+                    productFlavors {
+                        create("free") {
+                            dimension = "tier"
+                        }
+                        create("premium") {
+                            dimension = "tier"
+                        }
+                        create("us") {
+                            dimension = "region"
+                        }
+                        create("eu") {
+                            dimension = "region"
+                        }
+                    }
+                }
+                configurations.matching { it.name.startsWith("ksp") && !it.name.endsWith("ProcessorClasspath") }.all {
+                    // Make sure ksp configs are not empty.
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
+                }
+                tasks.register("testConfigurations") {
+                    // Resolve all tasks to trigger classpath config creation
+                    dependsOn(tasks["tasks"])
+                    doLast {
+                        val freeUsDebugConfig = configurations["kspFreeUsDebugKotlinProcessorClasspath"]
+                        val testFreeUsDebugConfig = configurations["kspFreeUsDebugUnitTestKotlinProcessorClasspath"]
+                        val androidTestFreeUsDebugConfig =
+                            configurations["kspFreeUsDebugAndroidTestKotlinProcessorClasspath"]
+                        val freeUsDebugParentConfigs =
+                            setOf(
+                                "ksp",
+                                "kspDebug",
+                                "kspFree",
+                                "kspUs",
+                                "kspFreeUs",
+                                "kspFreeUsDebug"
+                            )
+                        val testFreeUsDebugParentConfigs =
+                            setOf(
+                                "ksp",
+                                "kspTest",
+                                "kspTestDebug",
+                                "kspTestFree",
+                                "kspTestUs",
+                                "kspTestFreeUs",
+                                "kspTestFreeUsDebug"
+                            )
+                        val androidTestFreeUsDebugParentConfigs =
+                            setOf(
+                                "ksp",
+                                "kspAndroidTest",
+                                "kspAndroidTestDebug",
+                                "kspAndroidTestFree",
+                                "kspAndroidTestUs",
+                                "kspAndroidTestFreeUs",
+                                "kspAndroidTestFreeUsDebug"
+                            )
+                        require(freeUsDebugConfig.extendsFrom.map { it.name }.toSet() == freeUsDebugParentConfigs)
+                        require(
+                            testFreeUsDebugConfig.extendsFrom.map { it.name }.toSet() == testFreeUsDebugParentConfigs
+                        )
+                        require(
+                            androidTestFreeUsDebugConfig.extendsFrom.map { it.name }.toSet() == androidTestFreeUsDebugParentConfigs
+                        )
+                    }
+                }
+            """.trimIndent()
+        )
+
+        gradleRunner.withArguments(":workload:testConfigurations").build()
+    }
+
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "KSP2={0}")


### PR DESCRIPTION
Use AGP's new addKspConfigurations() API when possible.

Bug: https://github.com/google/ksp/issues/2250
Test: AGP741IT and existing ProcessorClasspathConfigurationsTest