### PR TITLE
Add `BugState` enum to `Bug` annotation

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.test
 
 import com.google.devtools.ksp.test.annotations.Bug
+import com.google.devtools.ksp.test.annotations.Negative
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.test
 
+import com.google.devtools.ksp.test.annotations.Bug
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -18,6 +18,7 @@
 package com.google.devtools.ksp.test
 
 import com.google.devtools.ksp.test.annotations.Bug
+import com.google.devtools.ksp.test.annotations.BugState
 import com.google.devtools.ksp.test.annotations.Negative
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Disabled
@@ -75,7 +76,7 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
-    @Bug("https://github.com/google/ksp/issues/2912")
+    @Bug("https://github.com/google/ksp/issues/2912", BugState.OPEN)
     @Negative("KEEP-402 specifies that the :all meta-target cannot be applied to annotation groups.")
     fun testAllUseSiteTargetAppliedToAnnotationList() {
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
@@ -297,7 +298,7 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/errorTypes.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/2913")
+    @Bug("https://github.com/google/ksp/issues/2913", BugState.OPEN)
     @Negative("Constructor params not declared with val do not have generated properties or backing fields.")
     abstract fun testFieldAndPropertyUseSiteTargetOnConstructorParameters()
 
@@ -670,7 +671,7 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("repeatedNonRepeatableAnnotations.kt")
     @Test
-    @Bug("https://github.com/google/ksp/issues/2919")
+    @Bug("https://github.com/google/ksp/issues/2919", BugState.FIXED)
     fun testRepeatedNonRepeatableAnnotations() {
         runTest("$AA_PATH/getSymbolsWithAnnotation/repeatedNonRepeatableAnnotations.kt")
     }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Bug.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Bug.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.test
+package com.google.devtools.ksp.test.annotations
 
 /**
  * Indicates that a test case was introduced to reproduce or verify a fix for a specific bug.

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Bug.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Bug.kt
@@ -24,9 +24,10 @@ package com.google.devtools.ksp.test.annotations
  * (e.g., GitHub issues, YouTrack tickets).
  *
  * @property id The unique identifier of the issue (e.g., a GitHub issue link or `KT-` identifier).
+ * @property state The current resolution status of the bug (e.g., whether it is still open or fixed).
  * @property description An optional brief explanation of the bug or why the test was added.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Repeatable
-annotation class Bug(val id: String, val description: String = "")
+annotation class Bug(val id: String, val state: BugState, val description: String = "")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/BugState.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/BugState.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.test.annotations
+
+/**
+ * Represents the resolution status of a bug tracked by the [Bug] annotation.
+ */
+enum class BugState {
+    /**
+     * The bug is open and has not yet been resolved.
+     */
+    OPEN,
+
+    /**
+     * The bug has been resolved and the test serves as a regression test.
+     */
+    FIXED
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Negative.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/annotations/Negative.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.test
+package com.google.devtools.ksp.test.annotations
 
 /**
  * Indicates that a test case is a "negative test," validating how KSP handles invalid or problematic input.


### PR DESCRIPTION
This PR enhances the `@Bug` annotation with a `BugState`, so the reader can know if they should pay attention to the failing test. If a bug is closed / fixed then if the test fails it's a regression whereas if it's still open but then fails, the bug might just be fixed by the change.
In the future, we can explore tooling to ensure the linked issue is always in the same state as the give `BugState`. Lastly, it's also just a bit distracting to navigate to a GitHub issue just to see if it's still relevant.

Related to https://github.com/google/ksp/issues/2918