### PR TITLE
Introduce AnnotationUseSiteTarget.ALL

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -230,6 +230,7 @@ package com.google.devtools.ksp.symbol {
   public enum AnnotationUseSiteTarget {
     method @NonNull public static com.google.devtools.ksp.symbol.AnnotationUseSiteTarget valueOf(String value) throws java.lang.IllegalArgumentException, java.lang.NullPointerException;
     method @NonNull public static com.google.devtools.ksp.symbol.AnnotationUseSiteTarget[] values();
+    enum_constant public static final com.google.devtools.ksp.symbol.AnnotationUseSiteTarget ALL;
     enum_constant public static final com.google.devtools.ksp.symbol.AnnotationUseSiteTarget DELEGATE;
     enum_constant public static final com.google.devtools.ksp.symbol.AnnotationUseSiteTarget FIELD;
     enum_constant public static final com.google.devtools.ksp.symbol.AnnotationUseSiteTarget FILE;

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/AnnotationUseSiteTarget.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/AnnotationUseSiteTarget.kt
@@ -25,5 +25,6 @@ enum class AnnotationUseSiteTarget {
     RECEIVER,
     PARAM,
     SETPARAM,
-    DELEGATE
+    DELEGATE,
+    ALL,
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -137,8 +137,7 @@ class KSAnnotationImpl private constructor(
             CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
             SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
             PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
-            // FIXME
-            ALL -> null
+            ALL -> AnnotationUseSiteTarget.ALL
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -43,7 +43,6 @@ abstract class KSPropertyAccessorImpl(
         ktPropertyAccessorSymbol.annotations.asSequence()
             .filter { it.useSiteTarget != AnnotationUseSiteTarget.SETTER_PARAMETER }
             .map { KSAnnotationResolvedImpl.getCached(it, this) }
-            .plus(findAnnotationFromUseSiteTarget())
     }
 
     internal val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -96,7 +96,7 @@ class KSValueParameterImpl private constructor(
     }
 
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
-        ktValueParameterSymbol.annotations(this).plus(findAnnotationFromUseSiteTarget())
+        ktValueParameterSymbol.annotations(this)
     }
     override val origin: Origin by lazy {
         val symbolOrigin = mapAAOrigin(ktValueParameterSymbol)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -133,8 +133,7 @@ class KSAnnotationResolvedImpl private constructor(
             CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
             SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
             PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
-            // FIXME:
-            ALL -> null
+            ALL -> AnnotationUseSiteTarget.ALL
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -458,40 +458,6 @@ internal fun KaType.typeArguments(): List<KaTypeProjection> {
     }
 }
 
-internal fun KSAnnotated.findAnnotationFromUseSiteTarget(): Sequence<KSAnnotation> {
-    return when (this) {
-        is KSPropertyGetter -> (this.receiver as? AbstractKSDeclarationImpl)?.let { decl ->
-            decl.originalAnnotations.filter { it.useSiteTarget == AnnotationUseSiteTarget.GET }
-        }
-
-        is KSPropertySetter -> (this.receiver as? AbstractKSDeclarationImpl)?.let { decl ->
-            decl.originalAnnotations.filter { it.useSiteTarget == AnnotationUseSiteTarget.SET }
-        }
-
-        is KSValueParameter -> {
-            var parent = this.parent
-            // TODO: eliminate annotationsFromParents to make this fully sequence.
-            val annotationsFromParents = mutableListOf<KSAnnotation>()
-            (parent as? KSPropertyAccessorImpl)?.let { propertyAccessor ->
-                annotationsFromParents.addAll(
-                    propertyAccessor.originalAnnotations
-                        .filter { it.useSiteTarget == AnnotationUseSiteTarget.SETPARAM }
-                )
-                parent = (parent as KSPropertyAccessorImpl).receiver
-            }
-            (parent as? KSPropertyDeclarationImpl)?.let { propertyDeclaration ->
-                annotationsFromParents.addAll(
-                    propertyDeclaration.originalAnnotations
-                        .filter { it.useSiteTarget == AnnotationUseSiteTarget.SETPARAM }
-                )
-            }
-            annotationsFromParents.asSequence()
-        }
-
-        else -> emptySequence()
-    } ?: emptySequence()
-}
-
 internal fun KaSymbolVisibility.toModifier(): Modifier {
     return when (this) {
         KaSymbolVisibility.PUBLIC -> Modifier.PUBLIC

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -74,6 +74,7 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             javaSourcePath,
             "-d", outDir.absolutePath,
             "-no-stdlib",
+            "-Xannotation-target-all",
             "-module-name", moduleName,
             "-classpath", classpath.joinToString(File.pathSeparator)
         )

--- a/kotlin-analysis-api/testData/annotationInDependencies.kt
+++ b/kotlin-analysis-api/testData/annotationInDependencies.kt
@@ -28,8 +28,8 @@
 // parameter param1 : annotations.ValueParameterTarget{[value = onParam1]}
 // parameter param2 : annotations.NoTargetAnnotation{[value = onParam2]}
 // parameter param2 : annotations.ValueParameterTarget{[value = onParam2]}
-// parameter value : annotations.ValueParameterTarget{[value = onPropSetter]}
 // parameter value : annotations.ValueParameterTarget{[value = onProp]}
+// property prop : annotations.AllTarget{[value = all:]}
 // property prop : annotations.FieldTarget2{[value = field:]}
 // property prop : annotations.FieldTarget{[value = onProp]}
 // property prop : annotations.NoTargetAnnotation{[value = onProp]}
@@ -40,12 +40,16 @@
 // class lib.KotlinClass : annotations.NoTargetAnnotation{[value = onClass]}
 // function myFun : annotations.FunctionTarget{[value = onMyFun]}
 // function myFun : annotations.NoTargetAnnotation{[value = onMyFun]}
+// getter of property prop : annotations.AllTarget{[value = all:]}
 // getter of property prop : annotations.PropertyGetterTarget{[value = get:]}
 // parameter param1 : annotations.NoTargetAnnotation{[value = onParam1]}
 // parameter param1 : annotations.ValueParameterTarget{[value = onParam1]}
 // parameter param2 : annotations.NoTargetAnnotation{[value = onParam2]}
 // parameter param2 : annotations.ValueParameterTarget{[value = onParam2]}
 // parameter propInConstructor : annotations.ValueParameterTarget{[value = propInConstructor]}
+// parameter value : annotations.AllTarget{[value = all:]}
+// property prop : annotations.AllTarget{[value = all:]}
+// property prop : annotations.AllTarget{[value = all:]}
 // property prop : annotations.FieldTarget2{[value = field:]}
 // property prop : annotations.FieldTarget{[value = onProp]}
 // property prop : annotations.NoTargetAnnotation{[value = onProp]}
@@ -55,9 +59,12 @@
 // class main.DataClass : annotations.ClassTarget{[value = onDataClass]}
 // class main.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
 // getter of property constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// parameter constructorParam : annotations.AllTarget{[value = all:]}
 // parameter constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
 // parameter constructorParam : annotations.ValueParameterTarget{[value = onConstructorParam]}
 // parameter value : annotations.ValueParameterTarget{[value = onConstructorParam]}
+// property constructorParam : annotations.AllTarget{[value = all:]}
+// property constructorParam : annotations.AllTarget{[value = all:]}
 // property constructorParam : annotations.FieldTarget2{[value = field:]}
 // property constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
 // property constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
@@ -67,8 +74,13 @@
 // lib.DataClass ->
 // class lib.DataClass : annotations.ClassTarget{[value = onDataClass]}
 // class lib.DataClass : annotations.NoTargetAnnotation{[value = onDataClass]}
+// getter of property constructorParam : annotations.AllTarget{[value = all:]}
 // getter of property constructorParam : annotations.PropertyGetterTarget{[value = get:]}
+// parameter constructorParam : annotations.AllTarget{[value = all:]}
 // parameter constructorParam : annotations.NoTargetAnnotation{[value = onConstructorParam]}
+// parameter value : annotations.AllTarget{[value = all:]}
+// property constructorParam : annotations.AllTarget{[value = all:]}
+// property constructorParam : annotations.AllTarget{[value = all:]}
 // property constructorParam : annotations.FieldTarget2{[value = field:]}
 // property constructorParam : annotations.FieldTarget{[value = onConstructorParam]}
 // property constructorParam : annotations.PropertyTarget{[value = onConstructorParam]}
@@ -106,6 +118,8 @@ annotation class ValueParameterTarget(val value:String)
 @Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.FIELD)
 annotation class ValueParameterAndFieldTarget(val value: String)
 
+annotation class AllTarget(val value: String)
+
 // MODULE: lib(annotations)
 // FILE: ClassInLib.kt
 package lib;
@@ -119,6 +133,7 @@ class KotlinClass(@ValueParameterTarget("propInConstructor") val propInConstruct
     @set:PropertySetterTarget("set:")
     @get:PropertyGetterTarget("get:")
     @field:FieldTarget2("field:")
+    @all:AllTarget("all:")
     var prop : String = ""
 
     @NoTargetAnnotation("onMyFun")
@@ -143,6 +158,7 @@ class DataClass(
     @set:PropertySetterTarget("set:")
     @get:PropertyGetterTarget("get:")
     @field:FieldTarget2("field:")
+    @all:AllTarget("all:")
     var constructorParam : String = ""
 )
 // FILE: lib/JavaClass.java
@@ -163,9 +179,8 @@ class KotlinClass {
     @get:PropertyGetterTarget("get:")
     @field:FieldTarget2("field:")
     @setparam:ValueParameterTarget("onProp")
+    @all:AllTarget("all:")
     var prop : String = ""
-        @setparam:ValueParameterTarget("onPropSetter")
-        set
 
     @NoTargetAnnotation("onMyFun")
     @FunctionTarget("onMyFun")
@@ -192,6 +207,7 @@ class DataClass(
     @field:ValueParameterAndFieldTarget("valueParameterAndField")
     @setparam:ValueParameterTarget("onConstructorParam")
     @ValueParameterTarget("onConstructorParam")
+    @all:AllTarget("all:")
     var constructorParam : String = ""
 )
 // FILE: main/JavaClassInModule2.java

--- a/test-utils/testData/api/nestedAnnotations.kt
+++ b/test-utils/testData/api/nestedAnnotations.kt
@@ -24,10 +24,12 @@
 // END
 
 class MyClass(@param:MyNestedAnnotation param: String) {
-    @field:MyNestedAnnotation val field: String = TODO()
-    @property:MyNestedAnnotation val property: String = TODO()
-        @setparam:MyNestedAnnotation
-        set(value) {}
+    @field:MyNestedAnnotation
+    val field: String = TODO()
+
+    @property:MyNestedAnnotation
+    @setparam:MyNestedAnnotation
+    var property: String = TODO()
     annotation class MyNestedAnnotation
 }
 


### PR DESCRIPTION
for the new `all` annotation use site target.

https://github.com/Kotlin/KEEP/blob/master/proposals/annotation-target-in-properties.md

Also fixed a couple of tests where `setparam` should only be propagated
to synthetic setter paramaters.

TODO: configure `-Xannotation-defaulting` / `LanguageFeature.PropertyParamAnnotationDefaultTargetMode` according to the corresponding compilation.