### PR TITLE
Fix potential file handle leaks by clearing IntelliJ VFS cache

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/RerunTasksIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/RerunTasksIT.kt
@@ -1,0 +1,50 @@
+package com.google.devtools.ksp.test
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * This test is used mostly to confirm Windows releases file locks after symbol processing is complete.
+ * However, it will run on Linux too for completeness purposes
+ */
+class RerunTasksIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject("android-rerun")
+
+    @Test
+    fun testPlaygroundAndroid() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(
+            ":lib:common:media:assembleDebug",
+            "--no-configuration-cache",
+            "--no-build-cache",
+            "--rerun-tasks",
+        )
+            .build().let { result ->
+                val output = result.output.lines()
+                val kspTask = output.filter {
+                    it.contains(":lib:common:media:kspDebugKotlin")
+                }
+                Assert.assertTrue(kspTask.isNotEmpty())
+            }
+
+        gradleRunner.withArguments(
+            ":lib:common:media:assembleDebug",
+            "--no-configuration-cache",
+            "--no-build-cache",
+            "--rerun-tasks",
+        )
+            .build().let { result ->
+                val output = result.output.lines()
+                val kspTask = output.filter {
+                    it.contains(":lib:common:media:kspDebugKotlin")
+                }
+                Assert.assertTrue(kspTask.isNotEmpty())
+            }
+    }
+}

--- a/integration-tests/src/test/resources/android-rerun/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-rerun/build.gradle.kts
@@ -1,0 +1,26 @@
+buildscript {
+    val testRepo: String by project
+
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}
+
+plugins {
+    id("com.android.library") apply false
+    kotlin("android") apply false
+    id("com.google.devtools.ksp") apply false
+}
+
+allprojects {
+    val testRepo: String by project
+    repositories {
+        maven(testRepo)
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+        google()
+    }
+}

--- a/integration-tests/src/test/resources/android-rerun/gradle.properties
+++ b/integration-tests/src/test/resources/android-rerun/gradle.properties
@@ -1,0 +1,3 @@
+android.builtInKotlin=false
+android.newDsl=false
+org.gradle.configuration-cache=false

--- a/integration-tests/src/test/resources/android-rerun/lib/common/collections/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-rerun/lib/common/collections/build.gradle.kts
@@ -1,0 +1,31 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.google.devtools.ksp")
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.common.collections"
+
+    compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    defaultConfig {
+        minSdk = 26
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
+
+dependencies {
+}

--- a/integration-tests/src/test/resources/android-rerun/lib/common/collections/src/main/java/com/example/A.kt
+++ b/integration-tests/src/test/resources/android-rerun/lib/common/collections/src/main/java/com/example/A.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class A

--- a/integration-tests/src/test/resources/android-rerun/lib/common/media/build.gradle.kts
+++ b/integration-tests/src/test/resources/android-rerun/lib/common/media/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+plugins {
+    id("com.google.devtools.ksp")
+    id("com.android.library")
+    kotlin("android")
+}
+
+android {
+    namespace = "com.example.common.media"
+
+    compileSdk = 36
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
+    defaultConfig {
+        minSdk = 26
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
+}
+
+dependencies {
+    implementation(project(":lib:common:collections"))
+    ksp("androidx.room:room-compiler:2.8.4")
+}

--- a/integration-tests/src/test/resources/android-rerun/lib/common/media/src/main/java/com/example/B.kt
+++ b/integration-tests/src/test/resources/android-rerun/lib/common/media/src/main/java/com/example/B.kt
@@ -1,0 +1,3 @@
+package com.example
+
+class B(val a: A)

--- a/integration-tests/src/test/resources/android-rerun/settings.gradle.kts
+++ b/integration-tests/src/test/resources/android-rerun/settings.gradle.kts
@@ -1,0 +1,21 @@
+pluginManagement {
+    val kotlinVersion: String by settings
+    val kspVersion: String by settings
+    val testRepo: String by settings
+    val agpVersion: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion apply false
+        kotlin("android") version kotlinVersion apply false
+        id("com.android.library") version agpVersion apply false
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    }
+}
+
+include(":lib:common:collections")
+include(":lib:common:media")

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -297,8 +297,8 @@ publishing {
                             "kotlinx-coroutines-core-jvm",
                             aaCoroutinesVersion
                         )
-                        addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
-                        addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version)
+                        addDependency("com.google.devtools.ksp", "symbol-processing-api", version, "compile")
+                        addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version, "compile")
                     }
                 }
             }


### PR DESCRIPTION
Improves resource management in the KSP Analysis API implementation by ensuring IntelliJ file handlers are properly cleaned up. When using the Kotlin Analysis API, the underlying CoreJarFileSystem maintains a cache of file handlers. If not explicitly cleared, this leads to issues in Windows where the OS holds the lock on a specific file making it impossible to re-run the build unless the existing gradle daemon is terminated. Linux and Mac os are more lenient in terms of file locking so this does not seem to be an issue there

Fixes: #2774
