### PR TITLE
A couple of fixes to compilation avoidance

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -92,27 +92,30 @@ abstract class KspAATask @Inject constructor(
         }
 
         val changedClasses = if (kspConfig.incremental.get()) {
-            if (kspConfig.platformType.get() == KotlinPlatformType.jvm) {
-                getCPChanges(
-                    inputChanges,
-                    listOf(
-                        kspConfig.sourceRoots,
-                        kspConfig.javaSourceRoots,
-                        kspConfig.commonSourceRoots,
+            when (kspConfig.platformType.get()) {
+                KotlinPlatformType.jvm, KotlinPlatformType.androidJvm -> {
+                    getCPChanges(
+                        inputChanges,
+                        listOf(
+                            kspConfig.sourceRoots,
+                            kspConfig.javaSourceRoots,
+                            kspConfig.commonSourceRoots,
+                            kspConfig.classpathStructure,
+                        ),
+                        kspConfig.cachesDir.asFile.get(),
                         kspConfig.classpathStructure,
-                    ),
-                    kspConfig.cachesDir.asFile.get(),
-                    kspConfig.classpathStructure,
-                    kspConfig.libraries,
-                    kspConfig.processorClasspath,
-                )
-            } else {
-                if (
-                    !inputChanges.isIncremental ||
-                    inputChanges.getFileChanges(kspConfig.nonJvmLibraries).iterator().hasNext()
-                )
-                    kspConfig.cachesDir.get().asFile.deleteRecursively()
-                emptyList()
+                        kspConfig.libraries,
+                        kspConfig.processorClasspath,
+                    )
+                }
+                else -> {
+                    if (
+                        !inputChanges.isIncremental ||
+                        inputChanges.getFileChanges(kspConfig.nonJvmLibraries).iterator().hasNext()
+                    )
+                        kspConfig.cachesDir.get().asFile.deleteRecursively()
+                    emptyList()
+                }
             }
         } else {
             kspConfig.cachesDir.get().asFile.deleteRecursively()

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -192,12 +192,14 @@ abstract class KspAATask @Inject constructor(
                     if (kotlinCompilation is KotlinJvmAndroidCompilation) {
                         // Workaround of a dependency resolution issue of AGP.
                         // FIXME: figure out how to filter or set variant attributes correctly.
+                        val kaptGeneratedClassesDir = getKaptGeneratedClassesDir(project, sourceSetName)
                         val kspOutputDir = KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target)
                         cfg.libraries.from(
                             project.files(
                                 Callable {
                                     kotlinCompileProvider.get().libraries.filter {
                                         !kspOutputDir.isParentOf(it) &&
+                                            !kaptGeneratedClassesDir.isParentOf(it) &&
                                             !(it.isDirectory && it.listFiles()?.isEmpty() == true)
                                     }
                                 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -42,6 +42,7 @@ import org.gradle.work.InputChanges
 import org.jetbrains.kotlin.buildtools.api.SourcesChanges
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.internal.Kapt3GradleSubplugin
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.CLASS_STRUCTURE_ARTIFACT_TYPE
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.ClasspathSnapshot
 import org.jetbrains.kotlin.gradle.internal.kapt.incremental.KaptClasspathChanges
@@ -383,6 +384,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
 
             if (kotlinCompilation is KotlinJvmAndroidCompilation) {
                 // Workaround of a dependency resolution issue of AGP.
+                val kaptGeneratedClassesDir = getKaptGeneratedClassesDir(project, sourceSetName)
                 kspTask.libraries.setFrom(
                     project.files(
                         Callable {
@@ -390,7 +392,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                                 // manually exclude KAPT generated class folder from class path snapshot.
                                 // TODO: remove in 1.9.0.
 
-                                !kspOutputDir.isParentOf(it) && !(it.isDirectory && it.listFiles()?.isEmpty() == true)
+                                !kspOutputDir.isParentOf(it) &&
+                                    !kaptGeneratedClassesDir.isParentOf(it) &&
+                                    !(it.isDirectory && it.listFiles()?.isEmpty() == true)
                             }
                         }
                     )
@@ -919,3 +923,6 @@ internal fun FileCollection.nonSelfDeps(selfTaskName: String): List<Task> =
     buildDependencies.getDependencies(null).filterNot {
         it.name == selfTaskName
     }
+
+internal fun getKaptGeneratedClassesDir(project: Project, sourceSetName: String) =
+    Kapt3GradleSubplugin.getKaptGeneratedClassesDir(project, sourceSetName)


### PR DESCRIPTION
1. Exclude KAPT generated classes from class path snapshots. This fixes #1280. Tested locally with a sample project from @luboganev. Not sure why this bug is not caught by `KAPT3IT` yet and still investigating.
2. Enable class path snapshots based incremental processing on Android builds, which was accidentally omitted previously. Hopefully this will make Android builds much faster.