### PR TITLE
1.0.31-release: bump to Kotlin 2.1.20-RC

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-suite:$junitPlatformVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$kotlinBaseVersion")
+    testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$kotlinBaseVersion")
     testImplementation(project(":test-utils"))
 
     libsForTesting(kotlin("stdlib", kotlinBaseVersion))

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -56,10 +56,10 @@ import com.intellij.psi.*
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
-import org.jetbrains.kotlin.codegen.ClassBuilderMode
-import org.jetbrains.kotlin.codegen.OwnerKind
 import org.jetbrains.kotlin.codegen.signature.BothSignatureWriter
 import org.jetbrains.kotlin.codegen.state.KotlinTypeMapper
+import org.jetbrains.kotlin.config.ApiVersion
+import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.container.ComponentProvider
 import org.jetbrains.kotlin.container.get
@@ -147,9 +147,8 @@ class ResolverImpl(
 
     private val moduleIdentifier = module.name.getNonSpecialIdentifier()
     private val typeMapper = KotlinTypeMapper(
-        BindingContext.EMPTY, ClassBuilderMode.LIGHT_CLASSES,
         moduleIdentifier,
-        KotlinTypeMapper.LANGUAGE_VERSION_SETTINGS_DEFAULT, // TODO use proper LanguageVersionSettings
+        LanguageVersionSettingsImpl(LanguageVersion.KOTLIN_1_9, ApiVersion.KOTLIN_1_9),
         true
     )
     private val qualifiedExpressionResolver = QualifiedExpressionResolver(LanguageVersionSettingsImpl.DEFAULT)
@@ -893,17 +892,13 @@ class ResolverImpl(
 
     @KspExperimental
     override fun getJvmName(accessor: KSPropertyAccessor): String? {
-        return resolvePropertyAccessorDeclaration(accessor)?.let {
-            typeMapper.mapFunctionName(it, OwnerKind.IMPLEMENTATION)
-        }
+        return resolvePropertyAccessorDeclaration(accessor)?.let(typeMapper::mapFunctionName)
     }
 
     @KspExperimental
     override fun getJvmName(declaration: KSFunctionDeclaration): String? {
         // function names might be mangled if they receive inline class parameters or they are internal
-        return (resolveFunctionDeclaration(declaration) as? FunctionDescriptor)?.let {
-            typeMapper.mapFunctionName(it, OwnerKind.IMPLEMENTATION)
-        }
+        return (resolveFunctionDeclaration(declaration) as? FunctionDescriptor)?.let(typeMapper::mapFunctionName)
     }
 
     @KspExperimental

--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/symbol/impl/kotlin/KSAnnotationImpl.kt
@@ -103,6 +103,7 @@ class KSAnnotationImpl private constructor(val ktAnnotationEntry: KtAnnotationEn
             CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
             SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
             PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
+            ALL -> null
         }
     }
 

--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -22,6 +22,8 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.TestDataFile
+import org.jetbrains.kotlin.analysis.test.framework.services.TargetPlatformDirectives
+import org.jetbrains.kotlin.analysis.test.framework.services.TargetPlatformProviderForAnalysisApiTests
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
@@ -121,9 +123,11 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
         useAdditionalService<TemporaryDirectoryManager>(::TemporaryDirectoryManagerImpl)
         useAdditionalService<ApplicationDisposableProvider> { ExecutionListenerBasedDisposableProvider() }
         useAdditionalService<KotlinStandardLibrariesPathProvider> { StandardLibrariesPathProviderForKotlinProject }
+        useAdditionalService<TargetPlatformProvider>(::TargetPlatformProviderForAnalysisApiTests)
 
         useDirectives(*AbstractKotlinCompilerTest.defaultDirectiveContainers.toTypedArray())
         useDirectives(JvmEnvironmentConfigurationDirectives)
+        useDirectives(TargetPlatformDirectives)
 
         defaultDirectives {
             +JvmEnvironmentConfigurationDirectives.FULL_JDK
@@ -163,7 +167,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
     open fun compileModule(module: TestModule, testServices: TestServices) {
         val javaFiles = module.writeJavaFiles()
         val compilerConfiguration = testServices.compilerConfigurationProvider.getCompilerConfiguration(module)
-        val dependencies = module.allDependencies.map { outDirForModule(it.moduleName) }
+        val dependencies = module.allDependencies.map { outDirForModule(it.dependencyModule.name) }
         compilerConfiguration.addJvmClasspathRoots(dependencies)
         compilerConfiguration.addJavaSourceRoot(module.javaDir)
 
@@ -185,7 +189,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             "-classpath", classpath,
             "-d", module.outDir.path
         )
-        compileJavaFiles(javaFiles, options, assertions = JUnit5Assertions)
+        compileJavaFiles(javaFiles, options)
     }
 
     fun runTest(@TestDataFile path: String) {
@@ -196,8 +200,8 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             path,
             testConfiguration.directives,
         )
-        val dependencyProvider = DependencyProviderImpl(testServices, moduleStructure.modules)
-        testServices.registerDependencyProvider(dependencyProvider)
+        val dependencyProvider = ArtifactsProvider(testServices, moduleStructure.modules)
+        testServices.registerArtifactsProvider(dependencyProvider)
         testServices.register(TestModuleStructure::class, moduleStructure)
 
         val mainModule = moduleStructure.modules.last()

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.10
+kotlinBaseVersion=2.1.20-Beta2
 agpBaseVersion=8.10.0-alpha03
 intellijVersion=233.13135.128
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.20-Beta2
+kotlinBaseVersion=2.1.20-RC
 agpBaseVersion=8.10.0-alpha03
 intellijVersion=233.13135.128
 junitVersion=4.13.1


### PR DESCRIPTION
do not merge before the release of 2.1.10-1.0.31.