### PR TITLE
Store collected symbols by annotations

### DIFF
--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
@@ -44,8 +44,7 @@ class CollectAnnotatedSymbolsVisitor(private val inDepth: Boolean) : KSVisitorVo
     }
 
     override fun visitTypeAlias(typeAlias: KSTypeAlias, data: Unit) {
-        if (typeAlias.annotations.any())
-            symbols.add(typeAlias)
+        visitAnnotated(typeAlias, data)
     }
 
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {

--- a/kotlin-analysis-api/testData/locations.kt
+++ b/kotlin-analysis-api/testData/locations.kt
@@ -24,7 +24,6 @@
 // T:J.java:73
 // T:J.java:73
 // T:K.kt:54
-// T:K.kt:54
 // f1:J.java:77
 // f1:K.kt:61
 // p1:K.kt:56
@@ -38,6 +37,7 @@
 // v3.setter():K.kt:67
 // v3:J.java:82
 // END
+
 
 // FILE: Location.kt
 


### PR DESCRIPTION
Previous implementation needs to scan through all symbols with annotations each time getSymbolsWithAnnotation is called. Let's just store the symbols in a map and index by annotations.