### PR TITLE
Avoid recording Java symbol lookups in non-incremental builds

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -484,6 +484,9 @@ abstract class IncrementalContextBase(
 
     // Insert Java file -> names lookup records.
     fun recordLookup(psiFile: PsiJavaFile, fqn: String) {
+        if (!isIncremental)
+            return
+
         val path = psiFile.virtualFile.path
         val name = fqn.substringAfterLast('.')
         val scope = fqn.substringBeforeLast('.', "<anonymous>")
@@ -511,6 +514,9 @@ abstract class IncrementalContextBase(
     }
 
     fun recordGetSealedSubclasses(classDeclaration: KSClassDeclaration) {
+        if (!isIncremental)
+            return
+
         val name = classDeclaration.simpleName.asString()
         val scope = classDeclaration.qualifiedName?.asString()
             ?.let { it.substring(0, (it.length - name.length - 1).coerceAtLeast(0)) } ?: return

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
@@ -137,6 +137,9 @@ class IncrementalContextAA(
     }
 
     fun recordLookup(type: KaType, context: KSNode?) {
+        if (!isIncremental)
+            return
+
         val file = (context?.containingFile as? KSFileJavaImpl)?.psi ?: return
 
         recordWithArgs(type, file)
@@ -160,6 +163,9 @@ class IncrementalContextAA(
     }
 
     fun recordLookupForPropertyOrMethod(declaration: KSDeclaration) {
+        if (!isIncremental)
+            return
+
         val file = (declaration.containingFile as? KSFileJavaImpl)?.psi ?: return
 
         val symbol = when (declaration) {
@@ -172,6 +178,9 @@ class IncrementalContextAA(
     }
 
     internal fun recordLookupForGetAll(supers: List<KaType>, predicate: (KaSymbol) -> Boolean) {
+        if (!isIncremental)
+            return
+
         val visited: MutableSet<KaType> = mutableSetOf()
         analyze {
             supers.forEach {
@@ -208,6 +217,9 @@ class IncrementalContextAA(
         }
 
     fun recordLookupWithSupertypes(ktType: KaType, visited: MutableSet<KaType>, extra: (KaType, PsiJavaFile) -> Unit) {
+        if (!isIncremental)
+            return
+
         analyze {
             fun record(type: KaType) {
                 if (type in visited)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -138,6 +138,7 @@ abstract class AbstractKSPAATest : AbstractKSPTest(FrontendKinds.FIR) {
             resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
             cachesDir = File(testRoot, "kspTest/kspCaches")
             outputBaseDir = File(testRoot, "kspTest")
+            incremental = true
         }.build()
         val exitCode = KotlinSymbolProcessing(kspConfig, listOf(testProcessor), CommandLineKSPLogger()).execute()
         if (exitCode != KotlinSymbolProcessing.ExitCode.OK) {


### PR DESCRIPTION
which can be very expensive in some cases.