### PR TITLE
Limit memory to 1gb in gradle integration tests

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
@@ -40,8 +40,8 @@ class TemporaryTestProject(
             appendProperty("org.gradle.parallel=false")
         }
 
-        appendProperty("org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
-        appendProperty("kotlin.daemon.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=1024m")
+        appendProperty("org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=1024m")
+        appendProperty("kotlin.daemon.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=1024m")
 
         // To debug compiler and compiler plugin:
         // 1. s/kotlin-compiler/kotlin-compiler-embeddable in integration-tests/build.gradle.kts, and


### PR DESCRIPTION
This should further help reduce OOM in CI.