### PR TITLE
Add test for self referencing type variables

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -718,6 +718,14 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/sealedClass.kt")
     }
 
+    @TestMetadata("javaWildcardsSelfReferencing.kt")
+    @Test
+    @Bug("https://github.com/google/ksp/issues/1729", BugState.FIXED)
+    @Bug("https://github.com/google/ksp/issues/1705", BugState.FIXED)
+    fun testJavaWildcardsSelfReferencing() {
+        runTest("$AA_PATH/javaWildcardsSelfReferencing.kt")
+    }
+
     @TestMetadata("shadowingAnnotations.kt")
     @Test
     fun testShadowingAnnotations() {

--- a/kotlin-analysis-api/testData/javaWildcardsSelfReferencing.kt
+++ b/kotlin-analysis-api/testData/javaWildcardsSelfReferencing.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// WITH_RUNTIME
+// TEST PROCESSOR: JavaWildcard2Processor
+// EXPECTED:
+// ref : SelfRef<out Any?>
+// ref.getter() : SelfRef<out Any?>
+// SelfRef : Any
+// A : SelfRef<A>
+// synthetic constructor for SelfRef : SelfRef<out Any?>
+// A : SelfRef<A>
+// END
+
+class SelfRef<A : SelfRef<A>>
+
+val ref: SelfRef<*> = TODO()


### PR DESCRIPTION
This PR adds a test to reproduce #1729 and #1705. However, the stack overflows have been fixed in KSP2 due to the Analysis API. I did not find a regression test for it, though, so adding one now and closing this issues.

Closes #1729
Closes #1705