### PR TITLE
Update tests with anonymous classes

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 
 class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbol: KaFunctionSymbol) :
     KSFunctionDeclaration,
@@ -161,7 +162,9 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
         val psi = ktFunctionSymbol.psi as? KtFunction ?: return@lazyMemoizedSequence emptySequence()
         if (!psi.hasBlockBody()) {
-            emptySequence()
+            val decl = psi.bodyExpression as? KtObjectLiteralExpression ?: return@lazyMemoizedSequence emptySequence()
+            val sym = analyze { decl.symbol.toKSDeclaration() } ?: return@lazyMemoizedSequence emptySequence()
+            sequenceOf(sym)
         } else {
             psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.flatMap {
                 analyze {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -171,17 +171,29 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
                 else -> emptySequence()
             }
         } else {
-            psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.flatMap { decl ->
-                analyze {
-                    when (val symbol = decl.symbol) {
-                        is KaDestructuringDeclarationSymbol -> {
-                            symbol.entries.mapNotNull { it.toKSDeclaration() }
+            when (val body = psi.bodyBlockExpression) {
+                null -> error("Predicate 'psi.hasBlockBody()' is true but 'psi.bodyBlockExpression' is null")
+                else -> {
+                    val anonDecls =
+                        body.statements.asSequence().filterIsInstance<KtObjectLiteralExpression>().mapNotNull { obj ->
+                            analyze {
+                                obj.symbol.toKSDeclaration()
+                            }
                         }
+                    val decls = body.statements.asSequence().filterIsInstance<KtDeclaration>().flatMap { decl ->
+                        analyze {
+                            when (val symbol = decl.symbol) {
+                                is KaDestructuringDeclarationSymbol -> {
+                                    symbol.entries.mapNotNull { it.toKSDeclaration() }
+                                }
 
-                        else -> listOfNotNull(symbol.toKSDeclaration())
+                                else -> listOfNotNull(symbol.toKSDeclaration())
+                            }
+                        }
                     }
+                    decls + anonDecls
                 }
-            } ?: emptySequence()
+            }
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -162,13 +162,18 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
         val psi = ktFunctionSymbol.psi as? KtFunction ?: return@lazyMemoizedSequence emptySequence()
         if (!psi.hasBlockBody()) {
-            val decl = psi.bodyExpression as? KtObjectLiteralExpression ?: return@lazyMemoizedSequence emptySequence()
-            val sym = analyze { decl.symbol.toKSDeclaration() } ?: return@lazyMemoizedSequence emptySequence()
-            sequenceOf(sym)
+            when (val decl = psi.bodyExpression) {
+                is KtObjectLiteralExpression -> {
+                    val sym = analyze { decl.symbol.toKSDeclaration() } ?: return@lazyMemoizedSequence emptySequence()
+                    sequenceOf(sym)
+                }
+
+                else -> emptySequence()
+            }
         } else {
-            psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.flatMap {
+            psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.flatMap { decl ->
                 analyze {
-                    when (val symbol = it.symbol) {
+                    when (val symbol = decl.symbol) {
                         is KaDestructuringDeclarationSymbol -> {
                             symbol.entries.mapNotNull { it.toKSDeclaration() }
                         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -383,7 +383,7 @@ internal fun KaSymbol.toKSDeclaration(): KSDeclaration? = toKSAnnotated() as? KS
 // For efficiency & simplicity, KaDestructuringDeclarationSymbol is handled by caller.
 internal fun KaSymbol.toKSAnnotated(): KSAnnotated = when (this) {
     is KaPropertySymbol -> toKSPropertyDeclaration()
-    is KaNamedClassSymbol -> toKSClassDeclaration()
+    is KaClassSymbol -> toKSClassDeclaration()
     is KaFunctionSymbol -> toKSFunctionDeclaration()
     is KaTypeAliasSymbol -> toKSTypeAlias()
     is KaJavaFieldSymbol -> this@toKSAnnotated.toKSPropertyDeclaration()
@@ -398,7 +398,7 @@ internal fun KaSymbol.toKSAnnotated(): KSAnnotated = when (this) {
 internal fun KaPropertySymbol.toKSPropertyDeclaration(): KSPropertyDeclarationImpl =
     KSPropertyDeclarationImpl.getCached(this)
 
-internal fun KaNamedClassSymbol.toKSClassDeclaration(): KSClassDeclarationImpl =
+internal fun KaClassSymbol.toKSClassDeclaration(): KSClassDeclarationImpl =
     KSClassDeclarationImpl.getCached(this)
 
 internal fun KaFunctionSymbol.toKSFunctionDeclaration(): KSFunctionDeclarationImpl =

--- a/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
+++ b/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
@@ -47,6 +47,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== Bnno inDepth = false ====
 // <init>:KSFunctionDeclaration
 // File: Foo.kt:KSFile
@@ -87,6 +95,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== A2 inDepth = false ====
 // <init>:KSFunctionDeclaration
 // Bar:KSClassDeclaration
@@ -117,6 +133,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== Cnno inDepth = true ====
 // constructorParameterFoo:KSPropertyDeclaration
 // constructorParameterFoo:KSValueParameter
@@ -159,6 +183,22 @@ class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, 
     fun runner(): Runnable = object : Runnable {
         @Anno
         override fun run() {}
+
+        @Anno
+        fun runKotlin() {}
+    }
+
+    fun runner2(): Runnable {
+        val result = object : Runnable {
+            @Anno
+            override fun run() {
+            }
+
+            @Anno
+            fun runKotlin2() {
+            }
+        }
+        return result
     }
 }
 
@@ -190,6 +230,19 @@ class Bar {
         return new Runnable() {
             @Anno
             void run() {}
+
+            @Anno
+            void runJava() {}
         };
+    }
+    Runnable runner() {
+        Runnable result = new Runnable() {
+            @Anno
+            void run() {}
+
+            @Anno
+            void runJava2() {}
+        };
+        return result;
     }
 }

--- a/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
+++ b/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
@@ -138,9 +138,9 @@ import Anno
 import Anno as A3
 
 @Anno
-class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, @Anno param: Int){
-    @Bnno constructor() {
-
+class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, @Anno param: Int) {
+    @Bnno
+    constructor() {
     }
 
     @Anno
@@ -155,6 +155,11 @@ class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, 
 
     @setparam:Cnno
     var a = 1
+
+    fun runner(): Runnable = object : Runnable {
+        @Anno
+        override fun run() {}
+    }
 }
 
 class C(@Cnno val x: Int)
@@ -171,9 +176,20 @@ class Burp
 @Anno
 typealias Flux = String
 
-enum class RGB{
+enum class RGB {
     R,
     G,
     @Anno
     B
+}
+
+//FILE: Bar.java
+class Bar {
+
+    Runnable runner() {
+        return new Runnable() {
+            @Anno
+            void run() {}
+        };
+    }
 }

--- a/kotlin-analysis-api/testData/locations.kt
+++ b/kotlin-analysis-api/testData/locations.kt
@@ -26,10 +26,10 @@
 // T:J.java:81
 // T:J.java:81
 // T:K.kt:60
-// delegateProp:K2.kt:110
+// delegateProp:K2.kt:116
 // f1:J.java:85
 // f1:K.kt:67
-// fieldProp:K2.kt:105
+// fieldProp:K2.kt:111
 // p1:K.kt:62
 // p2:J.java:85
 // p2:K.kt:67
@@ -40,7 +40,7 @@
 // v3.getter():K.kt:74
 // v3.setter():K.kt:75
 // v3:J.java:94
-// value:K2.kt:113
+// value:K2.kt:119
 // x1.getter():NonExistLocation
 // END
 
@@ -92,6 +92,12 @@ class K<@Location T> {
 
     @Location
     List<Double> v3 = List<double>()
+
+    Runnable f3() {
+        return new Runnable() {
+            @Location void run() {}
+        };
+    }
 }
 
 // FILE: K1.kt

--- a/test-utils/testData/api/getSymbolsFromAnnotation.kt
+++ b/test-utils/testData/api/getSymbolsFromAnnotation.kt
@@ -47,6 +47,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== Bnno inDepth = false ====
 // <init>:KSFunctionDeclaration
 // File: Foo.kt:KSFile
@@ -87,6 +95,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== A2 inDepth = false ====
 // <init>:KSFunctionDeclaration
 // Bar:KSClassDeclaration
@@ -117,6 +133,14 @@
 // p1:KSValueParameter
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// run:KSFunctionDeclaration
+// runJava:KSFunctionDeclaration
+// runJava2:KSFunctionDeclaration
+// runKotlin:KSFunctionDeclaration
+// runKotlin2:KSFunctionDeclaration
 // ==== Cnno inDepth = true ====
 // constructorParameterFoo:KSPropertyDeclaration
 // constructorParameterFoo:KSValueParameter
@@ -159,6 +183,22 @@ class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, 
     fun runner(): Runnable = object : Runnable {
         @Anno
         override fun run() {}
+
+        @Anno
+        fun runKotlin() {}
+    }
+
+    fun runner2(): Runnable {
+        val result = object : Runnable {
+            @Anno
+            override fun run() {
+            }
+
+            @Anno
+            fun runKotlin2() {
+            }
+        }
+        return result
     }
 }
 
@@ -190,6 +230,19 @@ class Bar {
         return new Runnable() {
             @Anno
             void run() {}
+
+            @Anno
+            void runJava() {}
         };
+    }
+    Runnable runner() {
+        Runnable result = new Runnable() {
+            @Anno
+            void run() {}
+
+            @Anno
+            void runJava2() {}
+        };
+        return result;
     }
 }

--- a/test-utils/testData/api/getSymbolsFromAnnotation.kt
+++ b/test-utils/testData/api/getSymbolsFromAnnotation.kt
@@ -1,6 +1,6 @@
 /*
- * Copyright 2022 Google LLC
- * Copyright 2010-2022 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2024 Google LLC
+ * Copyright 2010-2024 JetBrains s.r.o. and Kotlin Programming Language contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,14 +138,14 @@ import Anno
 import Anno as A3
 
 @Anno
-class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, @Anno param: Int){
-    @Bnno constructor() {
-
+class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, @Anno param: Int) {
+    @Bnno
+    constructor() {
     }
 
     @Anno
     val propertyFoo: String
-    @Bnno get() = TODO()
+        @Bnno get() = TODO()
 
     @Anno
     fun functionFoo(@Anno p1: Int, @Bnno p2: Int) {
@@ -155,6 +155,11 @@ class Foo @Anno constructor(@Anno @param:Cnno val constructorParameterFoo: Int, 
 
     @setparam:Cnno
     var a = 1
+
+    fun runner(): Runnable = object : Runnable {
+        @Anno
+        override fun run() {}
+    }
 }
 
 class C(@Cnno val x: Int)
@@ -171,9 +176,20 @@ class Burp
 @Anno
 typealias Flux = String
 
-enum class RGB{
+enum class RGB {
     R,
     G,
     @Anno
     B
+}
+
+//FILE: Bar.java
+class Bar {
+
+    Runnable runner() {
+        return new Runnable() {
+            @Anno
+            void run() {}
+        };
+    }
 }

--- a/test-utils/testData/api/locations.kt
+++ b/test-utils/testData/api/locations.kt
@@ -17,25 +17,33 @@
 
 // TEST PROCESSOR: LocationsProcessor
 // EXPECTED:
-// A:K.kt:49
+// A:K.kt:57
 // File: K.kt:K.kt:1
-// K:J.java:71
-// K:K.kt:52
-// T:J.java:71
-// T:K.kt:52
-// f1:J.java:75
-// f1:K.kt:59
-// p1:K.kt:54
-// p2:J.java:75
-// p2:K.kt:59
-// v1:K.kt:53
-// v1:K.kt:53
-// v2:J.java:72
-// v2:K.kt:56
-// v3.getter():K.kt:64
-// v3.setter():K.kt:65
-// v3:J.java:80
+// K:J.java:81
+// K:K.kt:60
+// Q:J.java:89
+// Q:K.kt:69
+// T:J.java:81
+// T:J.java:81
+// T:K.kt:60
+// delegateProp:K2.kt:116
+// f1:J.java:85
+// f1:K.kt:67
+// fieldProp:K2.kt:111
+// p1:K.kt:62
+// p2:J.java:85
+// p2:K.kt:67
+// v1:K.kt:61
+// v1:K.kt:61
+// v2:J.java:82
+// v2:K.kt:64
+// v3.getter():K.kt:74
+// v3.setter():K.kt:75
+// v3:J.java:94
+// value:K2.kt:119
+// x1.getter():NonExistLocation
 // END
+
 
 // FILE: Location.kt
 
@@ -58,6 +66,8 @@ class K<@Location T>(
     @Location
     fun f1(@Location p2: Int) = Unit
 
+    fun <@Location Q> f2() = Unit
+
     @get:Location
     @set:Location
     var v3: List<Double>
@@ -76,6 +86,37 @@ class K<@Location T> {
 
     }
 
+    <@Location Q> void f2() {
+
+    }
+
     @Location
     List<Double> v3 = List<double>()
+
+    Runnable f3() {
+        return new Runnable() {
+            @Location void run() {}
+        };
+    }
 }
+
+// FILE: K1.kt
+
+class A(@get:Location val x1: Int)
+
+// FILE: K2.kt
+
+class L {
+    @field:Location
+    val fieldProp: Int = 0
+
+    private val backing = 42
+
+    @delegate:Location
+    val delegateProp: Int by backing
+
+    var setParamProp: Int = 0
+        set(@setparam:Location value) { field = value }
+}
+
+fun @receiver:Location String.extFun() = Unit


### PR DESCRIPTION
@ting-yuan are we sure this is the right behavior? It seems to me that when `inDepth = true`, the processor should pick up the `Anno` annotations on the `run` methods of the anonymous classes. Note that I have not added the newly annotated symbols to the expected test results (only updated line numbers in `locations.kt`), yet the tests still pass.

Related to https://github.com/google/ksp/pull/2846