### PR TITLE
Add `Bug` annotation

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/Bug.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/Bug.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.test
+
+/**
+ * Indicates that a test case was introduced to reproduce or verify a fix for a specific bug.
+ *
+ * This annotation helps track the origin of tests back to their corresponding issue reports
+ * (e.g., GitHub issues, YouTrack tickets).
+ *
+ * @property id The unique identifier of the issue (e.g., a GitHub issue link or `KT-` identifier).
+ * @property description An optional brief explanation of the bug or why the test was added.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+@Repeatable
+annotation class Bug(val id: String, val description: String = "")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -73,6 +73,7 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
+    @Bug("https://github.com/google/ksp/issues/2912")
     fun testAllUseSiteTargetAppliedToAnnotationList() {
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
@@ -293,6 +294,7 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/errorTypes.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/2913")
     abstract fun testFieldAndPropertyUseSiteTargetOnConstructorParameters()
 
     @TestMetadata("functionTypeAlias.kt")
@@ -664,6 +666,7 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("repeatedNonRepeatableAnnotations.kt")
     @Test
+    @Bug("https://github.com/google/ksp/issues/2919")
     fun testRepeatedNonRepeatableAnnotations() {
         runTest("$AA_PATH/getSymbolsWithAnnotation/repeatedNonRepeatableAnnotations.kt")
     }


### PR DESCRIPTION
This PR adds a `@Bug` annotation that can be used to link tests to their specific bug reports. For now there is no additional tooling help, but in the future that can be explored. At the moment it only serves as a marker annotation to indicate the test's purpose and reason.

Closes #2918 