### PR TITLE
Clean up task registering in kts build scripts

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -18,17 +18,13 @@ plugins {
     id("org.jetbrains.dokka")
 }
 
-tasks {
-    val sourcesJar by creating(Jar::class) {
-        archiveClassifier.set("sources")
-        from(sourceSets.main.get().allSource)
-    }
+val sourceJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier.set("sources")
+    from(sourceSets.main.map { it.allSource })
 }
-
-val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
-    dependsOn(tasks.dokkaJavadoc)
-    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
     archiveClassifier.set("javadoc")
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
 }
 
 publishing {
@@ -36,8 +32,8 @@ publishing {
         create<MavenPublication>("default") {
             artifactId = "symbol-processing-api"
             from(components["java"])
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["dokkaJavadocJar"])
+            artifact(sourceJar)
+            artifact(dokkaJavadocJar)
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing-api")
                 description.set("Symbol processing for Kotlin")

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -1,15 +1,7 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-evaluationDependsOn(":api")
-
 description = "Kotlin Symbol Processing Util"
 
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
-
-tasks.withType<KotlinCompile> {
-    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
-}
 
 plugins {
     kotlin("jvm")
@@ -22,8 +14,13 @@ dependencies {
     testImplementation("junit:junit:$junitVersion")
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+    }
+}
+
 val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
-    dependsOn(tasks.dokkaJavadoc)
-    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
     archiveClassifier.set("javadoc")
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
 }

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "Kotlin Symbol Processor"
 
@@ -10,10 +9,6 @@ val agpBaseVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 val aaCoroutinesVersion: String? by project
-
-tasks.withType<KotlinCompile> {
-    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
-}
 
 plugins {
     kotlin("jvm")
@@ -45,6 +40,12 @@ dependencies {
     lintChecks("androidx.lint:lint-gradle:1.0.0-alpha04")
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+    }
+}
+
 tasks.named("validatePlugins").configure {
     onlyIf {
         // while traversing classpath, this hits a class not found issue.
@@ -65,17 +66,13 @@ gradlePlugin {
     }
 }
 
-tasks {
-    val sourcesJar by creating(Jar::class) {
-        archiveClassifier.set("sources")
-        from(project.sourceSets.main.get().allSource)
-    }
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier.set("sources")
+    from(project.sourceSets.main.map { it.allSource })
 }
-
-val dokkaJavadocJar by tasks.register<Jar>("dokkaJavadocJar") {
-    dependsOn(tasks.dokkaJavadoc)
-    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
+val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
     archiveClassifier.set("javadoc")
+    from(tasks.dokkaJavadoc.flatMap { it.outputDirectory })
 }
 
 publishing {
@@ -84,8 +81,8 @@ publishing {
         // https://github.com/gradle/gradle/blob/master/subprojects/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/MavenPluginPublishPlugin.java#L73
         this.create<MavenPublication>("pluginMaven") {
             artifactId = "symbol-processing-gradle-plugin"
-            artifact(tasks["sourcesJar"])
-            artifact(tasks["dokkaJavadocJar"])
+            artifact(sourcesJar)
+            artifact(dokkaJavadocJar)
             pom {
                 name.set("symbol-processing-gradle-plugin")
                 description.set("Kotlin symbol processing integration for Gradle")

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -34,30 +34,23 @@ tasks.withType<ShadowJar> {
     relocate("com.intellij", "org.jetbrains.kotlin.com.intellij")
 }
 
-tasks {
-    val sourcesJar by creating(Jar::class) {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        archiveClassifier.set("sources")
-        from(project(":kotlin-analysis-api").sourceSets.main.get().allSource)
-    }
-    val javadocJar by creating(Jar::class) {
-        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        archiveClassifier.set("javadoc")
-        from(project(":compiler-plugin").tasks["dokkaJavadocJar"])
-    }
-    publish {
-        dependsOn(shadowJar)
-        dependsOn(javadocJar)
-        dependsOn(sourcesJar)
-    }
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier.set("sources")
+    from(project(":kotlin-analysis-api").sourceSets.main.get().allSource)
+}
+val javadocJar = tasks.register<Jar>("javadocJar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveClassifier.set("javadoc")
+    from(project(":compiler-plugin").tasks["dokkaJavadocJar"])
 }
 
 publishing {
     publications {
         create<MavenPublication>("shadow") {
             artifactId = "symbol-processing"
-            artifact(tasks["javadocJar"])
-            artifact(tasks["sourcesJar"])
+            artifact(javadocJar)
+            artifact(sourcesJar)
             artifact(tasks["shadowJar"])
             pom {
                 name.set("com.google.devtools.ksp:symbol-processing")

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,8 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
-tasks.withType<KotlinCompile> {
-    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
-}
 plugins {
     kotlin("jvm")
 }
@@ -17,4 +12,10 @@ repositories {
 dependencies {
     implementation(project(":api"))
     implementation(kotlin("reflect"))
+}
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+    }
 }


### PR DESCRIPTION
It reduces eagerly created tasks from 21 to 8
It also removes usages of deprecated tasks.create APIs

Before:
https://scans.gradle.com/s/c7nuxleridqpa/performance/configuration#summary-task-created-immediately

After:
https://scans.gradle.com/s/ujjfmvljy65xo/performance/configuration#summary-task-created-immediately