### PR TITLE
[KSP1] Fix missing KSP resources output in RuntimeLibraryClassesJar by adding ksp task dependency

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -172,13 +172,17 @@ object AndroidPluginIntegration {
             val kspJavaOutput = project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
             val kspKotlinOutput = project.fileTree(kotlinOutputDir).builtBy(kspTaskProvider)
             val kspClassOutput = project.fileTree(classOutputDir).builtBy(kspTaskProvider)
+            // PostJavacGeneratedBytecode will be used by bundleLibRuntimeToJar*
+            // We need add ksp task dependency for this output to avoid bundleLib task run before KSP
+            val resourcesOutput = project.files(resourcesOutputDir).builtBy(kspTaskProvider)
+
             kspJavaOutput.include("**/*.java")
             kspKotlinOutput.include("**/*.kt")
             kspClassOutput.include("**/*.class")
 
             kotlinCompilation.androidVariant.addJavaSourceFoldersToModel(kspKotlinOutput.dir)
             kotlinCompilation.androidVariant.registerExternalAptJavaOutput(kspJavaOutput)
-            kotlinCompilation.androidVariant.registerPostJavacGeneratedBytecode(project.files(resourcesOutputDir))
+            kotlinCompilation.androidVariant.registerPostJavacGeneratedBytecode(resourcesOutput)
             if (project.isAgpBuiltInKotlinUsed().not()) {
                 // This API leads to circular dependency with AGP + Built in kotlin
                 kotlinCompilation.androidVariant.registerPreJavacGeneratedBytecode(kspClassOutput)


### PR DESCRIPTION
# Issue
On KSP1, KSP resource output are registered to postJavacGeneratedBytecode outputs, these files will be placed in the MultipleArtifact.ALL_CLASSES_DIRS artifact in AGP 742 version, and it will have a filter by ArtifactTypeUtil
<img width="1336" height="354" alt="image" src="https://github.com/user-attachments/assets/69965d5f-7abc-47a9-874d-ef2e88d375ca" />
<img width="1648" height="518" alt="image" src="https://github.com/user-attachments/assets/d9dbcfe1-9de2-458a-bba1-de8c1b063b8f" />
This filter will filter by isDirectory, so if the directory is not exists when clean build, it will return false and filter the KSP resource output dir.

Meanwhile, the ALL_CLASSES_DIRS artifact is consumed by the bundleLibRuntimeJar* task during library bundling.
If there is no explicit dependency between bundleLibRuntime and the KSP resource generation tasks, this can lead to a race condition where the generated outputs are not yet produced when bundleLibRuntimeJar* task runs, resulting in missing artifacts in the final runtime_library_classesjar/*/classes.jar AAR.

# Root Cause
- postJavacGeneratedBytecode output → contributes to ALL_CLASSES_DIRS artifact.

- bundleLibRuntimeJar* → uses ALL_CLASSES_DIRS artifact without depending on the KSP resource tasks.

- Without this dependency, bundleLibRuntimeJar* may execute before KSP tasks finish, causing missing ksp resources in the final classes.jar.

# Fix

Add an explicit task dependency for resource output dir so that bundleLibRuntimeJar*. This guarantees resource output artifacts are available before packaging.
