### PR TITLE
Move KSVisitorVoid from api/.../symbol to api/.../visitor

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSVisitorVoid.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSVisitorVoid.kt
@@ -1,20 +1,31 @@
-/*
- * Copyright 2020 Google LLC
- * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package com.google.devtools.ksp.symbol
+package com.google.devtools.ksp.visitor
+
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSCallableReference
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSClassifierReference
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSDeclarationContainer
+import com.google.devtools.ksp.symbol.KSDefNonNullReference
+import com.google.devtools.ksp.symbol.KSDynamicReference
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSModifierListOwner
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSParenthesizedReference
+import com.google.devtools.ksp.symbol.KSPropertyAccessor
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSReferenceElement
+import com.google.devtools.ksp.symbol.KSTypeAlias
+import com.google.devtools.ksp.symbol.KSTypeArgument
+import com.google.devtools.ksp.symbol.KSTypeParameter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueArgument
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
 
 /**
  * A visitor that doesn't pass or return anything.

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
@@ -27,7 +27,7 @@ import com.google.devtools.ksp.symbol.KSPropertySetter
 import com.google.devtools.ksp.symbol.KSTypeAlias
 import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSValueParameter
-import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 // TODO: Make visitor a generator
 class CollectAnnotatedSymbolsVisitor(private val inDepth: Boolean) : KSVisitorVoid() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class AllFunctionsProcessor : AbstractTestProcessor() {
     val visitor = AllFunctionsVisitor()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -20,6 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class AnnotationArgumentProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BaseVisitor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BaseVisitor.kt
@@ -3,7 +3,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
-import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 open class BaseVisitor : KSVisitorVoid() {
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassWithCompanionProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassWithCompanionProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
-import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class ClassWithCompanionProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
     val visitor = ConstructorsVisitor()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/HelloProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/HelloProcessor.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class HelloProcessor : AbstractTestProcessor() {
     val results = mutableListOf<String>()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageAnnotationProcessor.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
-import com.google.devtools.ksp.symbol.KSVisitorVoid
+import com.google.devtools.ksp.visitor.KSVisitorVoid
 
 class PackageAnnotationProcessor : AbstractTestProcessor() {
     val result = mutableListOf<String>()


### PR DESCRIPTION
This is a breaking change since KSVisitorVoid will have to be reimported. However, it seems inconsistent to me that this is the only visitor in the symbol package, and that there is a dedicated visitor package.

I'm fully aware that we cannot easily merge this due to its breaking nature, but I wanted to see how many things were impacted by this refactoring and also to discuss when such a change would be possible.

Lastly, I did not update api.base to ensure CI fails.