### PR TITLE
Parameterize integration tests over `experimentalPsiResolution`

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionBuiltInKotlinIT.kt
@@ -12,27 +12,31 @@ import java.io.File
 
 @RunWith(Parameterized::class)
 class AGPVersionBuiltInKotlinIT(
-    private val agpVersion: String?,
-    private val kotlinVersion: String?,
-    private val gradleVersion: String?
+    private val agpVersion: String,
+    private val kotlinVersion: String,
+    private val gradleVersion: String,
+    experimentalPsiResolution: String
 ) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
         "playground-android-builtinkotlin",
-        "playground"
+        "playground",
+        experimentalPsiResolution.toBoolean()
     )
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}")
-        fun data(): Collection<Array<String?>> {
+        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}, Experimental: {3}")
+        fun data(): Collection<Array<String>> {
             return listOf(
                 arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-beta01", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-beta01", "2.2.10", "9.1.0"),
-            )
+            ).flatMap {
+                listOf(it.plus("true"), it.plus("false"))
+            }
         }
     }
 
@@ -41,10 +45,10 @@ class AGPVersionBuiltInKotlinIT(
         val gradleRunner = GradleRunner.create()
             .withProjectDir(project.root)
             .withArguments(":workload:compileDebugKotlin")
-        gradleVersion?.let { gradleRunner.withGradleVersion(it) }
+        gradleVersion.let { gradleRunner.withGradleVersion(it) }
 
-        agpVersion?.let { project.setAgpVersion(it) }
-        kotlinVersion?.let {
+        agpVersion.let { project.setAgpVersion(it) }
+        kotlinVersion.let {
             project.setKotlinVersion(it)
             setKotlinInBuildClasspath(it)
         }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
@@ -14,20 +14,22 @@ import java.io.File
 class AGPVersionIT(
     private val agpVersion: String?,
     private val kotlinVersion: String?,
-    private val gradleVersion: String?
+    private val gradleVersion: String?,
+    experimentalPsiResolution: String?
 ) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
         "playground-android-multi",
-        "playground"
+        "playground",
+        experimentalPsiResolution!!.toBoolean()
     )
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}")
         fun data(): Collection<Array<String?>> {
-            return listOf(
+            return listOf<Array<String?>>(
                 // Latest
                 arrayOf(null, null, null),
 
@@ -62,7 +64,9 @@ class AGPVersionIT(
                 // AGP 9.0.0-beta01
                 arrayOf("9.0.0-beta01", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-beta01", "2.2.10", "9.1.0"),
-            )
+            ).flatMap {
+                listOf(it.plus("true"), it.plus("false"))
+            }
         }
     }
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidBuiltInKotlinIT.kt
@@ -8,13 +8,26 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.JarFile
 
-class AndroidBuiltInKotlinIT {
+@RunWith(Parameterized::class)
+class AndroidBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground-android-builtinkotlin", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground-android-builtinkotlin",
+        "playground",
+        experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroidWithBuiltInKotlin() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
@@ -5,11 +5,23 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class AndroidDataBindingBuiltInKotlinIT {
+@RunWith(Parameterized::class)
+class AndroidDataBindingBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("android-data-binding-builtinkotlin")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "android-data-binding-builtinkotlin",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingBuiltInKotlinIT.kt
@@ -33,7 +33,7 @@ class AndroidDataBindingBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
             ":app:assemble",
             "--configuration-cache-problems=warn",
             "--info",
-            "--stacktrace"
+            "--stacktrace",
         )
             .build().let { result ->
                 val output = result.output.lines()

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidDataBindingIT.kt
@@ -5,11 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class AndroidDataBindingIT() {
+@RunWith(Parameterized::class)
+class AndroidDataBindingIT(experimentalPsiResolution: Boolean) {
+
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("android-data-binding")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "android-data-binding",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIT.kt
@@ -8,13 +8,27 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.JarFile
 
-class AndroidIT() {
+@RunWith(Parameterized::class)
+class AndroidIT(experimentalPsiResolution: Boolean) {
+
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground-android", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground-android",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidIncrementalIT.kt
@@ -24,12 +24,26 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class AndroidIncrementalIT() {
+@RunWith(Parameterized::class)
+class AndroidIncrementalIT(experimentalPsiResolution: Boolean) {
+
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground-android-multi",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun testWithExtraFlags() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidViewBindingIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AndroidViewBindingIT.kt
@@ -5,11 +5,23 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class AndroidViewBindingIT() {
+@RunWith(Parameterized::class)
+class AndroidViewBindingIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("android-view-binding")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "android-view-binding",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/BuildCacheIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/BuildCacheIT.kt
@@ -6,16 +6,33 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class BuildCacheIT() {
+@RunWith(Parameterized::class)
+class BuildCacheIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project1: TemporaryTestProject = TemporaryTestProject("buildcache", "playground")
+    val project1: TemporaryTestProject = TemporaryTestProject(
+        "buildcache",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
 
     @Rule
     @JvmField
-    val project2: TemporaryTestProject = TemporaryTestProject("buildcache", "playground")
+    val project2: TemporaryTestProject = TemporaryTestProject(
+        "buildcache",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testBuildCache() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/BuildCacheIncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/BuildCacheIncrementalIT.kt
@@ -4,12 +4,24 @@ import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class BuildCacheIncrementalIT() {
+@RunWith(Parameterized::class)
+class BuildCacheIncrementalIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("buildcache-incremental")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "buildcache-incremental",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     // See https://github.com/google/ksp/issues/2042 for details
     @Test

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedRefsIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedRefsIncIT.kt
@@ -5,12 +5,25 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class GeneratedRefsIncIT() {
+@RunWith(Parameterized::class)
+class GeneratedRefsIncIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("refs-gen", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "refs-gen",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testGeneratedRefsInc() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSourcesViaAndroidComponentsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSourcesViaAndroidComponentsIT.kt
@@ -5,12 +5,25 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class GeneratedSourcesViaAndroidComponentsIT {
+@RunWith(Parameterized::class)
+class GeneratedSourcesViaAndroidComponentsIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground-android-multi", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground-android-multi",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun `test no circular dependency for other source generating tasks depending on ksp`() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSrcsIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GeneratedSrcsIncIT.kt
@@ -5,12 +5,25 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class GeneratedSrcsIncIT() {
+@RunWith(Parameterized::class)
+class GeneratedSrcsIncIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("srcs-gen", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "srcs-gen",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testGeneratedSrcsInc() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/GetSealedSubclassesIncIT.kt
@@ -5,12 +5,25 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class GetSealedSubclassesIncIT() {
+@RunWith(Parameterized::class)
+class GetSealedSubclassesIncIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("sealed-subclasses", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "sealed-subclasses",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testGetSealedSubclassesInc() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/HmppIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/HmppIT.kt
@@ -5,11 +5,23 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class HmppIT() {
+@RunWith(Parameterized::class)
+class HmppIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("hmpp")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "hmpp",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     val taskToFilesTraditional = mapOf(
         ":workload:kspCommonMainKotlinMetadata" to "w: [ksp] EchoProcessor: CommonMain",

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalCPIT.kt
@@ -6,12 +6,24 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalCPIT() {
+@RunWith(Parameterized::class)
+class IncrementalCPIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("incremental-classpath")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental-classpath",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private val src2Dirty = listOf(
         "l1/src/main/kotlin/p1/L1.kt" to setOf(

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalEmptyCPIT.kt
@@ -6,13 +6,26 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalEmptyCPIT {
+@RunWith(Parameterized::class)
+class IncrementalEmptyCPIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
     val project: TemporaryTestProject =
-        TemporaryTestProject("incremental-classpath2", "incremental-classpath")
+        TemporaryTestProject(
+            "incremental-classpath2",
+            "incremental-classpath",
+            experimentalPsiResolution = experimentalPsiResolution
+        )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private val prop2Dirty = listOf(
         "l1/src/main/kotlin/p1/TopProp1.kt" to setOf(

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalIT.kt
@@ -7,12 +7,24 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalIT() {
+@RunWith(Parameterized::class)
+class IncrementalIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("incremental")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     // K2 did some more lookups, which might be a spec change or potential optimization opportunity.
     // TODO: check with JetBrains.

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalMultiChainIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalMultiChainIT.kt
@@ -5,12 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalMultiChainIT() {
+@RunWith(Parameterized::class)
+class IncrementalMultiChainIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("incremental-multi-chain")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental-multi-chain",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testMultiChain() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemoval2IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemoval2IT.kt
@@ -5,12 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalRemoval2IT() {
+@RunWith(Parameterized::class)
+class IncrementalRemoval2IT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("incremental-removal2")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental-removal2",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testRemoveOutputs() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemovalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/IncrementalRemovalIT.kt
@@ -5,12 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class IncrementalRemovalIT() {
+@RunWith(Parameterized::class)
+class IncrementalRemovalIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("incremental-removal")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental-removal",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testRemoveOutputs() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/InitPlusProviderIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/InitPlusProviderIT.kt
@@ -6,13 +6,25 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.JarFile
 
-class InitPlusProviderIT() {
+@RunWith(Parameterized::class)
+class InitPlusProviderIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("init-plus-provider")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "init-plus-provider",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testInitPlusProvider() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaNestedClassIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaNestedClassIT.kt
@@ -6,11 +6,23 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class JavaNestedClassIT() {
+@RunWith(Parameterized::class)
+class JavaNestedClassIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("javaNestedClass")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "javaNestedClass",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testJavaNestedClass() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaOnlyIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/JavaOnlyIT.kt
@@ -7,12 +7,25 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class JavaOnlyIT() {
+@RunWith(Parameterized::class)
+class JavaOnlyIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("java-only", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "java-only",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testJavaOnly() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KAPT3IT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KAPT3IT.kt
@@ -7,13 +7,25 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.JarFile
 
-class KAPT3IT() {
+@RunWith(Parameterized::class)
+class KAPT3IT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("kapt3")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "kapt3",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
         buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KMPImplementedIT.kt
@@ -9,13 +9,25 @@ import org.junit.Assume
 import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.*
 
-class KMPImplementedIT {
+@RunWith(Parameterized::class)
+class KMPImplementedIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("kmp")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "kmp",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun verify(jarName: String, contents: List<String>) {
         val artifact = File(project.root, jarName)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KSPCmdLineOptionsIT.kt
@@ -6,15 +6,27 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.net.URLClassLoader
 
-class KSPCmdLineOptionsIT() {
+@RunWith(Parameterized::class)
+class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("cmd-options")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "cmd-options",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun getKsp2Main(mainClassName: String): Method {
         val repoPath = "../build/repos/test/com/google/devtools/ksp/"

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KaptKspTest.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KaptKspTest.kt
@@ -5,12 +5,25 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class KaptKspTest() {
+@RunWith(Parameterized::class)
+class KaptKspTest(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("android-view-binding", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "android-view-binding",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinConstsInJavaIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinConstsInJavaIT.kt
@@ -8,12 +8,24 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class KotlinConstsInJavaIT() {
+@RunWith(Parameterized::class)
+class KotlinConstsInJavaIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("kotlin-consts-in-java")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "kotlin-consts-in-java",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
         buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/KotlinInjectIT.kt
@@ -4,12 +4,24 @@ import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class KotlinInjectIT() {
+@RunWith(Parameterized::class)
+class KotlinInjectIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("kotlin-inject")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "kotlin-inject",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun triggerException() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/LegacyKaptKspIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/LegacyKaptKspIT.kt
@@ -5,11 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class LegacyKaptKspIT {
+@RunWith(Parameterized::class)
+class LegacyKaptKspIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("legacy-kapt", "playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "legacy-kapt",
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/MultiplatformIT.kt
@@ -8,13 +8,25 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.*
 
-class MultiplatformIT {
+@RunWith(Parameterized::class)
+class MultiplatformIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground-mpp")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground-mpp",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testJVM() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/NullabilityAnnotationsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/NullabilityAnnotationsIT.kt
@@ -8,11 +8,23 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class NullabilityAnnotationsIT() {
+@RunWith(Parameterized::class)
+class NullabilityAnnotationsIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("nullability-annotations")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "nullability-annotations",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
         buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnErrorIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnErrorIT.kt
@@ -5,12 +5,24 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class OnErrorIT() {
+@RunWith(Parameterized::class)
+class OnErrorIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("on-error")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "on-error",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testOnError() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnlyResourcesFileIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OnlyResourcesFileIT.kt
@@ -4,11 +4,23 @@ import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class OnlyResourcesFileIT() {
+@RunWith(Parameterized::class)
+class OnlyResourcesFileIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("only-resources-file")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "only-resources-file",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun test() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/OutputDepsIt.kt
@@ -8,12 +8,24 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class OutputDepsIt() {
+@RunWith(Parameterized::class)
+class OutputDepsIt(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("output-deps")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "output-deps",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     val src2Dirty = listOf(
         "workload/src/main/java/p1/J1.java" to setOf(

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PartialCleanIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PartialCleanIT.kt
@@ -6,12 +6,25 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 
-class PartialCleanIT() {
+@RunWith(Parameterized::class)
+class PartialCleanIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("partial-clean", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "partial-clean",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testWorkaroundForIncorrectlyMarkedInputs() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -9,13 +9,25 @@ import org.junit.Assert
 import org.junit.Assume
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.*
 
-class PlaygroundIT {
+@RunWith(Parameterized::class)
+class PlaygroundIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("playground")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     private fun GradleRunner.buildAndCheck(vararg args: String, extraCheck: (BuildResult) -> Unit = {}) =
         buildAndCheckOutcome(*args, outcome = TaskOutcome.SUCCESS, extraCheck = extraCheck)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PsiCacheIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PsiCacheIT.kt
@@ -4,11 +4,24 @@ import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-class PsiCacheIT() {
+@RunWith(Parameterized::class)
+class PsiCacheIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("psi-cache", "test-processor")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "psi-cache",
+        "test-processor",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPsiCache() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/RerunTasksIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/RerunTasksIT.kt
@@ -5,15 +5,27 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
 /**
  * This test is used mostly to confirm Windows releases file locks after symbol processing is complete.
  * However, it will run on Linux too for completeness purposes
  */
-class RerunTasksIT {
+@RunWith(Parameterized::class)
+class RerunTasksIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
-    val project: TemporaryTestProject = TemporaryTestProject("android-rerun")
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "android-rerun",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
 
     @Test
     fun testPlaygroundAndroid() {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
@@ -6,6 +6,7 @@ import java.io.File
 class TemporaryTestProject(
     projectName: String,
     baseProject: String? = null,
+    val experimentalPsiResolution: Boolean
 ) : TemporaryFolder() {
     private val testProjectSrc = File("src/test/resources", projectName)
     private val baseProjectSrc = baseProject?.let { File("src/test/resources", baseProject) }
@@ -31,6 +32,7 @@ class TemporaryTestProject(
         appendProperty("org.gradle.configuration-cache=true")
         appendProperty("kotlin.jvm.target.validation.mode=warning")
         appendProperty("ksp.incremental.log=true")
+        appendProperty("ksp.experimental.psi.resolution=$experimentalPsiResolution")
         appendProperty("android.useAndroidX=true")
 
         appendProperty("org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1024m")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
@@ -273,7 +273,7 @@ class PsiResolutionStrategy(
      * Resolves the [KSFunctionDeclarationImpl] corresponding to this [PsiMethod].
      */
     private fun PsiMethod.resolve(): KSFunctionDeclarationImpl {
-        val sym = analyze { callableSymbol }
+        val sym = analyze { this@resolve.callableSymbol }
             ?: error("Unexpected null callable symbol at ${toLocation()}: $javaClass")
         return sym.toKSFunctionDeclaration()
             ?: error("Unexpected null KSFunctionDeclaration at ${toLocation()}: $javaClass")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,6 +1,7 @@
 package com.google.devtools.ksp.impl.visitor
 
 import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiCodeBlock
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiMethod
@@ -15,7 +16,8 @@ import org.jetbrains.kotlin.psi.KtFunction
 
 /**
  * A [PsiRecursiveElementWalkingVisitor] that collects [PsiElement]s which
- * are annotated at least once. It does **not** traverse function or method bodies.
+ * are annotated at least once. It does **not** traverse function or method bodies, i.e.,
+ * always assumes `inDepth = false`.
  */
 class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
 
@@ -69,11 +71,13 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
      * An element is skippable if one of the following holds:
      * - It is a Kotlin function body
      * - It is a Java method body
+     * - It is a Java anonymous class
      */
     private fun PsiElement.isSkippable(): Boolean =
         // TODO: Skip elements we are not interested in visiting, e.g., imports.
         isKotlinFunctionBody() ||
-            isJavaMethodBody()
+            isJavaMethodBody() ||
+            isJavaAnonymousClass()
 
     /**
      * Returns `true` if the [PsiElement] is a Kotlin function body.
@@ -89,4 +93,10 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     private fun PsiElement.isJavaMethodBody(): Boolean =
         this is PsiCodeBlock &&
             this.parent is PsiMethod
+
+    /**
+     * Returns `true` if the [PsiElement] is a Java anonymous class.
+     */
+    private fun PsiElement.isJavaAnonymousClass(): Boolean =
+        this is PsiAnonymousClass
 }


### PR DESCRIPTION
Related to https://github.com/google/ksp/issues/2816

There seems to be an issue returning the symbols of with anonymous classes. I will investigate this a bit further.