### PR TITLE
Fix KSAnnotationResolvedImpl.origin

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -3,6 +3,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin.resolved
 import com.google.devtools.ksp.common.IdKeyPair
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.java.KSValueArgumentLiteImpl
 import com.google.devtools.ksp.impl.symbol.java.calcValue
 import com.google.devtools.ksp.impl.symbol.kotlin.*
@@ -137,7 +138,14 @@ class KSAnnotationResolvedImpl private constructor(
         }
     }
 
-    override val origin: Origin = parent?.origin ?: Origin.KOTLIN_LIB
+    // Annotations on deeply synthesized members like getter of Java annotation arguments can still be real.
+    override val origin: Origin by lazy {
+        val parentOrigin = parent?.origin ?: Origin.SYNTHETIC
+        when (parentOrigin) {
+            Origin.SYNTHETIC -> containingFile?.origin ?: Origin.SYNTHETIC
+            else -> parentOrigin
+        }
+    }
 
     override val location: Location by lazy {
         NonExistLocation

--- a/kotlin-analysis-api/testData/libOrigins.kt
+++ b/kotlin-analysis-api/testData/libOrigins.kt
@@ -21,6 +21,7 @@
 // Validating Anno2
 // Validating Anno3
 // Validating Anno4
+// Validating Anno5
 // Validating JavaLib
 // Validating KotlinLibClass
 // Exception: [KotlinLibClass, T1, Any?]: SYNTHETIC
@@ -30,6 +31,12 @@
 // Validating File: JavaSrc.java
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc, JavaSrc]: SYNTHETIC
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, value, String]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, value, value.getter(), String]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, value, value.getter()]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, value]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, synthetic constructor for JavaAnno1, JavaAnno1]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, synthetic constructor for JavaAnno1]: SYNTHETIC
 // Validating File: KotlinSrc.kt
 // Exception: [File: KotlinSrc.kt, kotlinSrcProperty, kotlinSrcProperty.getter(), Short, Short]: SYNTHETIC
 // Exception: [File: KotlinSrc.kt, kotlinSrcProperty, kotlinSrcProperty.getter(), Short]: SYNTHETIC
@@ -56,6 +63,7 @@ annotation class Anno1
 annotation class Anno2
 annotation class Anno3
 annotation class Anno4
+annotation class Anno5(val p1: Int = 42, val p2: String = "default")
 
 @Anno1
 class KotlinLibClass<T1>(val p1: List<T1>, val p2: Int)  {
@@ -111,3 +119,7 @@ class JavaSrc {
     }
 }
 
+public @interface JavaAnno1 {
+    @Anno5(p1 = 1, p2 = "a2")
+    String value ();
+}

--- a/test-utils/testData/api/libOrigins.kt
+++ b/test-utils/testData/api/libOrigins.kt
@@ -21,6 +21,7 @@
 // Validating Anno2
 // Validating Anno3
 // Validating Anno4
+// Validating Anno5
 // Validating JavaLib
 // Validating KotlinLibClass
 // Validating kotlinLibFuntion
@@ -28,6 +29,8 @@
 // Validating File: JavaSrc.java
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc, JavaSrc]: SYNTHETIC
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, synthetic constructor for JavaAnno1, JavaAnno1]: SYNTHETIC
+// Exception: [File: JavaSrc.java, JavaAnno1, synthetic constructor for JavaAnno1]: SYNTHETIC
 // Validating File: KotlinSrc.kt
 // Exception: [File: KotlinSrc.kt, kotlinSrcProperty, kotlinSrcProperty.getter(), Short, Short]: SYNTHETIC
 // Exception: [File: KotlinSrc.kt, kotlinSrcProperty, kotlinSrcProperty.getter(), Short]: SYNTHETIC
@@ -59,6 +62,7 @@ annotation class Anno1
 annotation class Anno2
 annotation class Anno3
 annotation class Anno4
+annotation class Anno5(val p1: Int = 42, val p2: String = "default")
 
 @Anno1
 class KotlinLibClass<T1>(val p1: List<T1>, val p2: Int)  {
@@ -114,3 +118,7 @@ class JavaSrc {
     }
 }
 
+public @interface JavaAnno1 {
+    @Anno5(p1 = 1, p2 = "a2")
+    String value ();
+}


### PR DESCRIPTION
Annotations applied in sources can be attached to synthetic elements. In that case, they should still be considered as source.

Fixes #2425 