### PR TITLE
Remove "round x of processing" logging

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/PlaygroundIT.kt
@@ -441,7 +441,6 @@ class PlaygroundIT {
                     "i: [ksp] loaded provider(s): [TestProcessorProvider, TestProcessorProvider2]"
                 )
             )
-            Assert.assertTrue(result.output.contains("v: [ksp] round 3 of processing"))
         }
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -546,12 +546,10 @@ class KotlinSymbolProcessing(
                 }
             }
 
-            var rounds = 0
             // Run processors until either
             // 1) there is an error
             // 2) there is no more new files.
             while (!logger.hasError) {
-                logger.logging("round ${++rounds} of processing")
                 // FirSession in AA is created lazily. Getting it instantiates module providers, which requires source roots
                 // to be resolved. Therefore, due to the implementation, it has to be registered repeatedly after the files
                 // are created.


### PR DESCRIPTION
Mixing system logs and processor logs can be confusing. If round info is needed, processors can implement it easily.

It was also the last / only one message printed by KSP through logger.