### PR TITLE
Fix ClassNotFoundException in case there are no SymbolProcessorProviders.

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     // replace AGP dependency w/ gradle-api when we have source registering API available.
     compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
     compileOnly(gradleApi())
-    compileOnly(project(":kotlin-analysis-api"))
     // Ensure stdlib version is not inconsistent due to kotlin plugin version.
     compileOnly(kotlin("stdlib", version = kotlinBaseVersion))
     implementation(project(":api"))

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -20,7 +20,6 @@ package com.google.devtools.ksp.gradle
 import com.google.devtools.ksp.gradle.utils.allKotlinSourceSetsObservable
 import com.google.devtools.ksp.gradle.utils.canUseGeneratedKotlinApi
 import com.google.devtools.ksp.gradle.utils.enableProjectIsolationCompatibleCodepath
-import com.google.devtools.ksp.impl.KotlinSymbolProcessing
 import com.google.devtools.ksp.processing.ExitCode
 import com.google.devtools.ksp.processing.KSPCommonConfig
 import com.google.devtools.ksp.processing.KSPConfig
@@ -584,8 +583,13 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
         val kspGradleLogger = KspGradleLogger(gradleCfg.logLevel.get().ordinal)
 
         if (processorProviders.isEmpty()) {
-            kspGradleLogger.error("No providers found in processor classpath.")
-            throw Exception("KSP failed with exit code: ${KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR}")
+            kspGradleLogger.error(
+                "No providers found in processor classpath.\n" +
+                    "Make sure you have added KSP processor dependencies using 'ksp' configuration.\n" +
+                    "Processors must implement com.google.devtools.ksp.processing.SymbolProcessorProvider and " +
+                    "register the implementation via META-INF/services."
+            )
+            throw Exception("KSP failed with exit code: ${ExitCode.PROCESSING_ERROR}")
         } else {
             kspGradleLogger.info(
                 "loaded provider(s): " +


### PR DESCRIPTION
In case when there are no any SymbolProcessorProvider implementations in the ksp classpath, I catch an exception.

`java.lang.ClassNotFoundException: com.google.devtools.ksp.impl.KotlinSymbolProcessing$ExitCode`

There are no reasons to use this class to build an error message. So I fixed it, replaced with the class `com.google.devtools.ksp.processing.ExitCode`.

Also, I improved the error message to clarify what to do in case there a no symbol processor providers. And removed an unnecessary dependency `compileOnly(project(":kotlin-analysis-api"))`. It is unnecessary anymore.