### PR TITLE
Fix shadowed variable warning in `util`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -718,12 +718,12 @@ private fun KaType.canHaveSubtypesIgnoreNullability(): Boolean =
                 return@analyze true
             }
 
-            val type = projection.type
+            val projectionType = projection.type
             val effectiveVariance = getEffectiveVariance(param.variance, projection.variance)
-            if (effectiveVariance == Variance.OUT_VARIANCE && !type.isMostPreciseCovariantArgument()) {
+            if (effectiveVariance == Variance.OUT_VARIANCE && !projectionType.isMostPreciseCovariantArgument()) {
                 return@analyze true
             }
-            if (effectiveVariance == Variance.IN_VARIANCE && !type.isMostPreciseContravariantArgument()) {
+            if (effectiveVariance == Variance.IN_VARIANCE && !projectionType.isMostPreciseContravariantArgument()) {
                 return@analyze true
             }
         }


### PR DESCRIPTION
`val type` is defined twice in this scope, so this PR renames the latter definition to `projectionType`.