### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+* @ting-yuan @hfmehmed @jaschdoc
+
+/.github/ @ting-yuan @hfmehmed @jaschdoc
+/buildSrc/ @ting-yuan @hfmehmed
+/gradle-plugin/ @ting-yuan @hfmehmed
+build.gradle.kts @hfmehmed
+settings.gradle.kts @hfmehmed
+gradle.properties @hfmehmed
+gradlew @hfmehmed
+
+/api/ @ting-yuan @jaschdoc
+/symbol-processing/ @ting-yuan @jaschdoc
+/kotlin-analysis-api/ @ting-yuan @jaschdoc
+/symbol-processing-aa-embeddable/ @ting-yuan @hfmehmed @jaschdoc
+
+/integration-tests/ @ting-yuan @hfmehmed
+/benchmark/ @jaschdoc
+/test-utils/ @ting-yuan @jaschdoc 
+/common-util/ @ting-yuan @jaschdoc
+/common-deps/ @ting-yuan @jaschdoc
+
+/docs/ @ting-yuan @hfmehmed @jaschdoc
+/examples/ @ting-yuan @hfmehmed @jaschdoc
+README.md @ting-yuan @hfmehmed @jaschdoc
+CONTRIBUTING.md @ting-yuan @hfmehmed @jaschdoc
+DEVELOPMENT.md @ting-yuan @hfmehmed @jaschdoc


### PR DESCRIPTION
This is a suggestion for a `CODEOWNERS` file. It's based on`git-log` / `git-blame`. Are there any areas you think should be differently covered or in greater / less detail?
The `CODEOWNERS` file is there intended to ensure every PR receives attention from familiar contributors. It should be viewed as a baseline. Reviews from other relevant people should be encouraged for all PRs.