### PR TITLE
Enable new default annotation use-site rules

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -103,6 +103,7 @@ import org.jetbrains.kotlin.cli.jvm.compiler.setupIdeaStandaloneExecution
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.KotlinCompilerVersion
+import org.jetbrains.kotlin.config.LanguageFeature
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.diagnostics.KtRegisteredDiagnosticFactoriesStorage
@@ -222,7 +223,11 @@ class KotlinSymbolProcessing(
                 val apiVersion = LanguageVersion.fromFullVersionString(kspConfig.apiVersion)!!
                 languageVersionSettings = LanguageVersionSettingsImpl(
                     languageVersion,
-                    ApiVersion.createByLanguageVersion(apiVersion)
+                    ApiVersion.createByLanguageVersion(apiVersion),
+                    specificFeatures = mapOf(
+                        LanguageFeature.AnnotationDefaultTargetMigrationWarning to LanguageFeature.State.ENABLED,
+                        LanguageFeature.PropertyParamAnnotationDefaultTargetMode to LanguageFeature.State.ENABLED
+                    )
                 )
 
                 this.platform = platform


### PR DESCRIPTION
These flags configure the Kotlin compiler and its Analysis API to use KEEP 402.

See the following links:
- https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0402-annotation-target-in-properties.md
- https://youtrack.jetbrains.com/issue/KTLC-391/Changes-in-default-choice-of-use-site-targets
- https://youtrack.jetbrains.com/issue/KT-73255

Related to https://github.com/google/ksp/pull/2871