### PR TITLE
Fix origin of arguments of synthetic annotations

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -161,7 +161,7 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
 
     override val useSiteTarget: AnnotationUseSiteTarget? = null
 
-    override val origin: Origin = Origin.JAVA
+    override val origin: Origin = if (parent == null) Origin.SYNTHETIC else Origin.JAVA
 
     override val location: Location
         get() = psi.toLocation()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -42,7 +42,7 @@ abstract class KSPropertyAccessorImpl(
         // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
         ktPropertyAccessorSymbol.annotations.asSequence()
             .filter { it.useSiteTarget != AnnotationUseSiteTarget.SETTER_PARAMETER }
-            .map { KSAnnotationResolvedImpl.getCached(it, this) }
+            .map { KSAnnotationResolvedImpl.getCached(it, this, annotationOrigin) }
     }
 
     internal val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -42,7 +42,7 @@ abstract class KSPropertyAccessorImpl(
         // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
         ktPropertyAccessorSymbol.annotations.asSequence()
             .filter { it.useSiteTarget != AnnotationUseSiteTarget.SETTER_PARAMETER }
-            .map { KSAnnotationResolvedImpl.getCached(it, this, annotationOrigin) }
+            .map { KSAnnotationResolvedImpl.getCached(it, this, definitionOrigin) }
     }
 
     internal val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -62,7 +62,7 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktPropertySymbol.annotations.asSequence()
             .filter { !it.isUseSiteTargetAnnotation() }
-            .map { KSAnnotationResolvedImpl.getCached(it, this) }
+            .map { KSAnnotationResolvedImpl.getCached(it, this, annotationOrigin) }
             .plus(
                 if (ktPropertySymbol.isFromPrimaryConstructor) {
                     (parentDeclaration as? KSClassDeclaration)?.primaryConstructor?.parameters?.singleOrNull {
@@ -73,8 +73,9 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
                 }
             ).plus(
                 // TODO: optimize for psi
-                ktPropertySymbol.backingFieldSymbol?.annotations
-                    ?.map { KSAnnotationResolvedImpl.getCached(it, this@KSPropertyDeclarationImpl) } ?: emptyList()
+                ktPropertySymbol.backingFieldSymbol?.annotations?.map {
+                    KSAnnotationResolvedImpl.getCached(it, this@KSPropertyDeclarationImpl, annotationOrigin)
+                } ?: emptyList()
             )
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -62,7 +62,7 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktPropertySymbol.annotations.asSequence()
             .filter { !it.isUseSiteTargetAnnotation() }
-            .map { KSAnnotationResolvedImpl.getCached(it, this, annotationOrigin) }
+            .map { KSAnnotationResolvedImpl.getCached(it, this, definitionOrigin) }
             .plus(
                 if (ktPropertySymbol.isFromPrimaryConstructor) {
                     (parentDeclaration as? KSClassDeclaration)?.primaryConstructor?.parameters?.singleOrNull {
@@ -74,7 +74,7 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
             ).plus(
                 // TODO: optimize for psi
                 ktPropertySymbol.backingFieldSymbol?.annotations?.map {
-                    KSAnnotationResolvedImpl.getCached(it, this@KSPropertyDeclarationImpl, annotationOrigin)
+                    KSAnnotationResolvedImpl.getCached(it, this@KSPropertyDeclarationImpl, definitionOrigin)
                 } ?: emptyList()
             )
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
@@ -41,7 +41,7 @@ class KSValueArgumentImpl private constructor(
     override val isSpread: Boolean = false
 
     override val value: Any? by lazy {
-        namedAnnotationValue.expression.toValue()
+        namedAnnotationValue.expression.toValue(this, origin)
     }
 
     override val annotations: Sequence<KSAnnotation> = emptySequence()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -33,7 +33,7 @@ import org.jetbrains.kotlin.psi.KtFile
 class KSAnnotationResolvedImpl private constructor(
     private val annotationApplication: KaAnnotation,
     override val parent: KSNode?,
-    override val origin: Origin
+    override val origin: Origin,
 ) : KSAnnotation {
     companion object :
         KSObjectCache<IdKeyPair<KaAnnotation, KSNode?>, KSAnnotationResolvedImpl>() {
@@ -51,13 +51,13 @@ class KSAnnotationResolvedImpl private constructor(
         }
     }
     override val arguments: List<KSValueArgument> by lazy {
-        val presentArgs = annotationApplication.arguments.map {
+        val presentArgs = annotationApplication.arguments.map { arg ->
             val argOrigin = if (origin == Origin.SYNTHETIC) {
-                it.expression.sourcePsi?.containingFile?.let {
-                    if (it is KtFile) Origin.KOTLIN else Origin.JAVA
+                arg.expression.sourcePsi?.containingFile?.let { containingFile ->
+                    if (containingFile is KtFile) Origin.KOTLIN else Origin.JAVA
                 } ?: Origin.JAVA_LIB // FIXME: how to tell from KOTLIN_LIB?
             } else origin
-            KSValueArgumentImpl.getCached(it, this, argOrigin)
+            KSValueArgumentImpl.getCached(arg, this, argOrigin)
         }
         val presentNames = presentArgs.mapNotNull { it.name?.asString() }
         val absentArgs = analyze {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -74,7 +74,7 @@ class KSTypeReferenceResolvedImpl private constructor(
 
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktType.annotations(this) +
-            additionalAnnotations.asSequence().map { KSAnnotationResolvedImpl.getCached(it, this) }
+            additionalAnnotations.asSequence().map { KSAnnotationResolvedImpl.getCached(it, this, origin) }
     }
 
     override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -945,6 +945,6 @@ internal val KaDeclarationSymbol.internalSuffix: String
         }
     }
 
-// Annotations on deeply synthesized members like getter of Java annotation arguments can still be real.
-internal val KSNode.annotationOrigin: Origin
+// Annotations on deeply synthesized members like getter of Java annotation arguments can be defined in src.
+internal val KSNode.definitionOrigin: Origin
     get() = containingFile?.origin ?: origin

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -21,6 +21,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.ExceptionMessage
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.KSPCoreEnvironment
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSAnnotationResolvedImpl
@@ -487,9 +488,9 @@ internal inline fun <reified T : KSNode> KSNode.findParentOfType(): KSNode? {
     return result
 }
 
-internal fun KaAnnotationValue.toValue(): Any? = when (this) {
-    is KaAnnotationValue.ArrayValue -> this.values.map { it.toValue() }
-    is KaAnnotationValue.NestedAnnotationValue -> KSAnnotationResolvedImpl.getCached(this.annotation)
+internal fun KaAnnotationValue.toValue(parent: KSNode? = null, origin: Origin? = null): Any? = when (this) {
+    is KaAnnotationValue.ArrayValue -> this.values.map { it.toValue(parent, origin) }
+    is KaAnnotationValue.NestedAnnotationValue -> KSAnnotationResolvedImpl.getCached(this.annotation, parent, origin)
     // TODO: Enum entry should return a type, use declaration as a placeholder.
     is KaAnnotationValue.EnumEntryValue -> this.callableId?.classId?.let { classId ->
         analyze {
@@ -943,3 +944,7 @@ internal val KaDeclarationSymbol.internalSuffix: String
             else -> ""
         }
     }
+
+// Annotations on deeply synthesized members like getter of Java annotation arguments can still be real.
+internal val KSNode.annotationOrigin: Origin
+    get() = containingFile?.origin ?: origin

--- a/kotlin-analysis-api/testData/annotationValue/annotationValue_java.kt
+++ b/kotlin-analysis-api/testData/annotationValue/annotationValue_java.kt
@@ -42,10 +42,10 @@
 // [warning1, warning 2]
 // Sub: [i:42]
 // TestJavaLib: OtherAnnotation
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: KOTLIN
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: JAVA_LIB
 // END
 // MODULE: module1
 // FILE: placeholder.kt

--- a/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
+++ b/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
@@ -44,10 +44,10 @@
 // [warning1, warning 2]
 // Sub: [i:42]
 // TestJavaLib: OtherAnnotation
-// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA
-// TestNestedAnnotationDefaults: hij: SYNTHETIC: KOTLIN
-// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA_LIB
-// TestNestedAnnotationDefaults: hij: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaults: from Java annotation in src: SYNTHETIC: JAVA
+// TestNestedAnnotationDefaults: from Kotlin annotation in src: SYNTHETIC: KOTLIN
+// TestNestedAnnotationDefaults: from Java annotation in lib: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaults: from Kotlin annotation in lib: SYNTHETIC: JAVA_LIB
 // TestNestedAnnotationDefaultsWithGiven: Given1: KOTLIN: KOTLIN
 // TestNestedAnnotationDefaultsWithGiven: Given2: KOTLIN: KOTLIN
 // TestNestedAnnotationDefaultsWithGiven: Given3: KOTLIN: KOTLIN
@@ -82,11 +82,12 @@ public @interface OtherAnnotation {
 }
 // FILE: JavaAnnotationWithDefaults.java
 public @interface JavaAnnotationWithDefaults {
-    OtherAnnotation otherAnnotationVal() default @OtherAnnotation("def");
+    OtherAnnotation otherAnnotationVal() default @OtherAnnotation("from Java annotation in lib");
 }
 
 // FILE: KotlinAnnotationWithDefaults.kt
-annotation class KotlinAnnotationWithDefaults(val otherAnnotation: OtherAnnotation = OtherAnnotation("hij"))
+annotation class KotlinAnnotationWithDefaults(val otherAnnotation: OtherAnnotation =
+    OtherAnnotation("from Kotlin annotation in lib"))
 
 // MODULE: main(module1)
 // FILE: Test.java
@@ -170,11 +171,12 @@ class TestJavaLib {}
 
 // FILE: JavaAnnotationWithDefaultsInSource.java
 public @interface JavaAnnotationWithDefaultsInSource {
-    OtherAnnotation otherAnnotationVal() default @OtherAnnotation("def");
+    OtherAnnotation otherAnnotationVal() default @OtherAnnotation("from Java annotation in src");
 }
 
 // FILE: KotlinAnnotationWithDefaults.kt
-annotation class KotlinAnnotationWithDefaultsInSource(val otherAnnotation: OtherAnnotation = OtherAnnotation("hij"))
+annotation class KotlinAnnotationWithDefaultsInSource(val otherAnnotation: OtherAnnotation =
+    OtherAnnotation("from Kotlin annotation in src"))
 
 // FILE: KotlinClient.kt
 @JavaAnnotationWithDefaultsInSource

--- a/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
+++ b/kotlin-analysis-api/testData/annotationValue/annotationValue_java2.kt
@@ -44,10 +44,14 @@
 // [warning1, warning 2]
 // Sub: [i:42]
 // TestJavaLib: OtherAnnotation
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: KOTLIN
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaultsWithGiven: Given1: KOTLIN: KOTLIN
+// TestNestedAnnotationDefaultsWithGiven: Given2: KOTLIN: KOTLIN
+// TestNestedAnnotationDefaultsWithGiven: Given3: KOTLIN: KOTLIN
+// TestNestedAnnotationDefaultsWithGiven: Given4: KOTLIN: KOTLIN
 // END
 // MODULE: module1
 // FILE: placeholder.kt
@@ -178,3 +182,9 @@ annotation class KotlinAnnotationWithDefaultsInSource(val otherAnnotation: Other
 @JavaAnnotationWithDefaults
 @KotlinAnnotationWithDefaults
 class TestNestedAnnotationDefaults
+
+@JavaAnnotationWithDefaultsInSource(OtherAnnotation("Given1"))
+@KotlinAnnotationWithDefaultsInSource(OtherAnnotation("Given2"))
+@JavaAnnotationWithDefaults(OtherAnnotation("Given3"))
+@KotlinAnnotationWithDefaults(OtherAnnotation("Given4"))
+class TestNestedAnnotationDefaultsWithGiven

--- a/kotlin-analysis-api/testData/annotationValue/annotationValue_kt.kt
+++ b/kotlin-analysis-api/testData/annotationValue/annotationValue_kt.kt
@@ -39,10 +39,10 @@
 // Cls: argToA: b
 // Cls: argToB: 42
 // TestJavaLib: OtherAnnotation
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
-// TestNestedAnnotationDefaults: def
-// TestNestedAnnotationDefaults: hij
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: KOTLIN
+// TestNestedAnnotationDefaults: def: SYNTHETIC: JAVA_LIB
+// TestNestedAnnotationDefaults: hij: SYNTHETIC: JAVA_LIB
 // @JavaAnnotationWithDefaultsInSource(value:def) == @JavaAnnotationWithDefaultsInSource(value:def): true
 // @JavaAnnotationWithDefaultsInSource(value:def) == @KotlinAnnotationWithDefaultsInSource(value:hij): false
 // @JavaAnnotationWithDefaultsInSource(value:def) == @JavaAnnotationWithDefaults(value:def): true

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -94,17 +94,21 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
 
         resolver.getClassDeclarationByName("TestNestedAnnotationDefaults")?.let { cls ->
             cls.annotations.forEach { annotation ->
-                val arg = annotation.arguments.single().value as KSAnnotation
-                val argArg = arg.arguments.single()
-                results.add("${cls.simpleName.asString()}: ${argArg.value}: ${arg.origin}: ${argArg.origin}")
+                val otherAnnotationVal = annotation.arguments.single().value as KSAnnotation
+                val value = otherAnnotationVal.arguments.single()
+                results.add(
+                    "${cls.simpleName.asString()}: ${value.value}: ${otherAnnotationVal.origin}: ${value.origin}"
+                )
             }
         }
 
         resolver.getClassDeclarationByName("TestNestedAnnotationDefaultsWithGiven")?.let { cls ->
             cls.annotations.forEach { annotation ->
-                val arg = annotation.arguments.single().value as KSAnnotation
-                val argArg = arg.arguments.single()
-                results.add("${cls.simpleName.asString()}: ${argArg.value}: ${arg.origin}: ${argArg.origin}")
+                val otherAnnotationVal = annotation.arguments.single().value as KSAnnotation
+                val value = otherAnnotationVal.arguments.single()
+                results.add(
+                    "${cls.simpleName.asString()}: ${value.value}: ${otherAnnotationVal.origin}: ${value.origin}"
+                )
             }
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -94,8 +94,17 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
 
         resolver.getClassDeclarationByName("TestNestedAnnotationDefaults")?.let { cls ->
             cls.annotations.forEach { annotation ->
-                val annotationArg = annotation.arguments.single().value as KSAnnotation
-                results.add("${cls.simpleName.asString()}: ${annotationArg.arguments.single().value}")
+                val arg = annotation.arguments.single().value as KSAnnotation
+                val argArg = arg.arguments.single()
+                results.add("${cls.simpleName.asString()}: ${argArg.value}: ${arg.origin}: ${argArg.origin}")
+            }
+        }
+
+        resolver.getClassDeclarationByName("TestNestedAnnotationDefaultsWithGiven")?.let { cls ->
+            cls.annotations.forEach { annotation ->
+                val arg = annotation.arguments.single().value as KSAnnotation
+                val argArg = arg.arguments.single()
+                results.add("${cls.simpleName.asString()}: ${argArg.value}: ${arg.origin}: ${argArg.origin}")
             }
         }
 


### PR DESCRIPTION
Origin of arguments of synthetic / default anntations should be where they were mentioned.

TODO: unify the the implementations by getting rid of Kotlin psi and Java psi.