### PR TITLE
Validate shadow jar dependencies independent of platform

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -204,7 +204,8 @@ abstract class ValidateShadowJar : DefaultTask() {
         val actualOutput = stdout.toString()
         outputFile.get().asFile.writeText(actualOutput)
         val expectedOutput = baselineFile.get().asFile.readText()
-        if (actualOutput != expectedOutput) {
+        // Compare line by line to avoid CRLF and LF mismatches
+        if (actualOutput.lines() != expectedOutput.lines()) {
             throw Exception(
                 """
                 jdeps missing dependencies output has changed.


### PR DESCRIPTION
Line endings are now ignored, so the comparison is platform independent.

Fixes https://github.com/google/ksp/issues/2760