### PR TITLE
KSP2: fix the type of vararg for Kotlin sources

### DIFF
--- a/docs/ksp2api.md
+++ b/docs/ksp2api.md
@@ -83,8 +83,8 @@ class OverrideOrder2 : BaseInterface2, GrandBaseInterface1 {
 * KSP2: Type annotations on a type argument now present in the resolved type as well
 
 ##### vararg parameters
-* KSP1: Considered as an `Array` type
-* KSP2: Not considered as an `Array` type
+* KSP1: Considered as an `Array` type when it is from Java sources.
+* KSP2: Not considered as an `Array` type. KSValueParameter returns the declared type consistently.
 
 ##### Synthesized members of Enums
 * KSP1: `values` and `valueOf` are missing if the enum is defined in Kotlin sources

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -702,6 +702,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../test-utils/testData/api/validateTypes.kt")
     }
 
+    @TestMetadata("vararg.kt")
+    @Test
+    fun testVararg() {
+        runTest("../test-utils/testData/api/vararg.kt")
+    }
+
     @TestMetadata("visibilities.kt")
     @Test
     fun testVisibilities() {

--- a/kotlin-analysis-api/testData/equivalentJavaWildcards.kt
+++ b/kotlin-analysis-api/testData/equivalentJavaWildcards.kt
@@ -81,7 +81,7 @@
 // - COVARIANT X : X -> X
 // v7 : B<*> -> B<out Any?>
 // v8 : B<A<X, out Y>> -> B<A<X, Y>>
-// - INVARIANT A<INVARIANT X, COVARIANT Y> : A<X, out Y> -> A<X, Y>
+// - INVARIANT A<X, out Y> : A<X, out Y> -> A<X, Y>
 // - - INVARIANT X : X -> X
 // - - COVARIANT Y : Y -> Y
 // foo : Unit -> Unit

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VarargProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VarargProcessor.kt
@@ -1,0 +1,28 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class VarargProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        for (clsName in listOf("s.K", "s.J", "l.K", "l.J")) {
+            val clsDecl = resolver.getClassDeclarationByName(clsName)!!
+            val func = clsDecl.getDeclaredFunctions().single { it.simpleName.asString() == "foo" }
+            val funcName = func.qualifiedName!!.asString()
+            val param = func.parameters.single()
+            val paramName = param.name!!.asString()
+            val paramType = param.type.resolve()
+            val isVararg = if (param.isVararg) "vararg " else ""
+            results.add("$funcName($isVararg$paramName: $paramType)")
+        }
+        return emptyList()
+    }
+}

--- a/test-utils/testData/api/vararg.kt
+++ b/test-utils/testData/api/vararg.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Google LLC
+ * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: VarargProcessor
+// EXPECTED:
+// s.K.foo(vararg strings: String)
+// s.J.foo(vararg strings: (String..String?))
+// l.K.foo(vararg strings: String)
+// l.J.foo(vararg p0: (String..String?))
+// END
+
+// MODULE: lib
+// FILE: l/K.kt
+package l
+class K {
+    fun foo(vararg strings: String) = 0
+}
+
+// FILE: l/J.java
+package l;
+public class J {
+    int foo(String... strings) {
+        return 0;
+    }
+}
+
+// MODULE: main(lib)
+// FILE: s/K.kt
+package s
+class K {
+    fun foo(vararg strings: String) = 0
+}
+
+// FILE: s/J.java
+package s;
+public class J {
+    int foo(String... strings) {
+        return 0;
+    }
+}
+


### PR DESCRIPTION
Previously, KSValueParameter.type was an array when it is from Kotlin sources, while it is the declared type for Java and libraries.

For example, the KSValueParameter.type of strings is now consistently String.

    fun (vararg strings: String)

The equivalentJavaWildcards test is updated due to a toString() change.