### PR TITLE
Remove classpathSnapshotProperties.classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KotlinFactories.kt
@@ -215,7 +215,6 @@ abstract class KspTaskJvm @Inject constructor(
             sources,
             javaSources,
             commonSourceSet,
-            classpathSnapshotProperties.classpath,
             classpathStructure,
         )
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -480,11 +480,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                             configureAsAbstractKotlinCompileTool(kspTask as AbstractKotlinCompileTool<*>)
                             configurePluginOptions(kspTask)
                             configureLanguageVersion(kspTask)
-                            if (kspTask.classpathSnapshotProperties.useClasspathSnapshot.get() == false) {
-                                kspTask.compilerOptions.moduleName.convention(
-                                    kotlinCompileTask.compilerOptions.moduleName.map { "$it-ksp" }
-                                )
-                            }
 
                             kspTask.destination.value(kspOutputDir)
 


### PR DESCRIPTION
It was removed in the main branch in
2399ccd00f8dbc2d51cf223160c459b23e806f07 and blocking the auto-merger. It's not used anymore even in 2.0.2-release so let's remove it.