### PR TITLE
Clean mapAAOrigin up

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -98,15 +98,7 @@ internal fun mapAAOrigin(ktSymbol: KaSymbol): Origin {
     return if (symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true) {
         Origin.JAVA_LIB
     } else {
-        if (ktSymbol.psi == null) {
-            if (analyze { ktSymbol.containingModule is KaLibraryModule }) {
-                Origin.KOTLIN_LIB
-            } else {
-                Origin.SYNTHETIC
-            }
-        } else {
-            symbolOrigin
-        }
+        symbolOrigin
     }
 }
 

--- a/kotlin-analysis-api/testData/libOrigins.kt
+++ b/kotlin-analysis-api/testData/libOrigins.kt
@@ -22,12 +22,22 @@
 // Validating Anno3
 // Validating Anno4
 // Validating Anno5
+// Validating Foo
+// Validating FooProvider2
 // Validating JavaLib
 // Validating KotlinLibClass
 // Exception: [KotlinLibClass, T1, Any?]: SYNTHETIC
 // Exception: [KotlinLibClass, T1, Any?]: SYNTHETIC
 // Validating kotlinLibFuntion
 // Validating kotlinLibProperty
+// Validating File: App.java
+// Exception: [File: App.java, App, foo, getFoo, Foo]: SYNTHETIC
+// Exception: [File: App.java, App, foo, getFoo]: SYNTHETIC
+// Validating File: FooProvider1.kt
+// Exception: [File: FooProvider1.kt, FooProvider1, Any]: SYNTHETIC
+// Exception: [File: FooProvider1.kt, FooProvider1, foo, foo.getter(), Foo, Foo]: SYNTHETIC
+// Exception: [File: FooProvider1.kt, FooProvider1, foo, foo.getter(), Foo]: SYNTHETIC
+// Exception: [File: FooProvider1.kt, FooProvider1, foo, foo.getter()]: SYNTHETIC
 // Validating File: JavaSrc.java
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc, JavaSrc]: SYNTHETIC
 // Exception: [File: JavaSrc.java, JavaSrc, synthetic constructor for JavaSrc]: SYNTHETIC
@@ -89,6 +99,15 @@ class JavaLib<T2> {
     }
 }
 
+// FILE: FooProvider2.kt
+package foo.bar
+
+interface Foo
+
+interface FooProvider2 {
+    fun getFoo(): Foo
+}
+
 // MODULE: main(module1)
 // FILE: KotlinSrc.kt
 package foo.bar
@@ -101,6 +120,13 @@ class KotlinSrcClass<T3>(val q1: Set<T3>, val q2: Short)  {
     fun g1(q4: T3): Short = 0
     fun g2(q5: Set<T3>): Short = 0
     fun g3(q6: Set<Short>): Short = 0
+}
+
+// FILE: FooProvider1.kt
+package foo.bar
+
+interface FooProvider1 {
+    val foo: Foo
 }
 
 // FILE: JavaSrc.java
@@ -123,3 +149,8 @@ public @interface JavaAnno1 {
     @Anno5(p1 = 1, p2 = "a2")
     String value ();
 }
+
+// FILE: App.java
+package foo.bar;
+import foo.bar.FooProvider2;
+interface App extends FooProvider1, FooProvider2 {}


### PR DESCRIPTION
The hack was erroneous and no longer needed.

Also added sanity checks before calling asm's ClassReader, which doesn't expect invalid class formats.

Fixes #2548 