### PR TITLE
Use `GITHUB_REF` in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
     # Build KSP artifacts
     - name: build
       run: |
-        REF=${{ github.ref }} # refs/tags/$KSP_VERSION
+        REF=${GITHUB_REF} # refs/tags/$KSP_VERSION
         ./gradlew --info -PkspVersion=${REF:10} -PoutRepo=$(pwd)/build/repos/release publishAllPublicationsToMavenRepository
     - name: pack
       run: cd build/repos/release/ && zip -r ../../artifacts.zip .


### PR DESCRIPTION
This change is just to fast tack the LSC PRs opened by google-admin