### PR TITLE
Override `toString` in `InternalKSPException`

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/errors/InternalKSPException.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/errors/InternalKSPException.kt
@@ -46,6 +46,15 @@ internal class InternalKSPException(
         appendLine("   |")
     }
 ) {
+    override fun toString(): String {
+        // N.B.: Override the toString method to prevent the big error message being printed in the stack trace.
+        return buildString {
+            append(javaClass.name)
+            append(": ")
+            append("Internal KSP Error")
+        }
+    }
+
     internal companion object {
         private fun Location.render(): String {
             return when (this) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
@@ -49,6 +49,15 @@ internal class InternalKSPException(
         appendLine("   |")
     }
 ) {
+    override fun toString(): String {
+        // N.B.: Override the toString method to prevent the big error message being printed in the stack trace.
+        return buildString {
+            append(javaClass.name)
+            append(": ")
+            append("Internal KSP Error")
+        }
+    }
+
     companion object {
         fun Location.render(): String {
             return when (this) {


### PR DESCRIPTION
As suggested by the comment, this prevents the big error message from being printed in the stack trace and ruining the usability of it.