### PR TITLE
Rename 'TEST ANNOTATIONS' to 'PROCESSOR INPUT'

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -79,7 +79,7 @@ abstract class DisposableTest {
 abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
     companion object {
         const val TEST_PROCESSOR = "// TEST PROCESSOR:"
-        const val TEST_ANNOTATIONS = "// TEST ANNOTATIONS:"
+        const val PROCESSOR_INPUT = "// PROCESSOR INPUT:"
         const val EXPECTED_RESULTS = "// EXPECTED:"
         const val EXPECTED_RESULTS_END = "// END"
     }
@@ -289,8 +289,8 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
             .trim()
 
         val testAnnotationNames = fileContents
-            .find { it.startsWith(TEST_ANNOTATIONS) }
-            ?.substringAfter(TEST_ANNOTATIONS)
+            .find { it.startsWith(PROCESSOR_INPUT) }
+            ?.substringAfter(PROCESSOR_INPUT)
             ?.split(',')
             ?.map { it.trim() }
 

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/README.md
@@ -30,13 +30,13 @@ qualified names of the annotations the processor should use to look up symbols. 
 the `localClasses.kt` file declares an annotation class `Anno` and contains the line:
 
 ```kotlin
-// TEST ANNOTATIONS: Anno
+// PROCESSOR INPUT: Anno
 ```
 
 Likewise, the `metaAnnotations.kt` file contains the line:
 
 ```kotlin
-// TEST ANNOTATIONS: kotlin.annotation.Retention, kotlin.annotation.Target
+// PROCESSOR INPUT: kotlin.annotation.Retention, kotlin.annotation.Target
 ```
 
 It then finds all symbols annotated with `kotlin.annotation.Retention` and finds all symbols

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotations.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno1, Anno2, Anno3
+// PROCESSOR INPUT: Anno1, Anno2, Anno3
 // EXPECTED:
 // Anno1: File: Main.kt
 // Anno1: File: Other.kt

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotationsWithUseSiteTargets.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotationsWithUseSiteTargets.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno1, Anno2, Anno3
+// PROCESSOR INPUT: Anno1, Anno2, Anno3
 // EXPECTED:
 // Anno1: File: Main.kt
 // Anno1: File: Other.kt

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localAnnotationClass.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno
+// PROCESSOR INPUT: Anno
 // EXPECTED:
 // END
 

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/localClasses.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno
+// PROCESSOR INPUT: Anno
 // EXPECTED:
 // Anno: Outer
 // Anno: Outer.<no name provided>

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/metaAnnotations.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: kotlin.annotation.Retention, kotlin.annotation.Target
+// PROCESSOR INPUT: kotlin.annotation.Retention, kotlin.annotation.Target
 // EXPECTED:
 // kotlin.annotation.Retention: Anno
 // kotlin.annotation.Target: Anno

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno1, Anno2
+// PROCESSOR INPUT: Anno1, Anno2
 // EXPECTED:
 // END
 

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno
+// PROCESSOR INPUT: Anno
 // EXPECTED:
 // END
 

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/repeatedNonRepeatableAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/repeatedNonRepeatableAnnotations.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: Anno
+// PROCESSOR INPUT: Anno
 // EXPECTED:
 // Anno: MyClass
 // Anno: MyJavaClass

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/shadowingAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/shadowingAnnotations.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: FooAnno, Container.FooAnno
+// PROCESSOR INPUT: FooAnno, Container.FooAnno
 // EXPECTED:
 // Container.FooAnno: Container.member
 // FooAnno: Container

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
@@ -16,7 +16,7 @@
  */
 
 // TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
-// TEST ANNOTATIONS: com.example.Anno, com.example.FileAnno
+// PROCESSOR INPUT: com.example.Anno, com.example.FileAnno
 // EXPECTED:
 // com.example.Anno: TargetClass
 // com.example.Anno: TargetClass.<init>.allUseSite


### PR DESCRIPTION
This PR changes the name of the test comment, so the mechanism can be more easily used for general input to the test processor.