### PR TITLE
Configurable logging + docs + contributing task name fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ This project follows
 
 ## API verification
 
-For changes that involves API changes(new API, API signature change), please also update [api.base](./api/api.base) file. You can monitor api change with `./gradlew :api:apiCheck`, and`./gradlew :api:updateApi` to generate new api signature.
+For changes that involves API changes(new API, API signature change), please also update [api.base](./api/api.base) file. You can monitor api change with `./gradlew :api:checkApi`, and`./gradlew :api:updateApi` to generate new api signature.
 
 ## Testing
 For incoming PRs, we would like to request changes covered by tests for good practice.

--- a/docs/ksp2cmdline.md
+++ b/docs/ksp2cmdline.md
@@ -81,6 +81,6 @@ where:
 * `-friends` - classpath of the modules that are friends of the current module. This is usually the
   submodules this module depends on. Supported since [2.1.21-2.0.2](https://github.com/google/ksp/releases/tag/2.1.21-2.0.2). See also [friend modules](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.tasks/-base-kotlin-compile/friend-paths.html).
 
-### Jvm Args
+### Jvm Parameters
 
 * `-Dksp.logging` - logging level, one of `error`, `warn` or `warning`, `info`, `debug`. Default is `warn`. If an unrecognised level is specified, it will be treated as `warn`.

--- a/docs/ksp2cmdline.md
+++ b/docs/ksp2cmdline.md
@@ -80,3 +80,7 @@ where:
   (e.g. `~/.sdkman/candidates/java/current`) will help the processor locate the Java standard library.
 * `-friends` - classpath of the modules that are friends of the current module. This is usually the
   submodules this module depends on. Supported since [2.1.21-2.0.2](https://github.com/google/ksp/releases/tag/2.1.21-2.0.2). See also [friend modules](https://kotlinlang.org/api/kotlin-gradle-plugin/kotlin-gradle-plugin-api/org.jetbrains.kotlin.gradle.tasks/-base-kotlin-compile/friend-paths.html).
+
+### Jvm Args
+
+* `-Dksp.logging` - logging level, one of `error`, `warn` or `warning`, `info`, `debug`. Default is `warn`. If an unrecognised level is specified, it will be treated as `warn`.

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -34,7 +34,19 @@ internal fun printHelpMsg(optionsList: String) {
 }
 
 internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSPConfig, List<String>>) {
-    val logger = KspGradleLogger(KspGradleLogger.LOGGING_LEVEL_WARN)
+
+    val loggingVerbosity = System.getProperty("ksp.logging", "warn")
+    val loggingLevel = when (loggingVerbosity.lowercase()) {
+        "error" -> KspGradleLogger.LOGGING_LEVEL_ERROR
+        "warn" -> KspGradleLogger.LOGGING_LEVEL_WARN
+        "warning" -> KspGradleLogger.LOGGING_LEVEL_WARN
+        "info" -> KspGradleLogger.LOGGING_LEVEL_INFO
+        "debug" -> KspGradleLogger.LOGGING_LEVEL_LOGGING
+        else -> KspGradleLogger.LOGGING_LEVEL_WARN
+    }
+
+    val logger = KspGradleLogger(loggingLevel)
+
     val (config, classpath) = parse(args)
     val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
 


### PR DESCRIPTION
## Motivation

The ksp cmdline tools like `KspJvmMain` are a great tool for integrating with KSP as a proof of concept. During such experimentation, I've found myself changing the ksp sources and rebuilding, first because of the logging level that is hardcoded. 

The idea behind this PR is to make logging configurable (while still having the warn as a default.

## Implementation

The implementation simply accepts a jvm parameter `ksp.logging` (which of course you may suggest more fitting names) in order to configure the logging.

Passing the logging level in the configuration instead does not play well with the current wiring, as `KSPJvmConfig`, `KSPJsConfig`  and `KSPCommonConfig` which are subclasses of `KSPConfig` would either result in `KspConfig` having a redundant logging (as `KotlinSymbolProcessing` would end up getting both the logging configuration and the `KspConfig` which would create confusion) or an additional indirection, like a KSPCliConfig abstract class extending from `KspConfig` and it didn't seem worth doing so.

So in the end I decided passing a jvm parameter is simpler. 


## Other fixes

I've noticed the `./gradlew :api:apiCheck` should be `./gradlew :api:checkApi` instead


I hope you find this useful and I'm open to suggestions.

