### PR TITLE
Add test for context parameters

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -28,6 +28,12 @@ class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = f
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
 
+    @TestMetadata("contextParameters.kt")
+    @Test
+    override fun testContextParameters() {
+        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/contextParameters.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -233,6 +233,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/crossModuleTypeAlias.kt")
     }
 
+    @Bug(
+        "https://github.com/google/ksp/issues/2472",
+        BugState.OPEN,
+        "KEEP 367: Context parameters are stable in Kotlin 2.4.0"
+    )
+    abstract fun testContextParameters()
+
     @TestMetadata("declarationInconsistency.kt")
     @Test
     fun testDeclarationInconsistency() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -28,6 +28,12 @@ class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = 
         runTest("$AA_PATH/getSymbolsWithAnnotation/negative/allUseSiteTargetAppliedToAnnotationList.kt")
     }
 
+    @TestMetadata("contextParameters.kt")
+    @Test
+    override fun testContextParameters() {
+        runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/contextParameters.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/contextParameters.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/contextParameters.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: GetSymbolsWithAnnotationProcessor
+// PROCESSOR INPUT: Anno
+// EXPECTED:
+// Anno: MyClass.myImmProp
+// Anno: MyClass.myImmProp.ctxParam1
+// Anno: MyClass.myMutProp
+// Anno: MyClass.myMutProp.ctxParam1
+// Anno: MyClass.myMutProp.ctxParam2
+// Anno: MyClass.onlyOneCtxParamAnnotated.ctxParam2
+// Anno: bar.ctxParam1
+// Anno: bar.ctxParam2
+// Anno: bar.str
+// Anno: foo.ctxParam1
+// END
+
+// FILE: Main.kt
+
+annotation class Anno
+
+interface CtxParam1
+interface CtxParam2
+
+context(@Anno ctxParam1: CtxParam1)
+fun foo() {
+}
+
+context(@Anno ctxParam1: CtxParam1, @Anno ctxParam2: CtxParam2)
+fun bar(@Anno str: String) {
+}
+
+class MyClass {
+    context(@Anno ctxParam1: CtxParam1)
+    @Anno
+    val myImmProp: String get() = ""
+
+    context(@Anno ctxParam1: CtxParam1, @Anno ctxParam2: CtxParam2)
+    @Anno
+    var myMutProp: String get() = ""
+
+    context(ctxParam1: CtxParam1, @Anno ctxParam2: CtxParam2)
+    fun onlyOneCtxParamAnnotated() {}
+}


### PR DESCRIPTION
Adds a test for https://github.com/google/ksp/issues/2472. The test does not include annotations on context parameters in type ascriptions since KSP does not yet support it. See #2945.
More information in [KEEP 367](https://github.com/Kotlin/KEEP/blob/main/proposals/KEEP-0367-context-parameters.md).