### PR TITLE
cherry-pick: Publishing: Switch to Central Portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,10 @@ The KSP team will try to support KSP1 with best efforts so that users have more 
 can be made. Please plan migrating to KSP2 as early as possible.
 
 ## Nightly Builds
-Nightly builds of KSP for the latest Kotlin stable releases are published
-[here](https://oss.sonatype.org/content/repositories/snapshots/com/google/devtools/ksp/).
+Nightly builds of KSP for the latest Kotlin stable releases are published here:
 
 ```
-maven("https://oss.sonatype.org/content/repositories/snapshots")
+maven("https://central.sonatype.com/repository/maven-snapshots/")
 ```
 
 ## Feedback and Bug Reporting

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 
 plugins {
     kotlin("jvm")
-    id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
     // Adding plugins used in multiple places to the classpath for centralized version control
     id("com.gradleup.shadow") version "8.3.6" apply false
     id("org.jetbrains.dokka") version "1.9.20" apply false
@@ -37,6 +37,8 @@ nexusPublishing {
         sonatype {
             username.set(sonatypeUserName)
             password.set(sonatypePassword)
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
OSSRH was deprecated on 2025.6.30.

(cherry picked from commit bf0e0f7aefa753d639f52a163d777a767d0c28fd)