### PR TITLE
Fix KSP2 incremental cache path normalization mismatch

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/BuildCacheIncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/BuildCacheIncrementalIT.kt
@@ -28,24 +28,48 @@ class BuildCacheIncrementalIT(experimentalPsiResolution: Boolean) {
     fun testIncrementalBuildCache() {
         val buildCacheDir = File(project.root, "build-cache").absolutePath.replace(File.separatorChar, '/')
         File(project.root, "gradle.properties").appendText("\nbuildCacheDir=$buildCacheDir")
+        File(project.root, "gradle.properties").appendText("\norg.gradle.caching=true")
 
-        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).forwardOutput()
         val k1 = "workload/src/main/kotlin/p1/K1.kt"
         val k2 = "workload/src/main/kotlin/p1/K2.kt"
+        val app = "workload/src/main/kotlin/p1/App.kt"
 
-        gradleRunner.withArguments("assemble", "--stacktrace").build()
-
-        File(project.root, k2).writeText(
-            "package p1\n\n@MyAnnotation\nclass K2\n"
+        // App depends on K1Generated
+        File(project.root, app).writeText(
+            """
+            package p1
+            class App {
+                val k1Gen = K1Generated()
+            }
+            """.trimIndent()
         )
+
+        // Build 1: Initial clean build. Should generate K1Generated.kt.
+        println("--- BUILD 1 (Clean) ---")
         gradleRunner.withArguments("assemble", "--stacktrace").build()
 
-        File(project.root, k2).delete()
-        gradleRunner.withArguments("assemble", "--stacktrace").build()
-
+        // Modify K1.kt to remove annotation. K1.kt is now dirty.
+        // Since K1.kt is dirty, K1Generated.kt (associated with K1.kt) should NOT be restored.
+        // And since K1.kt no longer has the annotation, K1Generated.kt should NOT be regenerated.
+        // So K1Generated.kt should be gone.
+        // App.kt depends on K1Generated, so the build should FAIL.
         File(project.root, k1).writeText(
-            "package p1\n\nclass K1(val foo: String)\n"
+            """
+            package p1
+            class K1
+            """.trimIndent()
         )
-        gradleRunner.withArguments("assemble", "--stacktrace").build()
+
+        println("--- BUILD 2 (Incremental after modifying K1 to remove annotation) ---")
+        // We expect this to fail because K1Generated is missing.
+        // If it succeeds, it means K1Generated was incorrectly restored (bug).
+        val result = gradleRunner.withArguments("assemble", "--stacktrace").buildAndFail()
+        assert(result.output.contains("Unresolved reference 'K1Generated'") || result.output.contains("Unresolved reference: K1Generated")) {
+            "Expected build to fail with Unresolved reference 'K1Generated', but got: ${result.output}"
+        }
+        println("--- BUILD 2 FAILED AS EXPECTED (K1Generated was correctly not restored) ---")
+
+
     }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/BuildCacheIncrementalIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/BuildCacheIncrementalIT.kt
@@ -28,11 +28,36 @@ class BuildCacheIncrementalIT(experimentalPsiResolution: Boolean) {
     fun testIncrementalBuildCache() {
         val buildCacheDir = File(project.root, "build-cache").absolutePath.replace(File.separatorChar, '/')
         File(project.root, "gradle.properties").appendText("\nbuildCacheDir=$buildCacheDir")
+
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        val k1 = "workload/src/main/kotlin/p1/K1.kt"
+        val k2 = "workload/src/main/kotlin/p1/K2.kt"
+
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
+
+        File(project.root, k2).writeText(
+            "package p1\n\n@MyAnnotation\nclass K2\n"
+        )
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
+
+        File(project.root, k2).delete()
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
+
+        File(project.root, k1).writeText(
+            "package p1\n\nclass K1(val foo: String)\n"
+        )
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
+    }
+
+    // See https://github.com/google/ksp/issues/2854 for details
+    @Test
+    fun testIncrementalBuildCacheStaleOutputsPurged() {
+        val buildCacheDir = File(project.root, "build-cache").absolutePath.replace(File.separatorChar, '/')
+        File(project.root, "gradle.properties").appendText("\nbuildCacheDir=$buildCacheDir")
         File(project.root, "gradle.properties").appendText("\norg.gradle.caching=true")
 
         val gradleRunner = GradleRunner.create().withProjectDir(project.root).forwardOutput()
         val k1 = "workload/src/main/kotlin/p1/K1.kt"
-        val k2 = "workload/src/main/kotlin/p1/K2.kt"
         val app = "workload/src/main/kotlin/p1/App.kt"
 
         // App depends on K1Generated
@@ -46,7 +71,6 @@ class BuildCacheIncrementalIT(experimentalPsiResolution: Boolean) {
         )
 
         // Build 1: Initial clean build. Should generate K1Generated.kt.
-        println("--- BUILD 1 (Clean) ---")
         gradleRunner.withArguments("assemble", "--stacktrace").build()
 
         // Modify K1.kt to remove annotation. K1.kt is now dirty.
@@ -61,15 +85,67 @@ class BuildCacheIncrementalIT(experimentalPsiResolution: Boolean) {
             """.trimIndent()
         )
 
-        println("--- BUILD 2 (Incremental after modifying K1 to remove annotation) ---")
         // We expect this to fail because K1Generated is missing.
         // If it succeeds, it means K1Generated was incorrectly restored (bug).
         val result = gradleRunner.withArguments("assemble", "--stacktrace").buildAndFail()
-        assert(result.output.contains("Unresolved reference 'K1Generated'") || result.output.contains("Unresolved reference: K1Generated")) {
+        assert(
+            result.output.contains("Unresolved reference 'K1Generated'") ||
+                result.output.contains("Unresolved reference: K1Generated")
+        ) {
             "Expected build to fail with Unresolved reference 'K1Generated', but got: ${result.output}"
         }
-        println("--- BUILD 2 FAILED AS EXPECTED (K1Generated was correctly not restored) ---")
+    }
 
+    // See https://github.com/google/ksp/issues/2854 for details
+    @Test
+    fun testIncrementalBuildCacheCleanOutputsPreserved() {
+        val buildCacheDir = File(project.root, "build-cache").absolutePath.replace(File.separatorChar, '/')
+        File(project.root, "gradle.properties").appendText("\nbuildCacheDir=$buildCacheDir")
+        File(project.root, "gradle.properties").appendText("\norg.gradle.caching=true")
 
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root).forwardOutput()
+        val k1 = "workload/src/main/kotlin/p1/K1.kt"
+        val k2 = "workload/src/main/kotlin/p1/K2.kt"
+
+        // Create K2.kt with annotation
+        File(project.root, k2).writeText(
+            """
+            package p1
+            @MyAnnotation
+            class K2
+            """.trimIndent()
+        )
+
+        // K1 depends on K2Generated (which is generated from K2.kt)
+        File(project.root, k1).writeText(
+            """
+            package p1
+            @MyAnnotation
+            class K1 {
+                val k2Gen: K2Generated? = null
+            }
+            """.trimIndent()
+        )
+
+        // Build 1: Initial clean build. Should generate K1Generated.kt and K2Generated.kt.
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
+
+        // Modify K1.kt but KEEP annotation and dependency. K1.kt is dirty, K2.kt is clean.
+        // Since K2.kt is clean, K2Generated.kt should be preserved/restored from cache.
+        // K1.kt depends on K2Generated, so the build should SUCCEED.
+        File(project.root, k1).writeText(
+            """
+            package p1
+            @MyAnnotation
+            class K1 {
+                val k2Gen: K2Generated? = null
+                val change = 1
+            }
+            """.trimIndent()
+        )
+
+        // We expect this to succeed because K2Generated should be preserved.
+        // If it fails with "Unresolved reference 'K2Generated'", it means K2Generated was lost (bug).
+        gradleRunner.withArguments("assemble", "--stacktrace").build()
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -103,7 +103,15 @@ abstract class IncrementalContextBase(
 
     private val onDemandImportsCache = ConcurrentHashMap<PsiJavaFile, List<String>>()
 
-    private fun String.toRelativeFile() = File(this).relativeTo(baseDir)
+    private fun String.toRelativeFile(): File {
+        val file = File(this)
+        val absFile = if (file.isAbsolute) file else File(baseDir, this)
+        return absFile.absoluteFile.relativeTo(baseDir.absoluteFile)
+    }
+    private fun File.toRelativeFile(): File {
+        val absFile = if (this.isAbsolute) this else File(baseDir, this.path)
+        return absFile.absoluteFile.relativeTo(baseDir.absoluteFile)
+    }
     private val KSFile.relativeFile
         get() = filePath.toRelativeFile()
 
@@ -232,7 +240,7 @@ abstract class IncrementalContextBase(
         }
 
         val dirtyFilesByNewSyms = newSyms.flatMap {
-            symbolLookupCache[it].map(::File)
+            symbolLookupCache[it].map { it.toRelativeFile() }
         }
 
         val dirtyFilesBySealed = sealedMap.keys
@@ -241,8 +249,8 @@ abstract class IncrementalContextBase(
         val dirtyFilesByCP = changedClasses.flatMap { fqn ->
             val name = fqn.substringAfterLast('.')
             val scope = fqn.substringBeforeLast('.', "<anonymous>")
-            classLookupCache[LookupSymbolWrapper(name, scope)].map { File(it) } +
-                symbolLookupCache[LookupSymbolWrapper(name, scope)].map { File(it) }
+            classLookupCache[LookupSymbolWrapper(name, scope)].map { it.toRelativeFile() } +
+                symbolLookupCache[LookupSymbolWrapper(name, scope)].map { it.toRelativeFile() }
         }.toSet()
 
         // output files that exist in CURR~2 but not in CURR~1
@@ -441,7 +449,8 @@ abstract class IncrementalContextBase(
         // Assuming that the processors are deterministic, we are throwing away outputs from clean inputs, and
         // recovering them from the backup as a workaround for processors.
 
-        val unassociated = outputs - sourceToOutputs.values.flatten()
+        val relativeOutputs = outputs.map { it.toRelativeFile() }.toSet()
+        val unassociated = relativeOutputs - sourceToOutputs.values.flatten()
         val dirties = HashSet(unassociated)
         fun markDirty(file: File) {
             dirties.add(file)
@@ -468,7 +477,7 @@ abstract class IncrementalContextBase(
         val dirtySourceToOutputs = sourceToOutputs.filter { (src, _) ->
             isDirty(src)
         }
-        val dirtyOutputs = outputs.filter(::isDirty).toSet()
+        val dirtyOutputs = relativeOutputs.filter(::isDirty).toSet()
 
         updateCaches(dirtySources, dirtyOutputs, dirtySourceToOutputs)
 


### PR DESCRIPTION
Fix KSP2 incremental build failures caused by path normalization
mismatches in `IncrementalContextBase`.

This change:
- Resolves relative paths against `baseDir` before relativizing in
  `toRelativeFile()`.
- Consistently normalizes `dirtySources` and lookup cache entries.
- Updates `BuildCacheIncrementalIT` test

Attemps to fix #2854