### PR TITLE
KSP2: fix KSValueParameter.isVal and isVar

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ValueParameterProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ValueParameterProcessor.kt
@@ -1,0 +1,23 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class ValueParameterProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        for (clsName in listOf("MyClassSrc", "MyClassLib")) {
+            val clsDecl = resolver.getClassDeclarationByName(clsName)!!
+            clsDecl.primaryConstructor!!.parameters.sortedBy { it.name!!.asString() }.forEach {
+                results.add("$clsName.${it.name!!.asString()}: isVal: ${it.isVal}, isVar: ${it.isVar}")
+            }
+        }
+        return emptyList()
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -684,6 +684,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../kotlin-analysis-api/testData/typeParameterVariance.kt")
     }
 
+    @TestMetadata("valueParameter.kt")
+    @Test
+    fun testValueParameter() {
+        runTest("../kotlin-analysis-api/testData/valueParameter.kt")
+    }
+
     @TestMetadata("varianceTypeCheck.kt")
     @Test
     fun testVarianceTypeCheck() {

--- a/kotlin-analysis-api/testData/valueParameter.kt
+++ b/kotlin-analysis-api/testData/valueParameter.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Google LLC
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: ValueParameterProcessor
+// EXPECTED:
+// MyClassSrc.field: isVal: false, isVar: false
+// MyClassSrc.valField: isVal: true, isVar: false
+// MyClassSrc.varField: isVal: false, isVar: true
+// MyClassLib.field: isVal: false, isVar: false
+// MyClassLib.valField: isVal: true, isVar: false
+// MyClassLib.varField: isVal: false, isVar: true
+// END
+
+// MODULE: lib
+// FILE: lib.kt
+
+class MyClassLib(
+    field: String,
+    val valField: String,
+    var varField: String,
+)
+
+// MODULE: main(lib)
+// FILE: main.kt
+
+class MyClassSrc(
+    field: String,
+    val valField: String,
+    var varField: String,
+)
+


### PR DESCRIPTION
for symbols from libraries.

Fixes #1192 and #2348 