### PR TITLE
Support friend modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ compiler-plugin/dist
 kotlin-analysis-api/dist
 test-utils/dist
 .DS_Store
+.kotlin

--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
@@ -10,6 +10,7 @@ abstract class KSPConfig(
     val sourceRoots: List<File>,
     val commonSourceRoots: List<File>,
     val libraries: List<File>,
+    val friends: List<File>,
 
     val processorOptions: Map<String, String>,
 
@@ -38,6 +39,7 @@ abstract class KSPConfig(
         lateinit var sourceRoots: List<File>
         var commonSourceRoots: List<File> = emptyList()
         var libraries: List<File> = emptyList()
+        var friends: List<File> = emptyList()
 
         var processorOptions = mapOf<String, String>()
 
@@ -73,6 +75,7 @@ class KSPJvmConfig(
     sourceRoots: List<File>,
     commonSourceRoots: List<File>,
     libraries: List<File>,
+    friends: List<File>,
 
     processorOptions: Map<String, String>,
 
@@ -100,6 +103,7 @@ class KSPJvmConfig(
     sourceRoots,
     commonSourceRoots,
     libraries,
+    friends,
 
     processorOptions,
 
@@ -143,6 +147,7 @@ class KSPJvmConfig(
                 sourceRoots,
                 commonSourceRoots,
                 libraries,
+                friends,
 
                 processorOptions,
 
@@ -175,6 +180,7 @@ class KSPNativeConfig(
     sourceRoots: List<File>,
     commonSourceRoots: List<File>,
     libraries: List<File>,
+    friends: List<File>,
 
     processorOptions: Map<String, String>,
 
@@ -202,6 +208,7 @@ class KSPNativeConfig(
     sourceRoots,
     commonSourceRoots,
     libraries,
+    friends,
 
     processorOptions,
 
@@ -236,6 +243,7 @@ class KSPNativeConfig(
                 sourceRoots,
                 commonSourceRoots,
                 libraries,
+                friends,
 
                 processorOptions,
 
@@ -268,6 +276,7 @@ class KSPJsConfig(
     sourceRoots: List<File>,
     commonSourceRoots: List<File>,
     libraries: List<File>,
+    friends: List<File>,
 
     processorOptions: Map<String, String>,
 
@@ -295,6 +304,7 @@ class KSPJsConfig(
     sourceRoots,
     commonSourceRoots,
     libraries,
+    friends,
 
     processorOptions,
 
@@ -329,6 +339,7 @@ class KSPJsConfig(
                 sourceRoots,
                 commonSourceRoots,
                 libraries,
+                friends,
 
                 processorOptions,
 
@@ -366,6 +377,7 @@ class KSPCommonConfig(
     sourceRoots: List<File>,
     commonSourceRoots: List<File>,
     libraries: List<File>,
+    friends: List<File>,
 
     processorOptions: Map<String, String>,
 
@@ -393,6 +405,7 @@ class KSPCommonConfig(
     sourceRoots,
     commonSourceRoots,
     libraries,
+    friends,
 
     processorOptions,
 
@@ -427,6 +440,7 @@ class KSPCommonConfig(
                 sourceRoots,
                 commonSourceRoots,
                 libraries,
+                friends,
 
                 processorOptions,
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -188,6 +188,14 @@ class KotlinSymbolProcessing(
                     }
                 )
 
+                addFriendDependency(
+                    buildKspLibraryModule {
+                        this.platform = platform
+                        addBinaryRoots(kspConfig.friends.map { it.toPath() })
+                        libraryName = "Friends of $moduleName"
+                    }
+                )
+
                 if (kspConfig is KSPJvmConfig && kspConfig.jdkHome != null) {
                     addRegularDependency(
                         buildKspSdkModule {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -23,7 +23,6 @@ import com.google.devtools.ksp.processing.KSPJvmConfig
 import com.google.devtools.ksp.processor.AbstractTestProcessor
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
-import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.jvmModularRoots
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.languageVersionSettings
@@ -129,9 +128,9 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             jvmTarget = compilerConfiguration.get(JVMConfigurationKeys.JVM_TARGET)!!.description
             languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString
             apiVersion = compilerConfiguration.languageVersionSettings.apiVersion.versionString
-            libraries = libModules.map { it.outDir } +
-                compilerConfiguration.jvmModularRoots +
-                compilerConfiguration.jvmClasspathRoots
+            libraries = mainModule.regularDependencies.map { it.dependencyModule.outDir } +
+                compilerConfiguration.jvmModularRoots
+            friends = mainModule.friendDependencies.map { it.dependencyModule.outDir }
             projectBaseDir = testRoot
             classOutputDir = File(testRoot, "kspTest/classes/main")
             javaOutputDir = File(testRoot, "kspTest/src/main/java")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -352,6 +352,12 @@ class KSPAATest : AbstractKSPAATest() {
         runTest("../kotlin-analysis-api/testData/implicitPropertyAccessors.kt")
     }
 
+    @TestMetadata("internalOfFriends.kt")
+    @Test
+    fun testInternalOfFriends() {
+        runTest("../test-utils/testData/api/internalOfFriends.kt")
+    }
+
     @TestMetadata("inheritedTypeAlias.kt")
     @Test
     fun testInheritedTypeAlias() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InternalOfFriendsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InternalOfFriendsProcessor.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.*
+
+open class InternalOfFriendsProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getNewFiles().single().declarations.filterIsInstance<KSFunctionDeclaration>().forEach { f ->
+            val fn = f.simpleName.asString()
+            val r = f.returnType.toString()
+            val rt = f.returnType!!.resolve().toString()
+            results.add("$fn: $r: $rt")
+        }
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+}

--- a/test-utils/testData/api/internalOfFriends.kt
+++ b/test-utils/testData/api/internalOfFriends.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: InternalOfFriendsProcessor
+// EXPECTED:
+// fun1: MyClass0: MyClass0
+// fun2: <ERROR TYPE: hasInvoke1>: <ERROR TYPE: hasInvoke1>
+// fun3: MyClass2: MyClass2
+// fun4: MyClass3: MyClass3
+// END
+
+// MODULE: lib-1
+class MyClass0
+class MyClass1
+class MyClass2
+class MyClass3
+
+// MODULE: lib-regular(lib-1)
+internal class HasInvoke1 {
+    operator fun invoke() = MyClass1()
+}
+
+// MODULE: lib-friend(lib-1)
+internal class HasInvoke2 {
+    operator fun invoke() = MyClass2()
+}
+
+// MODULE: main(lib-regular, lib-1)(lib-friend)
+internal class HasInvoke3 {
+    operator fun invoke() = MyClass3()
+}
+
+fun fun1() = MyClass0()
+fun fun2(hasInvoke1: HasInvoke1) = hasInvoke1()
+fun fun3(hasInvoke2: HasInvoke2) = hasInvoke2()
+fun fun4(hasInvoke3: HasInvoke3) = hasInvoke3()


### PR DESCRIPTION
`KSPConfig.friends` is introduced and used to configure friend modules. It is similar to `KSPConfig.libraries`, the main difference is that their `internal` elements are visible to current module.

The flag in KGP isn't available yet so the Gradle part is in the ToDo list.