### PR TITLE
KSP2: Support generated binary classes

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -212,6 +212,8 @@ abstract class KspAATask @Inject constructor(
                         cfg.libraries.from(kotlinCompilation.compileDependencyFiles)
                     }
 
+                    val classOutputDir = KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target)
+
                     val compilerOptions = kotlinCompilation.compilerOptions.options
                     val langVer = compilerOptions.languageVersion.orNull?.version ?: KSP_KOTLIN_BASE_VERSION
                     val apiVer = compilerOptions.apiVersion.orNull?.version ?: KSP_KOTLIN_BASE_VERSION
@@ -223,7 +225,7 @@ abstract class KspAATask @Inject constructor(
                     cfg.outputBaseDir.value(KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target))
                     cfg.kotlinOutputDir.value(kotlinOutputDir)
                     cfg.javaOutputDir.value(javaOutputDir)
-                    cfg.classOutputDir.value(KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target))
+                    cfg.classOutputDir.value(classOutputDir)
                     cfg.resourceOutputDir.value(
                         KspGradleSubplugin.getKspResourceOutputDir(
                             project,
@@ -300,6 +302,10 @@ abstract class KspAATask @Inject constructor(
                         cfg.jvmTarget.value(compilerOptions.jvmTarget.map { it.target })
 
                         cfg.classpathStructure.from(getClassStructureFiles(project, cfg.libraries))
+
+                        // Don't support binary generation for non-JVM platforms yet.
+                        // FIXME: figure out how to add user generated libraries.
+                        kotlinCompilation.output.classesDirs.from(classOutputDir)
                     } else {
                         cfg.nonJvmLibraries.from(cfg.libraries)
                     }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -387,6 +387,25 @@ class PlaygroundIT(val useKSP2: Boolean) {
         }
     }
 
+    @Test
+    fun testGeneratedBinaryClass() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        File(project.root, "workload/src/main/java/NeedGenerated.kt").appendText("val v = BinaryClass()\n")
+        File(
+            project.root,
+            "test-processor/src/main/resources/META-INF/services/" +
+                "com.google.devtools.ksp.processing.SymbolProcessorProvider"
+        ).appendText("BinaryGenProcessorProvider")
+        gradleRunner.buildAndCheck("clean", "build") {
+            val artifact = File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar")
+            Assert.assertTrue(artifact.exists())
+
+            JarFile(artifact).use { jarFile ->
+                Assert.assertTrue(jarFile.getEntry("BinaryClass.class").size > 0)
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "KSP2={0}")

--- a/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BinaryGenProcessor.kt
+++ b/integration-tests/src/test/resources/playground/test-processor/src/main/kotlin/BinaryGenProcessor.kt
@@ -1,0 +1,42 @@
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.containingFile
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.*
+import com.google.devtools.ksp.symbol.*
+import java.io.OutputStream
+import kotlin.io.encoding.*
+
+class BinaryGenProcessor(val env: SymbolProcessorEnvironment) : SymbolProcessor {
+    val codeGenerator: CodeGenerator = env.codeGenerator
+    val logger: KSPLogger = env.logger
+
+    // public class BinaryClass {}
+    val content = "yv66vgAAADQADQoAAgADBwAEDAAFAAYBABBqYXZhL2xhbmcvT2JqZWN0AQAGPGluaXQ+AQADKClW" +
+        "BwAIAQALQmluYXJ5Q2xhc3MBAARDb2RlAQAPTGluZU51bWJlclRhYmxlAQAKU291cmNlRmlsZQEA" +
+        "EEJpbmFyeUNsYXNzLmphdmEAIQAHAAIAAAAAAAEAAQAFAAYAAQAJAAAAHQABAAEAAAAFKrcAAbEA" +
+        "AAABAAoAAAAGAAEAAAABAAEACwAAAAIADA=="
+
+    @OptIn(KspExperimental::class, ExperimentalEncodingApi::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val needGenerated = resolver.getNewFiles().any {
+            it.fileName == "NeedGenerated.kt"
+        }
+
+        if (needGenerated) {
+            codeGenerator.createNewFile(Dependencies(false), "", "BinaryClass", "class").use { outFile ->
+                val decoded = Base64.decode(content)
+                outFile.write(decoded)
+            }
+        }
+
+        return emptyList()
+    }
+}
+
+class BinaryGenProcessorProvider : SymbolProcessorProvider {
+    override fun create(
+        env: SymbolProcessorEnvironment
+    ): SymbolProcessor {
+        return BinaryGenProcessor(env)
+    }
+}


### PR DESCRIPTION
Currently,
1. It only works on JVM.
2. Generated classes are not available within processing rounds.