### PR TITLE
Add fast type alias heuristic for `PsiResolutionStrategy`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -17,9 +17,9 @@
 
 package com.google.devtools.ksp.common.impl
 
-import com.google.devtools.ksp.common.mergeMapNotNullKeys
 import com.google.devtools.ksp.common.visitor.CollectAnnotatedSymbolsPsiVisitor
 import com.google.devtools.ksp.containingFile
+import com.google.devtools.ksp.impl.FileCache
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFunctionDeclarationImpl
@@ -57,6 +57,12 @@ import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.PsiTypeParameterList
 import com.intellij.util.containers.addIfNotNull
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaTypeAliasSymbol
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -64,7 +70,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.parameterIndex
 import org.jetbrains.kotlin.utils.addToStdlib.flatGroupBy
-import kotlin.collections.buildList
+import kotlin.collections.mapValues
 
 /**
  * An [AnnotationResolutionStrategy] that uses a combination of Psi and Kotlin's Analysis API to resolve
@@ -249,15 +255,105 @@ class PsiResolutionStrategy(
      * "Annotation3" -> [fun3]
      * ```
      */
-    private val annotatedKotlinElementsByFullyQualifiedName: Map<String, Lazy<Collection<KSAnnotated>>> by lazy {
-        annotatedKotlinElements
-            .flatGroupBy { element -> element.annotationEntries }
-            .mapValues { entry ->
-                lazy { entry.value.flatMap { it.resolveToKSAnnotated(entry.key) } }
+    private val annotatedKotlinElementsByFullyQualifiedName: Map<String, Lazy<List<KSAnnotated>>> by lazy {
+        buildMap {
+            val fileCaches = mutableMapOf<KtFile, FileCache>()
+            annotatedKotlinElements.forEach { annotated ->
+                val file = annotated.containingKtFile
+                annotated.annotationEntries.forEach { annotationEntry ->
+                    // TODO: Cache (file, annotation.shortName) -> classId. Shadowing is a problem
+                    //  so we should only cache for known unique declarations in the file.
+                    //  See test shadowingAnnotations.kt
+                    val fileCache = fileCaches.getOrPut(file) { FileCache(file) }
+                    val classId = resolveAnnotationEntryClassId(annotationEntry, fileCache)
+                    // N.B.: Skip nullable qualified names without error. This is what the AA-based implementation does.
+                    //   For now, this is the intended behavior. If it is changed in the future, then it is an API change.
+                    val fqn = classId?.asFqNameString() ?: return@forEach
+                    getOrPut(fqn, ::mutableListOf)
+                        .add(annotated to annotationEntry)
+                }
             }
-            // N.B.: Skip nullable qualified names without error. This is what the AA-based implementation does.
-            //   For now, this is the intended behavior. If it is changed in the future, then it is an API change.
-            .mergeMapNotNullKeys { it.qualifiedName }
+        }.mapValues { entry ->
+            lazy {
+                entry.value.flatMap { (annotated, annotationEntry) ->
+                    annotated.resolveToKSAnnotated(annotationEntry)
+                }
+            }
+        }
+    }
+
+    /**
+     * Resolves the [ClassId] for a given [KtAnnotationEntry].
+     *
+     * It first attempts a [fastResolveClassId] and falls back to [slowResolveClassId] if that fails.
+     */
+    private fun resolveAnnotationEntryClassId(annotationEntry: KtAnnotationEntry, fileCache: FileCache): ClassId? =
+        fastResolveClassId(annotationEntry, fileCache)
+            ?: slowResolveClassId(annotationEntry)
+
+    /**
+     * Attempts to resolve the [ClassId] of an [annotationEntry] without full type resolution,
+     * by trying to guess the [ClassId] and asking the Analysis API if it is a type alias.
+     */
+    private fun fastResolveClassId(annotationEntry: KtAnnotationEntry, fileCache: FileCache): ClassId? {
+        val shortName = annotationEntry.shortName?.asString() ?: return null
+        val unresolvedTypeName = annotationEntry.typeReference?.text ?: return null
+
+        if (shortName != unresolvedTypeName) {
+            return null
+        }
+
+        val isPotentiallyShadowed = shortName in fileCache.localDeclarations
+        if (isPotentiallyShadowed) {
+            return null
+        }
+
+        // Check for explicit name import.
+        // If it exists, we have found the name, otherwise fall back to checking other candidates.
+        val candidateClassIds = fileCache.explicitImports[shortName]?.let { explicitFqn ->
+            // Direct name import found. Do not consider other imports.
+            listOf((ClassId.topLevel(explicitFqn)))
+        } ?: buildList {
+            // No direct name import found. Consider package imports, star imports, and default imports.
+            add(mkClassId(fileCache.packageName, shortName))
+            fileCache.starImports.forEach { add(mkClassId(it, shortName)) }
+            FileCache.DEFAULT_IMPORTS.forEach {
+                add(mkClassId(FqName(it), shortName))
+            }
+        }
+
+        return analyze {
+            candidateClassIds.firstNotNullOfOrNull { classId ->
+                when (val symbol = findClassLike(classId)) {
+                    null -> null
+
+                    is KaClassSymbol -> {
+                        // Class id found, return it!
+                        symbol.classId
+                    }
+
+                    is KaTypeAliasSymbol -> {
+                        // The symbol is a type alias. Fall back to expensive resolution
+                        symbol.expandedType.fullyExpandedType.symbol?.classId
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Creates a [ClassId] from a package name and a top-level class name.
+     */
+    private fun mkClassId(packageFqName: FqName, topLevelName: String): ClassId =
+        ClassId(packageFqName, Name.identifier(topLevelName))
+
+    /**
+     * Resolves the [ClassId] of an [annotationEntry] using full Analysis API resolution.
+     *
+     * This is used as a fallback when [fastResolveClassId] cannot determine the class ID.
+     */
+    private fun slowResolveClassId(annotationEntry: KtAnnotationEntry): ClassId? = analyze {
+        annotationEntry.typeReference?.type?.fullyExpandedType?.expandedSymbol?.classId
     }
 
     /**

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectClassifierNameVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectClassifierNameVisitor.kt
@@ -25,25 +25,35 @@ import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtTypeAlias
 
 /**
+ * Collects classifier names in the [KtFile] using
+ * [CollectClassifierNameVisitor].
+ */
+fun KtFile.collectClassifierNames(): Set<String> {
+    val visitor = CollectClassifierNameVisitor()
+    accept(visitor)
+    return visitor.result
+}
+
+/**
  * A [PsiRecursiveElementWalkingVisitor] that collects the names of classes, objects and type aliases.
  */
-class DeclarationNameVisitor : PsiRecursiveElementWalkingVisitor() {
+private class CollectClassifierNameVisitor : PsiRecursiveElementWalkingVisitor() {
 
-    private val internalResult = mutableSetOf<String>()
-    val result: Set<String> = internalResult
+    val result = mutableSetOf<String>()
 
     override fun visitElement(element: PsiElement) {
         if (element.isSkippable()) {
             return
         }
         when (element) {
-            is KtClassOrObject -> element.name?.let { internalResult.add(it) }
-            is KtTypeAlias -> element.name?.let { internalResult.add(it) }
+            is KtClassOrObject -> element.name?.let { result.add(it) }
+            is KtTypeAlias -> element.name?.let { result.add(it) }
         }
         super.visitElement(element)
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/DeclarationNameVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/DeclarationNameVisitor.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.common.visitor
+
+import com.intellij.psi.PsiComment
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDeclaration
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtTypeAlias
+
+/**
+ * A [PsiRecursiveElementWalkingVisitor] that collects the names of classes, objects and type aliases.
+ */
+class DeclarationNameVisitor : PsiRecursiveElementWalkingVisitor() {
+
+    private val internalResult = mutableSetOf<String>()
+    val result: Set<String> = internalResult
+
+    override fun visitElement(element: PsiElement) {
+        if (element.isSkippable()) {
+            return
+        }
+        when (element) {
+            is KtClassOrObject -> element.name?.let { internalResult.add(it) }
+            is KtTypeAlias -> element.name?.let { internalResult.add(it) }
+        }
+        super.visitElement(element)
+    }
+
+    /**
+     * A [PsiElement] may be skippable to avoid deep traversal of the AST.
+     *
+     * Returns `true` if the [PsiElement] is one of the following:
+     *   - An expression that is not a declaration
+     *   - An import list
+     *   - A package directive
+     *   - A doc comment
+     *   - A comment
+     */
+    private fun PsiElement.isSkippable(): Boolean = when (this) {
+        is KtExpression -> this !is KtDeclaration
+        is KtImportList,
+        is KtPackageDirective,
+        is KDoc,
+        is PsiComment,
+        is PsiWhiteSpace -> true
+
+        else -> false
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/FileCache.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/FileCache.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.impl
+
+import com.google.devtools.ksp.common.visitor.collectClassifierNames
+import org.jetbrains.kotlin.psi.KtFile
+
+/**
+ * A cache for information extracted from a [KtFile].
+ *
+ * This class pre-calculates and stores frequently accessed information from a Kotlin PSI file,
+ * such as its package name, imports, and local declarations, to avoid redundant PSI traversals.
+ *
+ * @param file The [KtFile] from which information is extracted.
+ */
+class FileCache(file: KtFile) {
+
+    /**
+     * The fully qualified package name of the file.
+     */
+    val packageName = file.packageFqName
+
+    /**
+     * A map of explicit (non-star) imports in the file.
+     *
+     * The keys are the names by which the imported symbols are referred to in the code
+     * (either an alias or the short name), and the values are their fully qualified names.
+     */
+    val explicitImports = file.importDirectives
+        .filter { !it.isAllUnder && it.importedFqName != null }
+        .associate { (it.aliasName ?: it.importedFqName!!.shortName().asString()) to it.importedFqName!! }
+
+    /**
+     * A list of fully qualified names of the star imports in the file.
+     */
+    val starImports = file.importDirectives
+        .filter { it.isAllUnder }
+        .mapNotNull { it.importedFqName }
+
+    /**
+     * A collection of names for all local declarations within the file.
+     */
+    val localDeclarations = file.collectClassifierNames()
+
+    companion object {
+        // TODO: Figure out if there is a better way to obtain default imports than hard coded list
+        // TODO: Move this list somewhere appropriate
+        @JvmStatic
+        val DEFAULT_IMPORTS = listOf(
+            "kotlin",
+            "kotlin.annotation",
+            "kotlin.collections",
+            "kotlin.comparisons",
+            "kotlin.io",
+            "kotlin.ranges",
+            "kotlin.sequences",
+            "kotlin.text",
+            "kotlin.jvm",
+            "java.lang"
+        )
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/ConfigurableKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/ConfigurableKSPTest.kt
@@ -655,6 +655,12 @@ abstract class ConfigurableKSPTest(
         runTest("../test-utils/testData/api/sealedClass.kt")
     }
 
+    @TestMetadata("shadowingAnnotations.kt")
+    @Test
+    fun testShadowingAnnotations() {
+        runTest("../kotlin-analysis-api/testData/getSymbolsWithAnnotation/shadowingAnnotations.kt")
+    }
+
     @TestMetadata("signatureMapper.kt")
     @Test
     fun testSignatureMapper() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/shadowingAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/shadowingAnnotations.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// TEST ANNOTATIONS: FooAnno, Container.FooAnno
+// EXPECTED:
+// Container.FooAnno: Container.member
+// FooAnno: Container
+// END
+
+annotation class FooAnno
+
+@FooAnno
+class Container {
+
+    annotation class FooAnno
+
+    @FooAnno
+    fun member() {}
+}


### PR DESCRIPTION
This PR adds a heuristic to `PsiResolutionStrategy` to quickly determine whether a name is a type alias or not. It works by stitching together a short name with import qualifiers and asks the Analysis API whether this name is a type alias or not. If the situation is ambiguous, such as when a name might be shadowed, it falls back to expensive type resolution. @bcorso 

Related to https://github.com/google/ksp/issues/2816