### PR TITLE
Fix build warnings in `TestModule`

### DIFF
--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestModule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestModule.kt
@@ -35,7 +35,7 @@ class TestModule(
     val plugins = LinkedHashSet(plugins)
     val dependencies = LinkedHashSet(dependencies)
     val buildFileAdditions = LinkedHashSet<String>()
-    val name = moduleRoot.name
+    val name: String = moduleRoot.name
 
     init {
         moduleRoot.mkdirs()
@@ -136,18 +136,18 @@ class TestModule(
      */
     fun writeBuildFile() {
         val contents = buildString {
-            appendln("plugins {")
+            appendLine("plugins {")
             plugins.forEach { plugin ->
-                appendln(plugin.toCode().prependIndent("    "))
+                appendLine(plugin.toCode().prependIndent("    "))
             }
-            appendln("}")
-            appendln("dependencies {")
+            appendLine("}")
+            appendLine("dependencies {")
             dependencies.forEach { dependency ->
-                appendln(dependency.toCode().prependIndent("    "))
+                appendLine(dependency.toCode().prependIndent("    "))
             }
-            appendln("}")
+            appendLine("}")
             buildFileAdditions.forEach {
-                appendln(it)
+                appendLine(it)
             }
         }
         buildFile.writeText(contents)


### PR DESCRIPTION
This PR removes calls the deprecated `StringBuilder.appendln` method and replaces it with `StringBuilder.appendLine`. It also asserts that `File.getName` is a non-null string and throws an error otherwise. Maybe the explicit throw can be omitted if it is handled by Kotlin's implicit non-null assertions? Although `File.getName` is annotated with `NotNull` it still seems safer to throw at the binding site.