### PR TITLE
Add clarification on possible value types of KSValueArgument.value

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
@@ -36,6 +36,23 @@ interface KSValueArgument : KSAnnotated {
 
     /**
      * The value of the argument.
+     *
+     * Can be of one of the possible types:
+     *
+     * * [Boolean];
+     * * [Byte];
+     * * [Char];
+     * * [Short];
+     * * [Int];
+     * * [Long];
+     * * [Float];
+     * * [Double];
+     * * [String];
+     * * [KSType] for annotation arguments of type [kotlin.reflect.KClass];
+     * * [KSClassDeclaration] for annotation arguments of type [Enum] (in this case[KSClassDeclaration.classKind]
+     *   equals to [ClassKind.ENUM_CLASS]);
+     * * [KSAnnotation] for embedded annotation arguments;
+     * * [Array] of a possible type listed above.
      */
     val value: Any?
 }


### PR DESCRIPTION
I was really confused with this API. Although it's pretty obvious which types are possible for Kotlin primitives, for some cases it's not. For example, it's unclear in following cases:

* `KClass<T>` - either `KSClassDeclaration`, `KSType`, `KSClassifierReference` or `KSTypeReference`
* `Enum` - did not have any idea until just found out by experimenting and looking through source code
* `Array<T>` - it could be `Array` or `List` in KSP.

So I believe this property deserves some clarification