### PR TITLE
Move kotlinx serialization versions to gradle.properties

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -6,6 +6,7 @@ description = "Kotlin Symbol Processing"
 
 val intellijVersion: String by project
 val kotlinBaseVersion: String by project
+val kotlinxSerializationVersion: String by project
 
 val junitVersion: String by project
 val junit5Version: String by project
@@ -47,7 +48,7 @@ dependencies {
     implementation(kotlin("stdlib", kotlinBaseVersion))
 
     compileOnly("org.jetbrains.kotlin:kotlin-compiler:$kotlinBaseVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
 
     implementation(project(":api"))
     implementation(project(":common-util"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
 kotlinBaseVersion=2.2.20-dev-2432
+kotlinxSerializationVersion=1.6.3
 agpBaseVersion=8.10.0-alpha03
 intellijVersion=241.19416.19
 junitVersion=4.13.1

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -4,6 +4,7 @@ import kotlin.math.max
 
 val junitVersion: String by project
 val kotlinBaseVersion: String by project
+val kotlinxSerializationVersion: String by project
 val agpBaseVersion: String by project
 val aaCoroutinesVersion: String by project
 
@@ -19,7 +20,7 @@ dependencies {
     testImplementation(project(":gradle-plugin"))
     testImplementation(project(":symbol-processing"))
     testImplementation(project(":symbol-processing-cmdline"))
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
 }
 

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -8,6 +8,7 @@ val signingKey: String? by project
 val signingPassword: String? by project
 
 val kotlinBaseVersion: String by project
+val kotlinxSerializationVersion: String by project
 
 val junitVersion: String by project
 val junit5Version: String by project
@@ -77,7 +78,7 @@ dependencies {
     }
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
 
     implementation("com.google.guava:guava:$aaGuavaVersion")

--- a/symbol-processing-cmdline/build.gradle.kts
+++ b/symbol-processing-cmdline/build.gradle.kts
@@ -5,6 +5,7 @@ evaluationDependsOn(":common-util")
 evaluationDependsOn(":compiler-plugin")
 
 val kotlinBaseVersion: String by project
+val kotlinxSerializationVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -71,7 +72,7 @@ publishing {
 
                     asNode().appendNode("dependencies").apply {
                         addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
-                        addDependency("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.6.3")
+                        addDependency("org.jetbrains.kotlinx", "kotlinx-serialization-json", kotlinxSerializationVersion)
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
                     }
                 }

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -5,6 +5,7 @@ evaluationDependsOn(":common-util")
 evaluationDependsOn(":compiler-plugin")
 
 val kotlinBaseVersion: String by project
+val kotlinxSerializationVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -75,7 +76,7 @@ publishing {
 
                     asNode().appendNode("dependencies").apply {
                         addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
-                        addDependency("org.jetbrains.kotlinx", "kotlinx-serialization-json", "1.6.3")
+                        addDependency("org.jetbrains.kotlinx", "kotlinx-serialization-json", kotlinxSerializationVersion)
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
                     }
                 }


### PR DESCRIPTION
It was scattered throughout the build files, these now all reference the same property as with other dependencies.