### PR TITLE
Fix detection of android base plugin usage

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -24,6 +24,7 @@ import com.android.build.api.variant.impl.DirectoryEntry
 import com.android.build.api.variant.impl.FlatSourceDirectoriesForJavaImpl
 import com.android.build.api.variant.impl.FlatSourceDirectoriesImpl
 import com.android.build.gradle.BaseExtension
+import com.android.build.gradle.api.AndroidBasePlugin
 import com.android.build.gradle.api.SourceKind
 import com.google.devtools.ksp.gradle.utils.canUseAddGeneratedSourceDirectoriesApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
@@ -48,9 +49,13 @@ import java.util.concurrent.Callable
 object AndroidPluginIntegration {
 
     fun forEachAndroidSourceSet(project: Project, onSourceSet: (String) -> Unit) {
-        project.pluginManager.withPlugin("com.android.base") {
-            // for android modules, we need a configuration per source set
-            decorateAndroidExtension(project, onSourceSet)
+        try {
+            project.plugins.withType(AndroidBasePlugin::class.java).configureEach {
+                // for android modules, we need a configuration per source set
+                decorateAndroidExtension(project, onSourceSet)
+            }
+        } catch (e: NoClassDefFoundError) {
+            // Android plugin not found, ignore
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.gradle
 
+import com.android.build.gradle.api.AndroidBasePlugin
 import com.google.devtools.ksp.gradle.utils.kotlinSourceSetsObservable
 import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
 import org.gradle.api.InvalidUserCodeException
@@ -104,12 +105,18 @@ class KspConfigurations(private val project: Project) {
             createAndroidSourceSetConfigurations(project, kotlinTarget = null)
         }
 
-        project.pluginManager.withPlugin("com.android.base") {
-            if (!project.useLegacyVariantApi()) {
-                val androidComponents =
-                    project.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
-                androidComponents?.addKspConfigurations(useGlobalConfiguration = allowAllTargetConfiguration)
+        try {
+            project.plugins.withType(AndroidBasePlugin::class.java).configureEach {
+                if (!project.useLegacyVariantApi()) {
+                    val androidComponents =
+                        project.extensions.findByType(
+                            com.android.build.api.variant.AndroidComponentsExtension::class.java
+                        )
+                    androidComponents?.addKspConfigurations(useGlobalConfiguration = allowAllTargetConfiguration)
+                }
             }
+        } catch (e: NoClassDefFoundError) {
+            // Android plugin not found, ignore
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -17,8 +17,10 @@
 package com.google.devtools.ksp.gradle
 
 import com.android.build.api.variant.Component
+import com.android.build.gradle.api.AndroidBasePlugin
 import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.gradle.model.builder.KspModelBuilder
+import com.google.devtools.ksp.gradle.utils.OldAgpDetectedException
 import com.google.devtools.ksp.gradle.utils.canUseGeneratedKotlinApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.checkMinimumAgpVersion
@@ -116,19 +118,25 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         kspConfigurations = KspConfigurations(target)
         registry.register(KspModelBuilder())
 
-        target.plugins.withId("com.android.base") {
-            target.checkMinimumAgpVersion()
-            val androidComponents =
-                target.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)!!
+        try {
+            target.plugins.withType(AndroidBasePlugin::class.java).configureEach {
+                target.checkMinimumAgpVersion()
+                val androidComponents =
+                    target.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)!!
 
-            val selector = androidComponents.selector().all()
-            androidComponents.onVariants(selector) { variant ->
-                for (component in variant.components) {
-                    androidComponentCache.computeIfAbsent(component.name) {
-                        component
+                val selector = androidComponents.selector().all()
+                androidComponents.onVariants(selector) { variant ->
+                    for (component in variant.components) {
+                        androidComponentCache.computeIfAbsent(component.name) {
+                            component
+                        }
                     }
                 }
             }
+        } catch (e: OldAgpDetectedException) {
+            throw e
+        } catch (e: NoClassDefFoundError) {
+            // Android plugin not found, ignore
         }
     }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -19,7 +19,7 @@ fun Project.isAgpBuiltInKotlinUsed() = isKotlinBaseApiPluginApplied() && isKotli
 
 fun Project.checkMinimumAgpVersion() {
     if (this.getAgpVersion() != null && this.getAgpVersion()!! < MINIMUM_SUPPORTED_AGP_VERSION) {
-        throw RuntimeException(
+        throw OldAgpDetectedException(
             "The minimum supported AGP version is ${MINIMUM_SUPPORTED_AGP_VERSION.version}. " +
                 "Please upgrade the AGP version in your project."
         )
@@ -59,3 +59,5 @@ fun Project.canUseInternalKspApis(): Boolean {
  * from the current KSP release date.
  */
 val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 3, 0)
+
+class OldAgpDetectedException(message: String) : RuntimeException(message)


### PR DESCRIPTION
When applying settings plugins (that come from composite gradle build), some classloader change leads to "com.android.base" plugin not being detected as applied by Gradle, leading to problems. 

When using the plugins.withType(Class) API this works, however now we face a Class not found error if the AGP plugin is not applied. So everything is wrapped in a try catch block.