### PR TITLE
Do not resolve configuration in configuration time

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -160,7 +160,11 @@ abstract class KspAATask @Inject constructor(
             ).apply {
                 isTransitive = false
             }
+            val incomingProcessors = processorClasspath.incoming.files
             val kspTaskProvider = project.tasks.register(kspTaskName, KspAATask::class.java) { kspAATask ->
+                kspAATask.onlyIf {
+                    !incomingProcessors.isEmpty()
+                }
                 kspAATask.kspClasspath.from(kspAADepCfg)
                 kspAATask.kspConfig.let { cfg ->
                     cfg.processorClasspath.from(processorClasspath)


### PR DESCRIPTION
and unconditionally register KSP tasks.

configurationsForMultiplatformApp_doesNotCrossCompilationBoundaries is
removed because the use case of declaring multiple similar targets is no
longer supported in Kotlin 2.2.

Fixes #1789 