### PR TITLE
Add negative test for explicit backing fields

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -34,6 +34,12 @@ class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = f
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/contextParameters.kt")
     }
 
+    @TestMetadata("getSymbolsWithAnnotation/explicitBackFields.kt")
+    @Test
+    override fun testExplicitBackingFields() {
+        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/explicitBackingFields.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -313,6 +313,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/errorTypes.kt")
     }
 
+    @Bug(
+        "https://github.com/google/ksp/issues/2873",
+        BugState.OPEN,
+        "KEEP 430: Explicit backing fields added in Kotlin 2.4.0"
+    )
+    abstract fun testExplicitBackingFields()
+
     @TestMetadata("fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
     @Test
     @Bug("https://github.com/google/ksp/issues/2913", BugState.FIXED)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -34,6 +34,12 @@ class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = 
         runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/contextParameters.kt")
     }
 
+    @TestMetadata("getSymbolsWithAnnotation/explicitBackFields.kt")
+    @Test
+    override fun testExplicitBackingFields() {
+        runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/explicitBackingFields.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/explicitBackingFields.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/explicitBackingFields.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// PROCESSOR INPUT: Anno
+// EXPECTED:
+// Anno: MyClass.annotatedProperty
+// Anno: MyClass.annotatedPropertyAndFieldViaUseSiteTargets
+// Anno: MyClass.annotatedPropertyAndFieldViaUseSiteTargets.field
+// Anno: MyClass.annotatedPropertyWithFieldTarget.field
+// Anno: MyClass.propertyWhereFieldIsDirectlyAnnotated.field
+// Anno: MyClass.propertyWithAllTarget
+// Anno: MyClass.propertyWithAllTarget.field
+// Anno: MyClass.propertyWithAllTarget.propertyWithAllTarget.getter()
+// END
+
+// FILE: Main.kt
+
+annotation class Anno
+
+class MyClass {
+    @Anno // Should just pick the property
+    val annotatedProperty: List<String>
+        field = MutableList<String>
+
+    val propertyWhereFieldIsDirectlyAnnotated: List<String>
+        @Anno field = MutableList<String>
+
+    @field:Anno
+    val annotatedPropertyWithFieldTarget: List<String>
+        field = MutableList<String>
+
+    @field:Anno
+    @property:Anno
+    val annotatedPropertyAndFieldViaUseSiteTargets: List<String>
+        field = MutableList<String>
+
+    @all:Anno
+    val propertyWithAllTarget: List<Int>
+        field = MutableList<Int>
+}


### PR DESCRIPTION
This PR adds a test for #2873, asserting that it is not yet implemented. An implementation will be added in a subsequent PR.

See KEEP 430 for further details of this feature (also linked in #2873)