### PR TITLE
Clean up threadlocals after processing

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -615,6 +615,7 @@ class KotlinSymbolProcessing(
         } finally {
             maybeRunInWriteAction {
                 Disposer.dispose(projectDisposable)
+                ResolverAAImpl.tearDown()
             }
         }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -85,6 +85,11 @@ class ResolverAAImpl(
             set(value) {
                 ktModule_prop.set(value)
             }
+
+        fun tearDown() {
+            instance_prop.remove()
+            ktModule_prop.remove()
+        }
     }
     lateinit var propertyAsMemberOfCache: MutableMap<Pair<KSPropertyDeclaration, KSType>, KSType>
     lateinit var functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>


### PR DESCRIPTION
Not cleaned up ThreadLocals are holding onto memory. The fix ensures that the ResolverAAImpl.instance ThreadLocal is cleared out in the finally block of the method where it is created.