### PR TITLE
Revert 'Refactor CollectAnnotatedSymbolsPsiVisitor'

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,41 +1,28 @@
-/*
- * Copyright 2026 Google LLC
- * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package com.google.devtools.ksp.common.visitor
 
 import com.google.devtools.ksp.InternalKSPException
-import com.google.devtools.ksp.symbol.NonExistLocation
-import com.intellij.psi.PsiAnnotationOwner
+import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
+import com.intellij.psi.PsiAnnotation
 import com.intellij.psi.PsiAnonymousClass
 import com.intellij.psi.PsiCodeBlock
-import com.intellij.psi.PsiComment
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiImportList
 import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifierList
 import com.intellij.psi.PsiPackageStatement
 import com.intellij.psi.PsiRecursiveElementWalkingVisitor
+import com.intellij.psi.PsiType
+import com.intellij.psi.PsiTypeElement
 import com.intellij.psi.PsiTypeParameter
-import com.intellij.psi.PsiWhiteSpace
 import com.intellij.psi.javadoc.PsiDocComment
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
-import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtDeclarationModifierList
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
@@ -54,12 +41,98 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         if (element.isSkippable()) {
             return
         }
-
         when (element) {
-            is KtAnnotated -> element.annotatedElement?.let { result.add(it) }
-            is PsiAnnotationOwner -> element.annotatedElement?.let { result.add(it) }
-        }
+            is KtAnnotationEntry -> when (val parent = element.parent) {
+                // Annotations on declarations. Examples:
+                // @MyAnnotation class MyClass
+                // @MyAnnotation val myVal = "";
+                // @MyAnnotation fun myFun() {}
+                // fun myMethodWithParameter(@MyAnnotation myParam: Int) {}
+                is KtDeclarationModifierList -> {
+                    result.add(parent.parent)
+                    return
+                }
 
+                // Annotations at the file level. Example:
+                // @file:MyAnnotation
+                is KtFileAnnotationList -> {
+                    result.add(parent.parent)
+                    return
+                }
+
+                // Annotations on expressions. Example:
+                // val x = @Suppress("UNCHECKED_CAST") list as List<String>
+                is KtAnnotatedExpression ->
+                    // Do nothing - KSP does not consider expressions / values
+                    return
+
+                // A group of annotations. Example:
+                // @[MyAnnotation1, MyAnnotation2] class MyClass
+                is KtAnnotation -> {
+                    result.add(parent.parent.parent)
+                    return
+                }
+
+                else ->
+                    // Explicit crash
+                    throw InternalKSPException(
+                        "Unexpected Kotlin Psi element",
+                        parent.toLocation(),
+                        parent.javaClass
+                    )
+            }
+
+            is PsiAnnotation -> when (val owner = element.owner) {
+                // Annotations on declarations. Examples:
+                // @MyAnnotation class MyClass {}
+                // @MyAnnotation String myField = "";
+                // @MyAnnotation void myMethod() {}
+                // void myMethodWithParameter(@MyAnnotation int myParam) {}
+                is PsiModifierList -> {
+                    result.add(owner.parent)
+                    return
+                }
+
+                // Type parameter annotations. Examples:
+                // class MyClass<@MyAnnotation A>
+                // fun <@MyAnnotation A> myFun() {}
+                is PsiTypeParameter -> {
+                    result.add(owner)
+                    return
+                }
+
+                is PsiTypeElement -> {
+                    result.add(owner)
+                    return
+                }
+
+                // Type argument annotation / type application. Example:
+                // interface <A> Foo<A> {}
+                // abstract class Abs {
+                //     Foo<String> bar(Foo2<@MyAnnotation Boolean> baz)
+                //     Foo<@MyAnnotation A> baz(Foo2<A> baz)
+                // }
+                is PsiType ->
+                    // Do nothing - Analysis API implementation does not collect these
+                    return
+
+                // Annotations used as values. Example with other annotation used as default value
+                // @interface MyAnnotation {
+                //     MyOtherAnnotation value() default @MyOtherAnnotation("default value here");
+                // }
+                null ->
+                    // Do nothing - Analysis API implementation does not collect these
+                    return
+
+                else ->
+                    // Explicit crash
+                    throw InternalKSPException(
+                        "Unexpected Java Psi element",
+                        (owner as? PsiElement).toLocation(),
+                        owner.javaClass
+                    )
+            }
+        }
         super.visitElement(element)
     }
 
@@ -76,7 +149,7 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     private fun PsiElement.isSkippable(): Boolean =
         isPackageDirective() ||
             isImport() ||
-            isComment() ||
+            isDocComment() ||
             isFunctionOrMethodBody() ||
             isObjectOrAnonymousClass()
 
@@ -90,9 +163,9 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         isKotlinImportList() || isJavaImportList()
 
     /**
-     * Return `true` if the [PsiElement] is either a Kotlin doc-comment or Java comment.
+     * Return `true` if the [PsiElement] is either a Kotlin or Java doc-comment.
      */
-    private fun PsiElement.isComment(): Boolean =
+    private fun PsiElement.isDocComment(): Boolean =
         isKotlinDocComment() || isJavaDocComment()
 
     /**
@@ -138,10 +211,10 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
         this is KDoc
 
     /**
-     * Returns `true` if the [PsiElement] is a Java comment.
+     * Returns `true` if the [PsiElement] is a Java doc-comment.
      */
     private fun PsiElement.isJavaDocComment(): Boolean =
-        this is PsiDocComment || this is PsiWhiteSpace || this is PsiComment
+        this is PsiDocComment
 
     /**
      * Returns `true` if the [PsiElement] is a Kotlin function body.
@@ -178,41 +251,4 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
      */
     private fun PsiElement.isJavaAnonymousClass(): Boolean =
         this is PsiAnonymousClass
-
-    /**
-     * The [PsiElement] that is annotated by this [KtAnnotated].
-     *
-     * @return The annotated [PsiElement], or `null` if there are no annotations, or if it is a [KtAnnotatedExpression].
-     */
-    private val KtAnnotated.annotatedElement: PsiElement?
-        get() {
-            if (this is KtAnnotatedExpression) {
-                // N.B.: Skip annotated expressions, since KSP does not provide access to them.
-                return null
-            }
-            if (this.annotationEntries.isEmpty()) {
-                return null
-            }
-            return this
-        }
-
-    /**
-     * The [PsiElement] that is annotated by this [PsiAnnotationOwner].
-     *
-     * @return The annotated [PsiElement], or `null` if there are no annotations.
-     */
-    private val PsiAnnotationOwner.annotatedElement: PsiElement?
-        get() {
-            if (this.annotations.isEmpty()) {
-                return null
-            }
-            if (this is PsiTypeParameter) {
-                // N.B.: A Java type parameter is itself the annotated element.
-                return this
-            }
-            if (this is PsiElement) {
-                return this.parent
-            }
-            throw InternalKSPException("Unexpected PsiAnnotationOwner", NonExistLocation, this.javaClass)
-        }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.ksp.common.visitor
 
 import com.google.devtools.ksp.InternalKSPException


### PR DESCRIPTION
As mentioned in #2948, this PR reverts the performance regression introduced by #2932 until we find a proper fix for it.

Related to https://github.com/google/ksp/issues/2948