### PR TITLE
feat: Update Gradle and AGP versions

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -3,7 +3,6 @@ package com.google.devtools.ksp.gradle
 import com.google.devtools.ksp.gradle.KspGradleSubplugin.Companion.agpBasePluginId
 import com.google.devtools.ksp.gradle.KspGradleSubplugin.Companion.agpKmpPluginId
 import com.google.devtools.ksp.gradle.utils.kotlinSourceSetsObservable
-import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
 import org.gradle.api.InvalidUserCodeException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -108,13 +107,11 @@ class KspConfigurations(private val project: Project) {
 
         listOf(agpBasePluginId, agpKmpPluginId).forEach { pluginId ->
             project.plugins.withId(pluginId) {
-                if (!project.useLegacyVariantApi()) {
-                    val androidComponents =
-                        project.extensions.findByType(
-                            com.android.build.api.variant.AndroidComponentsExtension::class.java
-                        )
-                    androidComponents?.addKspConfigurations(useGlobalConfiguration = allowAllTargetConfiguration)
-                }
+                val androidComponents =
+                    project.extensions.findByType(
+                        com.android.build.api.variant.AndroidComponentsExtension::class.java
+                    )
+                androidComponents?.addKspConfigurations(useGlobalConfiguration = allowAllTargetConfiguration)
             }
         }
     }
@@ -156,7 +153,7 @@ class KspConfigurations(private val project: Project) {
      */
     private fun decorateKotlinTarget(target: KotlinTarget, isKotlinMultiplatform: Boolean) {
         if (isPlainAndroidTarget(target) || isOldKmpAndroidTarget(target)) {
-            if (project.useLegacyVariantApi() || isKotlinMultiplatform) {
+            if (isKotlinMultiplatform) {
                 createAndroidSourceSetConfigurations(target.project, target)
             }
         } else {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -25,8 +25,6 @@ import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.checkMinimumAgpVersion
 import com.google.devtools.ksp.gradle.utils.enableProjectIsolationCompatibleCodepath
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
-import com.google.devtools.ksp.gradle.utils.minimumAndroidKotlinMultiplatformVersion
-import com.google.devtools.ksp.gradle.utils.useLegacyVariantApi
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -169,7 +167,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         val processorClasspath =
             project.configurations.maybeCreate("${kspTaskName}ProcessorClasspath").markResolvable()
         if (kotlinCompilation.platformType != KotlinPlatformType.androidJvm ||
-            project.useLegacyVariantApi() ||
             project.pluginManager.hasPlugin("kotlin-multiplatform")
         ) {
             val nonEmptyKspConfigurations =
@@ -266,7 +263,6 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         // androidComponentCache, before we attempt to query for the Component object
         project.afterEvaluate {
             if (project.isAndroidKmpProject() &&
-                project.minimumAndroidKotlinMultiplatformVersion() &&
                 kotlinCompilation is KotlinMultiplatformAndroidCompilation
             ) {
                 val component = androidComponentCache.get(kotlinCompilation.componentName)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -27,22 +27,6 @@ fun checkMinimumAgpVersion(pluginVersion: AndroidPluginVersion) {
 }
 
 /**
- * Returns false for AGP versions 8.10.0-alpha03 or higher.
- *
- * Returns true for older AGP versions or when AGP version cannot be determined.
- */
-fun Project.useLegacyVariantApi(): Boolean {
-    val agpVersion = project.getAgpVersion() ?: return true
-
-    if (providers.gradleProperty("force.legacy.variant.api").orNull == "true") {
-        return true
-    }
-
-    // Fall back to using the legacy Variant API if the AGP version can't be determined for now.
-    return agpVersion < AndroidPluginVersion(8, 10, 0).alpha(3)
-}
-
-/**
  * Returns true for AGP version is 8.12.0-alpha06 or higher.
  * That is the version where addGeneratedSourceDirectories API was fixed
  */
@@ -56,15 +40,10 @@ fun Project.canUseInternalKspApis(): Boolean {
     return agpVersion >= AndroidPluginVersion(9, 0, 0).alpha(14)
 }
 
-fun Project.minimumAndroidKotlinMultiplatformVersion(): Boolean {
-    val agpVersion = project.getAgpVersion() ?: return false
-    return agpVersion >= AndroidPluginVersion(8, 2, 0)
-}
-
 /**
  * Defines the minimum supported Android Gradle Plugin (AGP) version.
  *
  * KSP aims to support AGP versions released approximately within the last year
  * from the current KSP release date.
  */
-val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 3, 0)
+val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 10, 0)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 
 kotlinBaseVersion=2.3.20
 kotlinxSerializationVersion=1.6.3
-agpBaseVersion=9.0.0
+agpBaseVersion=9.3.0-alpha01
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
-distributionSha256Sum=a17ddd85a26b6a7f5ddb71ff8b05fc5104c0202c6e64782429790c933686c806
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-milestone-7-bin.zip
+distributionSha256Sum=be0a8f2e9f1c0f4d4764cc8903afcbce6c1134df8b980ae517583b18a0fce57b
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/AGPVersionIT.kt
@@ -34,8 +34,6 @@ class AGPVersionIT(
                 arrayOf(null, null, null),
 
                 // Alpha/beta versions
-                arrayOf("8.10.0-alpha03", "2.2.10", "8.11.1"),
-                arrayOf("8.10.0-alpha03", "2.3.0-RC", "8.11.1"),
                 arrayOf("8.12.0-alpha06", "2.2.10", "8.13"),
                 arrayOf("8.12.0-alpha06", "2.3.0-RC", "8.13"),
                 arrayOf("9.0.0-alpha12", "2.2.10", "9.1.0"),
@@ -43,15 +41,6 @@ class AGPVersionIT(
                 arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
 
-                // AGP 8.7.0
-                arrayOf("8.7.0", "2.3.0-RC", "8.11.1"),
-                arrayOf("8.7.0", "2.2.10", "8.11.1"),
-                // AGP 8.8.0
-                arrayOf("8.8.0", "2.3.0-RC", "8.11.1"),
-                arrayOf("8.8.0", "2.2.10", "8.11.1"),
-                // AGP 8.9.0
-                arrayOf("8.9.0", "2.3.0-RC", "8.11.1"),
-                arrayOf("8.9.0", "2.2.10", "8.11.1"),
                 // AGP 8.10.0
                 arrayOf("8.10.0", "2.3.0-RC", "8.11.1"),
                 arrayOf("8.10.0", "2.2.10", "8.11.1"),

--- a/integration-tests/src/test/resources/playground-android-builtinkotlin/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android-builtinkotlin/workload/build.gradle.kts
@@ -35,6 +35,7 @@ android {
             // For regression testing https://github.com/google/ksp/pull/467
             proguardFiles.add(file("proguard-rules.pro"))
             isMinifyEnabled = true
+            isShrinkResources = true
         }
     }
 }

--- a/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-android/workload/build.gradle.kts
@@ -38,6 +38,7 @@ android {
             // For regression testing https://github.com/google/ksp/pull/467
             proguardFiles.add(file("proguard-rules.pro"))
             isMinifyEnabled = true
+            isShrinkResources = true
         }
     }
 }


### PR DESCRIPTION
* This commit updates the Gradle wrapper and Android Gradle Plugin (AGP) versions across the project.
* Sets the min runtime version of AGP allowed to 8.10.0 (which was released one 1 year ago)
* Cleans up code that depends on AGP version < 8.10.0 which can no longer be true