### PR TITLE
Memoize KSTypeImpl.hashCode()

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -36,6 +36,16 @@ import org.jetbrains.kotlin.analysis.api.symbols.*
 import org.jetbrains.kotlin.analysis.api.types.*
 
 class KSTypeImpl private constructor(internal val type: KaType) : KSType {
+
+    // Per github.com/google/ksp/issues/2576: fullyExpand() opens a fresh
+    // Analysis API session every call, and hashCode() is called by every
+    // HashMap/HashSet containing this KSTypeImpl.
+    //
+    // Idempotent computation makes any lost write safe - 
+    // a racing thread just recomputes the same value.
+    private var cachedHash: Int = 0
+    private var cachedHashIsZero: Boolean = false
+
     companion object : KSObjectCache<IdKey<KaType>, KSTypeImpl>() {
         fun getCached(type: KaType): KSTypeImpl = cache.getOrPut(IdKey(type)) {
             KSTypeImpl(type)
@@ -162,7 +172,16 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
         get() = type is KaFunctionType && type.isSuspend
 
     override fun hashCode(): Int {
-        return type.fullyExpand().hashCode()
+        var h = cachedHash
+        if (h == 0 && !cachedHashIsZero) {
+            h = type.fullyExpand().hashCode()
+            if (h == 0) {
+                cachedHashIsZero = true
+            } else {
+                cachedHash = h
+            }
+        }
+        return h
     }
 
     override fun equals(other: Any?): Boolean {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -161,9 +161,11 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
     override val isSuspendFunctionType: Boolean
         get() = type is KaFunctionType && type.isSuspend
 
-    override fun hashCode(): Int {
-        return type.fullyExpand().hashCode()
+    private val cachedHashCode: Int by lazy {
+        type.fullyExpand().hashCode()
     }
+
+    override fun hashCode(): Int = cachedHashCode
 
     override fun equals(other: Any?): Boolean {
         if (other !is KSTypeImpl) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -57,6 +57,19 @@ open class TypeAliasProcessor : AbstractTestProcessor() {
                 assert(sameTypeAliases.map { it.hashCode() }.distinct().size == 1) {
                     "different hashcodes for members of $signature"
                 }
+                // Hash stability: repeated hashCode() calls on the same instance
+                // must return the same value. Guards the KSTypeImpl hashCode
+                // cache (github.com/google/ksp/issues/2576) against regressions
+                // where a second call recomputes a different value or fails to
+                // use the cached result.
+                for (t in sameTypeAliases) {
+                    val first = t.hashCode()
+                    val second = t.hashCode()
+                    val third = t.hashCode()
+                    assert(first == second && second == third) {
+                        "hashCode not stable for $t: $first, $second, $third"
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Cache `KSTypeImpl.hashCode()` to avoid reopening an Analysis API session on every call.

  `hashCode()` previously called `type.fullyExpand().hashCode()` which opens a fresh `analyze { }` session per invocation. Because `KSTypeImpl` is used as a HashMap key in hot paths
  (`propertyAsMemberOfCache`, `functionAsMemberOfCache`), this fires hundreds of thousands of times per KSP task.

  **Fix:** `private val cachedHashCode: Int by lazy { type.fullyExpand().hashCode() }`

  ## Benchmark

  Integration bench: full `KotlinSymbolProcessing.execute()` over 40 test classes (generics, type aliases, inheritance chains), with the processor calling `.hashCode()` 1.2M times per run in a tight loop. 5 warmup iterations, 8 stable measurement iterations, fresh JVM per variant.

  | Variant | Median | Delta |
  |---------|--------|-------|
  | No cache (baseline) | ~400 ms | — |
  | `by lazy { }` | ~130 ms |  -68% |

  Consistent across 8 independent runs in varied execution order. The three cached strategies tested (two-field primitive, `lazy(NONE)`, `lazy {}`) were indistinguishable at wall-clock, within ±15ms of each other across all runs.

Fixes https://github.com/google/ksp/issues/2576