### PR TITLE
Fallback to AA for unexpected Java psi type

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -125,7 +125,10 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
     internal open val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         if (ktDeclarationSymbol.psi is KtAnnotated) {
             (ktDeclarationSymbol.psi as KtAnnotated).annotations(ktDeclarationSymbol, this)
-        } else if (ktDeclarationSymbol.origin == KaSymbolOrigin.JAVA_SOURCE && ktDeclarationSymbol.psi != null) {
+        } else if (
+            ktDeclarationSymbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
+            ktDeclarationSymbol.psi is PsiJvmModifiersOwner
+        ) {
             (ktDeclarationSymbol.psi as PsiJvmModifiersOwner)
                 .annotations.map { KSAnnotationJavaImpl.getCached(it, this) }.asSequence()
         } else {


### PR DESCRIPTION
when getting annotations. Avoid the dangerous cast.

Still trying to reproduce for test case, but the fix straightforward enough from the stack trace. Let's unblock 2.0.4 first.

Fixes #2598 