### PR TITLE
Upgrade to Java 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ The form of the test itself is flexible as long as the logic is being covered.
 Here are some [sample test processors](compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor) for your reference.
 
 #### Steps for writing a test
-* KSP needs to be built with JDK 11+, because of some test dependencies.
+* KSP needs to be built with JDK 17+, because of some test dependencies.
 * Create a test processor under the sample processor folder.
 it should be extending [AbstractTestProcessor](test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt)
 * Write your logic by overriding corresponding functions. 

--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -34,7 +34,7 @@ application {
     mainClass = "com.google.devtools.ksp.BenchRunner"
 }
 tasks.withType<KotlinCompile> {
-    compilerOptions.jvmTarget = "1.8"
+    compilerOptions.jvmTarget = "17"
 }
 tasks.withType<Jar> {
     manifest {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,8 +104,8 @@ subprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         configure<JavaPluginExtension> {
             toolchain.languageVersion.set(compileJavaVersion)
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
         }
         configure<KotlinJvmProjectExtension> {
             compilerOptions {

--- a/docs/ksp2cmdline.md
+++ b/docs/ksp2cmdline.md
@@ -19,7 +19,7 @@ Taking `KSPJvmMain` for example,
 java -cp \
 symbol-processing-aa-2.2.10-2.0.2.jar:kotlin-analysis-api-2.2.10-2.0.2.jar:common-deps-2.2.10-2.0.2.jar:symbol-processing-api-2.2.10-2.0.2.jar:kotlin-stdlib-2.2.10.jar:kotlinx-coroutines-core-jvm-1.10.2.jar \
 com.google.devtools.ksp.cmdline.KSPJvmMain \
--jvm-target 11 \
+-jvm-target 17 \
 -module-name=main \
 -source-roots project_dir/src/kotlin/main \
 -project-base-dir project_dir/ \

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -124,8 +124,8 @@ java {
             resources.srcDir(testPropsOutDir)
         }
     }
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks.named("compileTestKotlin").configure {
@@ -182,7 +182,7 @@ kotlin {
         }
     }
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -80,12 +80,12 @@ tasks.check {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 kotlin {
     compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -91,7 +91,7 @@ open class TypeAliasProcessor : AbstractTestProcessor() {
         return buildList {
             while (self != null) {
                 add(self.toSignature())
-                self = (self?.declaration as? KSTypeAlias)?.type?.resolve()
+                self = (self.declaration as? KSTypeAlias)?.type?.resolve()
             }
         }
     }


### PR DESCRIPTION
Can we do this or could there be downstream problems from this? Upgrading would allows us to upgrade some dependencies such as JUnit and caffeine.