### PR TITLE
More optimizations for KSNode creation

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
@@ -34,7 +34,9 @@ class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile, Deferra
         fun getCached(psi: PsiJavaFile) = cache.getOrPut(psi) { KSFileJavaImpl(psi) }
     }
 
-    override val packageName: KSName = KSNameImpl.getCached(psi.packageName)
+    override val packageName: KSName by lazy {
+        KSNameImpl.getCached(psi.packageName)
+    }
 
     override val fileName: String = psi.name
 
@@ -50,7 +52,9 @@ class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile, Deferra
 
     override val origin: Origin = Origin.JAVA
 
-    override val location: Location = psi.toLocation()
+    override val location: Location by lazy {
+        psi.toLocation()
+    }
 
     override val parent: KSNode? = null
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -17,7 +17,7 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.common.IdKeyPair
+import com.google.devtools.ksp.common.IdKey
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.errorTypeOnInconsistentArguments
 import com.google.devtools.ksp.impl.ResolverAAImpl
@@ -31,14 +31,13 @@ import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Nullability
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
-import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotationList
 import org.jetbrains.kotlin.analysis.api.impl.base.types.KaBaseStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.*
 
 class KSTypeImpl private constructor(internal val type: KaType) : KSType {
-    companion object : KSObjectCache<IdKeyPair<KaType, KaAnnotationList>, KSTypeImpl>() {
-        fun getCached(type: KaType): KSTypeImpl = cache.getOrPut(IdKeyPair(type, type.annotations)) {
+    companion object : KSObjectCache<IdKey<KaType>, KSTypeImpl>() {
+        fun getCached(type: KaType): KSTypeImpl = cache.getOrPut(IdKey(type)) {
             KSTypeImpl(type)
         }
     }


### PR DESCRIPTION
1. KSFileJavaImpl: compuate packageName and location lazily
2. Simplify KSTypeImpl.getCached