### PR TITLE
Fix: Restore psi check for Origin

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -98,7 +98,15 @@ internal fun mapAAOrigin(ktSymbol: KaSymbol): Origin {
     return if (symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true) {
         Origin.JAVA_LIB
     } else {
-        symbolOrigin
+        if (ktSymbol.psi == null) {
+            if (analyze { ktSymbol.containingModule is KaLibraryModule }) {
+                Origin.KOTLIN_LIB
+            } else {
+                Origin.SYNTHETIC
+            }
+        } else {
+            symbolOrigin
+        }
     }
 }
 

--- a/kotlin-analysis-api/testData/visibilities.kt
+++ b/kotlin-analysis-api/testData/visibilities.kt
@@ -42,6 +42,7 @@
 // KtEnumWithVal: values: PUBLIC
 // KtEnumWithVal: valueOf: PUBLIC
 // JavaAnnotation: value: PUBLIC
+// IntersectionC: property: PUBLIC
 // END
 
 // MODULE: lib
@@ -68,6 +69,14 @@ open class KotlinClass {
 enum class LibEnum(val value: Int) {
     A(0), B(1), C(2);
 }
+// FILE: Intersection.kt
+interface IntersectionA {
+    val property: String
+}
+interface IntersectionB {
+    val property: String
+}
+interface IntersectionC: IntersectionA, IntersectionB
 
 // MODULE: main(lib)
 // FILE: a.kt

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
@@ -52,6 +52,7 @@ class VisibilityProcessor : AbstractTestProcessor() {
         val kotlinEnum = resolver.getClassDeclarationByName("KtEnum")!!
         val kotlinEnumWithVal = resolver.getClassDeclarationByName("KtEnumWithVal")!!
         val javaAnnotation = resolver.getClassDeclarationByName("JavaAnnotation")!!
+        val intersectionClass = resolver.getClassDeclarationByName("IntersectionC")!!
         javaClass.declarations.filterIsInstance<KSPropertyDeclaration>().map {
             "${it.simpleName.asString()}: ${it.getVisibility()},visible in A, B, D: " +
                 "${it.isVisibleFrom(symbolA)}, ${it.isVisibleFrom(symbolB)}, ${it.isVisibleFrom(symbolD)}"
@@ -81,6 +82,9 @@ class VisibilityProcessor : AbstractTestProcessor() {
         }.forEach { results.add(it) }
         javaAnnotation.declarations.filterIsInstance<KSPropertyDeclaration>().map {
             "${javaAnnotation.simpleName.asString()}: ${it.simpleName.asString()}: ${it.getVisibility() }"
+        }.forEach { results.add(it) }
+        intersectionClass.getAllProperties().map {
+            "${intersectionClass.simpleName.asString()}: ${it.simpleName.asString()}: ${it.getVisibility() }"
         }.forEach { results.add(it) }
         return emptyList()
     }


### PR DESCRIPTION
## Summary
This PR fixes #2663 by restoring some previous functionality. Based on that investigation, it seemed like #2625 cleaned up some needed code when resolving `Origin` from an external compilation