### PR TITLE
Fix invalid test

### DIFF
--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotations.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotations.kt
@@ -39,13 +39,14 @@
 
 // FILE: Main.kt
 
+@file:[Anno1 Anno2]
+
 annotation class Anno1
 
 annotation class Anno2
 
 annotation class Anno3
 
-@file:[Anno1 Anno2]
 @[Anno1 Anno2 Anno3]
 class MyClass(
     @param:[Anno1 Anno3] val paramWithAnno1AndAnno3,


### PR DESCRIPTION
The 'groupedAnnotations' test was invalid, because the file use-site annotation target was placed after the first declaration of the main file. The Kotlin documentation explicitly mentions that file-level annotations must be placed before package directives or imports.