### PR TITLE
Add minimum supported AGP version (8.3.0)

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.gradle.model.builder.KspModelBuilder
 import com.google.devtools.ksp.gradle.utils.canUseGeneratedKotlinApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
+import com.google.devtools.ksp.gradle.utils.checkMinimumAgpVersion
 import com.google.devtools.ksp.gradle.utils.enableProjectIsolationCompatibleCodepath
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
 import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
@@ -116,6 +117,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         registry.register(KspModelBuilder())
 
         target.plugins.withId("com.android.base") {
+            target.checkMinimumAgpVersion()
             val androidComponents =
                 target.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)!!
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -17,6 +17,15 @@ fun Project.getAgpVersion(): AndroidPluginVersion? = try {
 
 fun Project.isAgpBuiltInKotlinUsed() = isKotlinBaseApiPluginApplied() && isKotlinAndroidPluginApplied().not()
 
+fun Project.checkMinimumAgpVersion() {
+    if (this.getAgpVersion() != null && this.getAgpVersion()!! < MINIMUM_SUPPORTED_AGP_VERSION) {
+        throw RuntimeException(
+            "The minimum supported AGP version is ${MINIMUM_SUPPORTED_AGP_VERSION.version}. " +
+                "Please upgrade the AGP version in your project."
+        )
+    }
+}
+
 /**
  * Returns false for AGP versions 8.10.0-alpha03 or higher.
  *
@@ -42,3 +51,11 @@ fun Project.canUseInternalKspApis(): Boolean {
     val agpVersion = project.getAgpVersion() ?: return false
     return agpVersion >= AndroidPluginVersion(9, 0, 0).alpha(14)
 }
+
+/**
+ * Defines the minimum supported Android Gradle Plugin (AGP) version.
+ *
+ * KSP aims to support AGP versions released approximately within the last year
+ * from the current KSP release date.
+ */
+val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 3, 0)


### PR DESCRIPTION
This is a new policy of support. This target will keep moving as AGP releases new versions.

It will simplify the KSP code that strictly depends on the runtime version of AGP.