### PR TITLE
Remove dependency on KotlinCompile.libraries

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
@@ -1,0 +1,34 @@
+package com.google.devtools.ksp.test
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class AndroidDataBindingBuiltInKotlinIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("android-data-binding-builtinkotlin")
+
+    @Test
+    fun testPlaygroundAndroid() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        // Disabling configuration cache. See https://github.com/google/ksp/issues/299 for details
+        gradleRunner.withArguments(
+            "clean",
+            ":app:assemble",
+            "--configuration-cache-problems=warn",
+            "--info",
+            "--stacktrace"
+        )
+            .build().let { result ->
+                val output = result.output.lines()
+                val kspTask = output.filter {
+                    it.contains(":app:kspDebugKotlin")
+                }
+                Assert.assertTrue(kspTask.isNotEmpty())
+            }
+    }
+}

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/LegacyKaptKspIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/LegacyKaptKspIT.kt
@@ -1,0 +1,31 @@
+package com.google.devtools.ksp.test
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+class LegacyKaptKspIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("legacy-kapt", "playground")
+
+    @Test
+    fun testPlaygroundAndroid() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments(
+            "clean",
+            ":app:testDebugUnitTest",
+            "--configuration-cache-problems=warn",
+            "--info",
+            "--stacktrace"
+        ).build().let { result ->
+            val output = result.output.lines()
+            val kspTask = output.filter { it.contains(":app:kspDebugKotlin") }
+            val kaptTask = output.filter { it.contains(":app:kaptDebugKotlin") }
+            Assert.assertTrue(kspTask.isNotEmpty())
+            Assert.assertTrue(kaptTask.isNotEmpty())
+        }
+    }
+}

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/build.gradle.kts
@@ -1,0 +1,51 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+  id("com.android.application")
+  id("com.google.dagger.hilt.android") version "2.57.2"
+  id("com.google.devtools.ksp")
+}
+
+dependencies {
+    implementation("androidx.activity:activity:1.11.0")
+    implementation("com.google.dagger:hilt-android:2.57.2")
+    ksp("com.google.dagger:hilt-compiler:2.57.2")
+}
+
+android {
+  namespace = "com.example.databinding"
+  compileSdk = 36
+
+  defaultConfig {
+    applicationId = "com.example.databinding"
+    minSdk = 24
+    targetSdk = 36
+    versionCode = 1
+    versionName = "1.0"
+  }
+
+  buildFeatures {
+    dataBinding = true
+  }
+
+  dataBinding {
+    enable = true
+  }
+
+  compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+  }
+}
+
+kotlin {
+  compilerOptions {
+    jvmTarget = JvmTarget.JVM_11
+  }
+}
+
+hilt {
+  enableAggregatingTask = false
+}
+
+

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/AndroidManifest.xml
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <application
+    android:name=".App"
+    android:label="KSP #2597 Repro"
+    android:theme="@android:style/Theme.Material.Light.NoActionBar"
+    tools:ignore="MissingApplicationIcon">
+
+    <activity
+      android:name=".MainActivity"
+      android:exported="true">
+
+      <intent-filter>
+        <action android:name="android.intent.action.MAIN" />
+        <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+
+  </application>
+</manifest>

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/A.kt
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/A.kt
@@ -1,0 +1,8 @@
+package com.example.databinding
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton class A @Inject constructor() {
+  val string = "a"
+}

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/App.kt
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/App.kt
@@ -1,0 +1,7 @@
+package com.example.databinding
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class App : Application()

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/BindingActivity.kt
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/BindingActivity.kt
@@ -1,0 +1,20 @@
+package com.example.databinding
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
+import androidx.databinding.DataBindingUtil
+import androidx.databinding.ViewDataBinding
+
+abstract class BindingActivity<T : ViewDataBinding>(
+  @get:LayoutRes private val layoutId: Int,
+) : ComponentActivity() {
+  protected lateinit var binding: T
+    private set
+
+  @CallSuper override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding = DataBindingUtil.setContentView<T>(this, layoutId)
+  }
+}

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/MainActivity.kt
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/kotlin/MainActivity.kt
@@ -1,0 +1,16 @@
+package com.example.databinding
+
+import android.os.Bundle
+import com.example.databinding.databinding.ActivityMainBinding
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class MainActivity : BindingActivity<ActivityMainBinding>(R.layout.activity_main) {
+  @Inject lateinit var a: A
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+    binding.a = a
+  }
+}

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/res/layout/activity_main.xml
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools">
+
+  <data>
+    <variable
+      name="a"
+      type="com.example.databinding.A" />
+  </data>
+
+  <LinearLayout
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_margin="30dp"
+    tools:context=".MainActivity">
+
+    <TextView
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@{a.string}" />
+
+  </LinearLayout>
+</layout>

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/build.gradle.kts
@@ -1,0 +1,25 @@
+buildscript {
+    val testRepo: String by project
+
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}
+
+plugins {
+    id("com.android.application") apply false
+    id("com.google.devtools.ksp") apply false
+}
+
+allprojects {
+    val testRepo: String by project
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/gradle.properties
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/gradle.properties
@@ -1,0 +1,1 @@
+android.newDsl=false

--- a/integration-tests/src/test/resources/android-data-binding-builtinkotlin/settings.gradle.kts
+++ b/integration-tests/src/test/resources/android-data-binding-builtinkotlin/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    val agpVersion: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("jvm") version kotlinVersion apply false
+        id("com.android.application") version agpVersion apply false
+        id("com.android.library") version agpVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    }
+}
+
+include(":app")

--- a/integration-tests/src/test/resources/legacy-kapt/app/build.gradle.kts
+++ b/integration-tests/src/test/resources/legacy-kapt/app/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("com.android.application")
+    id("com.android.legacy-kapt")
+    id("com.google.devtools.ksp")
+}
+dependencies {
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    ksp("androidx.room:room-compiler:2.4.2")
+    implementation("androidx.room:room-runtime:2.4.2")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+}
+android {
+    namespace = "com.example.kspandroidtestapp"
+    defaultConfig {
+        minSdk = 24
+    }
+    compileSdk = 34
+    buildFeatures { 
+        viewBinding = true
+    }
+    viewBinding {
+        enable = true
+    }
+}

--- a/integration-tests/src/test/resources/legacy-kapt/app/src/main/AndroidManifest.xml
+++ b/integration-tests/src/test/resources/legacy-kapt/app/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest />

--- a/integration-tests/src/test/resources/legacy-kapt/app/src/main/kotlin/MainActivity.kt
+++ b/integration-tests/src/test/resources/legacy-kapt/app/src/main/kotlin/MainActivity.kt
@@ -1,0 +1,14 @@
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.example.kspandroidtestapp.databinding.ActivityMainBinding
+
+class MainActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val binding = ActivityMainBinding.inflate(layoutInflater)
+
+        setContentView(binding.root)
+    }
+}

--- a/integration-tests/src/test/resources/legacy-kapt/app/src/main/res/layout/activity_main.xml
+++ b/integration-tests/src/test/resources/legacy-kapt/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+xmlns:tools="http://schemas.android.com/tools"
+tools:context="MainActivity"
+    android:layout_height="wrap_content"
+    android:layout_width="wrap_content">
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/integration-tests/src/test/resources/legacy-kapt/build.gradle.kts
+++ b/integration-tests/src/test/resources/legacy-kapt/build.gradle.kts
@@ -1,0 +1,26 @@
+buildscript {
+    val testRepo: String by project
+
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}
+
+plugins {
+    id("com.android.application") apply false
+    id("com.android.legacy-kapt") apply false
+    id("com.google.devtools.ksp") apply false
+}
+
+allprojects {
+    val testRepo: String by project
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}

--- a/integration-tests/src/test/resources/legacy-kapt/gradle.properties
+++ b/integration-tests/src/test/resources/legacy-kapt/gradle.properties
@@ -1,0 +1,1 @@
+android.newDsl=false

--- a/integration-tests/src/test/resources/legacy-kapt/settings.gradle.kts
+++ b/integration-tests/src/test/resources/legacy-kapt/settings.gradle.kts
@@ -1,0 +1,22 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    val agpVersion: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("jvm") version kotlinVersion apply false
+        id("com.android.legacy-kapt") version agpVersion apply false
+        id("com.android.application") version agpVersion apply false
+        id("com.android.library") version agpVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    }
+}
+
+include(":app")


### PR DESCRIPTION
Fixes a circular dependency in KSP when in use with legacy-kapt plugin

KotlinCompile.libraries contains the output classes dir of kapt. Since this is a lazy gradle api, filtering does not remove the task dependency so ksp ends up depending on kapt. KAPT itself depends on KSP so this leads to a circular dependency.

Instead use KotlinCompilation.compileDependencyFiles which only contains the compilation jars. On top we need to add the android bootclasspath (containing android.jar and build tools jar)

Fixes #2743