### PR TITLE
Add `@Negative` annotation for tests

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -74,6 +74,7 @@ abstract class KSPUnitTestSuite(
     @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
     @Bug("https://github.com/google/ksp/issues/2912")
+    @Negative("KEEP-402 specifies that the :all meta-target cannot be applied to annotation groups.")
     fun testAllUseSiteTargetAppliedToAnnotationList() {
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
@@ -295,6 +296,7 @@ abstract class KSPUnitTestSuite(
     }
 
     @Bug("https://github.com/google/ksp/issues/2913")
+    @Negative("Constructor params not declared with val do not have generated properties or backing fields.")
     abstract fun testFieldAndPropertyUseSiteTargetOnConstructorParameters()
 
     @TestMetadata("functionTypeAlias.kt")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/Negative.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/Negative.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.test
+
+/**
+ * Indicates that a test case is a "negative test," validating how KSP handles invalid or problematic input.
+ *
+ * A negative test typically verifies that KSP correctly identifies errors, reports them appropriately,
+ * or handles invalid code constructs without crashing.
+ *
+ * @property description An optional brief explanation of the invalid scenario or expected failure.
+ */
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
+annotation class Negative(val description: String = "")


### PR DESCRIPTION
This PR adds a `@Negative` annotation for tests.
This allows the reader to clearly see the intention behind the test. Note that there is no `Positive` test since there are far more positive tests, and it would be cumbersome to write it every time. You can optionally provide a comment or description that tells the reader why it's there or what it's doing.
Additionally, when a bug is documented with a test, it clearly shows what the intended outcome is (when it is fixed).