### PR TITLE
Replace lazy Sequences by lazyMemoizedSequence

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
@@ -94,3 +94,11 @@ inline fun <reified T> PsiElement.findParentOfType(): T? {
 }
 
 fun <T> Sequence<T>.memoized() = MemoizedSequence(this)
+
+inline fun <T> lazyMemoizedSequence(crossinline initializer: () -> Sequence<T>): Lazy<Sequence<T>> = lazy {
+    val value = initializer()
+    if (value is MemoizedSequence<T>)
+        value
+    else
+        value.memoized()
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -89,8 +89,8 @@ class ResolverAAImpl(
     lateinit var functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>
     val javaFileManager = project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
     private val classBinaryCache = ClsKotlinBinaryClassCache()
-    private val packageInfoFiles by lazy {
-        allKSFiles.filter { it.fileName == "package-info.java" }.asSequence().memoized()
+    private val packageInfoFiles by lazyMemoizedSequence {
+        allKSFiles.filter { it.fileName == "package-info.java" }.asSequence()
     }
 
     // TODO: fix in upstream for builtin types.

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -17,6 +17,7 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.common.toKSModifiers
 import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.impl.symbol.util.toKSModifiers
@@ -52,9 +53,8 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
         KSNameImpl.getCached((ktDeclarationSymbol as? KaNamedSymbol)?.name?.asString() ?: "")
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
-        originalAnnotations
-    }
+    override val annotations: Sequence<KSAnnotation>
+        get() = originalAnnotations
 
     override val modifiers: Set<Modifier> by lazy {
         if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC) {
@@ -122,7 +122,7 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
     override val docString: String?
         get() = ktDeclarationSymbol.toDocString()
 
-    internal open val originalAnnotations: Sequence<KSAnnotation> by lazy {
+    internal open val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         if (ktDeclarationSymbol.psi is KtAnnotated) {
             (ktDeclarationSymbol.psi as KtAnnotated).annotations(ktDeclarationSymbol, this)
         } else if (ktDeclarationSymbol.origin == KaSymbolOrigin.JAVA_SOURCE && ktDeclarationSymbol.psi != null) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -112,10 +112,8 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
         return visitor.visitClassDeclaration(this, data)
     }
 
-    override val declarations: Sequence<KSDeclaration> by lazy {
-        // TODO: fix after .getDeclaredMemberScope() works for enum entry with no initializer.
-        emptySequence()
-    }
+    // TODO: fix after .getDeclaredMemberScope() works for enum entry with no initializer.
+    override val declarations: Sequence<KSDeclaration> = emptySequence()
 
     override fun toString(): String {
         return "$parent.${simpleName.asString()}"

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
@@ -58,7 +59,7 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
         psi.virtualFile.path
     }
 
-    override val declarations: Sequence<KSDeclaration> by lazy {
+    override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
         analyze {
             ktFileSymbol.fileScope.declarations.map {
                 when (it) {
@@ -84,7 +85,7 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
         return visitor.visitFile(this, data)
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         (ktFileSymbol.psi as? KtFile)?.annotations(ktFileSymbol) ?: ktFileSymbol.annotations(this)
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
@@ -42,7 +43,7 @@ class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile, Deferra
 
     override val filePath: String = psi.virtualFile.path
 
-    override val declarations: Sequence<KSDeclaration> by lazy {
+    override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
         psi.classes.asSequence().mapNotNull { psi ->
             analyze {
                 psi.namedClassSymbol?.let { KSClassDeclarationImpl.getCached(it) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -20,6 +20,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.*
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.recordLookupForPropertyOrMethod
 import com.google.devtools.ksp.impl.recordLookupWithSupertypes
@@ -146,8 +147,8 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
         return visitor.visitFunctionDeclaration(this, data)
     }
 
-    override val declarations: Sequence<KSDeclaration> by lazy {
-        val psi = ktFunctionSymbol.psi as? KtFunction ?: return@lazy emptySequence()
+    override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
+        val psi = ktFunctionSymbol.psi as? KtFunction ?: return@lazyMemoizedSequence emptySequence()
         if (!psi.hasBlockBody()) {
             emptySequence()
         } else {
@@ -178,13 +179,12 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
             )
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
-        if (isSyntheticConstructor()) {
+    override val annotations: Sequence<KSAnnotation>
+        get() = if (isSyntheticConstructor()) {
             emptySequence()
         } else {
             super.annotations
         }
-    }
 
     override fun toString(): String {
         // TODO: fix origin for implicit Java constructor in AA

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.KSObjectCache
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSAnnotationResolvedImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.impl.symbol.util.toKSModifiers
@@ -37,7 +38,7 @@ abstract class KSPropertyAccessorImpl(
     override val receiver: KSPropertyDeclaration
 ) : KSPropertyAccessor, Deferrable {
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
         ktPropertyAccessorSymbol.annotations.asSequence()
             .filter { it.useSiteTarget != AnnotationUseSiteTarget.SETTER_PARAMETER }
@@ -45,7 +46,7 @@ abstract class KSPropertyAccessorImpl(
             .plus(findAnnotationFromUseSiteTarget())
     }
 
-    internal val originalAnnotations: Sequence<KSAnnotation> by lazy {
+    internal val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
         ktPropertyAccessorSymbol.annotations(this)
     }
@@ -84,8 +85,8 @@ abstract class KSPropertyAccessorImpl(
     override val parent: KSNode?
         get() = ktPropertyAccessorSymbol.getContainingKSSymbol()
 
-    override val declarations: Sequence<KSDeclaration> by lazy {
-        val psi = ktPropertyAccessorSymbol.psi as? KtPropertyAccessor ?: return@lazy emptySequence()
+    override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
+        val psi = ktPropertyAccessorSymbol.psi as? KtPropertyAccessor ?: return@lazyMemoizedSequence emptySequence()
         if (!psi.hasBlockBody()) {
             emptySequence()
         } else {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -22,6 +22,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.recordLookupForPropertyOrMethod
 import com.google.devtools.ksp.impl.recordLookupWithSupertypes
@@ -58,7 +59,7 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     override val originalAnnotations: Sequence<KSAnnotation>
         get() = annotations
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktPropertySymbol.annotations.asSequence()
             .filter { !it.isUseSiteTargetAnnotation() }
             .map { KSAnnotationResolvedImpl.getCached(it, this) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -18,6 +18,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.IdKeyPair
 import com.google.devtools.ksp.common.KSObjectCache
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.recordLookup
 import com.google.devtools.ksp.impl.symbol.util.toKSModifiers
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -76,7 +77,7 @@ class KSTypeReferenceImpl(
         return KSTypeImpl.getCached(ktType)
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         val innerAnnotations = mutableListOf<Sequence<KtAnnotationEntry>>()
         visitNullableType {
             innerAnnotations.add(it.annotationEntries.asSequence())

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -20,6 +20,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirValueParameterSymbol
@@ -86,7 +87,7 @@ class KSValueParameterImpl private constructor(
         ktValueParameterSymbol.hasDefaultValue
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktValueParameterSymbol.annotations(this).plus(findAnnotationFromUseSiteTarget())
     }
     override val origin: Origin by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin.resolved
 
 import com.google.devtools.ksp.common.IdKeyPair
 import com.google.devtools.ksp.common.KSObjectCache
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.symbol.kotlin.Deferrable
 import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.annotations
@@ -59,7 +60,7 @@ class KSTypeArgumentResolvedImpl private constructor(
         kaType?.let { KSTypeReferenceResolvedImpl.getCached(it, this@KSTypeArgumentResolvedImpl) }
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         kaType?.annotations(this) ?: emptySequence()
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin.resolved
 
 import com.google.devtools.ksp.common.IdKeyTriple
 import com.google.devtools.ksp.common.KSObjectCache
+import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.recordLookup
 import com.google.devtools.ksp.impl.symbol.kotlin.Deferrable
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
@@ -71,7 +72,7 @@ class KSTypeReferenceResolvedImpl private constructor(
         return KSTypeImpl.getCached(ktType)
     }
 
-    override val annotations: Sequence<KSAnnotation> by lazy {
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktType.annotations(this) +
             additionalAnnotations.asSequence().map { KSAnnotationResolvedImpl.getCached(it, this) }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -21,7 +21,6 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.common.impl.KSNameImpl
-import com.google.devtools.ksp.common.memoized
 import com.google.devtools.ksp.impl.KSPCoreEnvironment
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSAnnotationResolvedImpl
@@ -264,7 +263,7 @@ internal fun KaDeclarationContainerSymbol.declarations(): Sequence<KSDeclaration
                 is KaJavaFieldSymbol -> KSPropertyDeclarationJavaImpl.getCached(symbol)
                 else -> throw IllegalStateException()
             }
-        }.memoized()
+        }
     }
 }
 


### PR DESCRIPTION
where the intermediate functions applied on the sequence are pure and cost effective.

Unlike simple lazy values, intermediate functions applied in lazy properties of Sequence types are computed repeatedly. For example, square() is called each time x is read.

    val x: Sequence<Int> by lazy { listOf(1, 2, 3).map { square(it) } }

lazyMemoizedSequence caches the values of the sequence.

Also replaced the stateful implementation of
KSClassDeclarationImpl.declarations by a stateless one.