### PR TITLE
Separate AGP tests from secondary integration tests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, gradle-check ]
+        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-agp, gradle-check ]
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' }}
+    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-agp' }}
     permissions:
       contents: write
 
@@ -102,9 +102,13 @@ jobs:
         if: matrix.test-suite == 'integration-test-secondary'
         run: ./gradlew :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
+      - name: Run agp integration tests
+        if: matrix.test-suite == 'integration-test-agp'
+        run: ./gradlew :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+
       - name: Run remaining tests and checks
         if: matrix.test-suite == 'gradle-check'
-        run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+        run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, gradle-check ]
+        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-agp, gradle-check ]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' }}
+    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-agp' }}
     defaults:
       run:
         shell: bash
@@ -86,9 +86,13 @@ jobs:
       if: matrix.test-suite == 'integration-test-secondary'
       run: ./gradlew :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
+    - name: Run agp integration tests
+      if: matrix.test-suite == 'integration-test-agp'
+      run: ./gradlew :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+
     - name: Run remaining tests and checks
       if: matrix.test-suite == 'gradle-check'
-      run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+      run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
     - name: Upload test results
       if: always()

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -64,9 +64,21 @@ val secondaryTest by tasks.registering(Test::class) {
     configureCommonSettings()
 }
 
+// Create a new test task for the secondary package
+val agpTest by tasks.registering(Test::class) {
+    description = "Runs integration tests in the agp package"
+    group = "verification"
+    include("com/google/devtools/ksp/test/agp/*.class")
+    // Set maxParallelForks to 1 to avoid race conditions when downloading SDKs with old AGPs
+    maxParallelForks = 1
+    testClassesDirs = sourceSets["test"].output.classesDirs
+    classpath = sourceSets["test"].runtimeClasspath
+    configureCommonSettings()
+}
+
 tasks.test {
     exclude("**/*")
-    dependsOn(primaryTest, secondaryTest)
+    dependsOn(primaryTest, secondaryTest, agpTest)
 }
 
 java {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionBuiltInKotlinIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.agp
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
@@ -11,46 +11,27 @@ import org.junit.runners.Parameterized
 import java.io.File
 
 @RunWith(Parameterized::class)
-class AGPVersionIT(
-    private val agpVersion: String?,
-    private val kotlinVersion: String?,
-    private val gradleVersion: String?,
-    experimentalPsiResolution: String?
+class AGPVersionBuiltInKotlinIT(
+    private val agpVersion: String,
+    private val kotlinVersion: String,
+    private val gradleVersion: String,
+    experimentalPsiResolution: String
 ) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
-        "playground-android-multi",
+        "playground-android-builtinkotlin",
         "playground",
-        experimentalPsiResolution!!.toBoolean()
+        experimentalPsiResolution.toBoolean()
     )
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}")
-        fun data(): Collection<Array<String?>> {
-            return listOf<Array<String?>>(
-                // Latest
-                arrayOf(null, null, null),
-
-                // Alpha/beta versions
-                arrayOf("8.12.0-alpha06", "2.2.10", "8.13"),
-                arrayOf("8.12.0-alpha06", "2.3.0-RC", "8.13"),
-                arrayOf("9.0.0-alpha12", "2.2.10", "9.1.0"),
-                arrayOf("9.0.0-alpha12", "2.3.0-RC", "9.1.0"),
+        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}, Experimental: {3}")
+        fun data(): Collection<Array<String>> {
+            return listOf(
                 arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
-
-                // AGP 8.10.0
-                arrayOf("8.10.0", "2.3.0-RC", "8.11.1"),
-                arrayOf("8.10.0", "2.2.10", "8.11.1"),
-                // AGP 8.11.0
-                arrayOf("8.11.0", "2.3.0-RC", "8.13"),
-                arrayOf("8.11.0", "2.2.10", "8.13"),
-                // AGP 8.12.0
-                arrayOf("8.12.0", "2.3.0-RC", "8.13"),
-                arrayOf("8.12.0", "2.2.10", "8.13"),
-                // AGP 9.0.0-beta01
                 arrayOf("9.0.0-beta01", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-beta01", "2.2.10", "9.1.0"),
             ).flatMap {
@@ -64,10 +45,10 @@ class AGPVersionIT(
         val gradleRunner = GradleRunner.create()
             .withProjectDir(project.root)
             .withArguments(":workload:compileDebugKotlin")
-        gradleVersion?.let { gradleRunner.withGradleVersion(it) }
+        gradleVersion.let { gradleRunner.withGradleVersion(it) }
 
-        agpVersion?.let { project.setAgpVersion(it) }
-        kotlinVersion?.let {
+        agpVersion.let { project.setAgpVersion(it) }
+        kotlinVersion.let {
             project.setKotlinVersion(it)
             setKotlinInBuildClasspath(it)
         }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.agp
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
@@ -11,27 +11,46 @@ import org.junit.runners.Parameterized
 import java.io.File
 
 @RunWith(Parameterized::class)
-class AGPVersionBuiltInKotlinIT(
-    private val agpVersion: String,
-    private val kotlinVersion: String,
-    private val gradleVersion: String,
-    experimentalPsiResolution: String
+class AGPVersionIT(
+    private val agpVersion: String?,
+    private val kotlinVersion: String?,
+    private val gradleVersion: String?,
+    experimentalPsiResolution: String?
 ) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
-        "playground-android-builtinkotlin",
+        "playground-android-multi",
         "playground",
-        experimentalPsiResolution.toBoolean()
+        experimentalPsiResolution!!.toBoolean()
     )
 
     companion object {
         @JvmStatic
-        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}, Experimental: {3}")
-        fun data(): Collection<Array<String>> {
-            return listOf(
+        @Parameterized.Parameters(name = "AGP: {0}, KGP: {1}, Gradle: {2}")
+        fun data(): Collection<Array<String?>> {
+            return listOf<Array<String?>>(
+                // Latest
+                arrayOf(null, null, null),
+
+                // Alpha/beta versions
+                arrayOf("8.12.0-alpha06", "2.2.10", "8.13"),
+                arrayOf("8.12.0-alpha06", "2.3.0-RC", "8.13"),
+                arrayOf("9.0.0-alpha12", "2.2.10", "9.1.0"),
+                arrayOf("9.0.0-alpha12", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
+
+                // AGP 8.10.0
+                arrayOf("8.10.0", "2.3.0-RC", "8.11.1"),
+                arrayOf("8.10.0", "2.2.10", "8.11.1"),
+                // AGP 8.11.0
+                arrayOf("8.11.0", "2.3.0-RC", "8.13"),
+                arrayOf("8.11.0", "2.2.10", "8.13"),
+                // AGP 8.12.0
+                arrayOf("8.12.0", "2.3.0-RC", "8.13"),
+                arrayOf("8.12.0", "2.2.10", "8.13"),
+                // AGP 9.0.0-beta01
                 arrayOf("9.0.0-beta01", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-beta01", "2.2.10", "9.1.0"),
             ).flatMap {
@@ -45,10 +64,10 @@ class AGPVersionBuiltInKotlinIT(
         val gradleRunner = GradleRunner.create()
             .withProjectDir(project.root)
             .withArguments(":workload:compileDebugKotlin")
-        gradleVersion.let { gradleRunner.withGradleVersion(it) }
+        gradleVersion?.let { gradleRunner.withGradleVersion(it) }
 
-        agpVersion.let { project.setAgpVersion(it) }
-        kotlinVersion.let {
+        agpVersion?.let { project.setAgpVersion(it) }
+        kotlinVersion?.let {
             project.setKotlinVersion(it)
             setKotlinInBuildClasspath(it)
         }


### PR DESCRIPTION
Splits AGP compatibility tests into its own package since it's slow on Windows targets. This change should hopefully reduce max time spent in CI.