### PR TITLE
Downgrade to Kotlin 2.1.10 on 1.0.31-release

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -66,7 +66,6 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-suite:$junitPlatformVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$kotlinBaseVersion")
-    testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$kotlinBaseVersion")
     testImplementation(project(":test-utils"))
 
     libsForTesting(kotlin("stdlib", kotlinBaseVersion))

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/KotlinSymbolProcessingExtension.kt
@@ -46,8 +46,6 @@ import com.google.devtools.ksp.symbol.Visibility
 import com.google.devtools.ksp.symbol.impl.java.KSFileJavaImpl
 import com.google.devtools.ksp.symbol.impl.kotlin.KSFileImpl
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.application.ApplicationManager
-import com.intellij.openapi.application.runWriteAction
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.StandardFileSystems
@@ -55,7 +53,6 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.impl.file.impl.JavaFileManager
-import com.intellij.util.ui.EDT
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl
@@ -167,10 +164,8 @@ abstract class AbstractKotlinSymbolProcessingExtension(
         logger.logging("round $rounds of processing")
         val psiManager = PsiManager.getInstance(project)
         if (initialized) {
-            maybeRunInWriteAction {
-                psiManager.dropPsiCaches()
-                psiManager.dropResolveCaches()
-            }
+            psiManager.dropPsiCaches()
+            psiManager.dropResolveCaches()
             invalidateKotlinCliJavaFileManagerCache(project)
         } else {
             // In case of broken builds.
@@ -533,21 +528,4 @@ private fun invalidateKotlinCliJavaFileManagerCache(project: Project): Boolean {
         return false
     (privateCacheField.get(javaFileManager) as? MutableMap<*, *>)?.clear() ?: return false
     return true
-}
-
-private fun <R> maybeRunInWriteAction(f: () -> R) {
-    synchronized(EDT::class.java) {
-        if (!EDT.isCurrentThreadEdt()) {
-            val edt = EDT::class.java.getDeclaredField("myEventDispatchThread")
-            edt.isAccessible = true
-            edt.set(null, Thread.currentThread())
-        }
-        if (ApplicationManager.getApplication() != null) {
-            runWriteAction {
-                f()
-            }
-        } else {
-            f()
-        }
-    }
 }

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -103,7 +103,6 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
             CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
             SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
             PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
-            ALL -> null
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.2.0-dev-745
+kotlinBaseVersion=2.1.10
 agpBaseVersion=8.10.0-alpha03
-intellijVersion=241.19416.19
+intellijVersion=233.13135.128
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2


### PR DESCRIPTION
This patch is generated by `git diff origin/main origin/1.0.30-release`.