### PR TITLE
Fix release branch cherry-pick workflow

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+env:
+  RELEASE_BRANCH: "2.3.9-release"
+
 jobs:
   test:
     strategy:
@@ -44,7 +47,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: 2.3.9-release
+          ref: ${{ env.RELEASE_BRANCH }}
 
       - name: merge commits from main to release branch
         run: |
@@ -131,7 +134,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: 2.3.8-release
+          ref: ${{ env.RELEASE_BRANCH }}
 
       - name: merge commits from main to release branch
         run: |


### PR DESCRIPTION
This PR fixes the auto-merge workflow that cherry picks changes to the upcoming release. The PR that bumped the version from `2.3.8` to `2.3.9` can be found here https://github.com/google/ksp/pull/2946. Importantly, it did not bump the version number in both places (it was duplicated in https://github.com/google/ksp/pull/2920). Thus, this PR fixes the issue by introducing a workflow-wide env var and sets it to `2.3.9-release`