### PR TITLE
Add kotlin-reflect to isolated KSP classpath

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -174,6 +174,7 @@ abstract class KspAATask @Inject constructor(
                     "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-aa-embeddable:$KSP_VERSION"
                 ),
                 project.dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:$KSP_KOTLIN_BASE_VERSION"),
+                project.dependencies.create("org.jetbrains.kotlin:kotlin-reflect:$KSP_KOTLIN_BASE_VERSION"),
                 project.dependencies.create(
                     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$KSP_COROUTINES_VERSION"
                 ),


### PR DESCRIPTION
KSP task loads `kotlin-stdlib` jar, which contains `kotlin.jvm.internal.ClassReference`. The classloader that loads this class is used as a parent classloader for actual processors. The processors might load `kotlin-reflect` library which contains `kotlin.reflect.jvm.internal.KClassImpl` (extends `ClassReference`). Since `ClassReference` is loaded in a different classloader, it can't be type cast to `KClassImpl` later on. That makes it impossible to use Kotlin reflection in KSP processors. Explicitly adding `kotlin-reflect` to the parent classloader fixes the issue.