### PR TITLE
2.0.3-release: Bump to Kotlin 2.2.0

### DIFF
--- a/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/compiler-plugin/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -24,6 +24,7 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.testFramework.TestDataFile
 import org.jetbrains.kotlin.analysis.test.framework.services.TargetPlatformDirectives
 import org.jetbrains.kotlin.analysis.test.framework.services.TargetPlatformProviderForAnalysisApiTests
+import org.jetbrains.kotlin.cli.common.disposeRootInWriteAction
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoot
@@ -60,13 +61,13 @@ abstract class DisposableTest {
     protected val disposable: Disposable get() = _disposable!!
 
     @BeforeEach
-    private fun initDisposable(testInfo: TestInfo) {
+    fun initDisposable(testInfo: TestInfo) {
         _disposable = Disposer.newDisposable("disposable for ${testInfo.displayName}")
     }
 
     @AfterEach
-    private fun disposeDisposable() {
-        _disposable?.let { Disposer.dispose(it) }
+    fun disposeDisposable() {
+        _disposable?.let { disposeRootInWriteAction(it) }
         _disposable = null
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -58,6 +58,7 @@ import org.gradle.work.NormalizeLineEndings
 import org.gradle.workers.WorkAction
 import org.gradle.workers.WorkParameters
 import org.gradle.workers.WorkerExecutor
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -308,11 +309,20 @@ abstract class KspAATask @Inject constructor(
                             cfg.jdkVersion.value(it.toInt())
                         }
 
-                        val jvmDefaultMode = compilerOptions.freeCompilerArgs
+                        val oldJvmDefaultMode = compilerOptions.freeCompilerArgs
                             .map { args -> args.filter { it.startsWith("-Xjvm-default=") } }
-                            .map { it.lastOrNull()?.substringAfter("=") ?: "disable" }
+                            .map { it.lastOrNull()?.substringAfter("=") ?: "undefined" }
 
-                        cfg.jvmDefaultMode.value(jvmDefaultMode)
+                        cfg.jvmDefaultMode.value(
+                            project.provider {
+                                when (oldJvmDefaultMode.get()) {
+                                    "all" -> "no-compatibility"
+                                    "all-compatibility" -> "enable"
+                                    "disable" -> "disable"
+                                    else -> compilerOptions.jvmDefault.getOrElse(JvmDefaultMode.ENABLE).compilerArgument
+                                }
+                            }
+                        )
 
                         cfg.jvmTarget.value(compilerOptions.jvmTarget.map { it.target })
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.2.20-dev-2432
+kotlinBaseVersion=2.2.0
 agpBaseVersion=8.10.0-alpha03
 intellijVersion=241.19416.19
 junitVersion=4.13.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 # Copied from kotlinc
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 
-kotlinBaseVersion=2.1.21
+kotlinBaseVersion=2.2.20-dev-2432
 agpBaseVersion=8.10.0-alpha03
-intellijVersion=233.13135.128
+intellijVersion=241.19416.19
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -310,7 +310,7 @@ class PlaygroundIT(val useKSP2: Boolean) {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
         gradleRunner.buildAndCheck("clean", "build") { result ->
             Assert.assertTrue(result.output.contains("platform: JVM"))
-            Assert.assertTrue(result.output.contains("jvm default mode: all"))
+            Assert.assertTrue(result.output.contains("jvm default mode: no-compatibility"))
         }
         project.restore(buildFile.path)
     }


### PR DESCRIPTION
There are 2 commits in this PR:
1. Most of the changes come from [Revert "Downgrade to Kotlin 2.1.21"](https://github.com/google/ksp/commit/73947b2f22563ad56216134483c304f20f81c610).
2. The second commit is a single line change in the `gradle.properties` that changed the Kotlin version for KSP1 and KSP Gradle Plugin to 2.2.0.