### PR TITLE
Incremental: include AnyChangesWildcard to initial dirty set

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -260,12 +260,7 @@ abstract class IncrementalContextBase(
         initialSet.addAll(dirtyFilesBySealed)
         initialSet.addAll(noSourceFiles)
 
-        // modified can be seen as removed + new. Therefore the following check doesn't work:
-        //   if (modified.any { it !in sourceToOutputsMap.keys }) ...
-        // Removed files affect aggregating outputs if they were generated unconditionally.
-        if (modified.isNotEmpty() || changedClasses.isNotEmpty() || removed.isNotEmpty()) {
-            initialSet.add(anyChangesWildcard)
-        }
+        initialSet.add(anyChangesWildcard)
 
         val dirtyFiles = DirtinessPropagator(
             symbolLookupCache,

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
@@ -1,0 +1,63 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class IncrementalEmptyCPIT(val useKSP2: Boolean) {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject =
+        TemporaryTestProject("incremental-classpath2", "incremental-classpath", useKSP2 = useKSP2)
+
+    private val emptyMessage = setOf("w: [ksp] processing done")
+
+    private val prop2Dirty = listOf(
+        "l1/src/main/kotlin/p1/TopProp1.kt" to setOf(
+            "w: [ksp] p1/K1.kt",
+            "w: [ksp] p1/K2.kt",
+            "w: [ksp] p1/K3.kt",
+        ),
+    )
+
+    @Test
+    fun testCPChangesForProperties() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        // Dummy changes
+        prop2Dirty.forEach { (src, _) ->
+            File(project.root, src).appendText("\n\n")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                // Trivial changes should not result in re-processing.
+                Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
+            }
+        }
+
+        // Value changes. It is not really used but should still trigger reprocessing of aggregating outputs.
+        prop2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).writeText("package p1\n\nval MyTopProp1: Int = 1")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                // Value changes will result in re-processing of aggregating outputs.
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.lines().filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(expectedDirties, dirties)
+            }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "KSP2={0}")
+        fun params() = listOf(arrayOf(true), arrayOf(false))
+    }
+}

--- a/integration-tests/src/test/resources/incremental-classpath2/validator/src/main/kotlin/Validator.kt
+++ b/integration-tests/src/test/resources/incremental-classpath2/validator/src/main/kotlin/Validator.kt
@@ -26,6 +26,7 @@ class Validator : SymbolProcessor {
         if (processed) {
             return emptyList()
         }
+
         val validator = object : KSDefaultVisitor<OutputStreamWriter, Unit>() {
             override fun defaultHandler(node: KSNode, data: OutputStreamWriter) = Unit
 
@@ -41,7 +42,7 @@ class Validator : SymbolProcessor {
             logger.warn("${file.packageName.asString()}/${file.fileName}")
             val output = OutputStreamWriter(
                 codeGenerator.createNewFile(
-                    Dependencies(false, file),
+                    Dependencies(true, file),
                     file.packageName.asString(),
                     file.fileName,
                     "log"
@@ -52,28 +53,6 @@ class Validator : SymbolProcessor {
             }
             output.close()
         }
-
-        // create an output from k3 + l4
-        val k3 = resolver.getClassDeclarationByName("p1.K3")!!
-        val l4 = resolver.getClassDeclarationByName("p1.L4")!!
-        codeGenerator.createNewFile(Dependencies(false), "p1", "l4", "log")
-        codeGenerator.associateWithClasses(listOf(k3, l4), "p1", "l4", "log")
-
-        // create an output from l5
-        val l5 = resolver.getClassDeclarationByName("p1.L5")!!
-        codeGenerator.createNewFile(Dependencies(false), "p1", "l5", "log")
-        codeGenerator.associateWithClasses(listOf(l5), "p1", "l5", "log")
-
-        // create an output from MyTopFunc1, declared in TopFunc1.kt
-        val myTopFunc1 = resolver.getFunctionDeclarationsByName("p1.MyTopFunc1", true).single()
-        codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopFunc1", "log")
-        codeGenerator.associateWithFunctions(listOf(myTopFunc1), "p1", "MyTopFunc1", "log")
-
-        // create an output from MyTopProp1, declared in TopProp1.kt
-        val myTopProp1 = resolver.getPropertyDeclarationByName("p1.MyTopProp1", true)!!
-        codeGenerator.createNewFile(Dependencies(false), "p1", "MyTopProp1", "log")
-        codeGenerator.associateWithProperties(listOf(myTopProp1), "p1", "MyTopProp1", "log")
-        logger.warn("processing done")
 
         processed = true
         return emptyList()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -261,12 +261,7 @@ abstract class IncrementalContextBase(
         initialSet.addAll(dirtyFilesBySealed)
         initialSet.addAll(noSourceFiles)
 
-        // modified can be seen as removed + new. Therefore the following check doesn't work:
-        //   if (modified.any { it !in sourceToOutputsMap.keys }) ...
-        // Removed files affect aggregating outputs if they were generated unconditionally.
-        if (modified.isNotEmpty() || changedClasses.isNotEmpty() || removed.isNotEmpty()) {
-            initialSet.add(anyChangesWildcard)
-        }
+        initialSet.add(anyChangesWildcard)
 
         val dirtyFiles = DirtinessPropagator(
             symbolLookupCache,


### PR DESCRIPTION
in case Gradle or processors don't calculate / provide dirty set / dependencies correctly.

Fixes #2252 