### PR TITLE
Clean up how KSP checks for klib cross-compilation support

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -77,6 +77,7 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.konan.target.HostManager
+import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectOutputStream
@@ -417,14 +418,19 @@ abstract class KspAATask @Inject constructor(
                     if (kotlinCompilation is KotlinNativeCompilation) {
                         val konanTargetName = kotlinCompilation.target.konanTarget.name
                         cfg.konanTargetName.value(konanTargetName)
-                        cfg.konanHome.value((kotlinCompileProvider.get() as KotlinNativeCompile).konanHome)
+                        cfg.konanHome.set(kotlinCompileProvider.flatMap { (it as KotlinNativeCompile).konanHome })
 
-                        val enableKlibsCrossCompilation = getKlibCrossCompilationSupport(project, kotlinCompilation)
-
-                        kspAATask.onlyIf {
-                            HostManager().enabled.any {
-                                it.name == konanTargetName
-                            } || enableKlibsCrossCompilation.getOrElse(false)
+                        val isHostSupported = HostManager().enabled.any {
+                            it.name == konanTargetName
+                        }
+                        if (!isHostSupported) {
+                            val isKlibCrossCompilationEnabled = getKlibCrossCompilationSupport(
+                                project,
+                                kotlinCompilation
+                            )
+                            kspAATask.onlyIf {
+                                isKlibCrossCompilationEnabled.get()
+                            }
                         }
                     }
 
@@ -443,23 +449,25 @@ abstract class KspAATask @Inject constructor(
 
         /**
          * Returns a Provider<Boolean> indicating whether klib cross-compilation is enabled.
-         * Prioritizes subproject-level overrides (e.g., subproject `ext` or `gradle.properties`),
-         * and falls back to the global Gradle property `kotlin.native.enableKlibsCrossCompilation`
-         * (defaulting to false if not configured).
+         * For Kotlin 2.3.20-Beta2+, uses KotlinNativeCompilation.crossCompilationSupported.
+         * For earlier versions, falls back to checking the gradle property kotlin.native.enableKlibsCrossCompilation.
          */
         private fun getKlibCrossCompilationSupport(
             project: Project,
             kotlinCompilation: KotlinNativeCompilation
         ): Provider<Boolean> {
-            val projectValue = project.findProperty("kotlin.native.enableKlibsCrossCompilation")?.toString()
+            val kotlinVersion = project.getKotlinPluginVersion()
+            val isSupportCrossCompilationPropertyAvailable =
+                KotlinToolingVersion(kotlinVersion) >= KotlinToolingVersion("2.3.20-Beta2")
 
-            return project.objects.property(Boolean::class.java)
-                .convention(
-                    project.providers.gradleProperty("kotlin.native.enableKlibsCrossCompilation")
-                        .orElse("false")
-                        .map { it.toBoolean() }
-                )
-                .value(projectValue?.toBoolean())
+            return if (isSupportCrossCompilationPropertyAvailable) {
+                kotlinCompilation.crossCompilationSupported
+            } else {
+                // Fallback for Kotlin versions before 2.3.20-Beta2
+                project.providers.gradleProperty(
+                    "kotlin.native.enableKlibsCrossCompilation"
+                ).orElse("false").map { it.toBoolean() }
+            }
         }
     }
 }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -77,7 +77,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.konan.target.HostManager
-import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.ObjectOutputStream
@@ -420,14 +419,12 @@ abstract class KspAATask @Inject constructor(
                         cfg.konanTargetName.value(konanTargetName)
                         cfg.konanHome.value((kotlinCompileProvider.get() as KotlinNativeCompile).konanHome)
 
-                        val isKlibCrossCompilationEnabled = getKlibCrossCompilationSupport(
-                            project,
-                            kotlinCompilation
-                        )
+                        val enableKlibsCrossCompilation = getKlibCrossCompilationSupport(project, kotlinCompilation)
+
                         kspAATask.onlyIf {
-                            isKlibCrossCompilationEnabled.get() || HostManager().enabled.any {
+                            HostManager().enabled.any {
                                 it.name == konanTargetName
-                            }
+                            } || enableKlibsCrossCompilation.getOrElse(false)
                         }
                     }
 
@@ -446,25 +443,23 @@ abstract class KspAATask @Inject constructor(
 
         /**
          * Returns a Provider<Boolean> indicating whether klib cross-compilation is enabled.
-         * For Kotlin 2.3.20-Beta2+, uses KotlinNativeCompilation.crossCompilationSupported.
-         * For earlier versions, falls back to checking the gradle property kotlin.native.enableKlibsCrossCompilation.
+         * Prioritizes subproject-level overrides (e.g., subproject `ext` or `gradle.properties`),
+         * and falls back to the global Gradle property `kotlin.native.enableKlibsCrossCompilation`
+         * (defaulting to false if not configured).
          */
         private fun getKlibCrossCompilationSupport(
             project: Project,
             kotlinCompilation: KotlinNativeCompilation
         ): Provider<Boolean> {
-            val kotlinVersion = project.getKotlinPluginVersion()
-            val isSupportCrossCompilationPropertyAvailable =
-                KotlinToolingVersion(kotlinVersion) >= KotlinToolingVersion("2.3.20-Beta2")
+            val projectValue = project.findProperty("kotlin.native.enableKlibsCrossCompilation")?.toString()
 
-            return if (isSupportCrossCompilationPropertyAvailable) {
-                kotlinCompilation.crossCompilationSupported
-            } else {
-                // Fallback for Kotlin versions before 2.3.20-Beta2
-                project.providers.gradleProperty(
-                    "kotlin.native.enableKlibsCrossCompilation"
-                ).orElse("false").map { it.toBoolean() }
-            }
+            return project.objects.property(Boolean::class.java)
+                .convention(
+                    project.providers.gradleProperty("kotlin.native.enableKlibsCrossCompilation")
+                        .orElse("false")
+                        .map { it.toBoolean() }
+                )
+                .value(projectValue?.toBoolean())
         }
     }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
@@ -289,8 +289,13 @@ class AnnoOnProperty {
     @Test
     fun testNativeConfigurationCacheReuse() {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
-        project.appendProperty("kotlin.native.enableKlibsCrossCompilation=false")
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        // Warmup build to download and extract Kotlin Native compiler
+        gradleRunner.withArguments(
+            "--no-configuration-cache",
+            ":workload-linuxX64:assemble"
+        ).build()
 
         // First run: calculates and stores configuration cache
         val result1 = gradleRunner.withArguments(
@@ -298,7 +303,10 @@ class AnnoOnProperty {
             "--configuration-cache-problems=fail",
             ":workload-linuxX64:assemble"
         ).build()
-        Assert.assertTrue(result1.output.contains("Configuration cache entry stored."))
+        Assert.assertTrue(
+            "Expected 'Configuration cache entry stored.' but output was:\n${result1.output}",
+            result1.output.contains("Configuration cache entry stored.")
+        )
 
         // Second run: should reuse the configuration cache
         val result2 = gradleRunner.withArguments(
@@ -306,14 +314,16 @@ class AnnoOnProperty {
             "--configuration-cache-problems=fail",
             ":workload-linuxX64:assemble"
         ).build()
-        Assert.assertTrue(result2.output.contains("Reusing configuration cache."))
+        Assert.assertTrue(
+            "Expected 'Reusing configuration cache.' but output was:\n${result2.output}",
+            result2.output.contains("Reusing configuration cache.")
+        )
     }
 
     @Test
     fun testSubprojectPropertyOverride() {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Mac", ignoreCase = true))
-        project.appendProperty("kotlin.native.enableKlibsCrossCompilation=false")
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         val buildScript = File(project.root, "workload-linuxX64/build.gradle.kts")
@@ -336,24 +346,21 @@ class AnnoOnProperty {
         // 2. Add kspIosArm64 dependency
         buildScript.appendText("\ndependencies {\n    add(\"kspIosArm64\", project(\":test-processor\"))\n}\n")
 
-        // 3. Run without KSP override. The iosArm64 task should be skipped.
+        // 3. Run without KSP override. The iosArm64 task should be run.
         val result1 = gradleRunner.withArguments(
             ":workload-linuxX64:kspKotlinIosArm64"
         ).build()
-        Assert.assertEquals(TaskOutcome.SKIPPED, result1.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, result1.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
 
-        // 4. Enable cross-compilation via subproject property override
-        buildScript.appendText(
-            """
-            ext["kotlin.native.enableKlibsCrossCompilation"] = "true"
-            """.trimIndent()
-        )
+        // 4. Disable cross-compilation via subproject property override
+        val subprojectProperties = File(project.root, "workload-linuxX64/gradle.properties")
+        subprojectProperties.writeText("kotlin.native.enableKlibsCrossCompilation=false")
 
-        // 5. Run with override. The iosArm64 task should execute successfully.
+        // 5. Run with override. The iosArm64 task should be skipped.
         val result2 = gradleRunner.withArguments(
             ":workload-linuxX64:kspKotlinIosArm64"
         ).build()
-        Assert.assertEquals(TaskOutcome.SUCCESS, result2.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
+        Assert.assertEquals(TaskOutcome.SKIPPED, result2.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
     }
 
     @Test

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
@@ -287,6 +287,76 @@ class AnnoOnProperty {
     }
 
     @Test
+    fun testNativeConfigurationCacheReuse() {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+        project.appendProperty("kotlin.native.enableKlibsCrossCompilation=false")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        // First run: calculates and stores configuration cache
+        val result1 = gradleRunner.withArguments(
+            "--configuration-cache",
+            "--configuration-cache-problems=fail",
+            ":workload-linuxX64:assemble"
+        ).build()
+        Assert.assertTrue(result1.output.contains("Configuration cache entry stored."))
+
+        // Second run: should reuse the configuration cache
+        val result2 = gradleRunner.withArguments(
+            "--configuration-cache",
+            "--configuration-cache-problems=fail",
+            ":workload-linuxX64:assemble"
+        ).build()
+        Assert.assertTrue(result2.output.contains("Reusing configuration cache."))
+    }
+
+    @Test
+    fun testSubprojectPropertyOverride() {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Mac", ignoreCase = true))
+        project.appendProperty("kotlin.native.enableKlibsCrossCompilation=false")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        val buildScript = File(project.root, "workload-linuxX64/build.gradle.kts")
+
+        // 1. Add iosArm64 target to build script
+        buildScript.writeText(
+            buildScript.readText().replace(
+                "linuxX64() {",
+                "linuxX64() {\n        binaries {\n            executable()\n        }\n    }\n    iosArm64() {"
+            )
+        )
+        val annotationsBuildScript = File(project.root, "annotations/build.gradle.kts")
+        annotationsBuildScript.writeText(
+            annotationsBuildScript.readText().replace(
+                "linuxX64() {",
+                "linuxX64() {\n    }\n    iosArm64() {"
+            )
+        )
+
+        // 2. Add kspIosArm64 dependency
+        buildScript.appendText("\ndependencies {\n    add(\"kspIosArm64\", project(\":test-processor\"))\n}\n")
+
+        // 3. Run without KSP override. The iosArm64 task should be skipped.
+        val result1 = gradleRunner.withArguments(
+            ":workload-linuxX64:kspKotlinIosArm64"
+        ).build()
+        Assert.assertEquals(TaskOutcome.SKIPPED, result1.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
+
+        // 4. Enable cross-compilation via subproject property override
+        buildScript.appendText(
+            """
+            ext["kotlin.native.enableKlibsCrossCompilation"] = "true"
+            """.trimIndent()
+        )
+
+        // 5. Run with override. The iosArm64 task should execute successfully.
+        val result2 = gradleRunner.withArguments(
+            ":workload-linuxX64:kspKotlinIosArm64"
+        ).build()
+        Assert.assertEquals(TaskOutcome.SUCCESS, result2.task(":workload-linuxX64:kspKotlinIosArm64")?.outcome)
+    }
+
+    @Test
     fun testLinuxX64() {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)


### PR DESCRIPTION
Querying KGP's `kotlinCompilation.crossCompilationSupported` eagerly writes a metadata JSON file inside the build directory during task graph serialization. This dynamic file creation invalidates the Gradle Configuration Cache on subsequent runs.

To fix:
1. Consolidated native cross-compilation support checking on KGP's standard kotlin.native.enableKlibsCrossCompilation property as the single source of truth.
2. Swapped the operands in the task `onlyIf` check so host native compiles (like linuxX64 on Linux) short-circuit immediately and skip querying the cross-compilation property entirely.
3. Added two integration tests to verify that the configuration cache now successfully reuses on native compilations, and that subproject DSL overrides are correctly captured and respected.

CC: @eygraber @liutikas 