### PR TITLE
New gradle property: `ksp.ksp2.profiling.mode`

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -354,6 +354,12 @@ abstract class KspAATask @Inject constructor(
                         }
                     }
 
+                    cfg.profilingMode.value(
+                        project.providers
+                            .gradleProperty("ksp.ksp2.profiling.mode")
+                            .map { it.toBoolean() }
+                            .orElse(false)
+                    )
                     // TODO: pass targets of common
                 }
             }
@@ -480,6 +486,9 @@ abstract class KspGradleConfig @Inject constructor() {
     @get:Input
     @get:Optional
     abstract val konanHome: Property<String>
+
+    @get:Internal
+    abstract val profilingMode: Property<Boolean>
 }
 
 interface KspAAWorkParameter : WorkParameters {
@@ -492,6 +501,7 @@ interface KspAAWorkParameter : WorkParameters {
 }
 
 var isolatedClassLoaderCache = mutableMapOf<String, URLClassLoader>()
+val doNotGC = mutableSetOf<Any>()
 
 abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
     override fun execute() {
@@ -516,6 +526,11 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
             gradleCfg.processorClasspath.files.map { it.toURI().toURL() }.toTypedArray(),
             isolatedClassLoader
         )
+        if (gradleCfg.profilingMode.get()) {
+            doNotGC.add(processorClassloader)
+        } else {
+            doNotGC.clear()
+        }
 
         val excludedProcessors = gradleCfg.excludedProcessors.get()
         val processorProviders = ServiceLoader.load(


### PR DESCRIPTION
Some profilers resolve names too late and the resolution may fail because the classloaders and processors are already garbage collected. This mode simply keeps references to processor classloaders. Therefore, it is disabled by default and should only be used when profiling.