### PR TITLE
KSTypeReferenceResolvedImpl.toString(): render unexpanded

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -116,7 +116,7 @@ class KSTypeReferenceResolvedImpl private constructor(
         }
 
     override fun toString(): String {
-        return ktType.render()
+        return ktType.abbreviationOrSelf.render()
     }
 
     override fun defer(): Restorable? {


### PR DESCRIPTION
instead of the underlying type, which can be confusing and inconsistent to other implementations of KSTypeReference.