### PR TITLE
Fix 'no element found' issue in KtAnnotationEntry.qualifiedName

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -17,7 +17,6 @@
 
 package com.google.devtools.ksp.common.impl
 
-import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.visitor.CollectAnnotatedSymbolsPsiVisitor
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.FileCache
@@ -57,6 +56,9 @@ import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.PsiTypeParameterList
 import com.intellij.util.containers.addIfNotNull
+import org.jetbrains.kotlin.analysis.api.resolution.KaAnnotationCall
+import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeAliasSymbol
@@ -353,28 +355,7 @@ class PsiResolutionStrategy(
      *
      * This is used as a fallback when [fastResolveClassId] cannot determine the class ID.
      */
-    private fun slowResolveClassId(annotationEntry: KtAnnotationEntry): ClassId? {
-        // Prepare error message in case of exception.
-        val error = { stackTrace: String ->
-            throw InternalKSPException(
-                buildString {
-                    appendLine("Unexpected exception occurred in Analysis API:")
-                    append("  ")
-                    append(stackTrace)
-                },
-                annotationEntry.toLocation(),
-                annotationEntry.javaClass
-            )
-        }
-        // Catch exception twice due to race conditions.
-        try {
-            return analyze { annotationEntry.typeReference?.type?.fullyExpandedType?.expandedSymbol?.classId }
-        } catch (e: Exception) {
-            error(e.stackTraceToString())
-        } catch (e: AssertionError) {
-            error(e.stackTraceToString())
-        }
-    }
+    private fun slowResolveClassId(annotationEntry: KtAnnotationEntry): ClassId? = annotationEntry.classId
 
     /**
      * Resolves this [PsiElement] to the set of [KSAnnotated] symbols targeted by [annotation].
@@ -685,17 +666,17 @@ class PsiResolutionStrategy(
         }
 
     /**
-     * The fully qualified name of the annotation entry.
+     * The fully expanded [ClassId] of the annotation entry.
      * This member is expensive to compute.
      */
-    private val KtAnnotationEntry.qualifiedName: String?
+    private val KtAnnotationEntry.classId: ClassId?
         get() = analyze {
-            this@qualifiedName.typeReference
-                ?.type
-                ?.fullyExpandedType
-                ?.expandedSymbol
-                ?.classId
-                ?.asFqNameString()
+            // N.B. do not use typeReference.type to get the ClassId because that can fail in certain edge cases, e.g.
+            //  https://github.com/google/ksp/issues/2913
+            this@classId.resolveToCall()
+                ?.successfulCallOrNull<KaAnnotationCall>()
+                ?.symbol
+                ?.containingClassId
         }
 
     /**

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -22,11 +22,9 @@ import org.junit.jupiter.api.Test
 
 class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = false) {
 
-    @TestMetadata("fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
+    @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
-    override fun testFieldAndPropertyUseSiteTargetOnConstructorParameters() {
-        runTest(
-            "$AA_PATH/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt"
-        )
+    override fun testAllUseSiteTargetAppliedToAnnotationList() {
+        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -71,13 +71,9 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/allFunctions_kt_inherits_java.kt")
     }
 
-    @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
-    @Test
     @Bug("https://github.com/google/ksp/issues/2912")
     @Negative("KEEP-402 specifies that the :all meta-target cannot be applied to annotation groups.")
-    fun testAllUseSiteTargetAppliedToAnnotationList() {
-        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
-    }
+    abstract fun testAllUseSiteTargetAppliedToAnnotationList()
 
     @TestMetadata("annotationInDependencies.kt")
     @Test
@@ -295,9 +291,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/errorTypes.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/2913")
-    @Negative("Constructor params not declared with val do not have generated properties or backing fields.")
-    abstract fun testFieldAndPropertyUseSiteTargetOnConstructorParameters()
+    @TestMetadata("fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
+    @Test
+    fun testFieldAndPropertyUseSiteTargetOnConstructorParameters() {
+        runTest(
+            "$AA_PATH/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt"
+        )
+    }
 
     @TestMetadata("functionTypeAlias.kt")
     @Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -74,13 +74,9 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/allFunctions_kt_inherits_java.kt")
     }
 
-    @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
-    @Test
     @Bug("https://github.com/google/ksp/issues/2912", BugState.OPEN)
     @Negative("KEEP-402 specifies that the :all meta-target cannot be applied to annotation groups.")
-    fun testAllUseSiteTargetAppliedToAnnotationList() {
-        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
-    }
+    abstract fun testAllUseSiteTargetAppliedToAnnotationList()
 
     @TestMetadata("annotationInDependencies.kt")
     @Test
@@ -305,9 +301,15 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/errorTypes.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/2913", BugState.OPEN)
+    @TestMetadata("fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
+    @Test
+    @Bug("https://github.com/google/ksp/issues/2913", BugState.FIXED)
     @Negative("Constructor params not declared with val do not have generated properties or backing fields.")
-    abstract fun testFieldAndPropertyUseSiteTargetOnConstructorParameters()
+    fun testFieldAndPropertyUseSiteTargetOnConstructorParameters() {
+        runTest(
+            "$AA_PATH/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt"
+        )
+    }
 
     @TestMetadata("functionTypeAlias.kt")
     @Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -21,11 +21,10 @@ import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Test
 
 class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = true) {
-    @TestMetadata("fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
+
+    @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
-    override fun testFieldAndPropertyUseSiteTargetOnConstructorParameters() {
-        runThrowingTest(
-            "$AA_PATH/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt"
-        )
+    override fun testAllUseSiteTargetAppliedToAnnotationList() {
+        runTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
 }


### PR DESCRIPTION
This fixes a case where the experimentalPsiResolution strategy was failing due to an incorrect use-site on an annotation.

Fixes https://github.com/google/ksp/issues/2913