### PR TITLE
Remove java.io.tmpdir as an input to test tasks

### DIFF
--- a/compiler-plugin/build.gradle.kts
+++ b/compiler-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.google.devtools.ksp.RelativizingInternalPathProvider
 import com.google.devtools.ksp.RelativizingPathProvider
 
 evaluationDependsOn(":common-util")
@@ -116,5 +117,5 @@ tasks.test.configure {
         .asFile
         .apply { if (!exists()) mkdirs() }
     jvmArgumentProviders.add(RelativizingPathProvider("idea.home.path", ideaHomeDir))
-    jvmArgumentProviders.add(RelativizingPathProvider("java.io.tmpdir", temporaryDir))
+    jvmArgumentProviders.add(RelativizingInternalPathProvider("java.io.tmpdir", temporaryDir))
 }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import com.google.devtools.ksp.RelativizingInternalPathProvider
 import com.google.devtools.ksp.RelativizingPathProvider
 import java.io.ByteArrayOutputStream
 
@@ -318,5 +319,5 @@ tasks.test {
         .asFile
         .apply { if (!exists()) mkdirs() }
     jvmArgumentProviders.add(RelativizingPathProvider("idea.home.path", ideaHomeDir))
-    jvmArgumentProviders.add(RelativizingPathProvider("java.io.tmpdir", temporaryDir))
+    jvmArgumentProviders.add(RelativizingInternalPathProvider("java.io.tmpdir", temporaryDir))
 }


### PR DESCRIPTION
While the test task should use this directory as a working directory, it is not an input to the task. Without this change, the two test tasks are never up-to-date for from the build cache.

This can be made nicely visible when using the [Develocity plugin for IntelliJ IDEs](https://plugins.jetbrains.com/plugin/27471-develocity) or a Build Scan:

Before:
<img width="1824" height="338" alt="image" src="https://github.com/user-attachments/assets/bf8074e0-0b5b-432c-a54d-5fcf34d7004d" />
https://ge.gradle.org/s/iqzfk42bwoq5u/timeline?details=xbobeshl4ibdu

After:
<img width="1838" height="345" alt="image" src="https://github.com/user-attachments/assets/93212aba-a9ba-4699-9098-7e5c189930c9" />
https://ge.gradle.org/s/bwheijwcvj6nm