### PR TITLE
Decouple AGP tests with other integration tests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -72,7 +72,7 @@ jobs:
   
       # Run ksp generated tests
       - name: test
-        run: ./gradlew --stacktrace --info test
+        run: ./gradlew --stacktrace --info check
 
       - name: push to release branch
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,6 @@ jobs:
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-    # Run ktlint
-    - name: lint
-      if: matrix.os == 'ubuntu-latest'
-      run: ./gradlew ktlint
 
     # Check API compatibility
     - name: API compatibility check
@@ -71,7 +67,7 @@ jobs:
     # Run tests
     - name: test
       shell: bash
-      run: ./gradlew --stacktrace --info test
+      run: ./gradlew --stacktrace --info check
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     # Run tests
     - name: test
       shell: bash
-      run: ./gradlew --stacktrace --info test
+      run: ./gradlew --stacktrace --info check
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v4

--- a/buildSrc/src/main/kotlin/com/google/devtools/ksp/ApiCheck.kt
+++ b/buildSrc/src/main/kotlin/com/google/devtools/ksp/ApiCheck.kt
@@ -87,8 +87,7 @@ private fun JavaExec.configureCommonMetalavaArgs(
 
 private fun Project.getCompileClasspath(): String =
     configurations.findByName("compileClasspath")!!.files
-        .map { it.toRelativeString(projectDir) }
-        .joinToString(File.pathSeparator)
+        .joinToString(File.pathSeparator) { it.relativeToOrSelf(projectDir).path }
 
 private fun Project.getMetalavaConfiguration(): Configuration {
     return configurations.findByName("metalava") ?: configurations.create("metalava") {

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -58,7 +58,7 @@ val agpCompatibilityTest by tasks.registering(Test::class) {
     configureCommonSettings()
 }
 
-tasks.named<Test>("test") {
+tasks.test {
     maxParallelForks = max(1, Runtime.getRuntime().availableProcessors() / 2)
 
     // Exclude test classes from agpCompatibilityTest
@@ -67,7 +67,11 @@ tasks.named<Test>("test") {
     // Apply common settings
     configureCommonSettings()
 
-    // Ensure that 'test' depends on 'compatibilityTest'
+    // Ensure that 'test' runs after 'compatibilityTest'
+    mustRunAfter(agpCompatibilityTest)
+}
+
+tasks.check {
     dependsOn(agpCompatibilityTest)
 }
 


### PR DESCRIPTION
and update CI to use check instead of test.

This is a replacement of the attempt in #2178, which actually runs integration tests twice.

ktlint is removed from main.yml as it is included by `check` already.

Also fixed a case in ApiCheck where libraries can be out of project root.