### PR TITLE
Freshen up docs for latest ksp/kotlin versions

### DIFF
--- a/docs/ksp2cmdline.md
+++ b/docs/ksp2cmdline.md
@@ -2,22 +2,22 @@
 
 KSP2 has 4 main classes, one for each platform: `KSPJvmMain`, `KSPJsMain`, `KSPNativeMain`, `KSPCommonMain`. They reside
 in the same jars from the
-[artifacts.zip](https://github.com/google/ksp/releases/download/2.0.21-1.0.26/artifacts.zip) in the
-[release page](https://github.com/google/ksp/releases/tag/2.0.21-1.0.26):
-* `symbol-processing-aa-2.0.21-1.0.26.jar`
+[artifacts.zip](https://github.com/google/ksp/releases/download/2.2.10-2.0.2/artifacts.zip) in the
+[release page](https://github.com/google/ksp/releases/tag/2.2.10-2.0.2):
+* `symbol-processing-aa-2.2.10-2.0.2.jar`
 
 and depend on:
-* `symbol-processing-common-deps-2.0.21-1.0.26.jar`
+* `symbol-processing-common-deps-2.2.10-2.0.2.jar`
 
 You’ll also need the Kotlin runtime:
-* `kotlin-stdlib-2.0.21.jar`
-* `kotlinx-coroutines-core-jvm-1.6.4.jar`
+* `kotlin-stdlib-2.2.10.jar`
+* `kotlinx-coroutines-core-jvm-1.10.2.jar`
 
 Taking `KSPJvmMain` for example,
 
 ```
 java -cp \
-kotlin-analysis-api-2.0.21-1.0.26.jar:common-deps-2.0.21-1.0.26.jar:symbol-processing-api-2.0.21-1.0.26.jar:kotlin-stdlib-2.0.21.jar:kotlinx-coroutines-core-jvm-1.6.4.jar \
+symbol-processing-aa-2.2.10-2.0.2.jar:kotlin-analysis-api-2.2.10-2.0.2.jar:common-deps-2.2.10-2.0.2.jar:symbol-processing-api-2.2.10-2.0.2.jar:kotlin-stdlib-2.2.10.jar:kotlinx-coroutines-core-jvm-1.10.2.jar \
 com.google.devtools.ksp.cmdline.KSPJvmMain \
 -jvm-target 11 \
 -module-name=main \
@@ -48,6 +48,7 @@ Available options:
 *   -source-roots=List<File>
     -common-source-roots=List<File>
     -libraries=List<File>
+    -friends=List<File>
     -processor-options=Map<String, String>
 *   -project-base-dir=File
 *   -output-base-dir=File
@@ -71,3 +72,11 @@ where:
   List is colon separated. E.g., arg1:arg2:arg3
   Map is in the form key1=value1:key2=value2
 ```
+
+## Notable options
+
+* `-libraries` - classpath of the dependencies of the source files. This is usually the module compile classpath.
+* `-jdk-home` - Useful when the processor does not resolve java symbols. Pointing to a JDK home directory
+  (e.g. `~/.sdkman/candidates/java/current`) will help the processor locate the Java standard library.
+* `-friends` - classpath of the modules that are friends of the current module. This is usually the
+  submodules this module depends on. Supported since [2.1.21-2.0.2](https://github.com/google/ksp/releases/tag/2.1.21-2.0.2). See also [friend modules](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.tasks/-base-kotlin-compile/friend-paths.html).


### PR DESCRIPTION
Hello,

We are currently building support for [KSP 2 in mill](https://github.com/com-lihaoyi/mill/pull/5727) and after some trial and error, we were successful in building dagger/hilt and micronaut apps.

Since we've done the investigation, I thought you might be interested in freshening up the docs. This PR updates the versions to the latest kotlin and ksp and adds some notable mentions which took me some time to figure out and I believe it would be easier if these were mentioned (especially the `-libraries` is the argument I missed and spent a few ours looking around to figure out how classpaths are passed in).

Please let me know what you think and if this update is useful to you, otherwise feel free to close the pull request.

Kind regards
