### PR TITLE
jdkHome as internal and creating new jdkVersion input

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -270,6 +270,13 @@ abstract class KspAATask @Inject constructor(
                         // TODO: set proper jdk home
                         cfg.jdkHome.value(File(System.getProperty("java.home")))
 
+                        val javaVersion = System.getProperty("java.version")?.split(".")?.let {
+                            if (it[0] == "1") it.getOrNull(1) else it.getOrNull(0)
+                        }
+                        javaVersion?.let {
+                            cfg.jdkVersion.value(it.toInt())
+                        }
+
                         val jvmDefaultMode = compilerOptions.freeCompilerArgs
                             .map { args -> args.filter { it.startsWith("-Xjvm-default=") } }
                             .map { it.lastOrNull()?.substringAfter("=") ?: "disable" }
@@ -329,9 +336,12 @@ abstract class KspGradleConfig @Inject constructor() {
     @get:Classpath
     abstract val libraries: ConfigurableFileCollection
 
+    @get:Internal
+    abstract val jdkHome: Property<File>
+
     @get:Input
     @get:Optional
-    abstract val jdkHome: Property<File>
+    abstract val jdkVersion: Property<Int>
 
     @get:Internal
     abstract val projectBaseDir: Property<File>


### PR DESCRIPTION
### Proposal to Resolve Issue #2340

This PR is a quick proposal to address issue #2340.  

#### Problem  
The current implementation tracks `java.home` as an input, causing cache misses when the value differs. This not only affects CI vs. local builds but also causes issues in local environments if the user updates the minor or patch versions of Java, as the input value changes.  

#### Proposed Solution  
This PR updates the JDK home input to be marked as `@Internal` and introduces a new input, `jdkVersion`, to track the major Java version.  

The implementation follows the current style by retrieving the system property `java.version`. The purpose of using `jdkVersion` is to ensure that the task is invalidated if the major Java version changes, similar to how Java handles compatibility with the Java compiler.  

#### Concerns  
I am not entirely convinced by this approach because I don't see the current `KspAATask` implementation supporting `KotlinJavaToolChains` as `KspTaskJvm` does. Supporting `KotlinJavaToolChains` could help detect changes in the major version. However, I am unsure of the implementation details regarding why `java.home` is required in `KspAATask` and whether the symbol processor behavior should differ for minor or patch version changes.  

Feedback and suggestions are welcome!  