### PR TITLE
Track end line numbers and column information

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -254,12 +254,21 @@ package com.google.devtools.ksp.symbol {
   }
 
   public final class FileLocation extends com.google.devtools.ksp.symbol.Location {
-    ctor public FileLocation(@NonNull String filePath, int lineNumber);
+    ctor public FileLocation(@NonNull String filePath, int lineNumber, int column, int endLineNumber, int endColumn);
     method @NonNull public String component1();
     method public int component2();
-    method @NonNull public com.google.devtools.ksp.symbol.FileLocation copy(@NonNull String filePath, int lineNumber);
+    method public int component3();
+    method public int component4();
+    method public int component5();
+    method @NonNull public com.google.devtools.ksp.symbol.FileLocation copy(@NonNull String filePath, int lineNumber, int column, int endLineNumber, int endColumn);
+    method @InaccessibleFromKotlin public int getColumn();
+    method @InaccessibleFromKotlin public int getEndColumn();
+    method @InaccessibleFromKotlin public int getEndLineNumber();
     method @InaccessibleFromKotlin @NonNull public String getFilePath();
     method @InaccessibleFromKotlin public int getLineNumber();
+    property public int column;
+    property public int endColumn;
+    property public int endLineNumber;
     property @NonNull public String filePath;
     property public int lineNumber;
   }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/Location.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/Location.kt
@@ -18,6 +18,12 @@ package com.google.devtools.ksp.symbol
 
 sealed class Location
 
-data class FileLocation(val filePath: String, val lineNumber: Int) : Location()
+data class FileLocation(
+    val filePath: String,
+    val lineNumber: Int,
+    val column: Int,
+    val endLineNumber: Int,
+    val endColumn: Int,
+) : Location()
 
 object NonExistLocation : Location()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -75,6 +75,7 @@ import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_WILDCARD_ANNOTATION_FQ_
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.types.getEffectiveVariance
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
@@ -226,7 +227,16 @@ internal fun PsiElement?.toLocation(): Location {
     }
     val file = this.containingFile
     val document = KSPCoreEnvironment.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
-    return FileLocation(file.virtualFile.path, document.getLineNumber(this.textOffset) + 1)
+    val lineNumber = document.getLineNumber(textOffset)
+    val endLineNumber = document.getLineNumber(endOffset)
+
+    return FileLocation(
+        filePath = file.virtualFile.path,
+        lineNumber = lineNumber + 1,
+        column = textOffset - document.getLineStartOffset(lineNumber),
+        endLineNumber = endLineNumber + 1,
+        endColumn = document.getLineEndOffset(endLineNumber) - document.getLineStartOffset(endLineNumber),
+    )
 }
 
 internal fun KaSymbol.toContainingFile(): KSFile? {

--- a/kotlin-analysis-api/testData/locations.kt
+++ b/kotlin-analysis-api/testData/locations.kt
@@ -17,25 +17,25 @@
 
 // TEST PROCESSOR: LocationsProcessor
 // EXPECTED:
-// A:K.kt:51
-// File: K.kt:K.kt:1
-// K:J.java:73
-// K:K.kt:54
-// T:J.java:73
-// T:J.java:73
-// T:K.kt:54
-// f1:J.java:77
-// f1:K.kt:61
-// p1:K.kt:56
-// p2:J.java:77
-// p2:K.kt:61
-// v1:K.kt:55
-// v1:K.kt:55
-// v2:J.java:74
-// v2:K.kt:58
-// v3.getter():K.kt:66
-// v3.setter():K.kt:67
-// v3:J.java:82
+// A:K.kt:51,10-51,15
+// File: K.kt:K.kt:1,0-70,0
+// K:J.java:73,6-83,1
+// K:K.kt:54,6-68,1
+// T:J.java:73,8-73,22
+// T:J.java:73,8-73,22
+// T:K.kt:54,18-54,21
+// f1:J.java:77,9-79,5
+// f1:K.kt:61,8-61,36
+// p1:K.kt:56,14-56,25
+// p2:J.java:77,26-77,31
+// p2:K.kt:61,21-61,36
+// v1:K.kt:55,18-55,26
+// v1:K.kt:55,18-55,26
+// v2:J.java:74,18-74,25
+// v2:K.kt:58,18-58,25
+// v3.getter():K.kt:66,8-66,22
+// v3.setter():K.kt:67,8-67,35
+// v3:J.java:82,17-82,36
 // END
 
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocationsProcessor.kt
@@ -22,9 +22,13 @@ class LocationsProcessor : AbstractTestProcessor() {
                     is FileLocation -> {
                         val filename = File(location.filePath).name
                         val line = location.lineNumber
-                        result.add("$it:$filename:$line")
+                        val endLine = location.endLineNumber
+                        val column = location.column
+                        val endColumn = location.endColumn
+
+                        result += "$it:$filename:$line,$column-$endLine,$endColumn"
                     }
-                    is NonExistLocation -> result.add("$it:NonExistLocation")
+                    is NonExistLocation -> result += "$it:NonExistLocation"
                 }
             }
         }

--- a/test-utils/testData/api/locations.kt
+++ b/test-utils/testData/api/locations.kt
@@ -17,24 +17,24 @@
 
 // TEST PROCESSOR: LocationsProcessor
 // EXPECTED:
-// A:K.kt:49
-// File: K.kt:K.kt:1
-// K:J.java:71
-// K:K.kt:52
-// T:J.java:71
-// T:K.kt:52
-// f1:J.java:75
-// f1:K.kt:59
-// p1:K.kt:54
-// p2:J.java:75
-// p2:K.kt:59
-// v1:K.kt:53
-// v1:K.kt:53
-// v2:J.java:72
-// v2:K.kt:56
-// v3.getter():K.kt:64
-// v3.setter():K.kt:65
-// v3:J.java:80
+// A:K.kt:49,10-49,15
+// File: K.kt:K.kt:1,0-68,0
+// K:J.java:71,6-81,1
+// K:K.kt:52,6-66,1
+// T:J.java:71,8-71,22
+// T:K.kt:52,18-52,21
+// f1:J.java:75,9-77,5
+// f1:K.kt:59,8-59,36
+// p1:K.kt:54,14-54,25
+// p2:J.java:75,26-75,31
+// p2:K.kt:59,21-59,36
+// v1:K.kt:53,18-53,26
+// v1:K.kt:53,18-53,26
+// v2:J.java:72,18-72,25
+// v2:K.kt:56,18-56,25
+// v3.getter():K.kt:64,8-64,22
+// v3.setter():K.kt:65,8-65,35
+// v3:J.java:80,17-80,36
 // END
 
 // FILE: Location.kt


### PR DESCRIPTION
This change aims to improve source location tracking for purposes of error reporting. I deliberately maintained backwards compatibility, however the (original) choice of `textOffset` for determining the line number is questionable, as it typically points to the node's identifier rather than to the actual start of the node in the source code.

For example, in the test for `f1`, the reported `FileLocation` points to the start of the identifier `f1` rather than to the keyword `void`.
```java
@Location
void f1(@Location int p2) {

}
```

I would argue a more correct implementation would use `startOffset` rather than `textOffset`, perhaps exposing `textOffset` via another property of `FileLocation`. I'm happy to make changes here but went with the backwards-compatible default.

One more thing that occurred to me is that these line & column coordinates could be tracked in smaller classes still and exposed as two (or more) pairs in `FileLocation`, e.g. something like
```kt
data class FileLocation(
    val filePath: String,
    val start: SourceCoordinates, // based on startOffset
    val end: SourceCoordinates,
    val text: SourceCoordinates, // an extension based on textOffset
) : Location()
```
might be a better model. Such a backwards-incompatible API change might be rejected outright or take too long to incorporate and I'd personally prefer some column information rather than none. I'm happy to propose the necessary changes if maintainers are willing.