### PR TITLE
Add unused test `allFunctions_kotlin`

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -64,7 +64,7 @@ abstract class KSPUnitTestSuite(
     @TestMetadata("allFunctions_kotlin.kt")
     @Test
     fun testAllFunctions_kotlin() {
-        runTest("$AA_PATH/allFunctions_java_inherits_kt.kt")
+        runTest("$AA_PATH/allFunctions_kotlin.kt")
     }
 
     @TestMetadata("allFunctions_kt_inherits_java.kt")

--- a/kotlin-analysis-api/testData/allFunctions_kotlin.kt
+++ b/kotlin-analysis-api/testData/allFunctions_kotlin.kt
@@ -17,6 +17,7 @@
 
 // WITH_RUNTIME
 // TEST PROCESSOR: AllFunctionsProcessor
+// EXPECTED:
 // class: Data
 // a
 // <init>(kotlin.String): Data
@@ -47,7 +48,6 @@
 // foo(kotlin.String ...): kotlin.Unit
 // hashCode(): kotlin.Int
 // toString(): kotlin.String
-// EXPECTED:
 // END
 // FILE: a.kt
 data class Data(val a: String) {
@@ -69,4 +69,3 @@ abstract class SuperAbstract {
 
     }
 }
-


### PR DESCRIPTION
This PR adds a test that was unused from the `test-utils` directory at moves it to the `kotlin-analysis-api/testData` directory.. It seems like there was a unit test that was meant to test it but specified a different file path.

Related to https://github.com/google/ksp/issues/2940