### PR TITLE
Update tests in `IncrementalEmptyCPIT`

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
@@ -8,13 +8,11 @@ import org.junit.Rule
 import org.junit.Test
 import java.io.File
 
-class IncrementalEmptyCPIT() {
+class IncrementalEmptyCPIT {
     @Rule
     @JvmField
     val project: TemporaryTestProject =
         TemporaryTestProject("incremental-classpath2", "incremental-classpath")
-
-    private val emptyMessage = setOf("w: [ksp] processing done")
 
     private val prop2Dirty = listOf(
         "l1/src/main/kotlin/p1/TopProp1.kt" to setOf(
@@ -25,28 +23,54 @@ class IncrementalEmptyCPIT() {
     )
 
     @Test
-    fun testCPChangesForProperties() {
+    fun testTrivialChanges() {
+        // Trivial (non-AST) changes should not result in re-processing.
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         gradleRunner.withArguments("clean", "assemble").build().let { result ->
             Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
         }
 
-        // Dummy changes
         prop2Dirty.forEach { (src, _) ->
             File(project.root, src).appendText("\n\n")
             gradleRunner.withArguments("assemble").build().let { result ->
-                // Trivial changes should not result in re-processing.
                 Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
             }
         }
+    }
 
-        // Value changes. It is not really used but should still trigger reprocessing of aggregating outputs.
-        prop2Dirty.forEach { (src, expectedDirties) ->
+    @Test
+    fun testValueChanges() {
+        // Value changes should not result in re-processing, since values are not part of the AST.
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        prop2Dirty.forEach { (src, _) ->
             File(project.root, src).writeText("package p1\n\nval MyTopProp1: Int = 1")
             gradleRunner.withArguments("assemble").build().let { result ->
-                // Value changes will result in re-processing of aggregating outputs.
                 Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(":workload:kspKotlin")?.outcome)
+            }
+        }
+    }
+
+    @Test
+    fun testTypeChanges() {
+        // Type changes should result in re-processing of aggregating outputs, since such changes apply to the AST.
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:assemble")?.outcome)
+        }
+
+        prop2Dirty.forEach { (src, expectedDirties) ->
+            File(project.root, src).writeText("package p1\n\nval MyTopProp1: Boolean = true")
+            gradleRunner.withArguments("assemble").build().let { result ->
+                Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+                val dirties = result.output.lines().filter { it.startsWith("w: [ksp]") }.toSet()
+                Assert.assertEquals(expectedDirties, dirties)
             }
         }
     }


### PR DESCRIPTION
This PR fixes a compilation warning of an unused variable. Inspecting the commit history, indicates that the tests used to assert which files were outdated after changes. Additionally, the comments did not seem to match the test assertions. I have updated the tests to reflect the current state of KSP by splitting the tests into three distinct scenarios.