### PR TITLE
Fix support for annotation use-site targets

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
@@ -18,12 +18,17 @@
 package com.google.devtools.ksp.common.impl
 
 import com.google.devtools.ksp.common.visitor.CollectAnnotatedSymbolsVisitor
+import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.fullyExpand
 import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSValueParameter
 import org.jetbrains.kotlin.analysis.api.types.symbol
 
 /**
@@ -66,7 +71,8 @@ class AAResolutionStrategy(
                 for (annotation in annotated.annotations) {
                     val kaType = (annotation.annotationType.resolve() as? KSTypeImpl)?.type ?: continue
                     val annotationFqN = kaType.fullyExpand().symbol?.classId?.asFqNameString() ?: continue
-                    getOrPut(annotationFqN, ::mutableSetOf).add(annotated)
+                    val annotatedTarget = annotation.useSiteTarget.findTargetedSymbolFor(annotated)
+                    getOrPut(annotationFqN, ::mutableSetOf).addAll(annotatedTarget)
                 }
             }
         }
@@ -75,4 +81,42 @@ class AAResolutionStrategy(
     private val deferredSymbolsRestored: Set<KSAnnotated> by lazy {
         deferredSymbols.values.flatten().mapNotNull { it.restore() }.toSet()
     }
+
+    /**
+     * Returns the symbol(s) in [annotated], targeted by the [AnnotationUseSiteTarget].
+     */
+    private fun AnnotationUseSiteTarget?.findTargetedSymbolFor(annotated: KSAnnotated): Collection<KSAnnotated> =
+        buildList {
+            when (this@findTargetedSymbolFor) {
+                null -> add(annotated)
+                AnnotationUseSiteTarget.FILE -> when (annotated) {
+                    is KSFile -> add(annotated)
+                    else -> annotated.containingFile?.let { add(it) }
+                }
+
+                AnnotationUseSiteTarget.PROPERTY -> add(annotated)
+                AnnotationUseSiteTarget.FIELD -> add(annotated)
+                AnnotationUseSiteTarget.GET -> add(annotated)
+                AnnotationUseSiteTarget.SET -> add(annotated)
+                AnnotationUseSiteTarget.RECEIVER -> when (annotated) {
+                    is KSPropertyDeclaration -> annotated.extensionReceiver?.let { add(it) }
+                    is KSFunctionDeclaration -> annotated.extensionReceiver?.let { add(it) }
+                }
+
+                AnnotationUseSiteTarget.PARAM -> (annotated as? KSValueParameter)?.let { add(it) }
+                AnnotationUseSiteTarget.SETPARAM -> add(annotated)
+                AnnotationUseSiteTarget.DELEGATE -> add(annotated) // TODO: Add proper support for backing fields.
+                AnnotationUseSiteTarget.ALL -> when (annotated) {
+                    is KSValueParameter -> add(annotated)
+                    is KSPropertyDeclaration -> {
+                        // TODO: Add proper support for backing fields, the ALL use site target also targets the field
+                        // TODO: Add support for JvmRecord annotation according to KEEP 402
+                        add(annotated)
+                        annotated.getter?.let { add(it) }
+                        annotated.setter?.let { add(it) }
+                        annotated.setter?.parameter?.let { add(it) }
+                    }
+                }
+            }
+        }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -23,7 +23,6 @@ import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFunctionDeclarationImpl
-import com.google.devtools.ksp.impl.symbol.kotlin.KSValueParameterImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.impl.symbol.kotlin.analyze
 import com.google.devtools.ksp.impl.symbol.kotlin.getFqn
@@ -42,6 +41,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSTypeParameter
 import com.google.devtools.ksp.symbol.KSValueParameter
@@ -55,6 +55,7 @@ import com.intellij.psi.PsiModifierListOwner
 import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.PsiTypeParameterList
+import com.intellij.util.containers.addIfNotNull
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -63,6 +64,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.parameterIndex
 import org.jetbrains.kotlin.utils.addToStdlib.flatGroupBy
+import kotlin.collections.buildList
 
 /**
  * An [AnnotationResolutionStrategy] that uses a combination of Psi and Kotlin's Analysis API to resolve
@@ -307,7 +309,7 @@ class PsiResolutionStrategy(
     private fun KtDeclaration.resolve(annotationEntry: KtAnnotationEntry): Collection<KSAnnotated> {
         // TODO: This should perform case distinction instead of getTargetedSymbol
         val ksSym = analyze { symbol.toKSAnnotated() }
-        return ksSym.getTargetedSymbol(annotationEntry.ksUseSiteTarget)
+        return ksSym.findTargetedSymbol(annotationEntry.ksUseSiteTarget)
     }
 
     /**
@@ -375,20 +377,12 @@ class PsiResolutionStrategy(
     /**
      * Returns the targeted symbols by a given annotated symbol at its use site target.
      *
-     * E.g., `class A(@MyAnno val p: Int)` returns `p, p.getter`
+     * E.g., `class A(@MyAnno val p: Int)` returns `p, p`, once for the parameter and once for the property.
      */
-    private fun KSAnnotated.getTargetedSymbol(useSiteTarget: AnnotationUseSiteTarget?): Collection<KSAnnotated> =
-        // TODO: Rewrite this call chain as double dispatch visitor.
+    private fun KSAnnotated.findTargetedSymbol(useSiteTarget: AnnotationUseSiteTarget?): Collection<KSAnnotated> =
         when (useSiteTarget) {
             null -> when (this) {
-                is KSValueParameterImpl -> {
-                    val generatedPropertySymbol = this.getGeneratedProperty()
-                    if (generatedPropertySymbol != null) {
-                        listOf(this, generatedPropertySymbol)
-                    } else {
-                        listOf(this)
-                    }
-                }
+                is KSValueParameter -> listOfNotNull(this, this.getGeneratedProperty())
 
                 is KSFunctionDeclarationImpl -> when {
                     this.isGetter -> listOf(
@@ -404,21 +398,32 @@ class PsiResolutionStrategy(
                     else -> listOf(this)
                 }
 
-                else ->
-                    listOf(this)
+                else -> listOf(this)
             }
 
-            AnnotationUseSiteTarget.FILE ->
-                listOf(
+            AnnotationUseSiteTarget.FILE -> when (this) {
+                is KSFile -> listOf(this)
+                else -> listOf(
                     this.containingFile
                         ?: error("Missing file at $location: $javaClass")
                 )
+            }
 
-            AnnotationUseSiteTarget.PROPERTY ->
-                listOf(this)
+            AnnotationUseSiteTarget.PROPERTY -> when (this) {
+                is KSValueParameter -> listOf(
+                    this.getGeneratedProperty() ?: error("Missing property for parameter at $location: $javaClass")
+                )
 
-            AnnotationUseSiteTarget.FIELD ->
-                listOf(this)
+                else -> listOf(this)
+            }
+
+            AnnotationUseSiteTarget.FIELD -> when (this) {
+                is KSValueParameter -> listOf(
+                    this.getGeneratedProperty() ?: error("Missing property for parameter at $location: $javaClass")
+                )
+
+                else -> listOf(this)
+            }
 
             AnnotationUseSiteTarget.GET ->
                 listOf(
@@ -446,18 +451,54 @@ class PsiResolutionStrategy(
                 else -> error("Unexpected declaration at $location: $javaClass")
             }
 
-            AnnotationUseSiteTarget.PARAM ->
-                listOf(this)
+            AnnotationUseSiteTarget.PARAM -> when (this) {
+                is KSValueParameter -> listOf(this)
+                else -> error("Unexpected annotated symbol with param use-site target at $location: $javaClass")
+            }
 
-            AnnotationUseSiteTarget.SETPARAM ->
-                // Return this, since it's the parameter that's directly annotated.
-                listOf(this)
+            AnnotationUseSiteTarget.SETPARAM -> when (this) {
+                is KSValueParameter -> {
+                    listOf(
+                        (this.parent as? KSFunctionDeclaration)?.parameters?.singleOrNull()
+                            ?: error("Missing setter parameter at $location: $javaClass")
+                    )
+                }
+
+                is KSPropertyDeclaration -> listOf(
+                    setter?.parameter
+                        ?: error("Missing setter parameter at $location: $javaClass")
+                )
+
+                else -> error("Unexpected annotated symbol with 'setparam' use-site target at $location: $javaClass")
+            }
 
             AnnotationUseSiteTarget.DELEGATE ->
+                // TODO: Better impl for this
                 listOf(this)
 
-            AnnotationUseSiteTarget.ALL ->
-                listOf(this) // FIXME: Correct impl
+            AnnotationUseSiteTarget.ALL -> when (this) {
+                is KSValueParameter -> {
+                    buildList {
+                        add(this@findTargetedSymbol)
+                        this@findTargetedSymbol.getGeneratedProperty()?.findTargetedSymbol(useSiteTarget)
+                            ?.let { symbols ->
+                                symbols.forEach { addIfNotNull(it) }
+                            }
+                    }
+                }
+
+                is KSPropertyDeclaration ->
+                    // TODO: Add proper support for backing fields, the ALL use site target also targets the field
+                    // TODO: Add support for JvmRecord annotation according to KEEP 402
+                    buildList {
+                        add(this@findTargetedSymbol)
+                        addIfNotNull(this@findTargetedSymbol.getter)
+                        addIfNotNull(this@findTargetedSymbol.setter)
+                        addIfNotNull(this@findTargetedSymbol.setter?.parameter)
+                    }
+
+                else -> error("Unexpected annotated symbol with 'all' use-site target at $location: $javaClass")
+            }
         }
 
     /**

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -56,6 +56,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolLocation
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.analysis.api.symbols.name
 import org.jetbrains.kotlin.analysis.api.symbols.receiverType
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -174,7 +175,24 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
             is KaNamedFunctionSymbol -> KSNameImpl.getCached(ktFunctionSymbol.name.asString())
             is KaPropertyAccessorSymbol -> when (val psi = ktFunctionSymbol.psi) {
                 is PsiMethod -> KSNameImpl.getCached(psi.name)
-                else -> KSNameImpl.getCached(ktFunctionSymbol.callableId?.callableName?.asString() ?: "<no name>")
+                else -> {
+                    // 1. Try to get the callable id
+                    // 2. Try to synthetically construct the getter or setter as e.g., "propertyName.getter()"
+                    // 3. Fall back to <no name>
+                    val name = ktFunctionSymbol.callableId?.callableName?.asString()
+                        ?: analyze { ktFunctionSymbol.containingSymbol?.name?.asString() }?.let { propertyName ->
+                            buildString {
+                                append(propertyName)
+                                append(".")
+                                when (ktFunctionSymbol) {
+                                    is KaPropertyGetterSymbol -> append("getter")
+                                    is KaPropertySetterSymbol -> append("setter")
+                                }
+                                append("()")
+                            }
+                        } ?: "<no name>"
+                    KSNameImpl.getCached(name)
+                }
             }
 
             is KaConstructorSymbol -> KSNameImpl.getCached("<init>")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/ConfigurableKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/ConfigurableKSPTest.kt
@@ -721,6 +721,12 @@ abstract class ConfigurableKSPTest(
         runTest("../kotlin-analysis-api/testData/typeParameterVariance.kt")
     }
 
+    @TestMetadata("useSiteTargets.kt")
+    @Test
+    fun testUseSiteTargets() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt")
+    }
+
     @TestMetadata("valueParameter.kt")
     @Test
     fun testValueParameter() {

--- a/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
+++ b/kotlin-analysis-api/testData/getSymbolsFromAnnotation.kt
@@ -118,7 +118,6 @@
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
 // ==== Cnno inDepth = true ====
-// constructorParameterFoo:KSPropertyDeclaration
 // constructorParameterFoo:KSValueParameter
 // value:KSValueParameter
 // x:KSPropertyDeclaration

--- a/kotlin-analysis-api/testData/getSymbolsFromAnnotationInLib.kt
+++ b/kotlin-analysis-api/testData/getSymbolsFromAnnotationInLib.kt
@@ -115,7 +115,6 @@
 // param:KSValueParameter
 // propertyFoo:KSPropertyDeclaration
 // ==== Cnno inDepth = true ====
-// constructorParameterFoo:KSPropertyDeclaration
 // constructorParameterFoo:KSValueParameter
 // value:KSValueParameter
 // x:KSPropertyDeclaration

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// TEST ANNOTATIONS: com.example.Anno, com.example.FileAnno
+// EXPECTED:
+// com.example.Anno: TargetClass
+// com.example.Anno: TargetClass.<init>.allUseSite
+// com.example.Anno: TargetClass.<init>.noUseSite
+// com.example.Anno: TargetClass.<init>.paramAndPropertyUseSite
+// com.example.Anno: TargetClass.<init>.paramUseSite
+// com.example.Anno: TargetClass.allUseSite
+// com.example.Anno: TargetClass.allUseSite.allUseSite.getter()
+// com.example.Anno: TargetClass.allUseSite.allUseSite.setter()
+// com.example.Anno: TargetClass.allUseSite.allUseSite.setter().value
+// com.example.Anno: TargetClass.delegateUseSite
+// com.example.Anno: TargetClass.fieldUseSite
+// com.example.Anno: TargetClass.getAndSetUseSite.getAndSetUseSite.getter()
+// com.example.Anno: TargetClass.getAndSetUseSite.getAndSetUseSite.setter()
+// com.example.Anno: TargetClass.getterUseSite.getterUseSite.getter()
+// com.example.Anno: TargetClass.noUseSite
+// com.example.Anno: TargetClass.nonParamValAllUseSite
+// com.example.Anno: TargetClass.nonParamValAllUseSite.nonParamValAllUseSite.getter()
+// com.example.Anno: TargetClass.nonParamVarAllUseSite
+// com.example.Anno: TargetClass.nonParamVarAllUseSite.nonParamVarAllUseSite.getter()
+// com.example.Anno: TargetClass.nonParamVarAllUseSite.nonParamVarAllUseSite.setter()
+// com.example.Anno: TargetClass.nonParamVarAllUseSite.nonParamVarAllUseSite.setter().value
+// com.example.Anno: TargetClass.paramAndPropertyUseSite
+// com.example.Anno: TargetClass.propertyUseSite
+// com.example.Anno: TargetClass.setParamUseSiteOnSetParam.setParamUseSiteOnSetParam.setter().boolSetterParameter
+// com.example.Anno: TargetClass.setParamUseSiteOnVar.setParamUseSiteOnVar.setter().value
+// com.example.Anno: TargetClass.setterUseSite.setterUseSite.setter()
+// com.example.Anno: nothingFun.ReceiverFunClass
+// com.example.Anno: nothingProp.ReceiverPropClass
+// com.example.FileAnno: File: TargetFile.kt
+// END
+
+// FILE: Anno.kt
+
+package com.example
+
+annotation class Anno
+annotation class FileAnno
+
+// FILE: TargetFile.kt
+
+import com.example.Anno
+import com.example.FileAnno
+
+@file:FileAnno
+
+@Anno
+class TargetClass(
+    @Anno val noUseSite: Int,
+    @param:Anno val paramUseSite: String,
+    @property:Anno val propertyUseSite: Boolean,
+    @get:Anno val getterUseSite: Boolean,
+    @set:Anno var setterUseSite: Boolean,
+    @get:Anno @set:Anno var getAndSetUseSite: Boolean,
+    @field:Anno val fieldUseSite: Float,
+    @all:Anno var allUseSite: Char,
+    @param:Anno @property:Anno val paramAndPropertyUseSite: Long,
+) {
+
+    @all:Anno
+    var nonParamVarAllUseSite: String
+
+    @all:Anno
+    val nonParamValAllUseSite: String
+
+    @setparam:Anno
+    var setParamUseSiteOnVar = 42
+
+    var setParamUseSiteOnSetParam: Boolean
+        set(@setparam:Anno boolSetterParameter) {
+            field = boolSetterParameter
+        }
+
+    @delegate:Anno val delegateUseSite: Boolean by lazy { true }
+}
+
+class ReceiverFunClass
+
+class ReceiverPropClass
+
+@receiver:Anno
+fun ReceiverFunClass.nothingFun() {}
+
+@receiver:Anno
+val ReceiverPropClass.nothingProp: Unit get() = Unit


### PR DESCRIPTION
Adds a test in the `getSymbolWithAnnotation` subdirectory for constructor parameters. While there are tests for constructor parameters, there does not seem to be a test with constructor parameters and a symbol processor that calls `Resolver.getSymbolsWithAnnotation`.

Related to https://github.com/google/ksp/pull/2871