### PR TITLE
Log resolution trace and lookups

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -28,6 +28,7 @@ import com.intellij.psi.PsiImportStatement
 import com.intellij.psi.PsiJavaFile
 import com.intellij.psi.PsiPackage
 import com.intellij.util.containers.MultiMap
+import java.io.Closeable
 import java.io.File
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
@@ -86,7 +87,7 @@ abstract class IncrementalContextBase(
     private val rebuild = !cachesUpToDateFile.exists()
 
     private val logsDir = File(cachesDir, "logs").apply { mkdirs() }
-    private val buildTime = Date().time
+    protected val buildTime = Date().time
 
     private val modified = knownModified.map { it.relativeTo(baseDir) }.toSet()
     private val removed = knownRemoved.map { it.relativeTo(baseDir) }.toSet()
@@ -103,15 +104,19 @@ abstract class IncrementalContextBase(
 
     private val onDemandImportsCache = ConcurrentHashMap<PsiJavaFile, List<String>>()
 
+    protected val logFiles: MutableList<Closeable> = mutableListOf()
+
     private fun String.toRelativeFile(): File {
         val file = File(this)
         val absFile = if (file.isAbsolute) file else File(baseDir, this)
         return absFile.absoluteFile.relativeTo(baseDir.absoluteFile)
     }
+
     private fun File.toRelativeFile(): File {
         val absFile = if (this.isAbsolute) this else File(baseDir, this.path)
         return absFile.absoluteFile.relativeTo(baseDir.absoluteFile)
     }
+
     private val KSFile.relativeFile
         get() = filePath.toRelativeFile()
 
@@ -152,8 +157,7 @@ abstract class IncrementalContextBase(
         if (!incrementalLog)
             return
 
-        val logFile = File(logsDir, "kspSourceToOutputs.log")
-        logFile.appendText("=== Build $buildTime ===\n")
+        val logFile = mkLogFile("kspSourceToOutputs.log")
         logFile.appendText("Accumulated source to outputs map\n")
         sourceToOutputsMap.keys.forEach { source ->
             logFile.appendText("  $source:\n")
@@ -191,8 +195,7 @@ abstract class IncrementalContextBase(
         if (!incrementalLog)
             return
 
-        val logFile = File(logsDir, "kspDirtySet.log")
-        logFile.appendText("=== Build $buildTime ===\n")
+        val logFile = mkLogFile("kspDirtySet.log")
         logFile.appendText("All Files\n")
         allFiles.forEach { logFile.appendText("  ${it.relativeFile}\n") }
         logFile.appendText("Modified\n")
@@ -325,7 +328,7 @@ abstract class IncrementalContextBase(
             sourceToOutputsMap[src] = outs.toList()
         }
 
-        logSourceToOutputs(outputs, sourceToOutputs)
+        logBeforeCacheFlush(outputs, sourceToOutputs)
 
         sourceToOutputsMap.flush()
     }
@@ -423,6 +426,7 @@ abstract class IncrementalContextBase(
         symbolLookupCache.close()
         classLookupCache.close()
         sourceToOutputsMap.flush()
+        logFiles.forEach { it.close() }
     }
 
     // TODO: add a wildcard for outputs with no source and get rid of the outputs parameter.
@@ -540,6 +544,21 @@ abstract class IncrementalContextBase(
             ?.let { it.substring(0, (it.length - name.length - 1).coerceAtLeast(0)) } ?: return
         updatedSealed.putValue(classDeclaration.containingFile!!.relativeFile, LookupSymbolWrapper(name, scope))
     }
+
+    protected open fun logBeforeCacheFlush(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
+        logSourceToOutputs(outputs, sourceToOutputs)
+    }
+
+    protected fun mkFileInLogDir(fileName: String): File =
+        File(logsDir, fileName)
+            .also {
+                if (it.delete()) {
+                    it.createNewFile()
+                }
+            }
+
+    protected fun mkLogFile(fileName: String): File = mkFileInLogDir(fileName)
+        .also { it.appendText("=== Build $buildTime ===\n") }
 }
 
 internal class DirtinessPropagator(

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -157,31 +157,32 @@ abstract class IncrementalContextBase(
         if (!incrementalLog)
             return
 
-        val logFile = mkLogFile("kspSourceToOutputs.log")
-        logFile.appendText("Accumulated source to outputs map\n")
-        sourceToOutputsMap.keys.forEach { source ->
-            logFile.appendText("  $source:\n")
-            sourceToOutputsMap[source]!!.forEach { output ->
-                logFile.appendText("    $output\n")
+        mkLogFile("kspSourceToOutputs.log").bufferedWriter().use { logFile ->
+            logFile.write("Accumulated source to outputs map\n")
+            sourceToOutputsMap.keys.forEach { source ->
+                logFile.write("  $source:\n")
+                sourceToOutputsMap[source]!!.forEach { output ->
+                    logFile.write("    $output\n")
+                }
             }
-        }
-        logFile.appendText("\n")
+            logFile.write("\n")
 
-        logFile.appendText("Reprocessed sources and their outputs\n")
-        sourceToOutputs.forEach { (source, outputs) ->
-            logFile.appendText("  $source:\n")
+            logFile.write("Reprocessed sources and their outputs\n")
+            sourceToOutputs.forEach { (source, outputs) ->
+                logFile.write("  $source:\n")
+                outputs.forEach {
+                    logFile.write("    $it\n")
+                }
+            }
+            logFile.write("\n")
+
+            // Can be larger than the union of the above, because some outputs may have no source.
+            logFile.write("All reprocessed outputs\n")
             outputs.forEach {
-                logFile.appendText("    $it\n")
+                logFile.write("  $it\n")
             }
+            logFile.write("\n")
         }
-        logFile.appendText("\n")
-
-        // Can be larger than the union of the above, because some outputs may have no source.
-        logFile.appendText("All reprocessed outputs\n")
-        outputs.forEach {
-            logFile.appendText("  $it\n")
-        }
-        logFile.appendText("\n")
     }
 
     private fun logDirtyFiles(
@@ -195,29 +196,30 @@ abstract class IncrementalContextBase(
         if (!incrementalLog)
             return
 
-        val logFile = mkLogFile("kspDirtySet.log")
-        logFile.appendText("All Files\n")
-        allFiles.forEach { logFile.appendText("  ${it.relativeFile}\n") }
-        logFile.appendText("Modified\n")
-        modified.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Removed\n")
-        removed.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Disappeared Outputs\n")
-        removedOutputs.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Affected By CP\n")
-        dirtyFilesByCP.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Affected By new syms\n")
-        dirtyFilesByNewSyms.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Affected By sealed\n")
-        dirtyFilesBySealed.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("CP changes\n")
-        changedClasses.forEach { logFile.appendText("  $it\n") }
-        logFile.appendText("Dirty:\n")
-        files.forEach {
-            logFile.appendText("  ${it.relativeFile}\n")
+        mkLogFile("kspDirtySet.log").bufferedWriter().use { logFile ->
+            logFile.write("All Files\n")
+            allFiles.forEach { logFile.write("  ${it.relativeFile}\n") }
+            logFile.write("Modified\n")
+            modified.forEach { logFile.write("  $it\n") }
+            logFile.write("Removed\n")
+            removed.forEach { logFile.write("  $it\n") }
+            logFile.write("Disappeared Outputs\n")
+            removedOutputs.forEach { logFile.write("  $it\n") }
+            logFile.write("Affected By CP\n")
+            dirtyFilesByCP.forEach { logFile.write("  $it\n") }
+            logFile.write("Affected By new syms\n")
+            dirtyFilesByNewSyms.forEach { logFile.write("  $it\n") }
+            logFile.write("Affected By sealed\n")
+            dirtyFilesBySealed.forEach { logFile.write("  $it\n") }
+            logFile.write("CP changes\n")
+            changedClasses.forEach { logFile.write("  $it\n") }
+            logFile.write("Dirty:\n")
+            files.forEach {
+                logFile.write("  ${it.relativeFile}\n")
+            }
+            val percentage = "%.2f".format(files.size.toDouble() / allFiles.size.toDouble() * 100)
+            logFile.write("\nDirty / All: $percentage%\n\n")
         }
-        val percentage = "%.2f".format(files.size.toDouble() / allFiles.size.toDouble() * 100)
-        logFile.appendText("\nDirty / All: $percentage%\n\n")
     }
 
     // Beware: no side-effects here; Caches should only be touched in updateCaches.

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
@@ -60,6 +60,7 @@ import org.jetbrains.kotlin.incremental.components.ScopeKind
 import org.jetbrains.kotlin.incremental.storage.FileToPathConverter
 import org.jetbrains.kotlin.incremental.update
 import java.io.File
+import java.io.Writer
 
 class IncrementalContextAA(
     override val isIncremental: Boolean,
@@ -86,14 +87,37 @@ class IncrementalContextAA(
     private val icContext = IncrementalCompilationContext(PATH_CONVERTER, PATH_CONVERTER, true)
 
     private val symbolLookupCacheDir = File(cachesDir, "symbolLookups")
+
+    private val symbolTrackerLogFile: Writer? =
+        if (this.incrementalLog) {
+            mkLogFile("symbolTrackerTrace.log").bufferedWriter()
+                .also { logFiles.add(it) }
+        } else {
+            null
+        }
+
+    private val classTrackerLogFile: Writer? =
+        if (this.incrementalLog) {
+            mkLogFile("enumClassTrackerTrace.log").bufferedWriter()
+                .also { logFiles.add(it) }
+        } else {
+            null
+        }
+
     override val symbolLookupTracker =
-        LookupTrackerWrapperImpl((lookupTracker as? DualLookupTracker)?.symbolTracker ?: LookupTracker.DO_NOTHING)
+        LookupTrackerWrapperImpl(
+            (lookupTracker as? DualLookupTracker)?.symbolTracker ?: LookupTracker.DO_NOTHING,
+            symbolTrackerLogFile
+        )
     override val symbolLookupCache = LookupStorageWrapperImpl(LookupStorage(symbolLookupCacheDir, icContext))
 
     // TODO: rewrite LookupStorage to share file-to-id, etc.
     private val classLookupCacheDir = File(cachesDir, "classLookups")
     override val classLookupTracker =
-        LookupTrackerWrapperImpl((lookupTracker as? DualLookupTracker)?.classTracker ?: LookupTracker.DO_NOTHING)
+        LookupTrackerWrapperImpl(
+            (lookupTracker as? DualLookupTracker)?.classTracker ?: LookupTracker.DO_NOTHING,
+            classTrackerLogFile
+        )
     override val classLookupCache = LookupStorageWrapperImpl(LookupStorage(classLookupCacheDir, icContext))
 
     // Debugging and testing only.
@@ -101,7 +125,11 @@ class IncrementalContextAA(
         val map = mutableMapOf<String, List<String>>()
         symbolLookupTracker.lookups.entrySet().forEach { e ->
             val key = "${e.key.scope}.${e.key.name}"
-            map[key] = e.value.map { PATH_CONVERTER.toFile(it).path }
+            map[key] = e.value.map {
+                // Safely try to relativize, since it may fail on Windows
+                // where it and baseDir have different roots.
+                File(it).relativeToOrNull(baseDir)?.path ?: it
+            }
         }
         return map
     }
@@ -115,23 +143,28 @@ class IncrementalContextAA(
                 val fqn = type.classId.asFqNameString()
                 recordLookup(file, fqn)
             }
+
             is KaFlexibleType -> {
                 recordWithArgs(type.lowerBound, file)
                 recordWithArgs(type.upperBound, file)
             }
+
             is KaIntersectionType -> {
                 type.conjuncts.forEach {
                     recordWithArgs(it, file)
                 }
             }
+
             is KaCapturedType -> {
                 type.projection.type?.let {
                     recordWithArgs(it, file)
                 }
             }
+
             is KaDefinitelyNotNullType -> {
                 recordWithArgs(type.original, file)
             }
+
             is KaErrorType, is KaDynamicType, is KaTypeParameterType -> {}
         }
     }
@@ -238,6 +271,27 @@ class IncrementalContextAA(
             record(ktType)
         }
     }
+
+    override fun logBeforeCacheFlush(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
+        super.logBeforeCacheFlush(outputs, sourceToOutputs)
+        logLookupGraph()
+        logFiles.forEach { it.close() }
+    }
+
+    private fun logLookupGraph() {
+        if (!incrementalLog) {
+            return
+        }
+
+        mkLogFile("kspLookupGraph.log").bufferedWriter().use { logFile ->
+            val lookupRecords = dumpLookupRecords()
+            lookupRecords.forEach { (fqn, paths) ->
+                paths.forEach {
+                    logFile.write("$it -> $fqn\n")
+                }
+            }
+        }
+    }
 }
 
 internal fun recordLookup(ktType: KaType, context: KSNode?) =
@@ -265,7 +319,7 @@ internal fun recordGetSealedSubclasses(classDeclaration: KSClassDeclaration) {
     }
 }
 
-class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker) : LookupTrackerWrapper {
+class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker, val trackerLogFile: Writer?) : LookupTrackerWrapper {
     override val lookups: MultiMap<LookupSymbolWrapper, String>
         get() = MultiMap<LookupSymbolWrapper, String>().also { wrapper ->
             (lookupTracker as LookupTrackerImpl).lookups.entrySet().forEach { e ->
@@ -274,6 +328,7 @@ class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker) : LookupTracker
         }
 
     override fun record(filePath: String, scopeFqName: String, name: String) {
+        trackerLogFile?.write("$scopeFqName.$name $filePath\n")
         lookupTracker.record(filePath, Position.NO_POSITION, scopeFqName, ScopeKind.PACKAGE, name)
     }
 }


### PR DESCRIPTION
This PR adds a new log file to the logs for incremental builds including which symbols were looked up by which files. Additionally, the lookup graph is now both written as a log and as a graphviz file.