### PR TITLE
Enable project ksp project isolation when org.gradle.unsafe.isolated-projects=true

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -25,5 +25,7 @@ fun Project.canUseGeneratedKotlinApi(): Boolean {
 }
 
 fun Project.enableProjectIsolationCompatibleCodepath(): Boolean {
-    return providers.gradleProperty("ksp.project.isolation.enabled").orNull == "true"
+    return providers.gradleProperty("ksp.project.isolation.enabled").orNull == "true" ||
+        providers.gradleProperty("org.gradle.unsafe.isolated-projects").orNull == "true" ||
+        providers.systemProperty("org.gradle.unsafe.isolated-projects").orNull == "true"
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/ProjectIsolationIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/ProjectIsolationIT.kt
@@ -1,0 +1,40 @@
+package com.google.devtools.ksp.test
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import java.io.File
+import java.util.jar.JarFile
+
+class ProjectIsolationIT {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "playground",
+        experimentalPsiResolution = true
+    )
+
+    @Test
+    fun testProjectIsolationResources() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val result = gradleRunner.withArguments(
+            "clean", "build", "-Dorg.gradle.unsafe.isolated-projects=true",
+            "--configuration-cache", "--info", "--stacktrace"
+        ).build()
+
+        Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:build")?.outcome)
+
+        val artifact = File(project.root, "workload/build/libs/workload-1.0-SNAPSHOT.jar")
+        Assert.assertTrue("Artifact should exist at ${artifact.absolutePath}", artifact.exists())
+
+        JarFile(artifact).use { jarFile ->
+            // This is the resource that KSP generates
+            val entry = jarFile.getEntry("TestProcessor.log")
+            Assert.assertNotNull("TestProcessor.log should be present in the JAR", entry)
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2866