### PR TITLE
Replace urls to JetBrains Maven repositories 

### DIFF
--- a/benchmark/TachiyomiExhaustive/tachi.patch
+++ b/benchmark/TachiyomiExhaustive/tachi.patch
@@ -49,7 +49,7 @@ index c5607aa82..e274b0455 100644
      repositories {
          mavenCentral()
          google()
-+        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
++        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
          maven { setUrl("https://www.jitpack.io") }
      }
  }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ if (!extra.has("kspVersion")) {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 plugins {
@@ -51,7 +51,7 @@ subprojects {
     repositories {
         mavenCentral()
         google()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         maven("https://www.jetbrains.com/intellij-repository/releases")
     }
     pluginManager.withPlugin("maven-publish") {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,5 +10,5 @@ kotlin {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestProject.kt
@@ -74,7 +74,7 @@ class TestProject(
                         maven("${testConfig.mavenRepoPath}")
                         gradlePluginPortal()
                         google()
-                        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+                        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
                     }
                 }
         """.trimIndent()
@@ -102,7 +102,7 @@ class TestProject(
             repositories {
                 maven("${testConfig.mavenRepoPath}")
                 mavenCentral()
-                maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+                maven("https://redirector.kotlinlang.org/maven/bootstrap/")
                 google()
             }
             configurations.all {
@@ -116,7 +116,7 @@ class TestProject(
                 repositories {
                     maven("${testConfig.mavenRepoPath}")
                     mavenCentral()
-                    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+                    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
                     google()
                 }
                 configurations.all {

--- a/integration-tests/src/test/resources/android-view-binding/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-view-binding/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }
@@ -21,7 +21,7 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }

--- a/integration-tests/src/test/resources/android-view-binding/settings.gradle.kts
+++ b/integration-tests/src/test/resources/android-view-binding/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/buildcache-incremental/build.gradle.kts
+++ b/integration-tests/src/test/resources/buildcache-incremental/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/buildcache-incremental/settings.gradle.kts
+++ b/integration-tests/src/test/resources/buildcache-incremental/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/buildcache-incremental/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/buildcache-incremental/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/buildcache-incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/buildcache-incremental/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/buildcache/settings.gradle.kts
+++ b/integration-tests/src/test/resources/buildcache/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/cmd-options/build.gradle.kts
+++ b/integration-tests/src/test/resources/cmd-options/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/cmd-options/processors/build.gradle.kts
+++ b/integration-tests/src/test/resources/cmd-options/processors/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/cmd-options/settings.gradle.kts
+++ b/integration-tests/src/test/resources/cmd-options/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/cmd-options/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/cmd-options/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/hmpp/build.gradle.kts
+++ b/integration-tests/src/test/resources/hmpp/build.gradle.kts
@@ -7,6 +7,6 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/hmpp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/hmpp/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l1/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l2/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l3/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l4/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l4/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/l5/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/l5/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/validator/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-classpath/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-multi-chain/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-multi-chain/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/incremental-multi-chain/processors/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-multi-chain/processors/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-multi-chain/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-multi-chain/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental-multi-chain/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-multi-chain/workload/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-removal/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/incremental-removal/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental-removal/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/validator/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-removal/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal/workload/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-removal2/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal2/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/incremental-removal2/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal2/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental-removal2/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal2/validator/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental-removal2/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-removal2/workload/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/incremental/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/validator/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/init-plus-provider/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/init-plus-provider/provider-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/provider-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/init-plus-provider/settings.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/init-plus-provider/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/init-plus-provider/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/javaNestedClass/build.gradle.kts
+++ b/integration-tests/src/test/resources/javaNestedClass/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/javaNestedClass/settings.gradle.kts
+++ b/integration-tests/src/test/resources/javaNestedClass/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/javaNestedClass/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/javaNestedClass/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/javaNestedClass/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/javaNestedClass/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kapt3/build.gradle.kts
+++ b/integration-tests/src/test/resources/kapt3/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/kapt3/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kapt3/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/kapt3/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/kapt3/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kapt3/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kapt3/workload/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kmp/build.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/build.gradle.kts
@@ -7,6 +7,6 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/kmp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kmp/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kotlin-consts-in-java/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-consts-in-java/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/kotlin-inject/build.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-inject/build.gradle.kts
@@ -7,6 +7,6 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/kotlin-inject/settings.gradle.kts
+++ b/integration-tests/src/test/resources/kotlin-inject/settings.gradle.kts
@@ -10,7 +10,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/on-error/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/on-error-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/on-error/settings.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/on-error/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/only-resources-file/build.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/build.gradle.kts
@@ -7,6 +7,6 @@ subprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/only-resources-file/settings.gradle.kts
+++ b/integration-tests/src/test/resources/only-resources-file/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/output-deps/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/output-deps/settings.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/output-deps/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/application/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android-multi/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }
@@ -21,7 +21,7 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }

--- a/integration-tests/src/test/resources/playground-android-multi/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/settings.gradle.kts
@@ -15,7 +15,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/playground-android-multi/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-multi/workload/build.gradle.kts
@@ -12,7 +12,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }
@@ -14,7 +14,7 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         google()
     }
 }

--- a/integration-tests/src/test/resources/playground-android/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/settings.gradle.kts
@@ -14,7 +14,7 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -12,7 +12,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
@@ -7,6 +7,6 @@ allprojects {
     repositories {
         maven(testRepo)
         mavenCentral()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }

--- a/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/playground/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/playground/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/playground/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/playground/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground/workload/build.gradle.kts
@@ -12,7 +12,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/build.gradle.kts
@@ -4,5 +4,5 @@ plugins {
 
 repositories {
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }

--- a/integration-tests/src/test/resources/test-processor/settings.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/settings.gradle.kts
@@ -9,7 +9,7 @@ pluginManagement {
     repositories {
         maven(testRepo)
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
     }
 }
 

--- a/integration-tests/src/test/resources/test-processor/test-processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/test-processor/build.gradle.kts
@@ -11,7 +11,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/integration-tests/src/test/resources/test-processor/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/test-processor/workload/build.gradle.kts
@@ -10,7 +10,7 @@ version = "1.0-SNAPSHOT"
 repositories {
     maven(testRepo)
     mavenCentral()
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
 }
 
 dependencies {

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -148,7 +148,7 @@ repositories {
     flatDir {
         dirs("${project.rootDir}/third_party/prebuilt/repo/")
     }
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
+    maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")
     maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,7 @@ pluginManagement {
 
     repositories {
         gradlePluginPortal()
-        maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/bootstrap/")
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
         maven("https://www.jetbrains.com/intellij-repository/snapshots")
     }
 }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 version = "2.0.255-SNAPSHOT"
 
 repositories {
-    maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies")
+    maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")
     maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
 }
 


### PR DESCRIPTION
At JetBrains, we are moving our Maven repositories to a new hosting URL. Instead of using a direct link to the repositories, we’ve created a redirector that points to the current artifact location. This way, we won’t need to update the URL in projects using our Maven repositories in the future.