### PR TITLE
Restrict Gradle parallelism in CI

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -90,7 +90,7 @@ jobs:
   
       # Run ksp generated tests
       - name: test
-        run: ./gradlew --stacktrace --info check
+        run: ./gradlew --no-parallel --stacktrace --info check
 
       - name: push to release branch
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     # Run tests
     - name: test
       shell: bash
-      run: ./gradlew --stacktrace --info check
+      run: ./gradlew --no-parallel --stacktrace --info check
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
Opening this PR to check if it is a concurrency issue.

Related to https://github.com/google/ksp/issues/2890