### PR TITLE
Fix deprecation warning of `-Xjvm-default` Kotlin argument

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.google.devtools.ksp.configureMetalava
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 description = "Kotlin Symbol Processing API"
@@ -7,7 +8,9 @@ val signingKey: String? by project
 val signingPassword: String? by project
 
 tasks.withType<KotlinCompile> {
-    compilerOptions.freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+    compilerOptions {
+        jvmDefault.set(JvmDefaultMode.ENABLE)
+    }
 }
 
 plugins {

--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/PlatformInfo.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/PlatformInfo.kt
@@ -34,7 +34,7 @@ interface JvmPlatformInfo : PlatformInfo {
     val jvmTarget: String
 
     /**
-     * JVM default mode. Correspond to `-Xjvm-default' to Kotlin compiler
+     * JVM default mode. Correspond to `-jvm-default' to Kotlin compiler
      */
     val jvmDefaultMode: String
 }

--- a/common-deps/build.gradle.kts
+++ b/common-deps/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
+
 description = "Kotlin Symbol Processor"
 
 val junitVersion: String by project
@@ -30,7 +32,7 @@ val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+        jvmDefault.set(JvmDefaultMode.ENABLE)
     }
 }
 

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
+
 description = "Kotlin Symbol Processing Util"
 
 val junitVersion: String by project
@@ -16,7 +18,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+        jvmDefault.set(JvmDefaultMode.ENABLE)
     }
 }
 

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 description = "Kotlin Symbol Processor"
@@ -42,7 +43,7 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+        jvmDefault.set(JvmDefaultMode.ENABLE)
     }
 }
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -354,7 +354,12 @@ abstract class KspAATask @Inject constructor(
 
                         val oldJvmDefaultMode = compileTask.flatMap { task ->
                             task.compilerOptions.freeCompilerArgs
-                                .map { args -> args.filter { it.startsWith("-Xjvm-default=") } }
+                                .map { args ->
+                                    args.filter {
+                                        // Support both new and deprecated arguments (-Xjvm-* is deprecated)
+                                        it.startsWith("-jvm-default=") || it.startsWith("-Xjvm-default=")
+                                    }
+                                }
                                 .map { it.lastOrNull()?.substringAfter("=") ?: "undefined" }
                         }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -309,11 +309,16 @@ class PlaygroundIT() {
 
     @Test
     fun testJvmPlatformInfo() {
-        val kotlinCompile = "org.jetbrains.kotlin.gradle.tasks.KotlinCompile"
         val buildFile = File(project.root, "workload/build.gradle.kts")
-        buildFile.appendText("\ntasks.withType<$kotlinCompile> {")
-        buildFile.appendText("\n    compilerOptions.freeCompilerArgs.add(\"-Xjvm-default=all\")")
-        buildFile.appendText("\n}")
+        buildFile.appendText(
+            """
+            |tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+            |    compilerOptions {
+            |        jvmDefault.set(org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode.NO_COMPATIBILITY)
+            |    }
+            |}
+            |""".trimMargin()
+        )
 
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
         gradleRunner.buildAndCheck("clean", "build") { result ->

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
+
 plugins {
     kotlin("jvm")
 }
@@ -16,6 +18,6 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        freeCompilerArgs.add("-Xjvm-default=all-compatibility")
+        jvmDefault.set(JvmDefaultMode.ENABLE)
     }
 }


### PR DESCRIPTION
Gradle files should use `jvmDefault.set(JvmDefaultMode)` instead of `freeCompilerArgs.add(String)`. The `-Xjvm-default` argument should be replaced with `-jvm-default`.

See https://kotlinlang.org/docs/gradle-compiler-options.html#migrate-from-kotlinoptions-to-compileroptions