### PR TITLE
Fix shadowed lambda parameter

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -569,14 +569,16 @@ class KotlinSymbolProcessing(
                 ResolverAAImpl.instance.functionAsMemberOfCache = mutableMapOf()
                 ResolverAAImpl.instance.propertyAsMemberOfCache = mutableMapOf()
 
-                processors.forEach {
+                processors.forEach { processor ->
                     incrementalContext.closeFilesOnException {
-                        deferredSymbols[it] =
-                            it.process(resolver).filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
-                                .filterIsInstance<Deferrable>().mapNotNull(Deferrable::defer)
+                        deferredSymbols[processor] =
+                            processor.process(resolver)
+                                .filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
+                                .filterIsInstance<Deferrable>()
+                                .mapNotNull(Deferrable::defer)
                     }
-                    if (!deferredSymbols.containsKey(it) || deferredSymbols[it]!!.isEmpty()) {
-                        deferredSymbols.remove(it)
+                    if (!deferredSymbols.containsKey(processor) || deferredSymbols[processor]!!.isEmpty()) {
+                        deferredSymbols.remove(processor)
                     }
                 }
 


### PR DESCRIPTION
This change qualifies the outer parameter with `processor`. It's used in different scopes, so giving it a proper name makes its uses more explicit.