### PR TITLE
Add negative tests for `all` meta-use-site target

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,5 +1,6 @@
 package com.google.devtools.ksp.common.visitor
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
 import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnonymousClass
@@ -74,7 +75,11 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
 
                 else ->
                     // Explicit crash
-                    error("Unexpected Kotlin Psi element at ${parent.toLocation()}: ${parent.javaClass}")
+                    throw InternalKSPException(
+                        "Unexpected Kotlin Psi element",
+                        parent.toLocation(),
+                        parent.javaClass
+                    )
             }
 
             is PsiAnnotation -> when (val owner = element.owner) {
@@ -121,7 +126,11 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
 
                 else ->
                     // Explicit crash
-                    error("Unexpected Java Psi element at ${(owner as? PsiElement).toLocation()}: ${owner.javaClass}")
+                    throw InternalKSPException(
+                        "Unexpected Java Psi element",
+                        (owner as? PsiElement).toLocation(),
+                        owner.javaClass
+                    )
             }
         }
         super.visitElement(element)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.test
 
+import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.processor.AbstractTestProcessor
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
@@ -220,7 +221,6 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
     }
 
     fun runTest(@TestDataFile path: String) {
-        // TODO: refactor experimental psi mode into separate test class
         val testConfiguration = testConfiguration(path, configure)
         Disposer.register(disposable, testConfiguration.rootDisposable)
         val testServices = testConfiguration.testServices
@@ -286,6 +286,139 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             )
         }
         Assertions.assertEquals(expectedResults.joinToString("\n"), results.joinToString("\n"))
+    }
+
+    fun runFailingTest(@TestDataFile path: String) {
+        val testConfiguration = testConfiguration(path, configure)
+        Disposer.register(disposable, testConfiguration.rootDisposable)
+        val testServices = testConfiguration.testServices
+        val moduleStructure = testConfiguration.moduleStructureExtractor.splitTestDataByModules(
+            path,
+            testConfiguration.directives,
+        )
+        testServices.registerArtifactsProvider(ArtifactsProvider())
+        testServices.register(TestModuleStructure::class, moduleStructure)
+
+        val mainModule = moduleStructure.modules.last()
+        val libModules = moduleStructure.modules.dropLast(1)
+
+        for (lib in libModules) {
+            compileModule(lib, testServices)
+        }
+        val compilerConfigurationMain = testServices.compilerConfigurationProvider.getCompilerConfiguration(
+            mainModule,
+            CompilationStage.FIRST
+        )
+        compilerConfigurationMain.addJvmClasspathRoots(libModules.map { it.outDir })
+
+        val contents = mainModule.files.first().originalFile.readLines()
+
+        val testProcessorName = contents
+            .single { it.startsWith(TEST_PROCESSOR) }
+            .substringAfter(TEST_PROCESSOR)
+            .trim()
+
+        val testAnnotationNames = contents
+            .find { it.startsWith(TEST_ANNOTATIONS) }
+            ?.substringAfter(TEST_ANNOTATIONS)
+            ?.split(',')
+            ?.map { it.trim() }
+
+        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
+
+        val testProcessor: AbstractTestProcessor =
+            if (testAnnotationNames == null) {
+                // Instantiate processor class without constructor params
+                processorClass
+                    .getDeclaredConstructor()
+                    .newInstance() as AbstractTestProcessor
+            } else {
+                // Instantiate parameterized processor class
+                processorClass
+                    .getDeclaredConstructor(List::class.java)
+                    .newInstance(testAnnotationNames) as AbstractTestProcessor
+            }
+
+        val expectedResults = contents
+            .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
+            .drop(1)
+            .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
+            .map { it.substring(3).trim() }
+
+        val results = collectAllExceptions {
+            runTest(
+                testServices,
+                mainModule,
+                libModules,
+                testProcessor,
+            )
+        }
+        Assertions.assertNotEquals(expectedResults.joinToString("\n"), results.joinToString("\n"))
+    }
+
+    fun runThrowingTest(@TestDataFile path: String) {
+        val testConfiguration = testConfiguration(path, configure)
+        Disposer.register(disposable, testConfiguration.rootDisposable)
+        val testServices = testConfiguration.testServices
+        val moduleStructure = testConfiguration.moduleStructureExtractor.splitTestDataByModules(
+            path,
+            testConfiguration.directives,
+        )
+        testServices.registerArtifactsProvider(ArtifactsProvider())
+        testServices.register(TestModuleStructure::class, moduleStructure)
+
+        val mainModule = moduleStructure.modules.last()
+        val libModules = moduleStructure.modules.dropLast(1)
+
+        for (lib in libModules) {
+            compileModule(lib, testServices)
+        }
+        val compilerConfigurationMain = testServices.compilerConfigurationProvider.getCompilerConfiguration(
+            mainModule,
+            CompilationStage.FIRST
+        )
+        compilerConfigurationMain.addJvmClasspathRoots(libModules.map { it.outDir })
+
+        val contents = mainModule.files.first().originalFile.readLines()
+
+        val testProcessorName = contents
+            .single { it.startsWith(TEST_PROCESSOR) }
+            .substringAfter(TEST_PROCESSOR)
+            .trim()
+
+        val testAnnotationNames = contents
+            .find { it.startsWith(TEST_ANNOTATIONS) }
+            ?.substringAfter(TEST_ANNOTATIONS)
+            ?.split(',')
+            ?.map { it.trim() }
+
+        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
+
+        val testProcessor: AbstractTestProcessor =
+            if (testAnnotationNames == null) {
+                // Instantiate processor class without constructor params
+                processorClass
+                    .getDeclaredConstructor()
+                    .newInstance() as AbstractTestProcessor
+            } else {
+                // Instantiate parameterized processor class
+                processorClass
+                    .getDeclaredConstructor(List::class.java)
+                    .newInstance(testAnnotationNames) as AbstractTestProcessor
+            }
+
+        try {
+            collectAllExceptions {
+                runTest(
+                    testServices,
+                    mainModule,
+                    libModules,
+                    testProcessor,
+                )
+            }
+            Assertions.fail()
+        } catch (_: InternalKSPException) {
+        }
     }
 }
 

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -220,75 +220,45 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
         compileJavaFiles(javaFiles, options)
     }
 
+    /**
+     * Runs a positive test, asserting the actual output matches the expected output.
+     */
     fun runTest(@TestDataFile path: String) {
-        val testConfiguration = testConfiguration(path, configure)
-        Disposer.register(disposable, testConfiguration.rootDisposable)
-        val testServices = testConfiguration.testServices
-        val moduleStructure = testConfiguration.moduleStructureExtractor.splitTestDataByModules(
-            path,
-            testConfiguration.directives,
-        )
-        testServices.registerArtifactsProvider(ArtifactsProvider())
-        testServices.register(TestModuleStructure::class, moduleStructure)
-
-        val mainModule = moduleStructure.modules.last()
-        val libModules = moduleStructure.modules.dropLast(1)
-
-        for (lib in libModules) {
-            compileModule(lib, testServices)
-        }
-        val compilerConfigurationMain = testServices.compilerConfigurationProvider.getCompilerConfiguration(
-            mainModule,
-            CompilationStage.FIRST
-        )
-        compilerConfigurationMain.addJvmClasspathRoots(libModules.map { it.outDir })
-
-        val contents = mainModule.files.first().originalFile.readLines()
-
-        val testProcessorName = contents
-            .single { it.startsWith(TEST_PROCESSOR) }
-            .substringAfter(TEST_PROCESSOR)
-            .trim()
-
-        val testAnnotationNames = contents
-            .find { it.startsWith(TEST_ANNOTATIONS) }
-            ?.substringAfter(TEST_ANNOTATIONS)
-            ?.split(',')
-            ?.map { it.trim() }
-
-        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
-
-        val testProcessor: AbstractTestProcessor =
-            if (testAnnotationNames == null) {
-                // Instantiate processor class without constructor params
-                processorClass
-                    .getDeclaredConstructor()
-                    .newInstance() as AbstractTestProcessor
-            } else {
-                // Instantiate parameterized processor class
-                processorClass
-                    .getDeclaredConstructor(List::class.java)
-                    .newInstance(testAnnotationNames) as AbstractTestProcessor
-            }
-
-        val expectedResults = contents
-            .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
-            .drop(1)
-            .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
-            .map { it.substring(3).trim() }
-
-        val results = collectAllExceptions {
-            runTest(
-                testServices,
-                mainModule,
-                libModules,
-                testProcessor,
-            )
-        }
-        Assertions.assertEquals(expectedResults.joinToString("\n"), results.joinToString("\n"))
+        val (expected, actual) = loadTest(path)
+        Assertions.assertEquals(expected, collectAllExceptions { actual() })
     }
 
+    /**
+     * Runs a negative test, asserting the actual output does not match the expected output.
+     */
     fun runFailingTest(@TestDataFile path: String) {
+        val (expected, actual) = loadTest(path)
+        Assertions.assertNotEquals(expected, collectAllExceptions { actual() })
+    }
+
+    /**
+     * Runs a negative test, asserting that the implementation throws an [InternalKSPException].
+     * The test fails if that particular exception is not thrown, e.g., by not throwing at all
+     * or by throwing a different exception.
+     */
+    fun runThrowingTest(@TestDataFile path: String) {
+        val (_, run) = loadTest(path)
+        try {
+            run()
+            Assertions.fail("Expected InternalKSPException, but the run was successful.")
+        } catch (_: InternalKSPException) {
+            // Succeed by returning
+        }
+    }
+
+    /**
+     * Loads the located at test at [path].
+     *
+     * @return a [Pair] containing the expected results in the first entry
+     * and in the second entry a lambda that runs the test and returns the actual results.
+     * The expected results can be directly compared with the results of the lambda in the second entry.
+     */
+    private fun loadTest(@TestDataFile path: String): Pair<String, () -> String> {
         val testConfiguration = testConfiguration(path, configure)
         Disposer.register(disposable, testConfiguration.rootDisposable)
         val testServices = testConfiguration.testServices
@@ -311,14 +281,14 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
         )
         compilerConfigurationMain.addJvmClasspathRoots(libModules.map { it.outDir })
 
-        val contents = mainModule.files.first().originalFile.readLines()
+        val fileContents = mainModule.files.first().originalFile.readLines()
 
-        val testProcessorName = contents
+        val testProcessorName = fileContents
             .single { it.startsWith(TEST_PROCESSOR) }
             .substringAfter(TEST_PROCESSOR)
             .trim()
 
-        val testAnnotationNames = contents
+        val testAnnotationNames = fileContents
             .find { it.startsWith(TEST_ANNOTATIONS) }
             ?.substringAfter(TEST_ANNOTATIONS)
             ?.split(',')
@@ -339,92 +309,31 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
                     .newInstance(testAnnotationNames) as AbstractTestProcessor
             }
 
-        val expectedResults = contents
+        val expected = fileContents
             .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
             .drop(1)
             .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
-            .map { it.substring(3).trim() }
+            .joinToString("\n") {
+                // Remove '// ' prefix
+                it.substring(3).trim()
+            }
 
-        val results = collectAllExceptions {
+        val actual = {
             runTest(
                 testServices,
                 mainModule,
                 libModules,
-                testProcessor,
-            )
+                testProcessor
+            ).joinToString("\n")
         }
-        Assertions.assertNotEquals(expectedResults.joinToString("\n"), results.joinToString("\n"))
-    }
 
-    fun runThrowingTest(@TestDataFile path: String) {
-        val testConfiguration = testConfiguration(path, configure)
-        Disposer.register(disposable, testConfiguration.rootDisposable)
-        val testServices = testConfiguration.testServices
-        val moduleStructure = testConfiguration.moduleStructureExtractor.splitTestDataByModules(
-            path,
-            testConfiguration.directives,
-        )
-        testServices.registerArtifactsProvider(ArtifactsProvider())
-        testServices.register(TestModuleStructure::class, moduleStructure)
-
-        val mainModule = moduleStructure.modules.last()
-        val libModules = moduleStructure.modules.dropLast(1)
-
-        for (lib in libModules) {
-            compileModule(lib, testServices)
-        }
-        val compilerConfigurationMain = testServices.compilerConfigurationProvider.getCompilerConfiguration(
-            mainModule,
-            CompilationStage.FIRST
-        )
-        compilerConfigurationMain.addJvmClasspathRoots(libModules.map { it.outDir })
-
-        val contents = mainModule.files.first().originalFile.readLines()
-
-        val testProcessorName = contents
-            .single { it.startsWith(TEST_PROCESSOR) }
-            .substringAfter(TEST_PROCESSOR)
-            .trim()
-
-        val testAnnotationNames = contents
-            .find { it.startsWith(TEST_ANNOTATIONS) }
-            ?.substringAfter(TEST_ANNOTATIONS)
-            ?.split(',')
-            ?.map { it.trim() }
-
-        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
-
-        val testProcessor: AbstractTestProcessor =
-            if (testAnnotationNames == null) {
-                // Instantiate processor class without constructor params
-                processorClass
-                    .getDeclaredConstructor()
-                    .newInstance() as AbstractTestProcessor
-            } else {
-                // Instantiate parameterized processor class
-                processorClass
-                    .getDeclaredConstructor(List::class.java)
-                    .newInstance(testAnnotationNames) as AbstractTestProcessor
-            }
-
-        try {
-            collectAllExceptions {
-                runTest(
-                    testServices,
-                    mainModule,
-                    libModules,
-                    testProcessor,
-                )
-            }
-            Assertions.fail()
-        } catch (_: InternalKSPException) {
-        }
+        return Pair(expected, actual)
     }
 }
 
 /**
  * Collects exception from all threads when running `block`.
- * Throws a [[RuntimeException]] if any exception occurred.
+ * Throws an [Exception] if any exception occurred.
  *
  * Note that function is not a perfect solution as it only catches exceptions
  * that happen during `block`.

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -71,6 +71,12 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/allFunctions_kt_inherits_java.kt")
     }
 
+    @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
+    @Test
+    fun testAllUseSiteTargetAppliedToAnnotationList() {
+        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
+    }
+
     @TestMetadata("annotationInDependencies.kt")
     @Test
     fun testAnnotationsInDependencies() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// TEST ANNOTATIONS: Anno1, Anno2
+// EXPECTED:
+// END
+
+annotation class Anno1
+
+annotation class Anno2
+
+class MyClass {
+    @all:[Anno1 Anno2]
+    val bad = 0
+}


### PR DESCRIPTION
Depends on https://github.com/google/ksp/pull/2915

This PR adds the following:
- Adds a *failing* test for invalid use of the `all` use-site target on grouped annotations (see [KEEP 402](https://github.com/Kotlin/KEEP/blob/74a4b4a4937a0a9a70afff71276044c731c0e20b/proposals/KEEP-0402-annotation-target-in-properties.md?plain=1#L107))
- Adds a `runFailingTest` function to `AbstractKSPTest` that asserts the expected output does **not** match the actual output
- Adds a `runThrowingTest` function to `AbstractKSPTest` that asserts the test throws an `InternalKSPException`. This can be expanded to assert other types of exceptions, but for now the idea is that it forces throwing expressions to use `InternalKSPException` which provides an error message with a bit more information than what one might provide with `error` or `require`.

- [x] Refactor `runTest`, `runFailingTest`, `runThrowingTest` to reuse test setup code.