### PR TITLE
Move AnnotationResolutionStrategy-related files to common dir

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.impl
+package com.google.devtools.ksp.common.impl
 
 import com.google.devtools.ksp.common.visitor.CollectAnnotatedSymbolsVisitor
 import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeImpl

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.impl
+package com.google.devtools.ksp.common.impl
 
 import com.google.devtools.ksp.impl.symbol.kotlin.Restorable
 import com.google.devtools.ksp.processing.SymbolProcessor

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -15,9 +15,10 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.impl
+package com.google.devtools.ksp.common.impl
 
 import com.google.devtools.ksp.common.mergeMapNotNullKeys
+import com.google.devtools.ksp.common.visitor.CollectAnnotatedSymbolsPsiVisitor
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl
@@ -37,7 +38,6 @@ import com.google.devtools.ksp.impl.symbol.kotlin.toKSFile
 import com.google.devtools.ksp.impl.symbol.kotlin.toKSFunctionDeclaration
 import com.google.devtools.ksp.impl.symbol.kotlin.toKSPropertyDeclaration
 import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
-import com.google.devtools.ksp.impl.visitor.CollectAnnotatedSymbolsPsiVisitor
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotated

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.impl.visitor
+package com.google.devtools.ksp.common.visitor
 
 import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
 import com.intellij.psi.PsiAnnotation

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -21,10 +21,12 @@ package com.google.devtools.ksp.impl
 
 import com.google.devtools.ksp.common.AnyChanges
 import com.google.devtools.ksp.common.KSObjectCacheManager
+import com.google.devtools.ksp.common.impl.AAResolutionStrategy
 import com.google.devtools.ksp.common.impl.CodeGeneratorImpl
 import com.google.devtools.ksp.common.impl.JsPlatformInfoImpl
 import com.google.devtools.ksp.common.impl.JvmPlatformInfoImpl
 import com.google.devtools.ksp.common.impl.NativePlatformInfoImpl
+import com.google.devtools.ksp.common.impl.PsiResolutionStrategy
 import com.google.devtools.ksp.common.impl.UnknownPlatformInfoImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.Deferrable
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl


### PR DESCRIPTION
These files belong in the common directory since they are not directly tied to an implementation of an interface in the KSP API. There will probably also be more files added later which will only pollute the `impl` directory further with classes irrelevant to implementing the API.