### PR TITLE
Use excludedSources in AndroidPluginIntegration

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidComponentsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidComponentsIT.kt
@@ -1,0 +1,78 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class AndroidComponentsIT(useKSP2: Boolean) {
+
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground", useKSP2)
+
+    @Test
+    fun testDependencyResolutionCheck() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.12.1")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=8.9.0")
+        gradleRunner.withArguments(":workload:compileDebugKotlin").build().let { result ->
+            Assert.assertFalse(result.output.contains("was resolved during configuration time."))
+        }
+    }
+
+    @Test
+    fun testBreakingCircularTaskDependencyWithAndroidComponentGeneratedCode() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.12.1")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=8.9.0")
+        File(project.root, "workload/build.gradle.kts").appendText(
+            """
+                android {
+                    flavorDimensions += listOf("tier")
+                    productFlavors {
+                        create("free") {
+                            dimension = "tier"
+                        }
+                    }
+                }
+                configurations.matching { it.name.startsWith("ksp") && !it.name.endsWith("ProcessorClasspath") }.all {
+                    // Make sure ksp configs are not empty.
+                    project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
+                }
+                androidComponents {
+                    onVariants { variant ->
+                        val task = project.tasks.register(variant.name + "Gen", GenTask::class) {
+                            dependsOn(project.tasks.named("ksp" + variant.name.replaceFirstChar(Char::uppercase) + "Kotlin"))
+                            getOutputDirectory().set(project.layout.buildDirectory.dir("generated/" + variant.name))
+                        }
+                        ksp.excludedSources.from(task) // This breaks the circular dependency
+                        variant.sources.java?.addGeneratedSourceDirectory(task, GenTask::getOutputDirectory)
+                    }
+                }
+                abstract class GenTask : DefaultTask() {
+                    @OutputDirectory
+                    abstract fun getOutputDirectory(): DirectoryProperty
+
+                    @TaskAction
+                    fun generateCode() { }
+                }
+            """.trimIndent()
+        )
+
+        gradleRunner.withArguments(":workload:assemble", "--dry-run", "--stacktrace").build().let { result ->
+            val outputs = result.output.lines().joinToString("\n")
+            println(outputs)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "KSP2={0}")
+        fun params() = listOf(arrayOf(true), arrayOf(false))
+    }
+}


### PR DESCRIPTION
We're seeing an issue in our internal use with KSP that's leading to a circular dependency. Similar to the integration test I've written to go with this change, we have a task that generates code but relies on the output of the KSP task before it runs. We do not need KSP to perform and work on the code generated from our task, so we used the `excludedSources` API.

The issue is that in the `AndroidPluginIntegration` class, Android Sources are being added to the source and dependencies of the KSP task without filtering against the `excludedSources` set. This means that a task added to the Android Sources via an API like [`SourceDirectories.addGeneratedSourceDirectory()`](https://developer.android.com/reference/tools/gradle-api/8.6/com/android/build/api/variant/SourceDirectories#addGeneratedSourceDirectory(org.gradle.api.tasks.TaskProvider,kotlin.Function1)) cannot currently be excluded from KSP.

This PR adds logic to that filter in `AndroidPluginIntegration` that has it respect sources added to `excludedSources`, allowing us to break the circular dependency.

---

excludedSources prevents KSP tasks from taking dependencies on any task that is added to the list in an effort to prevent circular dependencies. However, if an output is added via Android Gradle Plugin's APIs, KSP can still end up with a dependency on the task that generates the output, potentially leading to a circular dependency.

This change modifies the filter logic for adding outputs of Android projects to respect outputs added to `excludedSources`, which can be used to break the circular dependency at the cost of KSP ignoring the added source.