### PR TITLE
Add better default error messages

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp
+
+import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.NonExistLocation
+
+/**
+ * Internal exception that signals a bug in KSP.
+ *
+ * Marked internal to avoid users depending on the type.
+ */
+internal class InternalKSPException(
+    message: String,
+    val location: Location,
+    val originatingClass: Class<*>
+) : Exception(
+    buildString {
+        appendLine(">>> Internal KSP Error")
+        appendLine("   | *** THIS IS A BUG IN KSP ***")
+        appendLine("   |")
+        message.lines().forEach { messageLine ->
+            appendLine("   | $messageLine")
+        }
+        appendLine("   |")
+        appendLine("   | Location           : ${location.render()}")
+        appendLine("   | Class at occurrence: $originatingClass")
+        appendLine("   |")
+        appendLine("   | You can report it at https://github.com/google/ksp/issues/new")
+        appendLine("   |")
+    }
+) {
+    internal companion object {
+        fun Location.render(): String {
+            return when (this) {
+                is FileLocation -> "${this.filePath}:${this.lineNumber}"
+                is NonExistLocation -> "<unknown location>"
+            }
+        }
+    }
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -179,7 +179,11 @@ fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
                 is KSClassDeclaration -> sequenceOf(resolvedDeclaration)
                 is KSTypeAlias -> sequenceOf(resolvedDeclaration.findActualType())
                 is KSTypeParameter -> resolvedDeclaration.getTypesUpperBound()
-                else -> throw IllegalStateException("unhandled type parameter bound, $ExceptionMessage")
+                else -> throw InternalKSPException(
+                    "Unhandled type parameter bound",
+                    resolvedDeclaration.location,
+                    resolvedDeclaration.javaClass,
+                )
             }
         }
 
@@ -188,12 +192,16 @@ fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
         .plus(
             this.superTypes
                 .map { it.resolve().declaration }
-                .flatMap { declaration ->
-                    when (declaration) {
-                        is KSClassDeclaration -> declaration.getAllSuperTypes()
-                        is KSTypeAlias -> declaration.findActualType().getAllSuperTypes()
-                        is KSTypeParameter -> declaration.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
-                        else -> throw IllegalStateException("unhandled super type kind, $ExceptionMessage")
+                .flatMap {
+                    when (it) {
+                        is KSClassDeclaration -> it.getAllSuperTypes()
+                        is KSTypeAlias -> it.findActualType().getAllSuperTypes()
+                        is KSTypeParameter -> it.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
+                        else -> throw InternalKSPException(
+                            "Unhandled super type kind",
+                            it.location,
+                            it.javaClass,
+                        )
                     }
                 }
         )

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp
+
+import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.NonExistLocation
+
+/**
+ * Internal exception that signals a bug in KSP.
+ *
+ * Copy of InternalKSPException in API package which is also marked
+ * internal to avoid users depending on the type.
+ */
+internal class InternalKSPException(
+    message: String,
+    val location: Location,
+    val originatingClass: Class<*>
+) : Exception(
+    buildString {
+        appendLine(">>> Internal KSP Error")
+        appendLine("   | *** THIS IS A BUG IN KSP ***")
+        appendLine("   |")
+        message.lines().forEach { messageLine ->
+            appendLine("   | $messageLine")
+        }
+        appendLine("   |")
+        appendLine("   | Location           : ${location.render()}")
+        appendLine("   | Class at occurrence: $originatingClass")
+        appendLine("   |")
+        appendLine("   | You can report it at https://github.com/google/ksp/issues/new")
+        appendLine("   |")
+    }
+) {
+    internal companion object {
+        fun Location.render(): String {
+            return when (this) {
+                is FileLocation -> "${this.filePath}:${this.lineNumber}"
+                is NonExistLocation -> "<unknown location>"
+            }
+        }
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -19,6 +19,7 @@
 package com.google.devtools.ksp.impl
 
 import com.google.devtools.ksp.*
+import com.google.devtools.ksp.InternalKSPException.Companion.render
 import com.google.devtools.ksp.common.*
 import com.google.devtools.ksp.common.impl.*
 import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
@@ -235,7 +236,11 @@ class ResolverAAImpl(
                     ?.fieldAccFlags?.get(this.simpleName.asString()) ?: 0
             }
 
-            else -> throw IllegalStateException("this function expects only KOTLIN_LIB or JAVA_LIB")
+            else -> throw InternalKSPException(
+                "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
+                this.location,
+                this.javaClass
+            )
         }
 
     internal val KSFunctionDeclaration.jvmAccessFlag: Int
@@ -249,7 +254,11 @@ class ResolverAAImpl(
                     ?.methodAccFlags?.get(this.simpleName.asString() + jvmDesc) ?: 0
             }
 
-            else -> throw IllegalStateException("this function expects only KOTLIN_LIB or JAVA_LIB")
+            else -> throw InternalKSPException(
+                "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
+                this.location,
+                this.javaClass,
+            )
         }
 
     override fun getAllFiles(): Sequence<KSFile> {
@@ -282,7 +291,11 @@ class ResolverAAImpl(
             when (it) {
                 is KaNamedClassSymbol -> KSClassDeclarationImpl.getCached(it)
                 is KaEnumEntrySymbol -> KSClassDeclarationEnumEntryImpl.getCached(it)
-                else -> throw IllegalStateException()
+                else -> throw InternalKSPException(
+                    "Unexpected class declaration symbol: '$it'",
+                    it.psi.toLocation(),
+                    it.javaClass,
+                )
             }
         }
     }
@@ -549,7 +562,17 @@ class ResolverAAImpl(
                 }
                 )
             if (topLevelResult != null && nonTopLevelResult != null) {
-                throw IllegalStateException("Found multiple properties with same qualified name")
+                throw InternalKSPException(
+                    buildString {
+                        appendLine("Found multiple properties with same qualified name.")
+                        appendLine("Top-level: '$topLevelResult' at ${topLevelResult.location.render()}")
+                        appendLine(
+                            "Non-top-level: '$nonTopLevelResult' at ${nonTopLevelResult.location.render()}"
+                        )
+                    },
+                    topLevelResult.location,
+                    topLevelResult.javaClass
+                )
             }
             nonTopLevelResult ?: topLevelResult
         }
@@ -790,8 +813,10 @@ class ResolverAAImpl(
                         var cnt = 0
                         while (it.substitute(result) != result) {
                             if (cnt > 100) {
-                                throw IllegalStateException(
-                                    "Potential infinite loop in type substitution for computeAsMemberOf"
+                                throw InternalKSPException(
+                                    message = "Potential infinite loop in type substitution for computeAsMemberOf",
+                                    property.location,
+                                    property.javaClass
                                 )
                             }
                             result = it.substitute(result)
@@ -845,8 +870,10 @@ class ResolverAAImpl(
                             funcToSub.receiverType != next.receiverType
                         ) {
                             if (cnt > 100) {
-                                throw IllegalStateException(
-                                    "Potential infinite loop in type substitution for computeAsMemberOf"
+                                throw InternalKSPException(
+                                    message = "Potential infinite loop in type substitution for computeAsMemberOf",
+                                    function.location,
+                                    function.javaClass
                                 )
                             }
                             funcToSub = next

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -16,6 +16,7 @@
  */
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.common.toKSModifiers
@@ -64,13 +65,21 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
                 is KaFunctionSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaJavaFieldSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaTypeAliasSymbol -> ktDeclarationSymbol.toModifiers()
-                else -> throw IllegalStateException("Unexpected symbol type ${ktDeclarationSymbol.javaClass}")
+                else -> throw InternalKSPException(
+                    "Unexpected symbol type: $ktDeclarationSymbol",
+                    this.location,
+                    ktDeclarationSymbol.javaClass
+                )
             }
         } else {
             when (val psi = ktDeclarationSymbol.psi) {
                 is KtModifierListOwner -> psi.toKSModifiers()
                 is PsiModifierListOwner -> psi.toKSModifiers()
-                else -> throw IllegalStateException("Unexpected symbol type ${ktDeclarationSymbol.psi?.javaClass}")
+                else -> throw InternalKSPException(
+                    "Unexpected symbol type ${ktDeclarationSymbol.psi?.javaClass}",
+                    this.location,
+                    psi?.javaClass ?: this.javaClass
+                )
             }
         }
     }
@@ -92,7 +101,11 @@ abstract class AbstractKSDeclarationImpl(val ktDeclarationSymbol: KaDeclarationS
             }?.let { KSNameImpl.getCached(it) }
                 //  null -> non top level declaration, find in parent
                 ?: ktDeclarationSymbol.getContainingKSSymbol()?.packageName
-                ?: throw IllegalStateException("failed to find package name for $this")
+                ?: throw InternalKSPException(
+                    "failed to find package name for $this",
+                    this.location,
+                    ktDeclarationSymbol.javaClass,
+                )
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.lazyMemoizedSequence
@@ -47,7 +48,11 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
     override val packageName: KSName by lazy {
         when (psi) {
             is KtFile -> KSNameImpl.getCached((psi as KtFile).packageFqName.asString())
-            else -> throw IllegalStateException("Unhandled psi file type ${psi.javaClass}")
+            else -> throw InternalKSPException(
+                "Unhandled psi file type",
+                psi.toLocation(),
+                psi.javaClass
+            )
         }
     }
 
@@ -67,7 +72,11 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
                     is KaNamedFunctionSymbol -> KSFunctionDeclarationImpl.getCached(it)
                     is KaPropertySymbol -> KSPropertyDeclarationImpl.getCached(it)
                     is KaTypeAliasSymbol -> KSTypeAliasImpl.getCached(it)
-                    else -> throw IllegalStateException("Unhandled ${it.javaClass}")
+                    else -> throw InternalKSPException(
+                        "Unhandled case in 'declarations'",
+                        it.psi.toLocation(),
+                        it.javaClass,
+                    )
                 }
             }
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -17,7 +17,8 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.*
+import com.google.devtools.ksp.InternalKSPException
+import com.google.devtools.ksp.closestClassDeclaration
 import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.common.lazyMemoizedSequence
@@ -25,10 +26,37 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.impl.recordLookupForPropertyOrMethod
 import com.google.devtools.ksp.impl.recordLookupWithSupertypes
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.isConstructor
+import com.google.devtools.ksp.isPublic
+import com.google.devtools.ksp.symbol.ClassKind
+import com.google.devtools.ksp.symbol.FunctionKind
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSExpectActual
+import com.google.devtools.ksp.symbol.KSFunction
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSType
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.KSVisitor
+import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
 import com.intellij.psi.PsiClass
 import com.intellij.psi.PsiMethod
-import org.jetbrains.kotlin.analysis.api.symbols.*
+import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaDestructuringDeclarationSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertyAccessorSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertyGetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySetterSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolLocation
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.analysis.api.symbols.receiverType
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFunction
@@ -53,7 +81,11 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
             }
 
             KaSymbolLocation.TOP_LEVEL -> FunctionKind.TOP_LEVEL
-            else -> throw IllegalStateException("Unexpected location ${ktFunctionSymbol.location}")
+            else -> throw InternalKSPException(
+                "Unexpected location ${ktFunctionSymbol.location}",
+                this.location,
+                ktFunctionSymbol.javaClass
+            )
         }
     }
 
@@ -146,7 +178,11 @@ class KSFunctionDeclarationImpl private constructor(internal val ktFunctionSymbo
             }
 
             is KaConstructorSymbol -> KSNameImpl.getCached("<init>")
-            else -> throw IllegalStateException("Unexpected function symbol type ${ktFunctionSymbol.javaClass}")
+            else -> throw InternalKSPException(
+                "Unexpected function symbol type ${ktFunctionSymbol.javaClass}",
+                this.location,
+                ktFunctionSymbol.javaClass
+            )
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
@@ -55,8 +56,11 @@ class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
                     while (prev != curr) {
                         val pair = Pair(prev, curr)
                         if (pair in seen) {
-                            val msg = "Recurrent substitution of bounds of $typeParam: $bound by $substitutor"
-                            throw IllegalStateException(msg)
+                            throw InternalKSPException(
+                                "Recurrent substitution of bounds of $typeParam: $bound by $substitutor",
+                                typeParam.psi.toLocation(),
+                                typeParam.javaClass
+                            )
                         }
                         seen.add(pair)
                         prev = curr

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -19,7 +19,7 @@
 
 package com.google.devtools.ksp.impl.symbol.kotlin
 
-import com.google.devtools.ksp.ExceptionMessage
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.KSPCoreEnvironment
@@ -97,7 +97,11 @@ internal val ktSymbolOriginToOrigin = mapOf(
 
 internal fun mapAAOrigin(ktSymbol: KaSymbol): Origin {
     val symbolOrigin = ktSymbolOriginToOrigin[ktSymbol.origin]
-        ?: throw IllegalStateException("unhandled origin ${ktSymbol.origin.name}")
+        ?: throw InternalKSPException(
+            "Unhandled origin ${ktSymbol.origin.name}",
+            ktSymbol.psi.toLocation(),
+            ktSymbol.javaClass,
+        )
     return if (symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true) {
         Origin.JAVA_LIB
     } else {
@@ -132,7 +136,11 @@ internal fun KaAnnotationValue.render(): String {
             if (type.isError) type.toString() else "$type::class"
         }
 
-        is KaAnnotationValue.UnsupportedValue -> throw IllegalStateException("Unsupported annotation value: $this")
+        is KaAnnotationValue.UnsupportedValue -> throw InternalKSPException(
+            "Unsupported annotation value: $this",
+            NonExistLocation,
+            this.javaClass
+        )
     }
 }
 
@@ -181,7 +189,11 @@ internal fun KaType.render(inFunctionType: Boolean = false): String {
                         .joinToString(separator = " & ", prefix = "(", postfix = ")") { it.render(inFunctionType) }
 
                 is KaTypeParameterType -> name.asString()
-                else -> throw IllegalStateException("Unhandled type ${this@render.javaClass}")
+                else -> throw InternalKSPException(
+                    "Unhandled type",
+                    NonExistLocation,
+                    this@render.javaClass
+                )
             }
         )
         if (analyze { isMarkedNullable }) {
@@ -199,7 +211,11 @@ internal fun KaType.toClassifierReference(parent: KSTypeReference?): KSReference
         is KaErrorType -> null
         is KaTypeParameterType -> KSClassifierParameterImpl.getCached(ktType, parent)
         is KaDefinitelyNotNullType -> KSDefNonNullReferenceImpl.getCached(ktType, parent)
-        else -> throw IllegalStateException("Unexpected type element ${ktType.javaClass}, $ExceptionMessage")
+        else -> throw InternalKSPException(
+            "Unexpected type element",
+            NonExistLocation,
+            ktType.javaClass,
+        )
     }
 }
 
@@ -260,7 +276,11 @@ internal fun KaDeclarationContainerSymbol.declarations(): Sequence<KSDeclaration
                 is KaEnumEntrySymbol -> KSClassDeclarationEnumEntryImpl.getCached(symbol)
                 is KaJavaFieldSymbol -> KSPropertyDeclarationJavaImpl.getCached(symbol)
                 is KaTypeAliasSymbol -> KSTypeAliasImpl.getCached(symbol)
-                else -> throw IllegalStateException()
+                else -> throw InternalKSPException(
+                    "Unexpected declaration symbol",
+                    symbol.psi.toLocation(),
+                    symbol.javaClass
+                )
             }
         }
     }
@@ -392,7 +412,11 @@ internal fun KaSymbol.toKSAnnotated(): KSAnnotated = when (this) {
     is KaTypeParameterSymbol -> toKSTypeParameter()
     is KaLocalVariableSymbol -> toKSPropertyDeclarationLocalVariable()
     is KaValueParameterSymbol -> toKSValueParameter()
-    else -> error("Unexpected class for KtSymbol: ${this.javaClass}")
+    else -> throw InternalKSPException(
+        "Unexpected class for KtSymbol",
+        this.psi.toLocation(),
+        this.javaClass
+    )
 }
 
 internal fun KaPropertySymbol.toKSPropertyDeclaration(): KSPropertyDeclarationImpl =
@@ -511,7 +535,11 @@ internal fun KSDeclaration.setter(): KSPropertySetter? = when (this) {
 internal fun KSValueParameter.getGeneratedProperty(): KSPropertyDeclaration? = when (this) {
     is KSValueParameterImpl -> if (isVal || isVar) generatedProperty else null
     is KSValueParameterLiteImpl -> null
-    else -> error("internal error $location")
+    else -> throw InternalKSPException(
+        "Unexpected KSValueParameter type",
+        this.location,
+        this.javaClass
+    )
 }
 
 @OptIn(ClassIdBasedLocality::class)
@@ -556,7 +584,11 @@ internal fun KaType.classifierSymbol(): KaClassifierSymbol? {
             is KaFlexibleType -> lowerBound.classifierSymbol()
             // TODO: KSP does not support intersection type.
             is KaIntersectionType -> null
-            else -> throw IllegalStateException("Unexpected type ${this.javaClass}")
+            else -> throw InternalKSPException(
+                "Unexpected type",
+                NonExistLocation,
+                this.javaClass
+            )
         }
     } catch (e: KotlinExceptionWithAttachments) {
         // The implementation for getting symbols from a type throws an exception
@@ -688,7 +720,11 @@ internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
                 }
             }
 
-            else -> throw IllegalStateException("Unhandled default value type ${psiElement.javaClass}")
+            else -> throw InternalKSPException(
+                "Unhandled default value type",
+                psiElement.toLocation(),
+                psiElement.javaClass,
+            )
         }
     }
 }
@@ -708,7 +744,11 @@ internal fun fillInDeepSubstitutor(context: KaType, substitutorBuilder: KaSubsti
     val parameters = unwrappedType.symbol.typeParameters
     val arguments = unwrappedType.typeArguments
     if (parameters.size != arguments.size) {
-        throw IllegalStateException("invalid substitution for $context")
+        throw InternalKSPException(
+            "Unexpected invalid substitution for $context",
+            NonExistLocation,
+            context.javaClass
+        )
     }
     parameters.zip(arguments).forEach { (param, projection) ->
         val arg = projection.type ?: param.upperBounds.firstOrNull() ?: analyze { useSiteSession.builtinTypes.any }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/PsiUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/PsiUtils.kt
@@ -17,7 +17,8 @@
 
 package com.google.devtools.ksp.impl.symbol.util
 
-import com.google.devtools.ksp.ExceptionMessage
+import com.google.devtools.ksp.InternalKSPException
+import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.Modifier
 import com.intellij.psi.PsiComment
@@ -107,6 +108,11 @@ fun KtClassOrObject.getClassType(): ClassKind {
             this.isAnnotation() -> ClassKind.ANNOTATION_CLASS
             else -> ClassKind.CLASS
         }
-        else -> throw IllegalStateException("Unexpected psi type ${this.javaClass}, $ExceptionMessage")
+
+        else -> throw InternalKSPException(
+            "Unexpected psi type",
+            this.toLocation(),
+            this.javaClass,
+        )
     }
 }


### PR DESCRIPTION
This PR adds `InternalKSPException` and uses it at all places where KSP actively throws an error. The benefit of this change is twofold: first, the error message is now prettier and always carries more information which makes debugging and error reporting easier. Second, the distinct type allows KSP to distinguish between internal exceptions and exceptions caused elsewhere such as the Kotlin compiler. This is however not yet implemented and will be done in a subsequent PR as it might introduce different behavior. For now, this PR just adds nice(r) error messages for the user (note that some places in the code, KSP just errors with any message at all).

- [x] Mark exception as internal
- [x] Double check all error occurrences in KSP
- [x] Update error string formatting