### PR TITLE
Fix validity check of annotations on properties

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/KSPCompilerPluginTest.kt
@@ -80,6 +80,12 @@ class KSPCompilerPluginTest : AbstractKSPCompilerPluginTest() {
         runTest("../test-utils/testData/api/annotationsRepeatable.kt")
     }
 
+    @TestMetadata("annotationTargets.kt")
+    @Test
+    fun testAnnotationTargets() {
+        runTest("../test-utils/testData/api/annotationTargets.kt")
+    }
+
     @TestMetadata("annotationWithArbitraryClassValue.kt")
     @Test
     fun testAnnotationWithArbitraryClassValue() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -88,6 +88,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../kotlin-analysis-api/testData/annotationsRepeatable.kt")
     }
 
+    @TestMetadata("annotationTargets.kt")
+    @Test
+    fun testAnnotationTargets() {
+        runTest("../test-utils/testData/api/annotationTargets.kt")
+    }
+
     @TestMetadata("annotationWithArbitraryClassValue.kt")
     @Test
     fun testAnnotationWithArbitraryClassValue() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationTargetsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationTargetsProcessor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+
+class AnnotationTargetsProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val myClassName = resolver.getKSNameFromString("com.example.MyClass")
+        val myClass: KSClassDeclaration = resolver.getClassDeclarationByName(myClassName)!!
+        val propForLib = myClass.getAllProperties().single { it.simpleName.asString() == "propForLib" }
+        val propForSrc = myClass.getAllProperties().single { it.simpleName.asString() == "propForSrc" }
+        results.add("$propForLib: ${propForLib.annotations.map { it.shortName.asString() }.toList()}")
+        results.add("$propForSrc: ${propForSrc.annotations.map { it.shortName.asString() }.toList()}")
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+}

--- a/test-utils/testData/api/annotationTargets.kt
+++ b/test-utils/testData/api/annotationTargets.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: AnnotationTargetsProcessor
+// EXPECTED:
+// propForLib: [MyAnnotationInLib]
+// propForSrc: [MyAnnotationInSrc]
+// END
+// MODULE: Anno
+// FILE: com/example/MyAnnotation.kt
+package com.example
+
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+public annotation class MyAnnotationInLib
+
+// MODULE: main(Anno)
+// FILE: com/exampel/MyClass.kt
+package com.example
+
+@Target(AnnotationTarget.PROPERTY, AnnotationTarget.VALUE_PARAMETER)
+public annotation class MyAnnotationInSrc
+
+class MyClass {
+    @MyAnnotationInLib lateinit var propForLib: String
+    @MyAnnotationInSrc lateinit var propForSrc: String
+}


### PR DESCRIPTION
Annotations on properties may come from corresponding parameters if they are declared in constructors. They may not be valid on properties and need to be filtered out. The previous implementation incorrectly excludes all annotations with @Target(AnnotationTarget.VALUE_PARAMETER), while what should be excluded are the ones with @Target and without @Target(AnnotationTarget.PROPERTY).