### PR TITLE
Fix invalid test

### DIFF
--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/useSiteTargets.kt
@@ -58,10 +58,10 @@ annotation class FileAnno
 
 // FILE: TargetFile.kt
 
+@file:FileAnno
+
 import com.example.Anno
 import com.example.FileAnno
-
-@file:FileAnno
 
 @Anno
 class TargetClass(


### PR DESCRIPTION
The 'useSiteTargets' test was invalid, because the file use-site annotation target was placed after the first declaration of the main file. The Kotlin documentation explicitly mentions that file-level annotations must be placed before package directives or imports.