### PR TITLE
KSP1: use new mangling scheme for inline classes

### DIFF
--- a/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
+++ b/compiler-plugin/src/main/kotlin/com/google/devtools/ksp/processing/impl/ResolverImpl.kt
@@ -149,7 +149,7 @@ class ResolverImpl(
     private val typeMapper = KotlinTypeMapper(
         moduleIdentifier,
         LanguageVersionSettingsImpl(LanguageVersion.KOTLIN_1_9, ApiVersion.KOTLIN_1_9),
-        true
+        false
     )
     private val qualifiedExpressionResolver = QualifiedExpressionResolver(LanguageVersionSettingsImpl.DEFAULT)
 


### PR DESCRIPTION
The old scheme was deprecated since 1.4.30.

Fixes #1493 