### PR TITLE
Allow declaring target test annotations in test file

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 
-class GetSymbolsWithAnnotationProcessor : AbstractTestProcessor() {
+class GetSymbolsWithAnnotationProcessor(val annotationNames: List<String>) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -13,8 +13,10 @@ class GetSymbolsWithAnnotationProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        resolver.getSymbolsWithAnnotation("Anno").forEach {
-            results.add(it.fqn)
+        annotationNames.forEach { annotationName ->
+            resolver.getSymbolsWithAnnotation(annotationName).forEach {
+                results.add("$annotationName: ${it.fqn}")
+            }
         }
         return emptyList()
     }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -77,8 +77,10 @@ abstract class DisposableTest {
 
 abstract class AbstractKSPTest(frontend: FrontendKind<*>, val experimentalPsiMode: Boolean) : DisposableTest() {
     companion object {
-        val TEST_PROCESSOR = "// TEST PROCESSOR:"
-        val EXPECTED_RESULTS = "// EXPECTED:"
+        const val TEST_PROCESSOR = "// TEST PROCESSOR:"
+        const val TEST_ANNOTATIONS = "// TEST ANNOTATIONS:"
+        const val EXPECTED_RESULTS = "// EXPECTED:"
+        const val EXPECTED_RESULTS_END = "// END"
     }
 
     val kspTestRoot = KtTestUtil.tmpDir("com/google/devtools/ksp/test/testgoogle/devtools/ksp/test/test")
@@ -232,13 +234,30 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val experimentalPsiMod
         val contents = mainModule.files.first().originalFile.readLines()
 
         val testProcessorName = contents
-            .filter { it.startsWith(TEST_PROCESSOR) }
-            .single()
+            .single { it.startsWith(TEST_PROCESSOR) }
             .substringAfter(TEST_PROCESSOR)
             .trim()
+
+        val testAnnotationNames = contents
+            .find { it.startsWith(TEST_ANNOTATIONS) }
+            ?.substringAfter(TEST_ANNOTATIONS)
+            ?.split(',')
+            ?.map { it.trim() }
+
+        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
+
         val testProcessor: AbstractTestProcessor =
-            Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
-                .getDeclaredConstructor().newInstance() as AbstractTestProcessor
+            if (testAnnotationNames == null) {
+                // Instantiate processor class without constructor params
+                processorClass
+                    .getDeclaredConstructor()
+                    .newInstance() as AbstractTestProcessor
+            } else {
+                // Instantiate parameterized processor class
+                processorClass
+                    .getDeclaredConstructor(List::class.java)
+                    .newInstance(testAnnotationNames) as AbstractTestProcessor
+            }
 
         val kspConfigBuilder = KSPJvmConfig.Builder().apply {
             experimentalPsiResolution = experimentalPsiMode
@@ -247,7 +266,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val experimentalPsiMod
         val expectedResults = contents
             .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
             .drop(1)
-            .takeWhile { !it.startsWith("// END") }
+            .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
             .map { it.substring(3).trim() }
 
         val results = collectAllExceptions {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAAPsiTest.kt
@@ -473,6 +473,12 @@ class KSPAAPsiTest : AbstractKSPAATest(true) {
         runTest("../kotlin-analysis-api/testData/mangledNames.kt")
     }
 
+    @TestMetadata("metaAnnotations")
+    @Test
+    fun testMetaAnnotations() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt")
+    }
+
     @TestMetadata("multipleModules.kt")
     @Test
     fun testMultipleModules() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPAATest.kt
@@ -472,6 +472,12 @@ class KSPAATest : AbstractKSPAATest(false) {
         runTest("../kotlin-analysis-api/testData/mangledNames.kt")
     }
 
+    @TestMetadata("metaAnnotations")
+    @Test
+    fun testMetaAnnotations() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt")
+    }
+
     @TestMetadata("multipleModules.kt")
     @Test
     fun testMultipleModules() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
@@ -22,3 +22,22 @@ they follow the same execution path.
 * **Isolation**: By keeping these tests separate, we avoid cluttering broader API tests while
 still ensuring that any changes to the resolution strategies are thoroughly validated across various
 code constructs (like nested or local classes).
+
+### Important note when writing tests
+
+Tests that use `GetSymbolsWithAnnotationProcessor` must always have a comment containing the fully
+qualified names of the annotations the processor should use to look up symbols. For instance,
+the `localClasses.kt` file declares an annotation class `Anno` and contains the line:
+
+```kotlin
+// TEST ANNOTATIONS: Anno
+```
+
+Likewise, the `metaAnnotations.kt` file contains the line:
+
+```kotlin
+// TEST ANNOTATIONS: kotlin.annotation.Retention, kotlin.annotation.Target
+```
+
+It then finds all symbols annotated with `kotlin.annotation.Retention` and finds all symbols
+annotated with `kotlin.annotation.Target`.

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
@@ -16,17 +16,19 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// TEST ANNOTATIONS: Anno
 // EXPECTED:
-// Outer
-// Outer.<no name provided>
-// Outer.Companion
-// Outer.Inner
-// Outer.Local
-// Outer.PrivateInner
-// Outer.PrivateLocal
+// Anno: Outer
+// Anno: Outer.<no name provided>
+// Anno: Outer.Companion
+// Anno: Outer.Inner
+// Anno: Outer.Local
+// Anno: Outer.PrivateInner
+// Anno: Outer.PrivateLocal
 // END
 
 // FILE: Anno.kt
+
 annotation class Anno
 
 // FILE: LocalClasses.kt

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt
@@ -16,19 +16,14 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno
+// TEST ANNOTATIONS: kotlin.annotation.Retention, kotlin.annotation.Target
 // EXPECTED:
+// kotlin.annotation.Retention: Anno
+// kotlin.annotation.Target: Anno
 // END
 
 // FILE: Anno.kt
 
-annotation class Anno {
-    companion object {
-        val instance = this
-    }
-}
-
-// FILE: Target.kt
-
-@Anno.instance
-class Target
+@Retention(AnnotationRetention.SOURCE)
+@Target(AnnotationTarget.CLASS)
+annotation class Anno


### PR DESCRIPTION
This PR allows tests to declare a list of annotations that the test processor should use somehow. It also adds tests for targeting meta annotations. Specifically, the test processor `GetSymbolsWithAnnotationProcessor` used in the `getSymbolsWithAnnotation` directory can now be configured with annotations that it should target. This makes the testing setup a bit more flexible going foward.

Depends on https://github.com/google/ksp/pull/2864