### PR TITLE
Bump Lint plugin and clean up usage of android.lint.useK2Uast

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     // Adding plugins used in multiple places to the classpath for centralized version control
     id("com.gradleup.shadow") version "8.3.9" apply false
     id("org.jetbrains.dokka") version "1.9.20" apply false
-    id("com.android.lint") version "8.10.0" apply false
+    id("com.android.lint") version "8.13.0" apply false
 }
 
 nexusPublishing {

--- a/gradle-plugin/lint-baseline.xml
+++ b/gradle-plugin/lint-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<issues format="6" by="lint 8.10.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.10.0)" variant="all" version="8.10.0">
+<issues format="6" by="lint 8.13.0" type="baseline" client="gradle" dependencies="false" name="AGP (8.13.0)" variant="all" version="8.13.0">
 
     <issue
         id="EagerGradleConfiguration"
@@ -8,18 +8,7 @@
         errorLine2="                                                             ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt"
-            line="89"
-            column="62"/>
-    </issue>
-
-    <issue
-        id="EagerGradleConfiguration"
-        message="Avoid using method get"
-        errorLine1="                    val destinationProperty = (kaptProvider?.get() as? KaptTask)?.destinationDir"
-        errorLine2="                                                             ~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt"
-            line="104"
+            line="109"
             column="62"/>
     </issue>
 
@@ -30,7 +19,7 @@
         errorLine2="                                                          ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="224"
+            line="226"
             column="59"/>
     </issue>
 
@@ -41,7 +30,7 @@
         errorLine2="                                                                   ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="343"
+            line="349"
             column="68"/>
     </issue>
 
@@ -52,7 +41,7 @@
         errorLine2="                                                             ~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="27"
+            line="28"
             column="62"/>
     </issue>
 
@@ -63,7 +52,7 @@
         errorLine2="                                      ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="46"
+            line="47"
             column="39"/>
     </issue>
 
@@ -74,7 +63,7 @@
         errorLine2="                                                 ~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="121"
+            line="122"
             column="50"/>
     </issue>
 
@@ -85,7 +74,7 @@
         errorLine2="                                   ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="296"
+            line="157"
             column="36"/>
     </issue>
 
@@ -96,7 +85,7 @@
         errorLine2="                                                     ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="315"
+            line="175"
             column="54"/>
     </issue>
 
@@ -107,41 +96,8 @@
         errorLine2="                                                                  ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="327"
+            line="183"
             column="67"/>
-    </issue>
-
-    <issue
-        id="EagerGradleConfiguration"
-        message="Avoid using method get"
-        errorLine1="                val kotlinCompileTask = kotlinCompileProvider.get()"
-        errorLine2="                                                              ~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="383"
-            column="63"/>
-    </issue>
-
-    <issue
-        id="EagerGradleConfiguration"
-        message="Avoid using method get"
-        errorLine1="                            kotlinCompileProvider.get().libraries.filter {"
-        errorLine2="                                                  ~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="430"
-            column="51"/>
-    </issue>
-
-    <issue
-        id="EagerGradleConfiguration"
-        message="Avoid using method get"
-        errorLine1="                            val kotlinCompileTask = kotlinCompileProvider.get() as KotlinNativeCompile"
-        errorLine2="                                                                          ~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="592"
-            column="75"/>
     </issue>
 
     <issue
@@ -151,7 +107,7 @@
         errorLine2="                 ~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="401"
+            line="407"
             column="18"/>
     </issue>
 
@@ -162,7 +118,7 @@
         errorLine2="                 ~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="408"
+            line="414"
             column="18"/>
     </issue>
 
@@ -173,7 +129,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt"
-            line="31"
+            line="35"
             column="1"/>
     </issue>
 
@@ -184,7 +140,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="45"
+            line="40"
             column="1"/>
     </issue>
 
@@ -195,7 +151,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="46"
+            line="41"
             column="1"/>
     </issue>
 
@@ -206,7 +162,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="47"
+            line="42"
             column="1"/>
     </issue>
 
@@ -217,7 +173,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="48"
+            line="43"
             column="1"/>
     </issue>
 
@@ -228,7 +184,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="49"
+            line="44"
             column="1"/>
     </issue>
 
@@ -239,7 +195,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="50"
+            line="45"
             column="1"/>
     </issue>
 
@@ -250,7 +206,7 @@
         errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="774"
+            line="328"
             column="26"/>
     </issue>
 
@@ -261,7 +217,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="789"
+            line="343"
             column="9"/>
     </issue>
 
@@ -272,7 +228,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="793"
+            line="347"
             column="9"/>
     </issue>
 
@@ -283,30 +239,8 @@
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="801"
+            line="355"
             column="29"/>
-    </issue>
-
-    <issue
-        id="InternalKgpApiUsage"
-        message="Avoid using internal Kotlin Gradle Plugin APIs"
-        errorLine1="    return if (this is KaptClasspathChanges.Known) {"
-        errorLine2="                       ~~~~~~~~~~~~~~~~~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="820"
-            column="24"/>
-    </issue>
-
-    <issue
-        id="InternalKgpApiUsage"
-        message="Avoid using internal Kotlin Gradle Plugin APIs (field names from org.jetbrains.kotlin.gradle.internal.kapt.incremental.KaptClasspathChanges.Known)"
-        errorLine1="        this.names.map { it.replace(&apos;/&apos;, &apos;.&apos;).replace(&apos;$&apos;, &apos;.&apos;) }.ifNotEmpty {"
-        errorLine2="        ~~~~~~~~~~">
-        <location
-            file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="821"
-            column="9"/>
     </issue>
 
     <issue
@@ -316,7 +250,7 @@
         errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="915"
+            line="396"
             column="36"/>
     </issue>
 
@@ -327,7 +261,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="916"
+            line="397"
             column="9"/>
     </issue>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,5 +27,3 @@ kotlin.jvm.target.validation.mode=warning
 # Build or runtime dependencies of this project
 buildKotlinVersion=2.2.10
 buildKspVersion=2.2.10-2.0.2
-
-android.lint.useK2Uast=true


### PR DESCRIPTION
Updates lint baseline file by `./gradlew updateLintBaseline`.

Refs https://github.com/androidx/androidx/commit/74499a002d1cec66a0fb9075c478cd7da787efc2.