### PR TITLE
Add PSI element implementations of KSFunctionDeclarationImpl and KSPropertyDeclarationJavaImpl

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
@@ -23,6 +23,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifierListOwner
 
 val jvmModifierMap = mapOf(
@@ -101,4 +102,21 @@ inline fun <T> lazyMemoizedSequence(crossinline initializer: () -> Sequence<T>):
         value
     else
         value.memoized()
+}
+
+/**
+ * Returns `true` if this [PsiMethod] represents one of the public instance methods
+ * from `java.lang.Object` (i.e., `equals`, `hashCode`, or `toString`).
+ */
+fun PsiMethod.isObjectOverride(): Boolean {
+    if (parameterList.parametersCount == 0) {
+        return name == "hashCode" || name == "toString"
+    }
+
+    if (parameterList.parametersCount == 1 && name == "equals") {
+        val paramType = parameterList.parameters[0].type.canonicalText
+        return paramType == "java.lang.Object" || paramType == "Object"
+    }
+
+    return false
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -488,6 +488,7 @@ class KotlinSymbolProcessing(
             val providers: List<SymbolProcessorProvider> = symbolProcessorProviders
             // KspModuleBuilder ensures this is always a KtSourceModule
             ResolverAAImpl.ktModule = modules.single() as KaSourceModule
+            ResolverAAImpl.kspConfig = kspConfig
 
             // Initializing environments
             val javaFileManager = if (kspConfig is KSPJvmConfig) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -86,6 +86,7 @@ import com.google.devtools.ksp.isProtected
 import com.google.devtools.ksp.isPublic
 import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.KSBuiltIns
+import com.google.devtools.ksp.processing.KSPConfig
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
@@ -159,21 +160,30 @@ class ResolverAAImpl(
 ) : Resolver {
     companion object {
         private val instance_prop: ThreadLocal<ResolverAAImpl> = ThreadLocal()
-        private val ktModule_prop: ThreadLocal<KaSourceModule> = ThreadLocal()
         var instance: ResolverAAImpl
             get() = instance_prop.get()
             set(value) {
                 instance_prop.set(value)
             }
+
+        private val ktModule_prop: ThreadLocal<KaSourceModule> = ThreadLocal()
         var ktModule: KaSourceModule
             get() = ktModule_prop.get()
             set(value) {
                 ktModule_prop.set(value)
             }
 
+        private val kspConfig_prop: ThreadLocal<KSPConfig> = ThreadLocal()
+        var kspConfig: KSPConfig
+            get() = kspConfig_prop.get()
+            set(value) {
+                kspConfig_prop.set(value)
+            }
+
         fun tearDown() {
             instance_prop.remove()
             ktModule_prop.remove()
+            kspConfig_prop.remove()
         }
     }
 
@@ -583,6 +593,12 @@ class ResolverAAImpl(
 
     // TODO: handle library symbols
     override fun getJvmName(declaration: KSFunctionDeclaration): String {
+        // FAST PATH: Java methods do not have Kotlin name mangling or @JvmName.
+        // Their JVM name is always exactly their simple name.
+        if (declaration.origin == Origin.JAVA || declaration.origin == Origin.JAVA_LIB) {
+            return declaration.simpleName.asString()
+        }
+
         val symbol: KaFunctionSymbol? = when (declaration) {
             is KSFunctionDeclarationImpl -> declaration.ktFunctionSymbol
             else -> null
@@ -814,10 +830,6 @@ class ResolverAAImpl(
         fun KSType.toSignature(): String {
             return if (this is KSTypeImpl) {
                 analyze {
-                    val decl = (this@toSignature.declaration as? KSClassDeclaration)
-                    // Force inline value class to be unwrapped.
-                    // Do not remove until AA fixes this.
-                    decl?.primaryConstructor
                     type.toSignature()
                 }
             } else {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -50,7 +50,9 @@ import org.jetbrains.kotlin.analysis.api.symbols.typeParameters
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtModifierListOwner
 
-abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationSymbol) : KSDeclaration, Deferrable {
+abstract class AbstractKSDeclarationImpl : KSDeclaration, Deferrable {
+    abstract val ktDeclarationSymbol: KaDeclarationSymbol
+
     override val origin: Origin by lazy {
         mapAAOrigin(ktDeclarationSymbol)
     }
@@ -68,7 +70,7 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
 
     override val modifiers: Set<Modifier> by lazy {
         if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC) {
-            when (ktDeclarationSymbol) {
+            when (val ktDeclarationSymbol = this.ktDeclarationSymbol) {
                 is KaPropertySymbol -> ktDeclarationSymbol.toModifiers()
                 is KaClassSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaFunctionSymbol -> ktDeclarationSymbol.toModifiers()
@@ -103,7 +105,7 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
             containingFile!!.packageName
         } else {
             // top level declaration
-            when (ktDeclarationSymbol) {
+            when (val ktDeclarationSymbol = this.ktDeclarationSymbol) {
                 is KaClassLikeSymbol -> ktDeclarationSymbol.classId?.packageFqName?.asString()
                 is KaCallableSymbol -> ktDeclarationSymbol.callableId?.packageName?.asString()
                 else -> null

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -25,8 +25,9 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaNamedClassSymbol
 
 class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntrySymbol: KaEnumEntrySymbol) :
     KSClassDeclaration,
-    AbstractKSDeclarationImpl(ktEnumEntrySymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktEnumEntrySymbol) {
+    override val ktDeclarationSymbol get() = ktEnumEntrySymbol
     companion object : KSObjectCache<KaEnumEntrySymbol, KSClassDeclarationEnumEntryImpl>() {
         fun getCached(ktEnumEntrySymbol: KaEnumEntrySymbol) =
             cache.getOrPut(ktEnumEntrySymbol) { KSClassDeclarationEnumEntryImpl(ktEnumEntrySymbol) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.errorTypeOnInconsistentArguments
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.impl.KSTypeReferenceSyntheticImpl
+import com.google.devtools.ksp.common.isObjectOverride
 import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.recordGetSealedSubclasses
@@ -29,17 +30,25 @@ import com.google.devtools.ksp.impl.recordLookupForGetAllFunctions
 import com.google.devtools.ksp.impl.recordLookupForGetAllProperties
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.symbol.*
+import com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
 import org.jetbrains.kotlin.analysis.api.impl.base.types.KaBaseStarTypeProjection
 import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSymbol: KaClassSymbol) :
     KSClassDeclaration,
-    AbstractKSDeclarationImpl(ktClassOrObjectSymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktClassOrObjectSymbol) {
+    private val isExperimentalPsiResolutionEnabled: Boolean by lazy {
+        ResolverAAImpl.kspConfig.experimentalPsiResolution
+    }
+
+    override val ktDeclarationSymbol = ktClassOrObjectSymbol
+
     companion object : KSObjectCache<KaClassSymbol, KSClassDeclarationImpl>() {
         fun getCached(ktClassOrObjectSymbol: KaClassSymbol) =
             cache.getOrPut(ktClassOrObjectSymbol) { KSClassDeclarationImpl(ktClassOrObjectSymbol) }
@@ -180,8 +189,88 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
     }
 
     override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
+        // FAST PATH: Use PSI directly for Java classes
+        if (isExperimentalPsiResolutionEnabled) {
+            ktClassOrObjectSymbol.psi?.let { psi ->
+                if (psi is PsiClass && canUsePsiResolution()) {
+                    return@lazyMemoizedSequence psi.getDeclarationsFromPsi()
+                }
+            }
+        }
+
+        // SLOW PATH: Original AA fallback for Kotlin classes (or if ASM failed)
+        getDeclarationsFromAnalysisApi()
+    }
+
+    private fun canUsePsiResolution(): Boolean {
+        return (origin == Origin.JAVA || origin == Origin.JAVA_LIB) &&
+            // Java annotations, enums, and types that map to Kotlin types (e.g. java.lang.String -> kotlin.String) have
+            // additional properties added by the Analysis API that don't actually exist in the Java type so just skip
+            // them to avoid this complexity.
+            classKind != ClassKind.ANNOTATION_CLASS &&
+            classKind != ClassKind.ENUM_CLASS &&
+            !ktClassOrObjectSymbol.isOrInheritsFromKotlinAlteredType()
+    }
+
+    private fun PsiClass.getDeclarationsFromPsi(): Sequence<KSDeclaration> {
+        // 1. Fields
+        val psiFields = fields.asSequence()
+            .map { KSPropertyDeclarationJavaImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
+
+        // 2. Methods (Non-constructors)
+        val psiMethods = methods.asSequence()
+            // Mimic FIR dropping malformed constructors that don't match class name, e.g. `class Foo { Bar() {} }`
+            .filter { !it.isConstructor }
+            // Mimic FIR dropping Object overrides in Java interfaces (e.g. `@Override boolean equals(Object)`).
+            .filter { !(isInterface && it.isObjectOverride()) }
+            .map { KSFunctionDeclarationImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
+
+        // 3. Constructors
+        // IntelliJ's PSI lacks implicit constructors. If none are explicitly declared,
+        // we must fetch the synthesized constructor from the Analysis API.
+        val psiConstructors = if (constructors.isEmpty() && !isInterface) {
+            analyze {
+                ktClassOrObjectSymbol.declaredMemberScope.constructors.map {
+                    KSFunctionDeclarationImpl.getCached(it)
+                }
+            }
+        } else {
+            constructors.asSequence()
+                .map { KSFunctionDeclarationImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
+        }
+
+        // 4. Inner Classes
+        val psiInnerClasses = innerClasses.asSequence()
+            .mapNotNull { psiInnerClass ->
+                analyze {
+                    val name = psiInnerClass.name?.let { Name.identifier(it) } ?: return@analyze null
+                    val instanceSymbols = ktClassOrObjectSymbol.declaredMemberScope.classifiers(name)
+                    val staticSymbols = ktClassOrObjectSymbol.staticDeclaredMemberScope.classifiers(name)
+                    (instanceSymbols + staticSymbols)
+                        .filterIsInstance<KaNamedClassSymbol>()
+                        .find { it.psi == psiInnerClass || it.psi?.isEquivalentTo(psiInnerClass) == true }
+                        ?.let { KSClassDeclarationImpl.getCached(it) }
+                }
+            }
+
+        // 5. Partition members into static and instance members to emulate FIR's ordering.
+        val (psiStaticMembers, psiInstanceMembers) = (psiFields + psiMethods + psiInnerClasses).partition {
+            Modifier.JAVA_STATIC in it.modifiers ||
+                // Nested classes in KSP don't get the static modifier.
+                (it is KSClassDeclaration && Modifier.INNER !in it.modifiers)
+        }
+
+        // Note: We could return declarations in source order by iterating over PsiClass.declarations directly.
+        // However, this ordering matches how things are done using the Analysis API to keep things consistent.
+        return psiInstanceMembers.asSequence() + psiConstructors + psiStaticMembers.asSequence()
+    }
+
+    private fun getDeclarationsFromAnalysisApi(): Sequence<KSDeclaration> {
         val decls = ktClassOrObjectSymbol.declarations()
-        if (origin == Origin.JAVA && classKind != ClassKind.ANNOTATION_CLASS) {
+            // The Analysis API is known to leak certain inherited members, so we filter those cases out here.
+            .filter { !it.isLeakedInheritedMember(this) }
+
+        return if ((origin == Origin.JAVA || origin == Origin.JAVA_LIB) && classKind != ClassKind.ANNOTATION_CLASS) {
             decls.flatMap { decl ->
                 if (decl is KSPropertyDeclarationImpl && decl.ktPropertySymbol is KaSyntheticJavaPropertySymbol) {
                     sequenceOf(decl.getter, decl.setter).mapNotNull { accessor ->

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -22,9 +22,11 @@ import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.lazyMemoizedSequence
+import com.google.devtools.ksp.common.toKSModifiers
 import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.recordLookupForPropertyOrMethod
 import com.google.devtools.ksp.impl.recordLookupWithSupertypes
+import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.isPublic
@@ -33,10 +35,11 @@ import com.google.devtools.ksp.symbol.FunctionKind
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSExpectActual
+import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSValueParameter
@@ -45,6 +48,8 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifier
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaDestructuringDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
@@ -52,6 +57,8 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertyAccessorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertyGetterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolLocation
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
@@ -59,22 +66,36 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
 import org.jetbrains.kotlin.analysis.api.symbols.name
 import org.jetbrains.kotlin.analysis.api.symbols.receiverType
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
 
-class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbol: KaFunctionSymbol) :
-    KSFunctionDeclaration,
-    AbstractKSDeclarationImpl(ktFunctionSymbol),
-    KSExpectActual by KSExpectActualImpl(ktFunctionSymbol) {
-    companion object : KSObjectCache<KaFunctionSymbol, KSFunctionDeclarationImpl>() {
-        fun getCached(ktFunctionSymbol: KaFunctionSymbol) =
-            cache.getOrPut(ktFunctionSymbol) { KSFunctionDeclarationImpl(ktFunctionSymbol) }
+sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclarationImpl() {
+    companion object {
+        // Factory for AA Slow Path
+        fun getCached(symbol: KaFunctionSymbol): KSFunctionDeclarationImpl =
+            KSFunctionDeclarationAAImpl.getCached(symbol)
+
+        // Factory for PSI Fast Path
+        fun getCached(psi: PsiMethod, parent: KSClassDeclarationImpl): KSFunctionDeclarationImpl =
+            KSFunctionDeclarationPsiImpl.getCached(psi, parent)
     }
+
+    abstract val ktFunctionSymbol: KaFunctionSymbol
+
+    override val ktDeclarationSymbol: KaFunctionSymbol get() = ktFunctionSymbol
+
+    // Manual delegation for KSExpectActual to avoid eager evaluation in the class header
+    private val expectActualImpl by lazy { KSExpectActualImpl(ktFunctionSymbol) }
+    override val isActual: Boolean get() = expectActualImpl.isActual
+    override val isExpect: Boolean get() = expectActualImpl.isExpect
+    override fun findActuals(): Sequence<KSDeclaration> = expectActualImpl.findActuals()
+    override fun findExpects(): Sequence<KSDeclaration> = expectActualImpl.findExpects()
 
     override val functionKind: FunctionKind by lazy {
         when (ktFunctionSymbol.location) {
             KaSymbolLocation.CLASS -> {
-                if (ktFunctionSymbol is KaNamedFunctionSymbol && ktFunctionSymbol.isStatic) {
+                if ((ktFunctionSymbol as? KaNamedFunctionSymbol)?.isStatic == true) {
                     FunctionKind.STATIC
                 } else {
                     FunctionKind.MEMBER
@@ -171,7 +192,7 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     }
 
     override val simpleName: KSName by lazy {
-        when (ktFunctionSymbol) {
+        when (val ktFunctionSymbol = this.ktFunctionSymbol) {
             is KaNamedFunctionSymbol -> KSNameImpl.getCached(ktFunctionSymbol.name.asString())
             is KaPropertyAccessorSymbol -> when (val psi = ktFunctionSymbol.psi) {
                 is PsiMethod -> KSNameImpl.getCached(psi.name)
@@ -286,6 +307,175 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
     val isSetter: Boolean by lazy {
         ktFunctionSymbol is KaPropertySetterSymbol
     }
+}
+
+private class KSFunctionDeclarationAAImpl(
+    override val ktFunctionSymbol: KaFunctionSymbol
+) : KSFunctionDeclaration, KSFunctionDeclarationImpl() {
+    companion object : KSObjectCache<KaFunctionSymbol, KSFunctionDeclarationAAImpl>() {
+        fun getCached(symbol: KaFunctionSymbol) = cache.getOrPut(symbol) {
+            KSFunctionDeclarationAAImpl(symbol)
+        }
+    }
+}
+
+private class KSFunctionDeclarationPsiImpl(
+    val psiMethod: PsiMethod,
+    val parentClass: KSClassDeclarationImpl
+) : KSFunctionDeclaration, KSFunctionDeclarationImpl() {
+    companion object : KSObjectCache<PsiMethod, KSFunctionDeclarationPsiImpl>() {
+        fun getCached(psiMethod: PsiMethod, parentClass: KSClassDeclarationImpl) = cache.getOrPut(psiMethod) {
+            KSFunctionDeclarationPsiImpl(psiMethod, parentClass)
+        }
+    }
+
+    override val ktFunctionSymbol: KaFunctionSymbol by lazy {
+        analyze { findKaFunctionSymbol(psiMethod, parentClass) }
+            ?: throw InternalKSPException(
+                "Failed to resolve KaFunctionSymbol for method ${parentClass.simpleName.asString()}.${psiMethod.name}",
+                psiMethod.toLocation(),
+                psiMethod.javaClass,
+            )
+    }
+
+    override val simpleName: KSName by lazy {
+        if (psiMethod.isConstructor) KSNameImpl.getCached("<init>") else KSNameImpl.getCached(psiMethod.name)
+    }
+
+    override val origin: Origin by lazy {
+        when (parent) {
+            // If our lazy parent resolution determined that this method belongs to a Kotlin property,
+            // it means FIR considers it a synthetic property accessor.
+            is KSPropertyDeclaration -> Origin.SYNTHETIC
+            else -> parentClass.origin
+        }
+    }
+
+    override val containingFile: KSFile? get() = parentClass.containingFile
+
+    override val packageName: KSName get() = parentClass.packageName
+
+    override val isAbstract: Boolean by lazy { psiMethod.hasModifierProperty(PsiModifier.ABSTRACT) }
+
+    override val functionKind: FunctionKind by lazy {
+        if (psiMethod.hasModifierProperty(PsiModifier.STATIC)) FunctionKind.STATIC else FunctionKind.MEMBER
+    }
+
+    override val modifiers: Set<Modifier> by lazy {
+        if (origin == Origin.JAVA) {
+            return@lazy psiMethod.toKSModifiers()
+        }
+
+        val psiModifiers = psiMethod.toKSModifiers().toMutableSet()
+
+        // Emulate AA: Strip JVM-specific modifiers from compiled Java methods
+        psiModifiers.remove(Modifier.JAVA_TRANSIENT)
+        psiModifiers.remove(Modifier.JAVA_VOLATILE)
+        psiModifiers.remove(Modifier.JAVA_SYNCHRONIZED)
+        psiModifiers.remove(Modifier.JAVA_NATIVE)
+        psiModifiers.remove(Modifier.JAVA_STRICT)
+        psiModifiers.remove(Modifier.JAVA_DEFAULT)
+
+        when {
+            psiMethod.isConstructor -> {
+                // Constructors are always final
+                psiModifiers.add(Modifier.FINAL)
+            }
+            psiMethod.hasModifierProperty(PsiModifier.STATIC) -> {
+                // Emulate AA: Static methods in compiled Java libraries are treated as final in Kotlin
+                psiModifiers.add(Modifier.FINAL)
+            }
+            !psiMethod.hasModifierProperty(PsiModifier.FINAL) &&
+                !psiMethod.hasModifierProperty(PsiModifier.PRIVATE) -> {
+                // Non-final, non-static, non-private Java instance methods are open in Kotlin
+                psiModifiers.add(Modifier.OPEN)
+            }
+        }
+
+        return@lazy psiModifiers
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
+        psiMethod.annotations.asSequence().map { KSAnnotationJavaImpl.getCached(it, this) }
+    }
+
+    // Java doesn't have extension receivers.
+    override val extensionReceiver: KSTypeReference? = null
+}
+
+/**
+ * Resolves the [KaFunctionSymbol] that corresponds to the given [PsiMethod] within the [parent] class.
+ *
+ * This method searches for a symbol whose underlying PSI matches the provided [psiMethod] using
+ * exact identity or equivalence. It handles several Kotlin Analysis API (FIR) interop edge cases:
+ *
+ * 1. **Performance Optimization (KT-85692):** For non-constructor methods, it queries `memberScope`
+ *    and `staticMemberScope` instead of `declaredMemberScope`. Querying the declared member scope
+ *    on Java classes triggers a severe performance bottleneck in the Analysis API, as it lacks a
+ *    dedicated declared enhancement scope for Java classes and falls back to resolving the entire
+ *    inherited use-site scope recursively.
+ * 2. **Property Accessor Fallback:** If a Java method follows getter/setter conventions (e.g., `getFoo()`)
+ *    and overrides a Kotlin property (`val foo`), FIR hides the method from the standard function scope
+ *    and exposes it as a property symbol instead. If the initial function match fails, this method
+ *    falls back to searching for property accessors via `findKaPropertyAccessorSymbols`.
+ *
+ * @param psiMethod The Java PSI method to resolve.
+ * @param parent The enclosing class declaration proxy.
+ * @return The resolved [KaFunctionSymbol], or null if the symbol could not be found.
+ */
+fun KaSession.findKaFunctionSymbol(psiMethod: PsiMethod, parentClass: KSClassDeclarationImpl): KaFunctionSymbol? {
+    fun Sequence<KaSymbol>.firstMatchingPsiMethod(psi: PsiMethod): KaFunctionSymbol? {
+        return filterIsInstance<KaFunctionSymbol>().find { it.psi == psi || it.psi?.isEquivalentTo(psi) == true }
+    }
+    val parentSymbol = parentClass.ktClassOrObjectSymbol
+    return if (psiMethod.isConstructor) {
+        parentSymbol.declaredMemberScope.constructors.firstMatchingPsiMethod(psiMethod)
+    } else {
+        val methodName = Name.identifier(psiMethod.name)
+        // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here since the psi method
+        // is declared in the parent. However, those methods trigger the performance issue mentioned in
+        // https://youtrack.jetbrains.com/issue/KT-85692, so stick with memberScope/staticMemberScope instead.
+        parentSymbol.memberScope.callables(methodName).firstMatchingPsiMethod(psiMethod)
+            ?: parentSymbol.staticMemberScope.callables(methodName).firstMatchingPsiMethod(psiMethod)
+            // If the above match failed, it means that FIR hid the method because it overrides a Kotlin property (e.g.
+            // `getX` -> `x`), so we need to find the property and get the KaFunctionSymbol from it instead.
+            ?: findKaPropertyAccessorSymbols(psiMethod, parentClass).firstMatchingPsiMethod(psiMethod)
+    }
+}
+
+private fun KaSession.findKaPropertyAccessorSymbols(
+    psiMethod: PsiMethod,
+    parentClass: KSClassDeclarationImpl
+): Sequence<KaPropertyAccessorSymbol> {
+    val methodName = psiMethod.name
+    val namesToSearch = when {
+        // A standard Java getter like `getFoo()` overrides a Kotlin property named `foo` or `Foo`.
+        methodName.startsWith("get") && methodName.length > 3 -> {
+            val accessorBase = methodName.substring(3)
+            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+            sequenceOf(propertyName, accessorBase)
+        }
+        // A Java boolean getter like `isFoo()` can override a Kotlin property named `foo` or `Foo`,
+        // OR a property explicitly named `isFoo`. All are valid in Kotlin interoperability.
+        methodName.startsWith("is") && methodName.length > 2 -> {
+            val accessorBase = methodName.substring(2)
+            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+            sequenceOf(propertyName, accessorBase, methodName)
+        }
+        // A Java setter like `setFoo()` can override a standard Kotlin property named `foo` or `Foo`,
+        // OR it can override a boolean property explicitly named `isFoo`.
+        methodName.startsWith("set") && methodName.length > 3 -> {
+            val accessorBase = methodName.substring(3)
+            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+            sequenceOf(propertyName, accessorBase, "is$accessorBase")
+        }
+        else -> return emptySequence()
+    }
+    return namesToSearch
+        .flatMap { parentClass.ktClassOrObjectSymbol.memberScope.callables(Name.identifier(it)) }
+        .filterIsInstance<KaPropertySymbol>()
+        .flatMap { sequenceOf(it.getter, it.setter) }
+        .filterNotNull()
 }
 
 internal fun KaFunctionSymbol.toModifiers(): Set<Modifier> {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -49,8 +49,9 @@ import org.jetbrains.kotlin.psi.KtProperty
 
 class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbol: KaPropertySymbol) :
     KSPropertyDeclaration,
-    AbstractKSDeclarationImpl(ktPropertySymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktPropertySymbol) {
+    override val ktDeclarationSymbol get() = ktPropertySymbol
     companion object : KSObjectCache<KaPropertySymbol, KSPropertyDeclarationImpl>() {
         fun getCached(ktPropertySymbol: KaPropertySymbol) =
             cache.getOrPut(ktPropertySymbol) { KSPropertyDeclarationImpl(ktPropertySymbol) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -1,22 +1,45 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
+import com.google.devtools.ksp.common.toKSModifiers
 import com.google.devtools.ksp.impl.ResolverAAImpl
+import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.symbol.*
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiModifier
+import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaJavaFieldSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.name.Name
 
-class KSPropertyDeclarationJavaImpl private constructor(val ktJavaFieldSymbol: KaJavaFieldSymbol) :
-    KSPropertyDeclaration,
-    AbstractKSDeclarationImpl(ktJavaFieldSymbol),
-    KSExpectActual by KSExpectActualImpl(ktJavaFieldSymbol) {
-    companion object : KSObjectCache<KaJavaFieldSymbol, KSPropertyDeclaration>() {
-        fun getCached(ktJavaFieldSymbol: KaJavaFieldSymbol): KSPropertyDeclaration =
-            cache.getOrPut(ktJavaFieldSymbol) { KSPropertyDeclarationJavaImpl(ktJavaFieldSymbol) }
+sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDeclarationImpl() {
+    companion object {
+        // Factory for PSI Fast Path
+        fun getCached(psi: PsiField, parent: KSClassDeclarationImpl): KSPropertyDeclarationJavaImpl =
+            KSPropertyDeclarationJavaPsiImpl.getCached(psi, parent)
+
+        // Factory for AA Slow Path
+        fun getCached(symbol: KaJavaFieldSymbol): KSPropertyDeclarationJavaImpl =
+            KSPropertyDeclarationJavaAAImpl.getCached(symbol)
     }
+
+    abstract val ktJavaFieldSymbol: KaJavaFieldSymbol
+
+    override val ktDeclarationSymbol: KaDeclarationSymbol
+        get() = ktJavaFieldSymbol
+
+    // Manual delegation for KSExpectActual to avoid eager evaluation in the class header
+    private val expectActualImpl by lazy { KSExpectActualImpl(ktJavaFieldSymbol) }
+    override val isActual: Boolean get() = expectActualImpl.isActual
+    override val isExpect: Boolean get() = expectActualImpl.isExpect
+    override fun findActuals(): Sequence<KSDeclaration> = expectActualImpl.findActuals()
+    override fun findExpects(): Sequence<KSDeclaration> = expectActualImpl.findExpects()
+
     override val getter: KSPropertyGetter?
         get() = null
 
@@ -67,6 +90,82 @@ class KSPropertyDeclarationJavaImpl private constructor(val ktJavaFieldSymbol: K
 
     override fun defer(): Restorable? {
         return ktJavaFieldSymbol.defer(::getCached)
+    }
+}
+
+private class KSPropertyDeclarationJavaAAImpl(
+    override val ktJavaFieldSymbol: KaJavaFieldSymbol
+) : KSPropertyDeclarationJavaImpl() {
+    companion object : KSObjectCache<KaJavaFieldSymbol, KSPropertyDeclarationJavaAAImpl>() {
+        fun getCached(symbol: KaJavaFieldSymbol) = cache.getOrPut(symbol) {
+            KSPropertyDeclarationJavaAAImpl(symbol)
+        }
+    }
+}
+
+private class KSPropertyDeclarationJavaPsiImpl(
+    val psiField: PsiField,
+    override val parent: KSClassDeclarationImpl,
+) : KSPropertyDeclarationJavaImpl() {
+    companion object : KSObjectCache<PsiField, KSPropertyDeclarationJavaPsiImpl>() {
+        fun getCached(psiField: PsiField, parent: KSClassDeclarationImpl) = cache.getOrPut(psiField) {
+            KSPropertyDeclarationJavaPsiImpl(psiField, parent)
+        }
+    }
+
+    override val ktJavaFieldSymbol: KaJavaFieldSymbol by lazy {
+        analyze {
+            val targetName = Name.identifier(psiField.name)
+            // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here since the psi
+            // field is declared in the parent. However, those scopes trigger the performance issue mentioned in
+            // https://youtrack.jetbrains.com/issue/KT-85692, so stick with memberScope/staticMemberScope instead.
+            val instanceSymbols = parent.ktClassOrObjectSymbol.memberScope.callables(targetName)
+            val staticSymbols = parent.ktClassOrObjectSymbol.staticMemberScope.callables(targetName)
+            (instanceSymbols + staticSymbols)
+                .find { it.psi == psiField || it.psi?.isEquivalentTo(psiField) == true } as? KaJavaFieldSymbol
+        } ?: throw InternalKSPException(
+            "Failed to resolve KaJavaFieldSymbol for field ${psiField.name}",
+            psiField.toLocation(),
+            psiField.javaClass,
+        )
+    }
+
+    override val simpleName: KSName by lazy {
+        KSNameImpl.getCached(psiField.name)
+    }
+
+    override val origin: Origin
+        get() = parentDeclaration?.origin ?: Origin.JAVA
+
+    override val containingFile: KSFile?
+        get() = parentDeclaration?.containingFile
+
+    override val packageName: KSName
+        get() = parentDeclaration?.packageName ?: KSNameImpl.getCached("")
+
+    override val isMutable: Boolean
+        get() = !psiField.hasModifierProperty(PsiModifier.FINAL)
+
+    override val modifiers: Set<Modifier> by lazy {
+        if (origin == Origin.JAVA) {
+            return@lazy psiField.toKSModifiers()
+        }
+
+        val psiModifiers = psiField.toKSModifiers().toMutableSet()
+
+        // Emulate AA: Strip JVM-specific modifiers from compiled Java fields
+        psiModifiers.remove(Modifier.JAVA_TRANSIENT)
+        psiModifiers.remove(Modifier.JAVA_VOLATILE)
+        psiModifiers.remove(Modifier.JAVA_SYNCHRONIZED)
+
+        // Emulate AA: Java fields are treated as final 'val' properties
+        psiModifiers.add(Modifier.FINAL)
+
+        return@lazy psiModifiers
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
+        psiField.annotations.asSequence().map { KSAnnotationJavaImpl.getCached(it, this) }
     }
 }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -1,22 +1,45 @@
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
+import com.google.devtools.ksp.common.lazyMemoizedSequence
+import com.google.devtools.ksp.common.toKSModifiers
 import com.google.devtools.ksp.impl.ResolverAAImpl
+import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.symbol.*
+import com.intellij.psi.PsiField
+import com.intellij.psi.PsiModifier
+import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaJavaFieldSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.name.Name
 
-class KSPropertyDeclarationJavaImpl private constructor(val ktJavaFieldSymbol: KaJavaFieldSymbol) :
-    KSPropertyDeclaration,
-    AbstractKSDeclarationImpl(ktJavaFieldSymbol),
-    KSExpectActual by KSExpectActualImpl(ktJavaFieldSymbol) {
-    companion object : KSObjectCache<KaJavaFieldSymbol, KSPropertyDeclaration>() {
-        fun getCached(ktJavaFieldSymbol: KaJavaFieldSymbol): KSPropertyDeclaration =
-            cache.getOrPut(ktJavaFieldSymbol) { KSPropertyDeclarationJavaImpl(ktJavaFieldSymbol) }
+sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDeclarationImpl() {
+    companion object {
+        // Factory for PSI Fast Path
+        fun getCached(psi: PsiField, parent: KSClassDeclarationImpl): KSPropertyDeclarationJavaImpl =
+            KSPropertyDeclarationJavaPsiImpl.getCached(psi, parent)
+
+        // Factory for AA Slow Path
+        fun getCached(symbol: KaJavaFieldSymbol): KSPropertyDeclarationJavaImpl =
+            KSPropertyDeclarationJavaAAImpl.getCached(symbol)
     }
+
+    abstract val ktJavaFieldSymbol: KaJavaFieldSymbol
+
+    override val ktDeclarationSymbol: KaDeclarationSymbol
+        get() = ktJavaFieldSymbol
+
+    // Manual delegation for KSExpectActual to avoid eager evaluation in the class header
+    private val expectActualImpl by lazy { KSExpectActualImpl(ktJavaFieldSymbol) }
+    override val isActual: Boolean get() = expectActualImpl.isActual
+    override val isExpect: Boolean get() = expectActualImpl.isExpect
+    override fun findActuals(): Sequence<KSDeclaration> = expectActualImpl.findActuals()
+    override fun findExpects(): Sequence<KSDeclaration> = expectActualImpl.findExpects()
+
     override val getter: KSPropertyGetter?
         get() = null
 
@@ -67,6 +90,82 @@ class KSPropertyDeclarationJavaImpl private constructor(val ktJavaFieldSymbol: K
 
     override fun defer(): Restorable? {
         return ktJavaFieldSymbol.defer(::getCached)
+    }
+}
+
+private class KSPropertyDeclarationJavaAAImpl(
+    override val ktJavaFieldSymbol: KaJavaFieldSymbol
+) : KSPropertyDeclarationJavaImpl() {
+    companion object : KSObjectCache<KaJavaFieldSymbol, KSPropertyDeclarationJavaAAImpl>() {
+        fun getCached(symbol: KaJavaFieldSymbol) = cache.getOrPut(symbol) {
+            KSPropertyDeclarationJavaAAImpl(symbol)
+        }
+    }
+}
+
+private class KSPropertyDeclarationJavaPsiImpl(
+    val psiField: PsiField,
+    override val parent: KSClassDeclarationImpl,
+) : KSPropertyDeclarationJavaImpl() {
+    companion object : KSObjectCache<PsiField, KSPropertyDeclarationJavaPsiImpl>() {
+        fun getCached(psiField: PsiField, parent: KSClassDeclarationImpl) = cache.getOrPut(psiField) {
+            KSPropertyDeclarationJavaPsiImpl(psiField, parent)
+        }
+    }
+
+    override val ktJavaFieldSymbol: KaJavaFieldSymbol by lazy {
+        analyze {
+            val targetName = Name.identifier(psiField.name)
+            // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here since the psi
+            // field is declared in the parent. However, those scopes trigger the performance issue mentioned in
+            // https://youtrack.jetbrains.com/issue/KT-85692, so stick with memberScope/staticMemberScope instead.
+            val instanceSymbols = parent.ktClassOrObjectSymbol.memberScope.callables(targetName)
+            val staticSymbols = parent.ktClassOrObjectSymbol.staticMemberScope.callables(targetName)
+            (instanceSymbols + staticSymbols)
+                .find { it.psi == psiField || it.psi?.isEquivalentTo(psiField) == true } as? KaJavaFieldSymbol
+        } ?: throw InternalKSPException(
+            "Failed to resolve KaJavaFieldSymbol for field ${psiField.name}",
+            psiField.toLocation(),
+            psiField.javaClass,
+        )
+    }
+
+    override val simpleName: KSName by lazy {
+        KSNameImpl.getCached(psiField.name)
+    }
+
+    override val origin: Origin
+        get() = parent.origin
+
+    override val containingFile: KSFile?
+        get() = parent.containingFile
+
+    override val packageName: KSName
+        get() = parent.packageName
+
+    override val isMutable: Boolean
+        get() = !psiField.hasModifierProperty(PsiModifier.FINAL)
+
+    override val modifiers: Set<Modifier> by lazy {
+        if (origin == Origin.JAVA) {
+            return@lazy psiField.toKSModifiers()
+        }
+
+        val psiModifiers = psiField.toKSModifiers().toMutableSet()
+
+        // Emulate AA: Strip JVM-specific modifiers from compiled Java fields
+        psiModifiers.remove(Modifier.JAVA_TRANSIENT)
+        psiModifiers.remove(Modifier.JAVA_VOLATILE)
+        psiModifiers.remove(Modifier.JAVA_SYNCHRONIZED)
+
+        // Emulate AA: Java fields are treated as final 'val' properties
+        psiModifiers.add(Modifier.FINAL)
+
+        return@lazy psiModifiers
+    }
+
+    override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
+        psiField.annotations.asSequence().map { KSAnnotationJavaImpl.getCached(it, this) }
     }
 }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationLocalVariableImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationLocalVariableImpl.kt
@@ -17,8 +17,9 @@ import org.jetbrains.kotlin.psi.KtProperty
 class KSPropertyDeclarationLocalVariableImpl private constructor(
     private val ktLocalVariableSymbol: KaLocalVariableSymbol
 ) : KSPropertyDeclaration,
-    AbstractKSDeclarationImpl(ktLocalVariableSymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktLocalVariableSymbol) {
+    override val ktDeclarationSymbol get() = ktLocalVariableSymbol
     companion object : KSObjectCache<KaLocalVariableSymbol, KSPropertyDeclarationLocalVariableImpl>() {
         fun getCached(ktLocalVariableSymbol: KaLocalVariableSymbol) =
             cache.getOrPut(ktLocalVariableSymbol) { KSPropertyDeclarationLocalVariableImpl(ktLocalVariableSymbol) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
@@ -24,8 +24,9 @@ import org.jetbrains.kotlin.analysis.api.symbols.*
 
 class KSTypeAliasImpl private constructor(private val ktTypeAliasSymbol: KaTypeAliasSymbol) :
     KSTypeAlias,
-    AbstractKSDeclarationImpl(ktTypeAliasSymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktTypeAliasSymbol) {
+    override val ktDeclarationSymbol get() = ktTypeAliasSymbol
     companion object : KSObjectCache<KaTypeAliasSymbol, KSTypeAliasImpl>() {
         fun getCached(ktTypeAliasSymbol: KaTypeAliasSymbol) =
             cache.getOrPut(ktTypeAliasSymbol) { KSTypeAliasImpl(ktTypeAliasSymbol) }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -31,8 +31,9 @@ class KSTypeParameterImpl private constructor(
     private val boundsSubstitued: List<KaType>?
 ) :
     KSTypeParameter,
-    AbstractKSDeclarationImpl(ktTypeParameterSymbol),
+    AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktTypeParameterSymbol) {
+    override val ktDeclarationSymbol get() = ktTypeParameterSymbol
     companion object : KSObjectCache<Pair<KaTypeParameterSymbol, List<KaType>?>, KSTypeParameterImpl>() {
         fun getCached(ktTypeParameterSymbol: KaTypeParameterSymbol, bounds: List<KaType>? = null) =
             cache.getOrPut(Pair(ktTypeParameterSymbol, bounds)) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -94,6 +94,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.analysis.api.symbols.KaSyntheticJavaPropertySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeAliasSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
@@ -117,6 +118,8 @@ import org.jetbrains.kotlin.analysis.api.types.KaTypeProjection
 import org.jetbrains.kotlin.analysis.api.types.KaUsualClassType
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap.mapJavaToKotlin
+import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap.mapKotlinToJava
 import org.jetbrains.kotlin.codegen.state.InfoForMangling
 import org.jetbrains.kotlin.codegen.state.collectFunctionSignatureForManglingSuffix
 import org.jetbrains.kotlin.codegen.state.md5base64
@@ -136,6 +139,7 @@ import org.jetbrains.kotlin.load.kotlin.TypeMappingMode
 import org.jetbrains.kotlin.metadata.jvm.deserialization.JvmProtoBufUtil
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.ClassIdBasedLocality
+import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_WILDCARD_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.psi.KtAnnotated
@@ -1195,6 +1199,125 @@ internal val KaDeclarationSymbol.internalSuffix: String
             else -> ""
         }
     }
+
+/**
+ * Checks if this symbol is an artifact of inheritance that the Kotlin Analysis API (FIR)
+ * incorrectly leaked into the current class's declarations list.
+ *
+ * KSP's contract dictates that `KSClassDeclaration.declarations` should only return
+ * explicitly declared members. This method identifies leaked or synthesized members
+ * so they can be filtered out.
+ *
+ * It specifically identifies the following Analysis API leaks:
+ *
+ * **1. Compiler-Generated Intersection Overrides**
+ * An intersection override occurs when a class inherits from multiple supertypes that
+ * declare the same member with the same signature. The compiler synthesizes a new member
+ * in the subclass.
+ * ```kotlin
+ * interface A { fun execute() }
+ * interface B { fun execute() }
+ * // FIR synthesizes an intersection override for `execute()` inside C.
+ * interface C : A, B
+ * ```
+ *
+ * **2. Compiler-Generated Substitution Overrides**
+ * A substitution override is created when a generic type parameter from a supertype
+ * is substituted with a concrete type in the subclass.
+ * ```kotlin
+ * interface Base<T> { fun process(item: T) }
+ * // FIR synthesizes a substitution override `fun process(item: String)` inside Derived.
+ * interface Derived : Base<String>
+ * ```
+ *
+ * **3. Inherited Synthetic Java Properties**
+ * The Analysis API exposes Java getter/setter methods that override a Kotlin property
+ * as synthetic property symbols. Due to a quirk in the FIR provider, these can leak
+ * into a subclass's declarations even if only inherited.
+ * ```kotlin
+ * interface FooProvider1 { val foo: Foo }
+ * ```
+ * ```java
+ * interface FooProvider2 { Foo getFoo(); }
+ * // App is empty, but FIR leaks a synthetic property for `foo`/`getFoo` into App's declarations.
+ * interface App extends FooProvider1, FooProvider2 {}
+ * ```
+ */
+internal fun KSDeclaration.isLeakedInheritedMember(currentClass: KSClassDeclarationImpl): Boolean {
+    val declarationSymbol = (this as? AbstractKSDeclarationImpl)?.ktDeclarationSymbol ?: return false
+    val origin = declarationSymbol.origin
+    if (origin == KaSymbolOrigin.INTERSECTION_OVERRIDE || origin == KaSymbolOrigin.SUBSTITUTION_OVERRIDE) {
+        return true
+    }
+
+    if (declarationSymbol is KaSyntheticJavaPropertySymbol) {
+        val getterClassId = declarationSymbol.javaGetterSymbol.callableId?.classId ?: return false
+        val currentClassId = currentClass.ktClassOrObjectSymbol.classId ?: return false
+        return getterClassId != currentClassId
+    }
+
+    return false
+}
+
+/**
+ * Performs a Breadth-First Search (BFS) over the FIR supertype hierarchy to determine if this
+ * class inherits from a Kotlin built-in type that structurally alters its Java members.
+ *
+ * This FIR-based traversal is required because PSI-based hierarchy checks (e.g.,
+ * `InheritanceUtil.isInheritor`) are unreliable for compiled library dependencies
+ * (`Origin.JAVA_LIB`) in KSP's isolated environments due to incomplete ASTs.
+ *
+ * If this returns true, KSP must bypass the PSI fast path to avoid exposing Java methods
+ * that FIR intentionally hides or renames (such as `remove(int)` or `entrySet()`), which
+ * would otherwise cause symbol resolution crashes during validation.
+ *
+ * @return `true` if this class or any of its supertypes requires specialized compiler mapping.
+ */
+fun KaClassSymbol.isOrInheritsFromKotlinAlteredType(): Boolean {
+    return analyze {
+        val queue = ArrayDeque<KaClassSymbol>()
+        val visited = mutableSetOf<KaClassSymbol>()
+        queue.add(this@isOrInheritsFromKotlinAlteredType)
+
+        while (queue.isNotEmpty()) {
+            val curr = queue.removeFirst()
+            if (!visited.add(curr)) continue
+
+            val fqName = curr.classId?.asFqNameString()
+            if (fqName != null && isKotlinAlteredType(fqName)) {
+                return@analyze true
+            }
+
+            // Traverse up the FIR hierarchy
+            curr.superTypes.forEach { superType -> superType.expandedSymbol?.let { queue.add(it) } }
+        }
+        false
+    }
+}
+
+/**
+ * Checks if the given fully qualified name belongs to a Kotlin built-in type that applies
+ * specialized mapping to its Java members.
+ *
+ * The Kotlin Analysis API (FIR) intentionally hides Java collection mutator methods and
+ * maps methods from specific types to properties or renamed identifiers (e.g., mapping
+ * `length()` to a property for `CharSequence`, or `remove` to `removeAt`). KSP must
+ * fall back to the Analysis API slow path for these types to maintain behavioral consistency.
+ */
+private fun isKotlinAlteredType(fqName: String): Boolean {
+    // Exclude benign mapped types that do not structurally alter Java members.
+    // kotlin.Any is at the root of every hierarchy, so it must be ignored to prevent
+    // the PSI fast path from being universally bypassed.
+    when (fqName) {
+        "kotlin.Any",
+        "kotlin.Cloneable",
+        "kotlin.Comparable",
+        "kotlin.Annotation" -> return false
+    }
+
+    // Check if the type is in the compiler's official mapped types list.
+    return mapKotlinToJava(FqNameUnsafe(fqName)) != null
+}
 
 // Annotations on deeply synthesized members like getter of Java annotation arguments can be defined in src.
 internal val KSNode.definitionOrigin: Origin

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -253,6 +253,12 @@ abstract class KSPUnitTestSuite(
         runTest("$UTIL_PATH/declarationsInAccessor.kt")
     }
 
+    @TestMetadata("declarationsInClass.kt")
+    @Test
+    fun testDeclarationsInClass() {
+        runTest("../test-utils/testData/api/declarationsInClass.kt")
+    }
+
     @TestMetadata("declarationOrder.kt")
     @Test
     fun testDeclarationOrder() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -256,6 +256,12 @@ abstract class KSPUnitTestSuite(
         runTest("$UTIL_PATH/declarationsInAccessor.kt")
     }
 
+    @TestMetadata("declarationsInClass.kt")
+    @Test
+    fun testDeclarationsInClass() {
+        runTest("$UTIL_PATH/declarationsInClass.kt")
+    }
+
     @TestMetadata("declarationOrder.kt")
     @Test
     fun testDeclarationOrder() {

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -65,6 +65,9 @@
 // DependencyOuterKotlinClass: OPEN PUBLIC : PUBLIC
 // HasTypeAliasFuns: Modifiers: []
 // HasTypeAliasFuns: Visibility: PUBLIC
+// JavaInterfaceImpl.<init>: FINAL PUBLIC : FINAL PUBLIC
+// JavaInterfaceImpl.otherInterfaceMethod: PUBLIC : PUBLIC
+// JavaInterfaceImpl: ABSTRACT PUBLIC : ABSTRACT PUBLIC
 // OuterJavaClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterJavaClass.InnerJavaClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterJavaClass.InnerJavaClass: PUBLIC : PUBLIC
@@ -188,6 +191,9 @@ class JavaDependency : DependencyOuterJavaClass()
 @Test
 class KotlinDependency : DependencyOuterKotlinClass()
 
+@Test
+class JavaInterfaceDependency : JavaInterfaceImpl {
+
 // FILE: C.java
 
 public abstract class C {
@@ -252,4 +258,16 @@ open class OuterKotlinClass {
 
     @Synchronized
     fun synchronizedFun(): String = ""
+}
+
+// FILE: JavaInterface.java
+public interface JavaInterface {
+    void interfaceMethod();
+    void otherInterfaceMethod();
+}
+
+// FILE: JavaInterfaceImpl.java
+public abstract class JavaInterfaceImpl implements JavaInterface {
+    @Override
+    public void otherInterfaceMethod() {}
 }

--- a/kotlin-analysis-api/testData/libOrigins.kt
+++ b/kotlin-analysis-api/testData/libOrigins.kt
@@ -31,8 +31,6 @@
 // Validating kotlinLibFuntion
 // Validating kotlinLibProperty
 // Validating File: App.java
-// Exception: [File: App.java, App, foo, getFoo, Foo]: SYNTHETIC
-// Exception: [File: App.java, App, foo, getFoo]: SYNTHETIC
 // Validating File: FooProvider1.kt
 // Exception: [File: FooProvider1.kt, FooProvider1, Any]: SYNTHETIC
 // Exception: [File: FooProvider1.kt, FooProvider1, foo, foo.getter(), Foo, Foo]: SYNTHETIC

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationsInClassProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationsInClassProcessor.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.*
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+
+class DeclarationsInClassProcessor : AbstractTestProcessor() {
+    val result = mutableListOf<String>()
+    override fun toResult(): List<String> {
+        return result.sorted()
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        fun processDeclaration(declaration: KSDeclaration) {
+            val origin = declaration.origin
+            when (declaration) {
+                is KSClassDeclaration -> {
+                    val name = declaration.qualifiedName?.asString()
+                    result.add("CLASS: $name ($origin)")
+                    declaration.declarations.forEach { processDeclaration(it) }
+                }
+                is KSFunctionDeclaration -> {
+                    val name = declaration.simpleName.asString()
+                    val parentName = when (val parentDeclaration = declaration.parentDeclaration) {
+                        is KSClassDeclaration -> parentDeclaration.simpleName.asString()
+                        is KSPropertyDeclaration -> parentDeclaration.parentDeclaration?.simpleName?.asString()
+                        else -> error("Unexpected declaration: ${parentDeclaration?.javaClass}")
+                    }
+                    if (declaration.isConstructor()) {
+                        result.add("CONSTRUCTOR: $parentName.$name ($origin)")
+                    } else {
+                        result.add("FUNCTION: $parentName.$name ($origin)")
+                    }
+                }
+                is KSPropertyDeclaration -> {
+                    val name = declaration.simpleName.asString()
+                    val parentName = declaration.parentDeclaration?.simpleName?.asString()
+                    result.add("PROPERTY: $parentName.$name ($origin)")
+                    declaration.getter?.let {
+                        result.add("GETTER: $parentName.$name (${it.origin})")
+                    }
+                    declaration.setter?.let {
+                        result.add("SETTER: $parentName.$name (${it.origin})")
+                    }
+                }
+            }
+        }
+        processDeclaration(resolver.getClassDeclarationByName("lib.CustomList")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.CustomMap")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.InterfaceWithObjectMethodOverrides")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.InterfaceWithNonObjectMethodOverrides")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.AbstractClassWithObjectMethodOverrides")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.ConcreteClassWithObjectMethodOverrides")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.BaseWithProperties")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.OverridesBaseWithProperties")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.BaseWithIsProperties")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.OverridesBaseWithIsProperties")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.BaseWithCapitalizedProperties")!!)
+        // TODO(https://github.com/google/ksp/issues/2925): Enable this once we've sorted out the differences between
+        //  the AA and PSI implementations. Currently, the main issue is that for the case where a property is
+        //  capitalized and a Java method overrides the getter, the AA implementation includes both the original Java
+        //  method and the synthetic accessor method; whereas the PSI implementation only includes the original method.
+        // processDeclaration(resolver.getClassDeclarationByName("lib.OverridesBaseWithCapitalizedProperties")!!)
+        processDeclaration(resolver.getClassDeclarationByName("lib.StaticVsMemberDeclarations")!!)
+        return emptyList()
+    }
+}

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
@@ -74,6 +74,9 @@ class JavaModifierProcessor : AbstractTestProcessor() {
 
         override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {
             results.add(function.toSignature())
+            if (function.modifiers.contains(Modifier.ABSTRACT) != function.isAbstract) {
+                results.add("Mismatched abstract modifiers")
+            }
         }
 
         @OptIn(KspExperimental::class)

--- a/test-utils/testData/api/declarationsInClass.kt
+++ b/test-utils/testData/api/declarationsInClass.kt
@@ -1,0 +1,254 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: DeclarationsInClassProcessor
+// EXPECTED:
+// CLASS: lib.AbstractClassWithObjectMethodOverrides (JAVA_LIB)
+// CLASS: lib.BaseWithCapitalizedProperties (KOTLIN_LIB)
+// CLASS: lib.BaseWithIsProperties (KOTLIN_LIB)
+// CLASS: lib.BaseWithProperties (KOTLIN_LIB)
+// CLASS: lib.ConcreteClassWithObjectMethodOverrides (JAVA_LIB)
+// CLASS: lib.CustomList (JAVA_LIB)
+// CLASS: lib.CustomMap (JAVA_LIB)
+// CLASS: lib.InterfaceWithNonObjectMethodOverrides (JAVA_LIB)
+// CLASS: lib.InterfaceWithObjectMethodOverrides (JAVA_LIB)
+// CLASS: lib.OverridesBaseWithIsProperties (JAVA_LIB)
+// CLASS: lib.OverridesBaseWithProperties (JAVA_LIB)
+// CLASS: lib.StaticVsMemberDeclarations (JAVA_LIB)
+// CLASS: lib.StaticVsMemberDeclarations.InnerC (JAVA_LIB)
+// CLASS: lib.StaticVsMemberDeclarations.NestedC (JAVA_LIB)
+// CONSTRUCTOR: AbstractClassWithObjectMethodOverrides.<init> (JAVA_LIB)
+// CONSTRUCTOR: ConcreteClassWithObjectMethodOverrides.<init> (JAVA_LIB)
+// CONSTRUCTOR: CustomList.<init> (JAVA_LIB)
+// CONSTRUCTOR: CustomMap.<init> (JAVA_LIB)
+// CONSTRUCTOR: InnerC.<init> (JAVA_LIB)
+// CONSTRUCTOR: NestedC.<init> (JAVA_LIB)
+// CONSTRUCTOR: OverridesBaseWithIsProperties.<init> (JAVA_LIB)
+// CONSTRUCTOR: OverridesBaseWithProperties.<init> (JAVA_LIB)
+// CONSTRUCTOR: StaticVsMemberDeclarations.<init> (JAVA_LIB)
+// FUNCTION: AbstractClassWithObjectMethodOverrides.equals (JAVA_LIB)
+// FUNCTION: AbstractClassWithObjectMethodOverrides.hashCode (JAVA_LIB)
+// FUNCTION: AbstractClassWithObjectMethodOverrides.toString (JAVA_LIB)
+// FUNCTION: ConcreteClassWithObjectMethodOverrides.equals (JAVA_LIB)
+// FUNCTION: ConcreteClassWithObjectMethodOverrides.hashCode (JAVA_LIB)
+// FUNCTION: ConcreteClassWithObjectMethodOverrides.toString (JAVA_LIB)
+// FUNCTION: CustomList.get (JAVA_LIB)
+// FUNCTION: CustomList.removeAt (JAVA_LIB)
+// FUNCTION: CustomList.size (SYNTHETIC)
+// FUNCTION: CustomMap.entrySet (SYNTHETIC)
+// FUNCTION: InterfaceWithNonObjectMethodOverrides.equals (JAVA_LIB)
+// FUNCTION: InterfaceWithNonObjectMethodOverrides.someMethod (JAVA_LIB)
+// FUNCTION: OverridesBaseWithIsProperties.getFoo (SYNTHETIC)
+// FUNCTION: OverridesBaseWithIsProperties.isBar (SYNTHETIC)
+// FUNCTION: OverridesBaseWithProperties.getFoo (SYNTHETIC)
+// FUNCTION: OverridesBaseWithProperties.getGetBar (SYNTHETIC)
+// FUNCTION: OverridesBaseWithProperties.getNonProperty (JAVA_LIB)
+// GETTER: BaseWithCapitalizedProperties.Foo (KOTLIN_LIB)
+// GETTER: BaseWithIsProperties.foo (KOTLIN_LIB)
+// GETTER: BaseWithIsProperties.isBar (KOTLIN_LIB)
+// GETTER: BaseWithProperties.foo (KOTLIN_LIB)
+// GETTER: BaseWithProperties.getBar (KOTLIN_LIB)
+// PROPERTY: BaseWithCapitalizedProperties.Foo (KOTLIN_LIB)
+// PROPERTY: BaseWithIsProperties.foo (KOTLIN_LIB)
+// PROPERTY: BaseWithIsProperties.isBar (KOTLIN_LIB)
+// PROPERTY: BaseWithProperties.foo (KOTLIN_LIB)
+// PROPERTY: BaseWithProperties.getBar (KOTLIN_LIB)
+// PROPERTY: InnerC.staticString (JAVA_LIB)
+// PROPERTY: InnerC.str (JAVA_LIB)
+// PROPERTY: NestedC.staticString (JAVA_LIB)
+// PROPERTY: NestedC.str (JAVA_LIB)
+// PROPERTY: StaticVsMemberDeclarations.staticString (JAVA_LIB)
+// PROPERTY: StaticVsMemberDeclarations.str (JAVA_LIB)
+// END
+
+// MODULE: lib
+// FILE: lib/CustomList.java
+package lib;
+
+import java.util.AbstractList;
+
+// Kotlin FIR intentionally hides the remove method and replaces it with `removeAt(Int)`.
+// As a compiled library (Origin.JAVA_LIB), this tests that KSP correctly identifies
+// the collection via FIR and routes it to the AA slow path to avoid this issue.
+public class CustomList<E> extends AbstractList<E> {
+    @Override
+    public E remove(int index) { return null; }
+
+    @Override
+    public E get(int index) { return null; }
+
+    @Override
+    public int size() { return 0; }
+}
+
+// FILE: lib/CustomMap.java
+package lib;
+
+import java.util.AbstractMap;
+import java.util.Set;
+
+// Kotlin FIR intentionally hides the `entrySet` Java method and replaces it with
+// the `entries` property. This tests that KSP correctly identifies this case via
+// FIR and routes it to the AA slow path to avoid this issue.
+public class CustomMap<K, V> extends AbstractMap<K, V> {
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return null;
+    }
+}
+
+// FILE: lib/InterfaceWithObjectMethodOverrides.java
+package lib;
+
+// Kotlin FIR intentionally drops Object methods like `equals` from an interface's
+// declarations. This tests that our PSI fast path explicitly filters them out to
+// exactly mirror FIR's behavior.
+public interface InterfaceWithObjectMethodOverrides {
+    boolean equals(Object obj);
+    int hashCode();
+    String toString();
+}
+
+// FILE: lib/InterfaceWithNonObjectMethodOverrides.java
+package lib;
+
+public interface InterfaceWithNonObjectMethodOverrides {
+    void someMethod();
+    boolean equals(String str);
+}
+
+// FILE: lib/AbstractClassWithObjectMethodOverrides.java
+package lib;
+
+public abstract class AbstractClassWithObjectMethodOverrides {
+    public abstract boolean equals(Object obj);
+    public abstract int hashCode();
+    public abstract String toString();
+}
+
+// FILE: lib/ConcreteClassWithObjectMethodOverrides.java
+package lib;
+
+public class ConcreteClassWithObjectMethodOverrides {
+    public boolean equals(Object obj) {
+        return false;
+    }
+    public int hashCode() {
+        return 0;
+    }
+    public String toString() {
+        return "";
+    }
+}
+
+// FILE: lib/BaseWithProperties.kt
+package lib
+
+interface BaseWithProperties {
+    // Test overriding conventional property getter
+    val foo: String
+
+    // Test overriding getter-like property getter
+    val getBar: String
+}
+
+// FILE: lib/OverridesBaseWithProperties.java
+package lib;
+
+public class OverridesBaseWithProperties implements BaseWithProperties {
+    // Test getter that doesn't override a property
+    public String getNonProperty() {
+        return "";
+    }
+
+    // Overrides val foo
+    @Override
+    public String getFoo() {
+        return "";
+    }
+
+    // Overrides val getBar
+    @Override
+    public String getGetBar() {
+        return "";
+    }
+}
+
+// FILE: lib/BaseWithIsProperties.kt
+package lib
+
+interface BaseWithIsProperties {
+    val foo: String
+
+    // Test overriding is-like property getter
+    val isBar: Boolean
+}
+
+// FILE: lib/OverridesBaseWithIsProperties.java
+package lib;
+
+public class OverridesBaseWithIsProperties implements BaseWithIsProperties {
+    // Overrides val foo
+    @Override
+    public String getFoo() {
+        return "";
+    }
+
+    // Overrides val isBar
+    @Override
+    public boolean isBar() {
+        return true;
+    }
+}
+
+// FILE: lib/BaseWithCapitalizedProperties.kt
+package lib
+
+interface BaseWithCapitalizedProperties {
+    // Test overriding capitalized property getter
+    val Foo: String
+}
+
+// FILE: lib/OverridesBaseWithCapitalizedProperties.java
+package lib;
+
+public class OverridesBaseWithCapitalizedProperties implements BaseWithCapitalizedProperties {
+    @Override
+    public String getFoo() {
+        return "Foo";
+    }
+}
+
+// FILE: lib/StaticVsMemberDeclarations.java
+package lib;
+
+public class StaticVsMemberDeclarations {
+    String str = "str";
+    static String staticString = "staticString";
+
+    public static class NestedC {
+        String str = "str";
+        static String staticString = "staticString";
+    }
+
+    public class InnerC {
+        String str = "str";
+        static String staticString = "staticString";
+    }
+}
+
+// MODULE: main(lib)


### PR DESCRIPTION
This change adds a PSI element implementation of `KSFunctionDeclarationImpl` and `KSPropertyDeclarationJavaImpl` to work around performance bugs in the Analysis API for java source/class file declaration resolution (https://youtrack.jetbrains.com/issue/KT-85692).

To use the new implementation, enable the `experimentalPsiResolution` flag.

Bug: https://youtrack.jetbrains.com/issue/KT-85692