### PR TITLE
Register KotlinStandalonePackageProviderFactory to project Disposable

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -259,7 +259,6 @@ class KotlinSymbolProcessing(
             kotlinCoreProjectEnvironment,
             ktFiles,
             createPackagePartProvider,
-            projectDisposable
         )
 
         CoreApplicationEnvironment.registerExtensionPoint(
@@ -296,7 +295,6 @@ class KotlinSymbolProcessing(
         kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment,
         ktFiles: List<KtFile>,
         packagePartProvider: (GlobalSearchScope) -> PackagePartProvider,
-        projectDisposable: Disposable,
     ) {
         val project = kotlinCoreProjectEnvironment.project
         project.apply {
@@ -345,10 +343,7 @@ class KotlinSymbolProcessing(
                 KotlinDeclarationProviderMerger::class.java,
                 KotlinStandaloneDeclarationProviderMerger(this)
             )
-            registerService(
-                KotlinPackageProviderFactory::class.java,
-                IncrementalKotlinPackageProviderFactory(project, projectDisposable)
-            )
+            registerService(KotlinPackageProviderFactory::class.java, IncrementalKotlinPackageProviderFactory(project))
 
             registerService(
                 SealedClassInheritorsProvider::class.java,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -259,6 +259,7 @@ class KotlinSymbolProcessing(
             kotlinCoreProjectEnvironment,
             ktFiles,
             createPackagePartProvider,
+            projectDisposable
         )
 
         CoreApplicationEnvironment.registerExtensionPoint(
@@ -295,6 +296,7 @@ class KotlinSymbolProcessing(
         kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment,
         ktFiles: List<KtFile>,
         packagePartProvider: (GlobalSearchScope) -> PackagePartProvider,
+        projectDisposable: Disposable,
     ) {
         val project = kotlinCoreProjectEnvironment.project
         project.apply {
@@ -343,7 +345,10 @@ class KotlinSymbolProcessing(
                 KotlinDeclarationProviderMerger::class.java,
                 KotlinStandaloneDeclarationProviderMerger(this)
             )
-            registerService(KotlinPackageProviderFactory::class.java, IncrementalKotlinPackageProviderFactory(project))
+            registerService(
+                KotlinPackageProviderFactory::class.java,
+                IncrementalKotlinPackageProviderFactory(project, projectDisposable)
+            )
 
             registerService(
                 SealedClassInheritorsProvider::class.java,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
@@ -12,8 +12,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class IncrementalKotlinPackageProviderFactory(
     private val project: Project,
-    private val projectDisposable: Disposable,
-) : KotlinPackageProviderFactory {
+) : KotlinPackageProviderFactory, Disposable {
     private val staticFactories: MutableList<KotlinStandalonePackageProviderFactory> = mutableListOf()
 
     override fun createPackageProvider(searchScope: GlobalSearchScope): KotlinPackageProvider {
@@ -23,7 +22,10 @@ class IncrementalKotlinPackageProviderFactory(
 
     fun update(files: Collection<KtFile>) {
         val staticFactory = KotlinStandalonePackageProviderFactory(project, files)
-        Disposer.register(projectDisposable, staticFactory)
+        Disposer.register(this, staticFactory)
         staticFactories.add(staticFactory)
+    }
+
+    override fun dispose() {
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
@@ -1,6 +1,8 @@
 package com.google.devtools.ksp.standalone
 
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.psi.search.GlobalSearchScope
 import org.jetbrains.kotlin.analysis.api.platform.packages.KotlinCompositePackageProvider
 import org.jetbrains.kotlin.analysis.api.platform.packages.KotlinPackageProvider
@@ -10,6 +12,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class IncrementalKotlinPackageProviderFactory(
     private val project: Project,
+    private val projectDisposable: Disposable,
 ) : KotlinPackageProviderFactory {
     private val staticFactories: MutableList<KotlinStandalonePackageProviderFactory> = mutableListOf()
 
@@ -20,6 +23,7 @@ class IncrementalKotlinPackageProviderFactory(
 
     fun update(files: Collection<KtFile>) {
         val staticFactory = KotlinStandalonePackageProviderFactory(project, files)
+        Disposer.register(projectDisposable, staticFactory)
         staticFactories.add(staticFactory)
     }
 }


### PR DESCRIPTION
It has to be done manually because it is wrapped by IncrementalPackageProviderFactory.

Tested with Room's test suite where the issue was discovered. Also verified with debugger that KotlinCachingPackageProviderFactory is no longer sticky.