### PR TITLE
Remove redundant analysis block

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
@@ -156,18 +156,16 @@ class PsiResolutionStrategy(
     /**
      * Returns all annotation entries for `element`.
      */
-    private fun getAnnotationsFor(element: PsiElement): Collection<KtOrPsiAnnotation> = analyze {
-        when (element) {
-            is KtAnnotated -> element.annotationEntries.map {
-                KtEntry(it)
-            }
-
-            is PsiModifierListOwner -> element.annotations.map {
-                PsiEntry(it)
-            }
-
-            else -> error("Unexpected PsiElement at ${element.toLocation()}: ${element.javaClass}")
+    private fun getAnnotationsFor(element: PsiElement): Collection<KtOrPsiAnnotation> = when (element) {
+        is KtAnnotated -> element.annotationEntries.map {
+            KtEntry(it)
         }
+
+        is PsiModifierListOwner -> element.annotations.map {
+            PsiEntry(it)
+        }
+
+        else -> error("Unexpected PsiElement at ${element.toLocation()}: ${element.javaClass}")
     }
 
     /**


### PR DESCRIPTION
No expression in the block depends on the properties exposed in the `analyze` block / lambda, so it can be safely removed.

Related to https://github.com/google/ksp/issues/2816