### PR TITLE
Make built jars reproducible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,4 +120,9 @@ subprojects {
     tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
         compilerOptions.freeCompilerArgs.add("-Xskip-prerelease-check")
     }
+
+    tasks.withType<Jar>().configureEach {
+        isPreserveFileTimestamps = false
+        isReproducibleFileOrder = true
+    }
 }


### PR DESCRIPTION
Disables timestamps and enables reproducable order for KSP jars

Test: ./gradlew publishToMavenLocal -> inspect jars