### PR TITLE
Do not cache KSValueArgumentLiteImpl

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -87,7 +87,7 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
                 } else {
                     calcValue(it.value)
                 }
-                KSValueArgumentLiteImpl.getCached(
+                KSValueArgumentLiteImpl(
                     name?.let { KSNameImpl.getCached(it) },
                     calculatedValue,
                     this@KSAnnotationJavaImpl,
@@ -125,7 +125,7 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
                                     } else {
                                         calcValue(value)
                                     }
-                                    KSValueArgumentLiteImpl.getCached(
+                                    KSValueArgumentLiteImpl(
                                         KSNameImpl.getCached(annoMethod.name),
                                         calculatedValue,
                                         this@KSAnnotationJavaImpl,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSValueArgumentLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSValueArgumentLiteImpl.kt
@@ -1,28 +1,15 @@
 package com.google.devtools.ksp.impl.symbol.java
 
-import com.google.devtools.ksp.common.IdKeyPair
-import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.impl.symbol.kotlin.AbstractKSValueArgumentImpl
 import com.google.devtools.ksp.symbol.*
 
-class KSValueArgumentLiteImpl private constructor(
+class KSValueArgumentLiteImpl(
     override val name: KSName?,
     override val value: Any?,
     override val parent: KSNode,
     override val origin: Origin,
     override val location: Location
 ) : AbstractKSValueArgumentImpl() {
-    companion object : KSObjectCache<IdKeyPair<KSName?, Any?>, KSValueArgumentLiteImpl>() {
-        fun getCached(
-            name: KSName?,
-            value: Any?,
-            parent: KSNode,
-            origin: Origin,
-            location: Location = NonExistLocation
-        ) = KSValueArgumentLiteImpl.cache.getOrPut(IdKeyPair(name, value)) {
-            KSValueArgumentLiteImpl(name, value, parent, origin, location)
-        }
-    }
     override val isSpread: Boolean = false
 
     override val annotations: Sequence<KSAnnotation> = emptySequence()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -95,7 +95,7 @@ class KSAnnotationImpl private constructor(
                                 } else {
                                     calcValue(value)
                                 }
-                                KSValueArgumentLiteImpl.getCached(
+                                KSValueArgumentLiteImpl(
                                     KSNameImpl.getCached(annoMethod.name),
                                     calculatedValue,
                                     this@KSAnnotationImpl,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -92,7 +92,7 @@ class KSAnnotationResolvedImpl private constructor(
                                 } else {
                                     calcValue(value)
                                 }
-                                KSValueArgumentLiteImpl.getCached(
+                                KSValueArgumentLiteImpl(
                                     KSNameImpl.getCached(annoMethod.name),
                                     calculatedValue,
                                     this@KSAnnotationResolvedImpl,


### PR DESCRIPTION
which is simple enough. Also, the previous implementation wrongly merged entries that have differrent parents, origins, and locations.