### PR TITLE
Make symbol-processing-api and common-deps compile dependency

### DIFF
--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -297,8 +297,8 @@ publishing {
                             "kotlinx-coroutines-core-jvm",
                             aaCoroutinesVersion
                         )
-                        addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
-                        addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version)
+                        addDependency("com.google.devtools.ksp", "symbol-processing-api", version, "compile")
+                        addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version, "compile")
                     }
                 }
             }


### PR DESCRIPTION
To fix #2289

KotlinSymbolProcessing which is on the public API of kotlin-analysis-api module exposes KSPConfig (from -api) and KSPLogger (from -common-deps) so those dependencies should be declared as "compile" for the consumers of the "symbol-processing-aa" published artifact