### PR TITLE
Change default value of 'ksp.allow.all.target.configuration' to false

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -24,7 +24,7 @@ class KspConfigurations(private val project: Project) {
         project.providers.gradleProperty("ksp.allow.all.target.configuration")
             .orNull
             ?.toBoolean()
-            ?: true
+            ?: false
 
     // The "ksp" configuration, applied to every compilation.
     private val configurationForAll = project.configurations.create(PREFIX).apply {
@@ -185,6 +185,7 @@ class KspConfigurations(private val project: Project) {
     }
 
     private fun isMppProject() = project.pluginManager.hasPlugin("kotlin-multiplatform")
+
     /**
      * Returns the user-facing configurations involved in the given compilation.
      * We use [KotlinCompilation.kotlinSourceSets], not [KotlinCompilation.allKotlinSourceSets] for a few reasons:

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -94,16 +94,25 @@ class GradleCompilationTest(isExperimentalPsiResolution: Boolean) {
                 }
             """.trimIndent()
         )
-        val kspConfigs =
-            """configurations.matching { it.name.startsWith("ksp") && !it.name.endsWith("ProcessorClasspath") }"""
-        testRule.appModule.buildFileAdditions.add(
+        val configs =
             """
-                $kspConfigs.all {
-                    // Make sure ksp configs are not empty.
-                    project.dependencies.add(name, project(":${testRule.processorModule.name}"))
-                }
-            """.trimIndent()
-        )
+            |val kspConfigs = configurations.matching {
+            |    it.name.startsWith("ksp") &&
+            |        it.name != "ksp" &&
+            |        !it.name.endsWith("ProcessorClasspath")
+            |}
+            |
+            |if (kspConfigs.isEmpty()) {
+            |    throw Exception("kspConfigs is empty")
+            |}
+            |
+            |kspConfigs.all {
+            |    // Make sure ksp configs are not empty.
+            |    project.dependencies.add(name, project(":${testRule.processorModule.name}"))
+            |}
+            |
+            |""".trimMargin()
+        testRule.appModule.buildFileAdditions.add(configs)
 
         class MyProcessor(private val codeGenerator: CodeGenerator) : SymbolProcessor {
             var count = 0

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -18,6 +18,7 @@ package com.google.devtools.ksp.gradle
 
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.ksp.gradle.testing.KspIntegrationTestRule
+import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -42,7 +43,21 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
     val testRule = KspIntegrationTestRule(tmpDir, isExperimentalPsiResolution)
 
     private val kspConfigs by lazy {
-        """configurations.matching { it.name.startsWith("ksp") && !it.name.endsWith("ProcessorClasspath") }"""
+        """ if (
+            |configurations.matching {
+            |    it.name.startsWith("ksp") &&
+            |        it.name != "ksp" &&
+            |        !it.name.endsWith("ProcessorClasspath")
+            |}.isEmpty()
+            |) {
+            |    throw Exception("kspConfigs is empty")
+            |}
+            |
+            |configurations.matching {
+            |    it.name.startsWith("ksp") &&
+            |        it.name != "ksp" &&
+            |        !it.name.endsWith("ProcessorClasspath")
+            |}""".trimMargin()
     }
 
     // config name is <KotlinCompileTaskName>.replace("compile", "ksp") + "ProcessorClasspath"
@@ -63,8 +78,8 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
                     doLast {
                         val main = configurations["kspKotlinProcessorClasspath"]
                         val test = configurations["kspTestKotlinProcessorClasspath"]
-                        require(main.extendsFrom.map { it.name } == listOf("ksp"))
-                        require(test.extendsFrom.map { it.name } == listOf("kspTest", "ksp"))
+                        require(main.extendsFrom.map { it.name } == listOf("kspJvm"))
+                        require(test.extendsFrom.map { it.name } == listOf("kspTestJvm", "kspJvm"))
                     }
                 }
             """.trimIndent()

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -80,8 +80,7 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
                         val test = configurations["kspTestKotlinProcessorClasspath"]
                         main.extendsFrom.forEach { println("DEBUG KSP TEST 2: ${'$'}{it.name}") }
                         test.extendsFrom.forEach { println("DEBUG KSP TEST 3: ${'$'}{it.name}") }
-                        // require(main.extendsFrom.map { it.name } == listOf("kspJvm"))
-                        // require(test.extendsFrom.map { it.name } == listOf("kspTestJvm", "kspJvm"))
+                        require(main.extendsFrom.map { it.name } == emptyList()) 
                         require(test.extendsFrom.map { it.name } == listOf("kspTest"))
                     }
                 }
@@ -108,7 +107,13 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
                     doLast {
                         val main = configurations["kspKotlinProcessorClasspath"]
                         val test = configurations["kspTestKotlinProcessorClasspath"]
-                        require(main.extendsFrom.map { it.name } == listOf("ksp"))
+                        main.extendsFrom.forEach { thing -> println(buildString {
+                            append("DEBUG KSP 4: ")
+                            append(thing.name)
+                        }) }
+                        println("DEBUG KSP 5")
+                        println(main.extendsFrom.map { it.name })
+                        require(main.extendsFrom.map { it.name } == emptyList())
                         require(test.extendsFrom.map { it.name } == listOf("kspTest"))
                     }
                 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/ProcessorClasspathConfigurationsTest.kt
@@ -18,7 +18,6 @@ package com.google.devtools.ksp.gradle
 
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.ksp.gradle.testing.KspIntegrationTestRule
-import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -70,6 +69,7 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
             """
                 $kspConfigs.all {
                     // Make sure ksp configs are not empty.
+                    println("DEBUG KSP TEST: ${'$'}name")
                     project.dependencies.add(name, "androidx.room:room-compiler:2.4.2")
                 }
                 tasks.register("testConfigurations") {
@@ -78,8 +78,11 @@ class ProcessorClasspathConfigurationsTest(isExperimentalPsiResolution: Boolean)
                     doLast {
                         val main = configurations["kspKotlinProcessorClasspath"]
                         val test = configurations["kspTestKotlinProcessorClasspath"]
-                        require(main.extendsFrom.map { it.name } == listOf("kspJvm"))
-                        require(test.extendsFrom.map { it.name } == listOf("kspTestJvm", "kspJvm"))
+                        main.extendsFrom.forEach { println("DEBUG KSP TEST 2: ${'$'}{it.name}") }
+                        test.extendsFrom.forEach { println("DEBUG KSP TEST 3: ${'$'}{it.name}") }
+                        // require(main.extendsFrom.map { it.name } == listOf("kspJvm"))
+                        // require(test.extendsFrom.map { it.name } == listOf("kspTestJvm", "kspJvm"))
+                        require(test.extendsFrom.map { it.name } == listOf("kspTest"))
                     }
                 }
             """.trimIndent()


### PR DESCRIPTION
This should have been changed when KSP2 became the default version. Changing it now that the new documentation mentions `false` as the default value.