### PR TITLE
fix: sanitize ':' in internal-name module suffix so KSP 2.3.9 works with Kotlin 2.4.0 default module names

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -142,6 +142,7 @@ import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.JvmStandardClassIds
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME
 import org.jetbrains.kotlin.name.JvmStandardClassIds.JVM_WILDCARD_ANNOTATION_FQ_NAME
+import org.jetbrains.kotlin.name.NameUtils
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtParameter
@@ -1197,7 +1198,7 @@ internal val KaDeclarationSymbol.internalSuffix: String
             else -> {}
         }
 
-        fun String.toSuffix(): String = "\$$this".replace('.', '_').replace('-', '_')
+        fun String.toSuffix(): String = "\$${NameUtils.sanitizeAsJavaIdentifier(this)}"
         when (val module = containingModule) {
             is KaSourceModule -> module.name.toSuffix()
             is KaLibraryModule -> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -43,6 +43,11 @@ import java.io.PrintStream
 import java.net.URLClassLoader
 
 abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : AbstractKSPTest(FrontendKinds.FIR) {
+    private companion object {
+        const val MODULE = "// MODULE:"
+        const val COMPILER_MODULE_NAME = "// COMPILER MODULE NAME:"
+    }
+
     val TestModule.kotlinSrc
         get() = File(testRoot, "kotlinSrc")
 
@@ -54,6 +59,26 @@ abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : Abstr
                 it.writeText(file.originalContent)
             }
         }
+    }
+
+    private fun TestModule.compilerModuleName(): String {
+        val originalFile = files.firstOrNull()?.originalFile ?: return name
+        var currentModule: String? = null
+        var compilerModuleName: String? = null
+        originalFile.forEachLine { line ->
+            when {
+                line.startsWith(MODULE) -> {
+                    currentModule = line.substringAfter(MODULE).substringBefore("(").trim()
+                }
+
+                currentModule == name && line.startsWith(COMPILER_MODULE_NAME) -> {
+                    if (compilerModuleName == null) {
+                        compilerModuleName = line.substringAfter(COMPILER_MODULE_NAME).trim()
+                    }
+                }
+            }
+        }
+        return compilerModuleName ?: name
     }
 
     private fun compileKotlin(
@@ -101,7 +126,14 @@ abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : Abstr
         val jvmTarget = testServices.compilerConfigurationProvider
             .getCompilerConfiguration(module, CompilationStage.FIRST)
             .get(JVMConfigurationKeys.JVM_TARGET)
-        compileKotlin(dependencies, module.kotlinSrc.path, module.javaDir.path, module.outDir, module.name, jvmTarget)
+        compileKotlin(
+            dependencies,
+            module.kotlinSrc.path,
+            module.javaDir.path,
+            module.outDir,
+            module.compilerModuleName(),
+            jvmTarget
+        )
         val classpath = (dependencies + KtTestUtil.getAnnotationsJar() + module.outDir)
             .joinToString(File.pathSeparator) { it.absolutePath }
         val options = listOf(
@@ -133,7 +165,7 @@ abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : Abstr
         val testRoot = mainModule.testRoot
 
         val kspConfig = KSPJvmConfig.Builder().apply {
-            moduleName = mainModule.name
+            moduleName = mainModule.compilerModuleName()
             sourceRoots = listOf(mainModule.kotlinSrc)
             javaSourceRoots = compilerConfiguration.javaSourceRoots.map { File(it) }.toList()
             jdkHome = compilerConfiguration.get(JVMConfigurationKeys.JDK_HOME)

--- a/kotlin-analysis-api/testData/mangledNames.kt
+++ b/kotlin-analysis-api/testData/mangledNames.kt
@@ -34,10 +34,10 @@
 // get-abstractVal -> getAbstractVal
 // get-abstractVar -> getAbstractVar
 // set-abstractVar -> setAbstractVar
-// get-internalAbstractVal -> getInternalAbstractVal$mainModule_abc
-// set-internalAbstractVal -> setInternalAbstractVal$mainModule_abc
-// get-internalAbstractVar -> getInternalAbstractVar$mainModule_abc
-// set-internalAbstractVar -> setInternalAbstractVar$mainModule_abc
+// get-internalAbstractVal -> getInternalAbstractVal$mainModule_abc_feature
+// set-internalAbstractVal -> setInternalAbstractVal$mainModule_abc_feature
+// get-internalAbstractVar -> getInternalAbstractVar$mainModule_abc_feature
+// set-internalAbstractVar -> setInternalAbstractVar$mainModule_abc_feature
 // mainPackage.Anno -> declarations
 // get-a -> a
 // mainPackage.Foo -> declarations
@@ -46,12 +46,12 @@
 // set-inlineProp -> setInlineProp-E03SJzc
 // inlineReceivingFun -> inlineReceivingFun-E03SJzc
 // inlineReturningFun -> inlineReturningFun-HRn7Rpw
-// get-internalInlineProp -> getInternalInlineProp-HRn7Rpw$mainModule_abc
-// set-internalInlineProp -> setInternalInlineProp-E03SJzc$mainModule_abc
-// internalInlineReceivingFun -> internalInlineReceivingFun-E03SJzc$mainModule_abc
-// internalInlineReturningFun -> internalInlineReturningFun-HRn7Rpw$mainModule_abc
-// get-internalProp -> getInternalProp$mainModule_abc
-// set-internalProp -> setInternalProp$mainModule_abc
+// get-internalInlineProp -> getInternalInlineProp-HRn7Rpw$mainModule_abc_feature
+// set-internalInlineProp -> setInternalInlineProp-E03SJzc$mainModule_abc_feature
+// internalInlineReceivingFun -> internalInlineReceivingFun-E03SJzc$mainModule_abc_feature
+// internalInlineReturningFun -> internalInlineReturningFun-HRn7Rpw$mainModule_abc_feature
+// get-internalProp -> getInternalProp$mainModule_abc_feature
+// set-internalProp -> setInternalProp$mainModule_abc_feature
 // get-jvmNameProp -> explicitGetterName
 // set-jvmNameProp -> explicitSetterName
 // normalFun -> normalFun
@@ -73,12 +73,12 @@
 // set-inlineProp -> setInlineProp-mQ73O9w
 // inlineReceivingFun -> inlineReceivingFun-mQ73O9w
 // inlineReturningFun -> inlineReturningFun-b_MPbnQ
-// get-internalInlineProp -> getInternalInlineProp-b_MPbnQ$lib_xyz_abc
-// set-internalInlineProp -> setInternalInlineProp-mQ73O9w$lib_xyz_abc
-// internalInlineReceivingFun -> internalInlineReceivingFun-mQ73O9w$lib_xyz_abc
-// internalInlineReturningFun -> internalInlineReturningFun-b_MPbnQ$lib_xyz_abc
-// get-internalProp -> getInternalProp$lib_xyz_abc
-// set-internalProp -> setInternalProp$lib_xyz_abc
+// get-internalInlineProp -> getInternalInlineProp-b_MPbnQ$lib_xyz_abc_feature
+// set-internalInlineProp -> setInternalInlineProp-mQ73O9w$lib_xyz_abc_feature
+// internalInlineReceivingFun -> internalInlineReceivingFun-mQ73O9w$lib_xyz_abc_feature
+// internalInlineReturningFun -> internalInlineReturningFun-b_MPbnQ$lib_xyz_abc_feature
+// get-internalProp -> getInternalProp$lib_xyz_abc_feature
+// set-internalProp -> setInternalProp$lib_xyz_abc_feature
 // get-jvmNameProp -> explicitGetterName
 // set-jvmNameProp -> explicitSetterName
 // normalFun -> normalFun
@@ -88,16 +88,16 @@
 // get-abstractVal -> getAbstractVal
 // get-abstractVar -> getAbstractVar
 // set-abstractVar -> setAbstractVar
-// get-internalAbstractVal -> getInternalAbstractVal$lib_xyz_abc
-// set-internalAbstractVal -> setInternalAbstractVal$lib_xyz_abc
-// get-internalAbstractVar -> getInternalAbstractVar$lib_xyz_abc
-// set-internalAbstractVar -> setInternalAbstractVar$lib_xyz_abc
+// get-internalAbstractVal -> getInternalAbstractVal$lib_xyz_abc_feature
+// set-internalAbstractVal -> setInternalAbstractVal$lib_xyz_abc_feature
+// get-internalAbstractVar -> getInternalAbstractVar$lib_xyz_abc_feature
+// set-internalAbstractVar -> setInternalAbstractVar$lib_xyz_abc_feature
 // libPackage.MyInterface -> declarations
 // get-x -> getX
 // get-y -> getY
 // set-y -> setY
 // END
-// MODULE: lib.xyz-abc
+// MODULE: lib.xyz-abc:feature
 // FILE: input.kt
 /**
  * control group
@@ -132,7 +132,7 @@ interface MyInterface {
     val x:Int
     var y:Int
 }
-// MODULE: mainModule.abc(lib.xyz-abc)
+// MODULE: mainModule.abc:feature(lib.xyz-abc:feature)
 // FILE: input.kt
 package mainPackage;
 inline class Inline1(val value:String)

--- a/kotlin-analysis-api/testData/mangledNames.kt
+++ b/kotlin-analysis-api/testData/mangledNames.kt
@@ -97,7 +97,8 @@
 // get-y -> getY
 // set-y -> setY
 // END
-// MODULE: lib.xyz-abc:feature
+// MODULE: lib.xyz-abc_feature
+// COMPILER MODULE NAME: lib.xyz-abc:feature
 // FILE: input.kt
 /**
  * control group
@@ -132,7 +133,8 @@ interface MyInterface {
     val x:Int
     var y:Int
 }
-// MODULE: mainModule.abc:feature(lib.xyz-abc:feature)
+// MODULE: mainModule.abc_feature(lib.xyz-abc_feature)
+// COMPILER MODULE NAME: mainModule.abc:feature
 // FILE: input.kt
 package mainPackage;
 inline class Inline1(val value:String)


### PR DESCRIPTION
## Summary

KSP's `internal`-member name mangling now sanitizes the module-name suffix the same way the Kotlin compiler does, instead of replacing only `.` and `-`. Kotlin 2.4.0's consistent `${project.group}:${project.name}` default module names inject a literal `:` into the mangled JVM name, and downstream processors that build generated class names from KSP's reported JVM name fail with `Can't escape identifier ... because it contains illegal characters: :` (the Dagger/Hilt report in #2964).

## Why this matters

KSP's reported JVM names need to agree byte-for-byte with what kotlinc actually emits. The compiler already solved the analogous problem for `.kotlin_module` files (KT-69701) with `NameUtils.sanitizeAsJavaIdentifier`; `toSuffix` in `kotlin-analysis-api/.../util.kt` now applies the same sanitization, covering both the `KaSourceModule` and `KaLibraryModule` branches. The workarounds in the issue thread (drop `internal`, override `moduleName`) stop being necessary.

## Testing

`mangledNames.kt` test data now covers a module name carrying `:` and other non-identifier characters. The colon-bearing compiler module name is passed through a test-harness hook (`AbstractKSPAATest`) rather than the test module directory name, so the Windows CI leg, where `:` is illegal in path components, is unaffected.

Fixes #2964
