### PR TITLE
[AGP] Register generated kotlin sources with java source set

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -1,7 +1,7 @@
 package com.google.devtools.ksp.gradle
 
-import com.google.devtools.ksp.gradle.AndroidPluginIntegration.useLegacyVariantApi
 import com.google.devtools.ksp.gradle.utils.kotlinSourceSetsObservable
+import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -18,8 +18,8 @@ package com.google.devtools.ksp.gradle
 
 import com.android.build.api.variant.Component
 import com.google.devtools.ksp.KspExperimental
-import com.google.devtools.ksp.gradle.AndroidPluginIntegration.useLegacyVariantApi
 import com.google.devtools.ksp.gradle.model.builder.KspModelBuilder
+import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.UnknownTaskException

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -14,3 +14,31 @@ fun Project.getAgpVersion(): AndroidPluginVersion? = try {
     // Perhaps a version of AGP before pluginVersion API was added.
     null
 }
+
+fun Project.isAgpBuiltInKotlinUsed() = isKotlinBaseApiPluginApplied() && isKotlinAndroidPluginApplied().not()
+
+/**
+ * Returns false for AGP versions 8.10.0-alpha03 or higher.
+ *
+ * Returns true for older AGP versions or when AGP version cannot be determined.
+ */
+fun Project.useLegacyVariantApi(): Boolean {
+    val agpVersion = project.getAgpVersion() ?: return true
+
+    // Fall back to using the legacy Variant API if the AGP version can't be determined for now.
+    return agpVersion < AndroidPluginVersion(8, 10, 0).alpha(3)
+}
+
+/**
+ * Returns true for AGP version is 8.12.0-alpha06 or higher.
+ * That is the version where addGeneratedSourceDirectories API was fixed
+ */
+fun Project.canUseAddGeneratedSourceDirectoriesApi(): Boolean {
+    val agpVersion = project.getAgpVersion() ?: return false
+    return agpVersion >= AndroidPluginVersion(8, 12, 0).alpha(6)
+}
+
+fun Project.canUseInternalKspApis(): Boolean {
+    val agpVersion = project.getAgpVersion() ?: return false
+    return agpVersion >= AndroidPluginVersion(9, 0, 0).alpha(14)
+}

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -1,5 +1,7 @@
 package com.google.devtools.ksp.gradle.utils
 
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
 import org.jetbrains.kotlin.gradle.utils.ObservableSet
@@ -9,3 +11,7 @@ internal val KotlinCompilation<*>.allKotlinSourceSetsObservable
 
 internal val KotlinCompilation<*>.kotlinSourceSetsObservable
     get() = this.kotlinSourceSets as ObservableSet<KotlinSourceSet>
+
+fun Project.isKotlinBaseApiPluginApplied() = plugins.findPlugin(KotlinBaseApiPlugin::class.java) != null
+
+fun Project.isKotlinAndroidPluginApplied() = pluginManager.hasPlugin("org.jetbrains.kotlin.android")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
@@ -52,7 +52,7 @@ class AndroidBuiltInKotlinIT {
     }
 
     @Test
-    fun testPlaygroundAndroidWithBuiltInKotlinAGP90BelowAlpha12() {
+    fun testPlaygroundAndroidWithBuiltInKotlinAGP90BelowAlpha14() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("9.0.0")
 
         File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-alpha05")
@@ -63,7 +63,7 @@ class AndroidBuiltInKotlinIT {
             Assert.assertTrue(
                 result.output.contains(
                     "KSP is not compatible with Android Gradle Plugin's built-in Kotlin prior to AGP " +
-                        "version 9.0.0-alpha12. Please upgrade to AGP 9.0.0-alpha12 or alternatively disable " +
+                        "version 9.0.0-alpha14. Please upgrade to AGP 9.0.0-alpha14 or alternatively disable " +
                         "built-in kotlin by adding android.builtInKotlin=false and android.newDsl=false to " +
                         "gradle.properties and apply kotlin(\"android\") plugin"
                 )
@@ -72,10 +72,10 @@ class AndroidBuiltInKotlinIT {
     }
 
     @Test
-    fun testPlaygroundAndroidWithBuiltInKotlinAGP90AboveAlpha12() {
-        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("9.0.0")
+    fun testPlaygroundAndroidWithBuiltInKotlinAGP90AboveAlpha14() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("9.1.0")
 
-        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-alpha12")
+        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-alpha14")
 
         gradleRunner.withArguments(
             "clean", "build", "minifyReleaseWithR8", "--configuration-cache", "--info", "--stacktrace"


### PR DESCRIPTION
Intially we registered java output folder with java sourceset and kotlin output folder with kotlin sourceset. Two reasons for this:
1. It seemed like the right way to model things
2. We could only register one directory with one sourcset (registering kotlin output with java sourcset would override the previous registration)

Number 2 is fixed in AGP 9.0.0-alpha14.

However, it turns out number 1 is problematic. Registering with kotlin sourceset ends up in a circular task dependency with built in kotlin feature enabled.

At the moment, we avoid the circular exception because we look at all the task dependencies of the kotlin sourceset and exclude the ksp task. But this is a project isolation breaking logic which we need to remove at some point.

The flow looks like the following more or less:
KSP task -> register kotlin output with kotlin.sources -> kotlin.sources flows into kotlinCompilation.defaultSourceSet.kotlin.srcDirs() this happens in AGP built in kotlin -> kotlin.srcDirs() is an input to ksp task leading to the circularlity.