### PR TITLE
Fix warnings for shadowed jump labels

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -107,16 +107,15 @@ class KSAnnotationImpl private constructor(
                 } else {
                     symbol.memberScope.constructors.singleOrNull()?.let {
                         it.valueParameters.mapNotNull { valueParameterSymbol ->
-                            valueParameterSymbol.getDefaultValue().let { constantValue ->
-                                KSValueArgumentImpl.getCached(
-                                    KaBaseNamedAnnotationValue(
-                                        valueParameterSymbol.name,
-                                        constantValue ?: return@let null
-                                    ),
-                                    this@KSAnnotationImpl,
-                                    Origin.SYNTHETIC
-                                )
-                            }
+                            val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
+                            KSValueArgumentImpl.getCached(
+                                KaBaseNamedAnnotationValue(
+                                    valueParameterSymbol.name,
+                                    constantValue
+                                ),
+                                this@KSAnnotationImpl,
+                                Origin.SYNTHETIC
+                            )
                         }
                     }
                 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -42,6 +42,7 @@ class KSAnnotationResolvedImpl private constructor(
                 KSAnnotationResolvedImpl(annotationApplication, parent, origin ?: Origin.SYNTHETIC)
             }
     }
+
     override val annotationType: KSTypeReference by lazy {
         analyze {
             KSTypeReferenceResolvedImpl.getCached(
@@ -104,16 +105,15 @@ class KSAnnotationResolvedImpl private constructor(
                 } else {
                     symbol.memberScope.constructors.singleOrNull()?.let {
                         it.valueParameters.mapNotNull { valueParameterSymbol ->
-                            valueParameterSymbol.getDefaultValue().let { constantValue ->
-                                KSValueArgumentImpl.getCached(
-                                    KaBaseNamedAnnotationValue(
-                                        valueParameterSymbol.name,
-                                        constantValue ?: return@let null
-                                    ),
-                                    this@KSAnnotationResolvedImpl,
-                                    Origin.SYNTHETIC
-                                )
-                            }
+                            val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
+                            KSValueArgumentImpl.getCached(
+                                KaBaseNamedAnnotationValue(
+                                    valueParameterSymbol.name,
+                                    constantValue
+                                ),
+                                this@KSAnnotationResolvedImpl,
+                                Origin.SYNTHETIC
+                            )
                         }
                     }
                 }


### PR DESCRIPTION
In each file, the expression `constantValue ?: return@let null` produced a warning since the inner `.let { ... }` call's implicit label shadows an outer `.let { ... }` call. In other words, the abbreviated structure looks like:
```kt
.let { 
    // ...
    .let {
        // ...
        constantValue ?: return@let null
    }
}
```
A warning was issue because of such shadowing / ambiguity.

This PR fixes it by introducing a regular binding `val constantValue = ...` and returning to the unique `mapNotNull` label instead. This is the same behavior as before, since returning to the innermost `let` label with a null value would result in retuning null to `mapNotNull`.