### PR TITLE
Enable configuration cache for AndroidIT

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -19,9 +19,8 @@ class AndroidIT(useKSP2: Boolean) {
     fun testPlaygroundAndroid() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
-        // Disabling configuration cache. See https://github.com/google/ksp/issues/299 for details
         gradleRunner.withArguments(
-            "clean", "build", "minifyReleaseWithR8", "--configuration-cache-problems=warn", "--info", "--stacktrace"
+            "clean", "build", "minifyReleaseWithR8", "--configuration-cache", "--info", "--stacktrace"
         ).build().let { result ->
             Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
             val mergedConfiguration = File(project.root, "workload/build/outputs/mapping/release/configuration.txt")


### PR DESCRIPTION
The issue mentioned in(https://github.com/google/ksp/issues/299#issuecomment-898207658) has been resolved in recent AGP