### PR TITLE
Fix kotlinx coroutines dependency

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -79,6 +79,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectOutputStream
 import java.lang.reflect.InvocationTargetException
+import java.net.URI
 import java.net.URLClassLoader
 import java.nio.file.Paths
 import java.util.*
@@ -136,6 +137,7 @@ abstract class KspAATask @Inject constructor(
                         kspConfig.processorClasspath,
                     )
                 }
+
                 else -> {
                     if (
                         !inputChanges.isIncremental ||
@@ -183,10 +185,13 @@ abstract class KspAATask @Inject constructor(
                 ),
                 project.dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:$KSP_KOTLIN_BASE_VERSION"),
                 project.dependencies.create(
-                    "org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:$KSP_COROUTINES_VERSION"
+                    "com.intellij.platform:kotlinx-coroutines-core-jvm:$KSP_COROUTINES_VERSION"
                 ),
             ).apply {
                 isTransitive = false
+            }
+            project.repositories.maven {
+                it.url = URI("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
             }
             val incomingProcessors = processorClasspath.incoming.artifactView { }.files
             val kspTaskProvider = project.tasks.register(kspTaskName, KspAATask::class.java) { kspAATask ->

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ aaFastutilVersion=8.5.14-jb1
 aaStax2Version=4.2.1
 aaAaltoXmlVersion=1.3.0
 aaStreamexVersion=0.7.2
-aaCoroutinesVersion=1.8.0-intellij-14
+aaCoroutinesVersion=1.8.0-intellij-13
 
 kotlin.jvm.target.validation.mode=warning
 

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -12,13 +12,17 @@ plugins {
     kotlin("jvm")
 }
 
+repositories {
+    maven("https://packages.jetbrains.team/maven/p/ij/intellij-dependencies")
+}
+
 dependencies {
     testImplementation("junit:junit:$junitVersion")
     testImplementation(gradleTestKit())
     testImplementation(project(":api"))
     testImplementation(project(":gradle-plugin"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    testImplementation("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    testImplementation("com.intellij.platform:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
 }
 
 fun Test.configureCommonSettings() {

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -107,8 +107,8 @@ dependencies {
     implementation("javax.inject:javax.inject:1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
     implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
-    compileOnly("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    compileOnly("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    compileOnly("com.intellij.platform:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    compileOnly("com.intellij.platform:kotlinx-coroutines-core:$aaCoroutinesVersion")
     implementation(
         "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil:$aaFastutilVersion"
     ) {
@@ -134,16 +134,16 @@ dependencies {
     testImplementation(project(":common-deps"))
     testImplementation(project(":test-utils"))
     testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$aaKotlinBaseVersion")
-    testImplementation("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    testImplementation("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    testImplementation("com.intellij.platform:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    testImplementation("com.intellij.platform:kotlinx-coroutines-core:$aaCoroutinesVersion")
     libsForTesting(kotlin("stdlib", aaKotlinBaseVersion))
     libsForTesting(kotlin("test", aaKotlinBaseVersion))
     libsForTesting(kotlin("script-runtime", aaKotlinBaseVersion))
     libsForTestingCommon(kotlin("stdlib-common", aaKotlinBaseVersion))
 
     depJarsForCheck("org.jetbrains.kotlin:kotlin-stdlib:$kotlinBaseVersion")
-    depJarsForCheck("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    depJarsForCheck("org.jetbrains.intellij.deps.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    depJarsForCheck("com.intellij.platform:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    depJarsForCheck("com.intellij.platform:kotlinx-coroutines-core:$aaCoroutinesVersion")
     depJarsForCheck(project(":api"))
     depJarsForCheck(project(":common-deps"))
 
@@ -293,7 +293,7 @@ publishing {
                     asNode().appendNode("dependencies").apply {
                         addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
                         addDependency(
-                            "org.jetbrains.intellij.deps.kotlinx",
+                            "com.intellij.platform",
                             "kotlinx-coroutines-core-jvm",
                             aaCoroutinesVersion
                         )

--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -292,7 +292,7 @@ publishing {
                     asNode().appendNode("dependencies").apply {
                         addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
                         addDependency(
-                            "org.jetbrains.intellij.deps.kotlinx",
+                            "com.intellij.platform",
                             "kotlinx-coroutines-core-jvm",
                             aaCoroutinesVersion
                         )


### PR DESCRIPTION
The `1.8.0-intellij-13` version is published under the `com.intellij.platform` group. This is the version that Kotlin uses, and consequently the one we need.