### PR TITLE
Evaluate `compilation.compileDependencyFiles` lazily

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -230,9 +230,11 @@ abstract class KspAATask @Inject constructor(
                             )
                         )
                     } else {
-                        cfg.libraries.from(project.provider {
-                            kotlinCompilation.compileDependencyFiles
-                        })
+                        cfg.libraries.from(
+                            project.provider {
+                                kotlinCompilation.compileDependencyFiles
+                            }
+                        )
                     }
 
                     val classOutputDir = KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -230,7 +230,9 @@ abstract class KspAATask @Inject constructor(
                             )
                         )
                     } else {
-                        cfg.libraries.from(kotlinCompilation.compileDependencyFiles)
+                        cfg.libraries.from(project.provider {
+                            kotlinCompilation.compileDependencyFiles
+                        })
                     }
 
                     val classOutputDir = KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target)


### PR DESCRIPTION
This fixes a weird bug we are seeing in the Apollo Kotlin repository. 

More specifically, this branch: https://github.com/apollographql/apollo-kotlin/tree/reproducer-ksp

Our KSP processor fails to find annotation in dependencies:

```
$ ./gradlew :apollo-debug-server:kspCommonMainKotlinMetadata


> Task :apollo-debug-server:kspCommonMainKotlinMetadata FAILED
e: [ksp] No '@GraphQLQuery' class found
```

After invastigating it, this seems to be because no libraries are passed to the KSP task.

More specifically, the sequence of operation is this:

* `compilation.compileDependencyFiles` is set [here](https://github.com/Jetbrains/kotlin/blob/56b84a68ab6c20ff99734bec499ad53d3cecaf2e/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/metadata/KotlinMetadataTargetConfigurator.kt#L220).
* `sharedCommonizerTarget.await()` is called [here](https://github.com/Jetbrains/kotlin/blob/56b84a68ab6c20ff99734bec499ad53d3cecaf2e/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/metadata/KotlinMetadataTargetConfigurator.kt#L249).
* During this time, the `KspAATask` gets configured [here](https://github.com/google/ksp/blob/dae2adf4186bc41fdf3a21d1796c39c60f7fe982/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt#L233) using the old value of `compilation.compileDependencyFiles`.
* KGP resumes work and `compilation.compileDependencyFiles` is overwritten [here](https://github.com/Jetbrains/kotlin/blob/56b84a68ab6c20ff99734bec499ad53d3cecaf2e/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/targets/metadata/KotlinMetadataTargetConfigurator.kt#L225), therefore leaving KSP with a dangling, incomplete value for the libraries.

I'm opening this to document the issue. Evaluating `compilation.compileDependencyFiles` lazily works but it might be that the root cause is somewhere else, feel free to close this PR if it's the case.