### PR TITLE
Cherry-pick "Switch to Lint with K2 UAST" to 2.0.2-release manually

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,5 @@ kotlin.jvm.target.validation.mode=warning
 # Build or runtime dependencies of this project
 buildKotlinVersion=2.1.20
 buildKspVersion=2.1.20-1.0.32
+
+android.lint.useK2Uast=true


### PR DESCRIPTION
due to a CR/LF conflict.