### PR TITLE
Call addGeneratedSourceDirectories behind AGP version runtime check

### DIFF
--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -41,7 +41,9 @@ fun Test.configureCommonSettings() {
     dependsOn(":symbol-processing-aa-embeddable:publishAllPublicationsToTestRepository")
 }
 
-val agpCompatibilityTestClasses = listOf("**/AGP731IT.class", "**/AGP741IT.class")
+val agpCompatibilityTestClasses = listOf(
+    "**/AGP731IT.class", "**/AGP741IT.class", "**/AGP812IT.class", "**/AGP810IT.class", "**/AGP890IT.class"
+)
 
 // Create a new test task for the AGP compatibility tests
 val agpCompatibilityTest by tasks.registering(Test::class) {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP810IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP810IT.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class AGP810IT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground", true)
+
+    @Test
+    fun testRunsKSP() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.11.1")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=8.10.0")
+        gradleRunner.withArguments(":workload:compileDebugKotlin").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspDebugKotlin")?.outcome)
+        }
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP812IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP812IT.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class AGP812IT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground", true)
+
+    @Test
+    fun testRunsKSP() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.13")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=8.12.0")
+        gradleRunner.withArguments(":workload:compileDebugKotlin").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspDebugKotlin")?.outcome)
+        }
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP890IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGP890IT.kt
@@ -1,0 +1,24 @@
+package com.google.devtools.ksp.test
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+
+class AGP890IT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground", true)
+
+    @Test
+    fun testRunsKSP() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("8.11.1")
+
+        File(project.root, "gradle.properties").appendText("\nagpVersion=8.9.0")
+        gradleRunner.withArguments(":workload:compileDebugKotlin").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspDebugKotlin")?.outcome)
+        }
+    }
+}


### PR DESCRIPTION
That API had a critical fix in 8.12.0-alpha06
Below that version we can't use that API