### PR TITLE
Fix crash in `PsiResolutionStrategy` for annotations with nullable fqn

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/MapUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/MapUtils.kt
@@ -18,20 +18,22 @@
 package com.google.devtools.ksp.common
 
 /**
- * Applies `transform` to each key-value pair, where the value is a collection,
+ * Applies [transform] to each key-value pair, where the value is a collection,
  * and merges the resulting collections of values.
+ *
+ * It will exclude any key-value pair where `transform(key)` is `null`.
  *
  * In other words, if `k1 -> [a, b, c], k2 -> [c, d, e]` and
  * `transform(k1) = transform(k2) = k3`, then the result is
  * `k3 -> [a, b, c, d, e]`.
  * Note the list is deduplicated.
  */
-internal fun <K, V, R> Map<K, Lazy<Collection<V>>>.mergeMapKeys(
-    transform: (K) -> R
+internal fun <K, V, R> Map<K, Lazy<Collection<V>>>.mergeMapNotNullKeys(
+    transform: (K) -> R?
 ): Map<R, Lazy<Collection<V>>> =
     mutableMapOf<R, Lazy<Collection<V>>>().apply {
-        this@mergeMapKeys.forEach {
-            transform(it.key).let { newKey ->
+        this@mergeMapNotNullKeys.forEach {
+            transform(it.key)?.let { newKey ->
                 if (newKey in this) {
                     // N.B.: Store the old value in a variable so the value is captured in the lazy
                     // lambda, instead of capturing the indexing expression `this[newKey]`, which

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/PsiResolutionStrategy.kt
@@ -17,7 +17,7 @@
 
 package com.google.devtools.ksp.impl
 
-import com.google.devtools.ksp.common.mergeMapKeys
+import com.google.devtools.ksp.common.mergeMapNotNullKeys
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl
@@ -253,15 +253,9 @@ class PsiResolutionStrategy(
             .mapValues { entry ->
                 lazy { entry.value.flatMap { it.resolveToKSAnnotated(entry.key) } }
             }
-            .mergeMapKeys {
-                it.qualifiedName
-                    ?: error(
-                        "Unexpected unqualified name for annotation with short name: " +
-                            "'${it.shortName}' " +
-                            "at ${it.toLocation()} " +
-                            "${it.javaClass}"
-                    )
-            }
+            // N.B.: Skip nullable qualified names without error. This is what the AA-based implementation does.
+            //   For now, this is the intended behavior. If it is changed in the future, then it is an API change.
+            .mergeMapNotNullKeys { it.qualifiedName }
     }
 
     /**

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
@@ -1,0 +1,35 @@
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSNode
+
+class GetSymbolsWithAnnotationProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results.toList().sorted()
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("Anno").forEach {
+            results.add(it.fqn)
+        }
+        return emptyList()
+    }
+
+    private val KSAnnotated.fqn: String
+        get() = findAllQualifiers(this).joinToString(separator = ".")
+
+    private fun findAllQualifiers(node: KSNode): List<KSNode> {
+        val result = mutableListOf(node)
+        var current = node.parent
+        while (current != null && current !is KSFile) {
+            result.add(current)
+            current = current.parent
+        }
+        result.reverse()
+        return result
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
@@ -443,6 +443,12 @@ class KSPAAPsiTest : AbstractKSPAATest(true) {
         runTest("../kotlin-analysis-api/testData/libOrigins.kt")
     }
 
+    @TestMetadata("localAnnotationClass")
+    @Test
+    fun testLocalAnnotationClass() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt")
+    }
+
     @TestMetadata("localClasses")
     @Test
     fun testLocalClasses() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
@@ -443,6 +443,12 @@ class KSPAAPsiTest : AbstractKSPAATest(true) {
         runTest("../kotlin-analysis-api/testData/libOrigins.kt")
     }
 
+    @TestMetadata("localClasses")
+    @Test
+    fun testLocalClasses() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt")
+    }
+
     @TestMetadata("locations.kt")
     @Test
     fun testLocations() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -442,6 +442,12 @@ class KSPAATest : AbstractKSPAATest(false) {
         runTest("../kotlin-analysis-api/testData/libOrigins.kt")
     }
 
+    @TestMetadata("localClasses")
+    @Test
+    fun testLocalClasses() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt")
+    }
+
     @TestMetadata("locations.kt")
     @Test
     fun testLocations() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -442,6 +442,12 @@ class KSPAATest : AbstractKSPAATest(false) {
         runTest("../kotlin-analysis-api/testData/libOrigins.kt")
     }
 
+    @TestMetadata("localAnnotationClass")
+    @Test
+    fun testLocalAnnotationClass() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt")
+    }
+
     @TestMetadata("localClasses")
     @Test
     fun testLocalClasses() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
@@ -1,0 +1,24 @@
+# Test directory for `Resolver.getSymbolsWithAnnotation`
+
+This test directory is dedicated to verifying the different implementations of
+`Resolver.getSymbolsWithAnnotation`, specifically focusing on parity between the two resolution
+strategies available in the KSP2 Kotlin Analysis API backend:
+
+1. **`AAResolutionStrategy`**: The default implementation that uses a full tree traversal
+(`CollectAnnotatedSymbolsVisitor`) and relies on the Analysis API for all resolutions.
+2. **`PsiResolutionStrategy`**: An experimental, optimized strategy that uses PSI to find
+annotations more efficiently by avoiding full resolution where possible.
+
+### Why this directory exists
+
+* **Coverage**: There are many tests in KSP that cover various scenarios, but they often
+use different processors that use other entry points than `Resolver.getSymbolsWithAnnotation`.
+This directory ensures we have a set of tests specifically running with
+`GetSymbolsWithAnnotationProcessor` to provide targeted coverage of these resolution strategies.
+* **`inDepth = false`**: These tests primarily target the default `inDepth = false` mode.
+This is the mode where the two strategies differ significantly. When `inDepth = true`,
+`PsiResolutionStrategy` currently delegates its implementation to `AAResolutionStrategy`, meaning
+they follow the same execution path.
+* **Isolation**: By keeping these tests separate, we avoid cluttering broader API tests while
+still ensuring that any changes to the resolution strategies are thoroughly validated across various
+code constructs (like nested or local classes).

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// EXPECTED:
+// END
+
+// FILE: Anno.kt
+annotation class Anno {
+    companion object {
+        val instance = this
+    }
+}
+
+// FILE: Target.kt
+
+@Anno.instance
+class Target

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// EXPECTED:
+// Outer
+// Outer.<no name provided>
+// Outer.Companion
+// Outer.Inner
+// Outer.Local
+// Outer.PrivateInner
+// Outer.PrivateLocal
+// END
+
+// FILE: Anno.kt
+annotation class Anno
+
+// FILE: LocalClasses.kt
+
+@Anno
+class Outer {
+    @Anno
+    class Local
+
+    @Anno
+    inner class Inner
+
+    @Anno
+    private class PrivateLocal
+
+    @Anno
+    private inner class PrivateInner
+
+    @Anno
+    object : Any {
+
+    }
+
+    @Anno
+    companion object {
+
+    }
+}


### PR DESCRIPTION
This PR fixes a crash in `PsiResolutionStrategy` if an annotation name has a nullable qualified name.

Related to https://github.com/google/ksp/issues/2816