### PR TITLE
Fix various editor warnings in `utils`

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -150,15 +150,18 @@ fun KSDeclaration.getVisibility(): Visibility {
                 else -> null
             } ?: Visibility.PUBLIC
         }
+
         this.isLocal() -> Visibility.LOCAL
         this.modifiers.contains(Modifier.PRIVATE) -> Visibility.PRIVATE
         this.modifiers.contains(Modifier.PROTECTED) ||
             this.modifiers.contains(Modifier.OVERRIDE) -> Visibility.PROTECTED
+
         this.modifiers.contains(Modifier.INTERNAL) -> Visibility.INTERNAL
         // for synthetic origin from Java source, synthetic members follow visibility from parent to avoid
         // package private synthetic members being mishandled as public.
         this.origin == Origin.SYNTHETIC && this.parentDeclaration?.origin == Origin.JAVA ->
             this.parentDeclaration!!.getVisibility()
+
         else -> if (this.origin != Origin.JAVA && this.origin != Origin.JAVA_LIB)
             Visibility.PUBLIC else Visibility.JAVA_PACKAGE
     }
@@ -284,10 +287,12 @@ fun KSDeclaration.isVisibleFrom(other: KSDeclaration): Boolean {
         this.isPublic() -> true
         this.isInternal() && other.containingFile != null && this.containingFile != null -> true
         this.isJavaPackagePrivate() -> this.isSamePackage(other)
-        this.isProtected() -> this.isVisibleInPrivate(other) || this.isSamePackage(other) ||
-            other.closestClassDeclaration()?.let {
-            this.closestClassDeclaration()!!.asStarProjectedType().isAssignableFrom(it.asStarProjectedType())
-        } ?: false
+        this.isProtected() -> {
+            this.isVisibleInPrivate(other) || this.isSamePackage(other) || other.closestClassDeclaration()?.let {
+                this.closestClassDeclaration()!!.asStarProjectedType().isAssignableFrom(it.asStarProjectedType())
+            } ?: false
+        }
+
         else -> false
     }
 }
@@ -373,6 +378,7 @@ private fun KSAnnotation.createInvocationHandler(clazz: Class<*>): InvocationHan
                     val value = { result.asArray(method, clazz) }
                     cache.getOrPut(Pair(method.returnType, result), value)
                 }
+
                 else -> {
                     when {
                         // Workaround for java annotation value array type
@@ -385,14 +391,17 @@ private fun KSAnnotation.createInvocationHandler(clazz: Class<*>): InvocationHan
                                 throw IllegalStateException("unhandled value type, $ExceptionMessage")
                             }
                         }
+
                         method.returnType.isEnum -> {
                             val value = { result.asEnum(method.returnType) }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.isAnnotation -> {
                             val value = { (result as KSAnnotation).asAnnotation(method.returnType) }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.name == "java.lang.Class" -> {
                             cache.getOrPut(Pair(method.returnType, result)) {
                                 when (result) {
@@ -407,26 +416,32 @@ private fun KSAnnotation.createInvocationHandler(clazz: Class<*>): InvocationHan
                                 }
                             }
                         }
+
                         method.returnType.name == "byte" -> {
                             val value = { result.asByte() }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.name == "short" -> {
                             val value = { result.asShort() }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.name == "long" -> {
                             val value = { result.asLong() }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.name == "float" -> {
                             val value = { result.asFloat() }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         method.returnType.name == "double" -> {
                             val value = { result.asDouble() }
                             cache.getOrPut(Pair(method.returnType, result), value)
                         }
+
                         else -> result // original value
                     }
                 }
@@ -465,11 +480,13 @@ private fun List<*>.asArray(method: Method, proxyClass: Class<*>) =
                 method.returnType.componentType.isEnum -> {
                     this.toArray(method) { result -> result.asEnum(method.returnType.componentType) }
                 }
+
                 method.returnType.componentType.isAnnotation -> {
                     this.toArray(method) { result ->
                         (result as KSAnnotation).asAnnotation(method.returnType.componentType)
                     }
                 }
+
                 else -> throw IllegalStateException("Unable to process type ${method.returnType.componentType.name}")
             }
         }
@@ -514,6 +531,7 @@ private fun Any.asDouble(): Double = if (this is Int) this.toDouble() else this 
 // for Class/KClass member
 @KspExperimental
 class KSTypeNotPresentException(val ksType: KSType, cause: Throwable) : RuntimeException(cause)
+
 // for Class[]/Array<KClass<*>> member.
 @KspExperimental
 class KSTypesNotPresentException(val ksTypes: List<KSType>, cause: Throwable) : RuntimeException(cause)

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -239,11 +239,7 @@ fun KSDeclaration.isPrivate() = this.modifiers.contains(Modifier.PRIVATE)
 fun KSDeclaration.isJavaPackagePrivate() = this.getVisibility() == Visibility.JAVA_PACKAGE
 
 fun KSDeclaration.closestClassDeclaration(): KSClassDeclaration? {
-    return if (this is KSClassDeclaration) {
-        this
-    } else {
-        this.parentDeclaration?.closestClassDeclaration()
-    }
+    return this as? KSClassDeclaration ?: this.parentDeclaration?.closestClassDeclaration()
 }
 
 // TODO: cross module visibility is not handled
@@ -507,12 +503,18 @@ private fun <T> Any.asEnum(returnType: Class<T>): T =
     returnType.getDeclaredMethod("valueOf", String::class.java)
         .invoke(
             null,
-            if (this is KSType) {
-                this.declaration.simpleName.getShortName()
-            } else if (this is KSClassDeclaration) {
-                this.simpleName.getShortName()
-            } else {
-                this.toString()
+            when (this) {
+                is KSType -> {
+                    this.declaration.simpleName.getShortName()
+                }
+
+                is KSClassDeclaration -> {
+                    this.simpleName.getShortName()
+                }
+
+                else -> {
+                    this.toString()
+                }
             }
         ) as T
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -174,7 +174,7 @@ fun KSDeclaration.getVisibility(): Visibility {
 fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
 
     fun KSTypeParameter.getTypesUpperBound(): Sequence<KSClassDeclaration> =
-        this.bounds.asSequence().flatMap {
+        this.bounds.flatMap {
             when (val resolvedDeclaration = it.resolve().declaration) {
                 is KSClassDeclaration -> sequenceOf(resolvedDeclaration)
                 is KSTypeAlias -> sequenceOf(resolvedDeclaration.findActualType())
@@ -184,17 +184,15 @@ fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
         }
 
     return this.superTypes
-        .asSequence()
         .map { it.resolve() }
         .plus(
             this.superTypes
-                .asSequence()
-                .mapNotNull { it.resolve().declaration }
-                .flatMap {
-                    when (it) {
-                        is KSClassDeclaration -> it.getAllSuperTypes()
-                        is KSTypeAlias -> it.findActualType().getAllSuperTypes()
-                        is KSTypeParameter -> it.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
+                .map { it.resolve().declaration }
+                .flatMap { declaration ->
+                    when (declaration) {
+                        is KSClassDeclaration -> declaration.getAllSuperTypes()
+                        is KSTypeAlias -> declaration.findActualType().getAllSuperTypes()
+                        is KSTypeParameter -> declaration.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
                         else -> throw IllegalStateException("unhandled super type kind, $ExceptionMessage")
                     }
                 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -119,14 +119,14 @@ fun KSDeclaration.isLocal(): Boolean {
 
 /**
  * Perform a validation on a given symbol to check if all interested types in symbols enclosed scope are valid, i.e. resolvable.
- * @param predicate: A lambda for filtering interested symbols for performance purpose. Default checks all.
+ * @param predicate A lambda for filtering interested symbols for performance purpose. Default checks all.
  */
 fun KSNode.validate(predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true }): Boolean {
     return this.accept(KSValidateVisitor(predicate), null)
 }
 
 /**
- * Find the KSClassDeclaration that the alias points to recursively.
+ * Find the KSClassDeclaration that the alias points to, recursively.
  */
 fun KSTypeAlias.findActualType(): KSClassDeclaration {
     val resolvedType = this.type.resolve().declaration


### PR DESCRIPTION
This PR fixes various warnings surfaced by IntelliJ in `utils`:
- Grammar in docs
- Formatting
- Redundant function calls
- Complicated if-expressions