### PR TITLE
Refactor CollectAnnotatedSymbolsPsiVisitor

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -3,12 +3,14 @@ package com.google.devtools.ksp.common.visitor
 import com.intellij.psi.PsiAnnotationOwner
 import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiCodeBlock
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiImportList
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiPackageStatement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.javadoc.PsiDocComment
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.psi.KtAnnotated
@@ -31,6 +33,30 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         if (element.isSkippable()) {
             return
         }
+        buildString {
+            appendLine("ELEMENT:")
+            append("  ")
+            append("element = ")
+            appendLine(element)
+            append("  ")
+            append("element.javaClass = ")
+            appendLine(element.javaClass)
+            append("  ")
+            append("element is KtAnnotated = ")
+            appendLine(element is KtAnnotated)
+            append("  ")
+            append("element.annotationEntries = ")
+            appendLine(if (element is KtAnnotated) element.annotationEntries else emptyList())
+            append("  ")
+            append("element.annotations = ")
+            appendLine(if (element is KtAnnotated) element.annotations else emptyList())
+            append("  ")
+            append("element is PsiAnnotationOwner = ")
+            appendLine(element is PsiAnnotationOwner)
+            append("  ")
+            append("element.annotations = ")
+            appendLine(if (element is PsiAnnotationOwner) element.annotations else "nothing")
+        }.let { println(it) }
         when (element) {
             is KtAnnotated -> {
                 // N.B.: Do not include annotated expressions, since KSP does not provide access to them.
@@ -61,7 +87,7 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     private fun PsiElement.isSkippable(): Boolean =
         isPackageDirective() ||
             isImport() ||
-            isDocComment() ||
+            isComment() ||
             isFunctionOrMethodBody() ||
             isObjectOrAnonymousClass()
 
@@ -75,9 +101,9 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         isKotlinImportList() || isJavaImportList()
 
     /**
-     * Return `true` if the [PsiElement] is either a Kotlin or Java doc-comment.
+     * Return `true` if the [PsiElement] is either a Kotlin doc-comment or Java comment.
      */
-    private fun PsiElement.isDocComment(): Boolean =
+    private fun PsiElement.isComment(): Boolean =
         isKotlinDocComment() || isJavaDocComment()
 
     /**
@@ -123,10 +149,10 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         this is KDoc
 
     /**
-     * Returns `true` if the [PsiElement] is a Java doc-comment.
+     * Returns `true` if the [PsiElement] is a Java comment.
      */
     private fun PsiElement.isJavaDocComment(): Boolean =
-        this is PsiDocComment
+        this is PsiDocComment || this is PsiWhiteSpace || this is PsiComment
 
     /**
      * Returns `true` if the [PsiElement] is a Kotlin function body.

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,28 +1,18 @@
 package com.google.devtools.ksp.common.visitor
 
-import com.google.devtools.ksp.InternalKSPException
-import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
-import com.intellij.psi.PsiAnnotation
+import com.intellij.psi.PsiAnnotationOwner
 import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiCodeBlock
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiImportList
 import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiPackageStatement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
-import com.intellij.psi.PsiType
-import com.intellij.psi.PsiTypeElement
-import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.javadoc.PsiDocComment
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
-import org.jetbrains.kotlin.psi.KtAnnotatedExpression
-import org.jetbrains.kotlin.psi.KtAnnotation
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtDeclarationModifierList
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
@@ -42,95 +32,17 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
             return
         }
         when (element) {
-            is KtAnnotationEntry -> when (val parent = element.parent) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass
-                // @MyAnnotation val myVal = "";
-                // @MyAnnotation fun myFun() {}
-                // fun myMethodWithParameter(@MyAnnotation myParam: Int) {}
-                is KtDeclarationModifierList -> {
-                    result.add(parent.parent)
-                    return
+            is KtAnnotated -> {
+                // N.B.: Do not include annotated expressions, since KSP does not provide access to them.
+                if (element !is KtExpression && element.annotationEntries.isNotEmpty()) {
+                    result.add(element)
                 }
-
-                // Annotations at the file level. Example:
-                // @file:MyAnnotation
-                is KtFileAnnotationList -> {
-                    result.add(parent.parent)
-                    return
-                }
-
-                // Annotations on expressions. Example:
-                // val x = @Suppress("UNCHECKED_CAST") list as List<String>
-                is KtAnnotatedExpression ->
-                    // Do nothing - KSP does not consider expressions / values
-                    return
-
-                // A group of annotations. Example:
-                // @[MyAnnotation1, MyAnnotation2] class MyClass
-                is KtAnnotation -> {
-                    result.add(parent.parent.parent)
-                    return
-                }
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Kotlin Psi element",
-                        parent.toLocation(),
-                        parent.javaClass
-                    )
             }
 
-            is PsiAnnotation -> when (val owner = element.owner) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass {}
-                // @MyAnnotation String myField = "";
-                // @MyAnnotation void myMethod() {}
-                // void myMethodWithParameter(@MyAnnotation int myParam) {}
-                is PsiModifierList -> {
-                    result.add(owner.parent)
-                    return
+            is PsiAnnotationOwner -> {
+                if (element.annotations.isNotEmpty()) {
+                    result.add(element.parent)
                 }
-
-                // Type parameter annotations. Examples:
-                // class MyClass<@MyAnnotation A>
-                // fun <@MyAnnotation A> myFun() {}
-                is PsiTypeParameter -> {
-                    result.add(owner)
-                    return
-                }
-
-                is PsiTypeElement -> {
-                    result.add(owner)
-                    return
-                }
-
-                // Type argument annotation / type application. Example:
-                // interface <A> Foo<A> {}
-                // abstract class Abs {
-                //     Foo<String> bar(Foo2<@MyAnnotation Boolean> baz)
-                //     Foo<@MyAnnotation A> baz(Foo2<A> baz)
-                // }
-                is PsiType ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                // Annotations used as values. Example with other annotation used as default value
-                // @interface MyAnnotation {
-                //     MyOtherAnnotation value() default @MyOtherAnnotation("default value here");
-                // }
-                null ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Java Psi element",
-                        (owner as? PsiElement).toLocation(),
-                        owner.javaClass
-                    )
             }
         }
         super.visitElement(element)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,28 +1,41 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.ksp.common.visitor
 
 import com.google.devtools.ksp.InternalKSPException
-import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
-import com.intellij.psi.PsiAnnotation
+import com.google.devtools.ksp.symbol.NonExistLocation
+import com.intellij.psi.PsiAnnotationOwner
 import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiCodeBlock
+import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiImportList
 import com.intellij.psi.PsiMethod
-import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiPackageStatement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
-import com.intellij.psi.PsiType
-import com.intellij.psi.PsiTypeElement
 import com.intellij.psi.PsiTypeParameter
+import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.javadoc.PsiDocComment
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
+import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
-import org.jetbrains.kotlin.psi.KtAnnotation
-import org.jetbrains.kotlin.psi.KtAnnotationEntry
-import org.jetbrains.kotlin.psi.KtDeclarationModifierList
 import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
@@ -41,98 +54,12 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         if (element.isSkippable()) {
             return
         }
+
         when (element) {
-            is KtAnnotationEntry -> when (val parent = element.parent) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass
-                // @MyAnnotation val myVal = "";
-                // @MyAnnotation fun myFun() {}
-                // fun myMethodWithParameter(@MyAnnotation myParam: Int) {}
-                is KtDeclarationModifierList -> {
-                    result.add(parent.parent)
-                    return
-                }
-
-                // Annotations at the file level. Example:
-                // @file:MyAnnotation
-                is KtFileAnnotationList -> {
-                    result.add(parent.parent)
-                    return
-                }
-
-                // Annotations on expressions. Example:
-                // val x = @Suppress("UNCHECKED_CAST") list as List<String>
-                is KtAnnotatedExpression ->
-                    // Do nothing - KSP does not consider expressions / values
-                    return
-
-                // A group of annotations. Example:
-                // @[MyAnnotation1, MyAnnotation2] class MyClass
-                is KtAnnotation -> {
-                    result.add(parent.parent.parent)
-                    return
-                }
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Kotlin Psi element",
-                        parent.toLocation(),
-                        parent.javaClass
-                    )
-            }
-
-            is PsiAnnotation -> when (val owner = element.owner) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass {}
-                // @MyAnnotation String myField = "";
-                // @MyAnnotation void myMethod() {}
-                // void myMethodWithParameter(@MyAnnotation int myParam) {}
-                is PsiModifierList -> {
-                    result.add(owner.parent)
-                    return
-                }
-
-                // Type parameter annotations. Examples:
-                // class MyClass<@MyAnnotation A>
-                // fun <@MyAnnotation A> myFun() {}
-                is PsiTypeParameter -> {
-                    result.add(owner)
-                    return
-                }
-
-                is PsiTypeElement -> {
-                    result.add(owner)
-                    return
-                }
-
-                // Type argument annotation / type application. Example:
-                // interface <A> Foo<A> {}
-                // abstract class Abs {
-                //     Foo<String> bar(Foo2<@MyAnnotation Boolean> baz)
-                //     Foo<@MyAnnotation A> baz(Foo2<A> baz)
-                // }
-                is PsiType ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                // Annotations used as values. Example with other annotation used as default value
-                // @interface MyAnnotation {
-                //     MyOtherAnnotation value() default @MyOtherAnnotation("default value here");
-                // }
-                null ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Java Psi element",
-                        (owner as? PsiElement).toLocation(),
-                        owner.javaClass
-                    )
-            }
+            is KtAnnotated -> element.annotatedElement?.let { result.add(it) }
+            is PsiAnnotationOwner -> element.annotatedElement?.let { result.add(it) }
         }
+
         super.visitElement(element)
     }
 
@@ -149,7 +76,7 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     private fun PsiElement.isSkippable(): Boolean =
         isPackageDirective() ||
             isImport() ||
-            isDocComment() ||
+            isComment() ||
             isFunctionOrMethodBody() ||
             isObjectOrAnonymousClass()
 
@@ -163,9 +90,9 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         isKotlinImportList() || isJavaImportList()
 
     /**
-     * Return `true` if the [PsiElement] is either a Kotlin or Java doc-comment.
+     * Return `true` if the [PsiElement] is either a Kotlin doc-comment or Java comment.
      */
-    private fun PsiElement.isDocComment(): Boolean =
+    private fun PsiElement.isComment(): Boolean =
         isKotlinDocComment() || isJavaDocComment()
 
     /**
@@ -211,10 +138,10 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         this is KDoc
 
     /**
-     * Returns `true` if the [PsiElement] is a Java doc-comment.
+     * Returns `true` if the [PsiElement] is a Java comment.
      */
     private fun PsiElement.isJavaDocComment(): Boolean =
-        this is PsiDocComment
+        this is PsiDocComment || this is PsiWhiteSpace || this is PsiComment
 
     /**
      * Returns `true` if the [PsiElement] is a Kotlin function body.
@@ -251,4 +178,41 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
      */
     private fun PsiElement.isJavaAnonymousClass(): Boolean =
         this is PsiAnonymousClass
+
+    /**
+     * The [PsiElement] that is annotated by this [KtAnnotated].
+     *
+     * @return The annotated [PsiElement], or `null` if there are no annotations, or if it is a [KtAnnotatedExpression].
+     */
+    private val KtAnnotated.annotatedElement: PsiElement?
+        get() {
+            if (this is KtAnnotatedExpression) {
+                // N.B.: Skip annotated expressions, since KSP does not provide access to them.
+                return null
+            }
+            if (this.annotationEntries.isEmpty()) {
+                return null
+            }
+            return this
+        }
+
+    /**
+     * The [PsiElement] that is annotated by this [PsiAnnotationOwner].
+     *
+     * @return The annotated [PsiElement], or `null` if there are no annotations.
+     */
+    private val PsiAnnotationOwner.annotatedElement: PsiElement?
+        get() {
+            if (this.annotations.isEmpty()) {
+                return null
+            }
+            if (this is PsiTypeParameter) {
+                // N.B.: A Java type parameter is itself the annotated element.
+                return this
+            }
+            if (this is PsiElement) {
+                return this.parent
+            }
+            throw InternalKSPException("Unexpected PsiAnnotationOwner", NonExistLocation, this.javaClass)
+        }
 }


### PR DESCRIPTION
The visitor now considers annotated elements instead of visiting annotations and then relying / knowing the internal structure of the AST to find the annotated elements. This implementation should be more resilient since it only assumes the API to be correct instead of the internal tree structure of the program.