### PR TITLE
Run macOS CI on pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        is_pull_request:
-          - ${{ github.event_name == 'pull_request' }}
-        exclude:
-          # Don't run slow targets on pull request.
-          - is_pull_request: true
-            os: macos-latest
 
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}
@@ -48,6 +42,7 @@ jobs:
         
         echo "Disk space after cleanup:"
         df -h
+
     - name: Setup Java 17
       uses: actions/setup-java@v5
       with:
@@ -66,6 +61,7 @@ jobs:
         # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
         restore-keys: |
           ${{ runner.os }}-gradle-
+
     - name: Cache gradle wrapper
       uses: actions/cache@v5
       with:
@@ -81,6 +77,7 @@ jobs:
     - name: test
       shell: bash
       run: ./gradlew check --stacktrace --info --scan --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+
     - name: Upload test results
       if: always()
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
While CI is still flaky on other runners, I would like to also run the macOS runner even though it's much slower than the other. We can then remove the macOS target when we improve the CI infrastructure a bit. But for now, I believe it's better to catch as many errors up front before merging.