### PR TITLE
KSFunction: return type aliases if possible

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.typeParameters
 import org.jetbrains.kotlin.analysis.api.types.KaSubstitutor
 import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import java.util.*
 
@@ -35,11 +36,11 @@ class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
 ) : KSFunction {
 
     override val returnType: KSType? by lazy {
-        functionSignature.returnType.let { KSTypeImpl.getCached(it) }
+        functionSignature.returnType.abbreviationOrSelf.let { KSTypeImpl.getCached(it) }
     }
 
     override val parameterTypes: List<KSType?> by lazy {
-        functionSignature.valueParameters.map { it.returnType.let { KSTypeImpl.getCached(it) } }
+        functionSignature.valueParameters.map { it.returnType.abbreviationOrSelf.let { KSTypeImpl.getCached(it) } }
     }
 
     @OptIn(KaExperimentalApi::class)
@@ -69,7 +70,7 @@ class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
     }
 
     override val extensionReceiverType: KSType? by lazy {
-        functionSignature.receiverType?.let { KSTypeImpl.getCached(it) }
+        functionSignature.receiverType?.abbreviationOrSelf?.let { KSTypeImpl.getCached(it) }
     }
 
     override val isError: Boolean = false

--- a/kotlin-analysis-api/testData/typeAlias.kt
+++ b/kotlin-analysis-api/testData/typeAlias.kt
@@ -34,6 +34,8 @@
 // viewBinderProviders : Map<Class<BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = (expanded) Map<Class<BaseViewHolder>, Provider<ViewBinder<BaseViewHolder, SpaceshipEmbedModel>>>
 // nested1 : MyList<ListOfInt> = List<T> = (expanded) List<List<Int>>
 // nested2 : List<ListOfInt> = (expanded) List<List<Int>>
+// param w.o. asMemberOf: MyAlias<String> = Foo<Bar<T>, Baz<T>> = (expanded) Foo<Bar<String>, Baz<String>>
+// param with asMemberOf: MyAlias<String> = Foo<Bar<T>, Baz<T>> = (expanded) Foo<Bar<String>, Baz<String>>
 // END
 
 // MODULE: module1
@@ -78,3 +80,9 @@ typealias BaseEmbedViewBinder = ViewBinder<out BaseViewHolder, out SpaceshipEmbe
 val viewBinderProviders: Map<Class<out BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = TODO()
 val nested1: MyList<ListOfInt>
 val nested2: List<ListOfInt>
+
+class Subject(val param: MyAlias<String>)
+typealias MyAlias<T> = Foo<Bar<T>, Baz<T>>
+class Foo<T1, T2>
+class Bar<T>
+class Baz<T>

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.processor
 
+import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
@@ -57,6 +58,19 @@ open class TypeAliasProcessor : AbstractTestProcessor() {
                 }
             }
         }
+
+        val subjectName = resolver.getKSNameFromString("Subject")
+        val subject = resolver.getClassDeclarationByName(subjectName)!!
+        val constructor = subject.getConstructors().single()
+        val type1 = constructor.parameters.single().type.resolve()
+        val type2 = constructor.asMemberOf(subject.asType(emptyList())).parameterTypes.single()!!
+        val type1Signatures = type1.typeAliasSignatures().joinToString(" = ")
+        val type2Signatures = type2.typeAliasSignatures().joinToString(" = ")
+        val type1Expanded = resolver.expandType(type1).toSignature()
+        val type2Expanded = resolver.expandType(type2).toSignature()
+
+        results.add("param w.o. asMemberOf: $type1Signatures = (expanded) $type1Expanded")
+        results.add("param with asMemberOf: $type2Signatures = (expanded) $type2Expanded")
         return emptyList()
     }
 

--- a/test-utils/testData/api/typeAlias.kt
+++ b/test-utils/testData/api/typeAlias.kt
@@ -34,6 +34,8 @@
 // viewBinderProviders : Map<Class<BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = (expanded) Map<Class<BaseViewHolder>, Provider<ViewBinder<BaseViewHolder, SpaceshipEmbedModel>>>
 // nested1 : MyList<ListOfInt> = List<T> = (expanded) List<List<Int>>
 // nested2 : List<ListOfInt> = (expanded) List<List<Int>>
+// param w.o. asMemberOf: MyAlias<String> = Foo<Bar<T>, Baz<T>> = (expanded) Foo<Bar<String>, Baz<String>>
+// param with asMemberOf: MyAlias<String> = Foo<Bar<T>, Baz<T>> = (expanded) Foo<Bar<String>, Baz<String>>
 // END
 
 // MODULE: module1
@@ -79,3 +81,9 @@ typealias BaseEmbedViewBinder = ViewBinder<out BaseViewHolder, out SpaceshipEmbe
 val viewBinderProviders: Map<Class<out BaseViewHolder>, @JvmSuppressWildcards Provider<BaseEmbedViewBinder>> = TODO()
 val nested1: MyList<ListOfInt>
 val nested2: List<ListOfInt>
+
+class Subject(val param: MyAlias<String>)
+typealias MyAlias<T> = Foo<Bar<T>, Baz<T>>
+class Foo<T1, T2>
+class Bar<T>
+class Baz<T>


### PR DESCRIPTION
AA expands types by default. Luckily, the abbreviations are handily available. This change makes KSFunction behave the same as other parts that return KSType in the API.