### PR TITLE
Fix invalid test

### DIFF
--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotationsWithUseSiteTargets.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/groupedAnnotationsWithUseSiteTargets.kt
@@ -53,13 +53,14 @@
 
 // FILE: Main.kt
 
+@file:[Anno1 Anno2]
+
 annotation class Anno1
 
 annotation class Anno2
 
 annotation class Anno3
 
-@file:[Anno1 Anno2]
 @[Anno1 Anno2 Anno3]
 class MyClass(
     @param:[Anno1 Anno3] val paramWithAnno1AndAnno3: Int,


### PR DESCRIPTION
The 'groupedAnnotationsWithUseSiteTargets' test was invalid, because the file use-site annotation target was placed after the first declaration of the main file. The Kotlin documentation explicitly mentions that file-level annotations must be placed before package directives or imports.