### PR TITLE
Better support of Gradle compilation avoidance

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -498,6 +498,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                                     project.provider { processorClasspath }
                                 )
                             )
+                            kspTask.classpathStructure.from(classStructureFiles)
                         }
                         // Don't support binary generation for non-JVM platforms yet.
                         // FIXME: figure out how to add user generated libraries.

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
@@ -105,10 +105,7 @@ class IncrementalCPIT(val useKSP2: Boolean) {
             File(project.root, src).writeText("package p1\n\nfun MyTopFunc1(): Int = 1")
             gradleRunner.withArguments("assemble").build().let { result ->
                 // Value changes should not result in re-processing.
-                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
-                val dirties = result.output.lines().filter { it.startsWith("w: [ksp]") }.toSet()
-                // Non-signature changes should not affect anything.
-                Assert.assertEquals(emptyMessage, dirties)
+                Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
             }
         }
 
@@ -151,10 +148,7 @@ class IncrementalCPIT(val useKSP2: Boolean) {
             File(project.root, src).writeText("package p1\n\nval MyTopProp1: Int = 1")
             gradleRunner.withArguments("assemble").build().let { result ->
                 // Value changes should not result in re-processing.
-                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
-                val dirties = result.output.lines().filter { it.startsWith("w: [ksp]") }.toSet()
-                // Non-signature changes should not affect anything.
-                Assert.assertEquals(emptyMessage, dirties)
+                Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
             }
         }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
@@ -48,9 +48,7 @@ class IncrementalEmptyCPIT(val useKSP2: Boolean) {
             File(project.root, src).writeText("package p1\n\nval MyTopProp1: Int = 1")
             gradleRunner.withArguments("assemble").build().let { result ->
                 // Value changes will result in re-processing of aggregating outputs.
-                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
-                val dirties = result.output.lines().filter { it.startsWith("w: [ksp]") }.toSet()
-                Assert.assertEquals(expectedDirties, dirties)
+                Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
             }
         }
     }


### PR DESCRIPTION
Previously, KSP directly used the classpath/library to detect incremental changes and prevents compilation avoidance. Now, it uses classpathStructure which takes compilation avoidance and specialties of annotation processing into account.