### PR TITLE
[AGP Integration] Pass kotlin sources from variant api 

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -81,11 +81,14 @@ object AndroidPluginIntegration {
     ) {
         if (androidComponent != null && project.isAgpBuiltInKotlinUsed()) {
             if (project.canUseInternalKspApis()) {
-                val sources =
+                val javaSources =
                     (androidComponent.sources.java as? FlatSourceDirectoriesForJavaImpl)?.allButKspAndKaptGenerators()
 
+                val kotlinSources = androidComponent.sources.kotlin?.static
+
                 kspTaskProvider.configure { task ->
-                    task.kspConfig.javaSourceRoots.from(sources)
+                    task.kspConfig.javaSourceRoots.from(javaSources)
+                    task.kspConfig.javaSourceRoots.from(kotlinSources)
                 }
             } else {
                 throw RuntimeException(

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -8,6 +8,7 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.utils.ObservableSet
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 
+// NOTE: for AGP with built in kotlin enabled and android.disallowKotlinSourceSets=true, this returns empty set
 internal val KotlinCompilation<*>.allKotlinSourceSetsObservable
     get() = this.allKotlinSourceSets as ObservableSet<KotlinSourceSet>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfil
 org.gradle.parallel=true
 
 kotlinBaseVersion=2.3.0-RC
-agpBaseVersion=9.0.0-beta01
+agpBaseVersion=9.0.0-beta05
 intellijVersion=241.19416.19
 junitVersion=4.13.1
 junit5Version=5.8.2

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
@@ -75,7 +75,7 @@ class AndroidBuiltInKotlinIT {
     fun testPlaygroundAndroidWithBuiltInKotlinAGP90AboveAlpha14() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("9.1.0")
 
-        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-alpha14")
+        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-beta05")
 
         gradleRunner.withArguments(
             "clean", "build", "minifyReleaseWithR8", "--configuration-cache", "--info", "--stacktrace"
@@ -112,7 +112,7 @@ class AndroidBuiltInKotlinIT {
     fun testPlaygroundAndroidWithBuiltInKotlinProjectIsolationEnabled() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root).withGradleVersion("9.1.0")
 
-        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-alpha14")
+        File(project.root, "gradle.properties").appendText("\nagpVersion=9.0.0-beta05")
         File(project.root, "gradle.properties").appendText("\nkotlinVersion=2.3.0-Beta2")
         File(project.root, "gradle.properties").appendText("\nksp.project.isolation.enabled=true")
 


### PR DESCRIPTION
They are no longer being passed to ksp task via allKotlinSourceSetsObservable when built in kotlin is enabled and android.disallowKotlinSourceSets is set to true (default in AGP 9.0.0-beta05)