### PR TITLE
Marking processorOptions as internal (KspAATask)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -128,7 +128,6 @@ abstract class KspAATask @Inject constructor(
                         kspConfig.processorClasspath,
                     )
                 }
-
                 else -> {
                     if (
                         !inputChanges.isIncremental ||
@@ -271,6 +270,7 @@ abstract class KspAATask @Inject constructor(
                                 }
                             }
                         }
+
                     kspAATask.commandLineArgumentProviders.addAll(kspExtension.commandLineArgumentProviders)
                     cfg.processorOptions.putAll(kspAATask.commandLineArgumentProviders.mapArgProviders())
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -128,6 +128,7 @@ abstract class KspAATask @Inject constructor(
                         kspConfig.processorClasspath,
                     )
                 }
+
                 else -> {
                     if (
                         !inputChanges.isIncremental ||
@@ -254,6 +255,7 @@ abstract class KspAATask @Inject constructor(
                         )
                     )
                     cfg.processorOptions.putAll(kspExtension.apOptions)
+                    cfg.apOptions.putAll(kspExtension.apOptions)
 
                     fun ListProperty<CommandLineArgumentProvider>.mapArgProviders() =
                         map { providers ->
@@ -269,8 +271,7 @@ abstract class KspAATask @Inject constructor(
                                 }
                             }
                         }
-
-                    cfg.processorOptions.putAll(kspExtension.commandLineArgumentProviders.mapArgProviders())
+                    kspAATask.commandLineArgumentProviders.addAll(kspExtension.commandLineArgumentProviders)
                     cfg.processorOptions.putAll(kspAATask.commandLineArgumentProviders.mapArgProviders())
 
                     val logLevel = LogLevel.entries.first {
@@ -427,8 +428,11 @@ abstract class KspGradleConfig @Inject constructor() {
     @get:Input
     abstract val apiVersion: Property<String>
 
-    @get:Input
+    @get:Internal
     abstract val processorOptions: MapProperty<String, String>
+
+    @get:Input
+    abstract val apOptions: MapProperty<String, String>
 
     // Unfortunately, passing project.logger over is not possible.
     @get:Input


### PR DESCRIPTION
This PR addresses [google/ksp#2467](https://github.com/google/ksp/issues/2467).

The issue originates from the `MapProperty` `processorOptions` in `KspGradleConfig` when using `KspAATask`. This map is populated with command-line argument values, but it is not aware of Gradle’s path sensitivity requirements, which leads to incorrect behavior, causing remote cache misses.

As a workaround, this PR marks `processorOptions` as `@Internal` and instead relies on `commandLineArgumentProviders` in `KspAATask` to correctly track these inputs. To support this, similar to what is done in `KspJvmTask`, we inject the KSP extension's command-line argument providers into the task command line argument.

Since `processorOptions` is also populated from kspExtension.apOptions, we introduce a new MapProperty named `apOptions` to explicitly track these inputs.

Let me know your thoughts!

## Tests
Original issue when using ksp2 with room and comparing two builds with different location:
<img width="1351" alt="Screenshot 2025-05-27 at 4 59 52 PM" src="https://github.com/user-attachments/assets/f45e906e-a1e5-4f60-a5c4-5565f3149b16" />
https://ge.solutions-team.gradle.com/c/7miiiuiclpapk/bssjjcajc36gu/task-inputs

Same scenario, but with this PR approach:
<img width="1331" alt="Screenshot 2025-05-27 at 5 00 07 PM" src="https://github.com/user-attachments/assets/0d01a198-7a8d-4e17-9794-86b5bb8df05d" />

https://ge.solutions-team.gradle.com/c/nsld3bkfkwrmg/oqhb3co46yqto/task-inputs?cacheability=cacheable,overlapping-outputs,validation-failure

Now, forcing a change in the room gradle plugin configuration to use a different value to demonstrate that the inputs are tracked:

<img width="1116" alt="Screenshot 2025-05-27 at 5 08 10 PM" src="https://github.com/user-attachments/assets/71075b74-f755-41d7-8f2f-534f253c51b3" />

https://ge.solutions-team.gradle.com/c/d5yqiarcqmvnm/o52lpx2yreajg/task-inputs



And finally, defining a commandLine argument and using it in the ksp extension like:
```kotlin
extensions.configure<KspExtension> {
       arg("room.generateKotlin", "true")
       arg(Provider(project.layout.projectDirectory.dir("schemas2").asFile))
}
...
class Provider(roomOutputDir: File) : CommandLineArgumentProvider {

    @OutputDirectory
    val outputDir = roomOutputDir

    override fun asArguments(): Iterable<String> {
        return listOf(
            "test.schemaLocation=${outputDir.path}",

        )
    }
}
```
<img width="1085" alt="Screenshot 2025-05-27 at 5 05 12 PM" src="https://github.com/user-attachments/assets/b55e259f-4af9-4641-b87e-eb273fcf7622" />

https://ge.solutions-team.gradle.com/c/o52lpx2yreajg/kwryqqhvnrku6/task-inputs



