### PR TITLE
Don't register sources to kotlin srcDirs for android compilation

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
@@ -38,6 +38,8 @@ class AGPVersionIT(
                 arrayOf("8.12.0-alpha06", "2.3.0-RC", "8.13"),
                 arrayOf("9.0.0-alpha12", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha12", "2.3.0-RC", "9.1.0"),
+                arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
+                arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
 
                 // AGP 8.7.0
                 arrayOf("8.7.0", "2.3.0-RC", "8.11.1"),


### PR DESCRIPTION
When built in kotlin enabled in AGP - avoid registering the ksp output with `kotlin.srcDir(..)`

The reason is, that it does not have any effect and in fact AGP started throwing warnings/error if external plugins use kotlin.srcDir(..) to add more sources