### PR TITLE
Limit CI resource usage

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -90,7 +90,7 @@ jobs:
   
       # Run ksp generated tests
       - name: test
-        run: ./gradlew --stacktrace --info check
+        run: ./gradlew check --stacktrace --info --scan --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
       - name: push to release branch
         if: success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
     # Run tests
     - name: test
       shell: bash
-      run: ./gradlew --stacktrace --info check
+      run: ./gradlew check --stacktrace --info --scan --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v7

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -58,7 +58,9 @@ val agpCompatibilityTest by tasks.registering(Test::class) {
 }
 
 tasks.test {
-    maxParallelForks = max(1, Runtime.getRuntime().availableProcessors() / 2)
+    // Disable parallelism on Windows to avoid file locking issues
+    val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+    maxParallelForks = if (isWindows) 1 else max(1, Runtime.getRuntime().availableProcessors() / 2)
 
     // Exclude test classes from agpCompatibilityTest
     exclude("**/AGPVersionIT.class")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
@@ -35,6 +35,11 @@ class TemporaryTestProject(
         appendProperty("ksp.experimental.psi.resolution=$experimentalPsiResolution")
         appendProperty("android.useAndroidX=true")
 
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+            // Disable parallelism on Windows to avoid file locking issues
+            appendProperty("org.gradle.parallel=false")
+        }
+
         appendProperty("org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
         appendProperty("kotlin.daemon.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
@@ -35,8 +35,8 @@ class TemporaryTestProject(
         appendProperty("ksp.experimental.psi.resolution=$experimentalPsiResolution")
         appendProperty("android.useAndroidX=true")
 
-        appendProperty("org.gradle.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1024m")
-        appendProperty("kotlin.daemon.jvmargs=-Xmx4096M -XX:MaxMetaspaceSize=1024m")
+        appendProperty("org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
+        appendProperty("kotlin.daemon.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
 
         // To debug compiler and compiler plugin:
         // 1. s/kotlin-compiler/kotlin-compiler-embeddable in integration-tests/build.gradle.kts, and


### PR DESCRIPTION
This PR has the following changes:
- Removes Gradle parallelism in CI
- Restricts memory usage of Gradle to 2gb
- Restricts memory usage of Kotlin to 2gb
- Disables all parallelism on Windows since file locks caused it to fail

While this PR increases the CI time on Windows, it removes some flakiness. We can then start to remove some of the restrictions to see if we can speed things up.

Fixes https://github.com/google/ksp/issues/2890