### PR TITLE
Use a Gradle version catalog for dependency versions #2968

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -14,10 +14,10 @@ tasks.withType<KotlinCompile> {
 }
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
+    alias(libs.plugins.dokka)
 }
 
 val sourceJar = tasks.register<Jar>("sourcesJar") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,12 +23,13 @@ repositories {
 }
 
 plugins {
-    kotlin("jvm")
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.gradle.nexus.publish)
     // Adding plugins used in multiple places to the classpath for centralized version control
-    id("com.gradleup.shadow") version "8.3.9" apply false
-    id("org.jetbrains.dokka") version "1.9.20" apply false
-    id("com.android.lint") version "8.13.0" apply false
+    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.shadow) apply false
+    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.android.lint) apply false
 }
 
 nexusPublishing {

--- a/cmdline-parser-gen/build.gradle.kts
+++ b/cmdline-parser-gen/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
+    implementation(libs.kotlin.stdlib)
     implementation(project(":api"))
 }

--- a/common-deps/build.gradle.kts
+++ b/common-deps/build.gradle.kts
@@ -2,21 +2,20 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processor"
 
-val junitVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
-    id("com.google.devtools.ksp")
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.ksp)
 }
 
 dependencies {
     compileOnly(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
 
     ksp(project(":cmdline-parser-gen"))
 }

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -2,18 +2,15 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processing Util"
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-
 plugins {
-    kotlin("jvm")
-    id("org.jetbrains.dokka")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.dokka)
 }
 
 dependencies {
     implementation(project(":api"))
-    implementation(kotlin("stdlib", kotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
+    implementation(libs.kotlin.stdlib)
+    testImplementation(libs.junit4)
 }
 
 kotlin {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -3,42 +3,37 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 description = "Kotlin Symbol Processor"
 
-val kotlinBaseVersion: String by project
-val junitVersion: String by project
-val googleTruthVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String? by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     id("java-gradle-plugin")
     `maven-publish`
     signing
-    id("org.jetbrains.dokka")
-    id("com.android.lint")
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.android.lint)
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
+    compileOnly(libs.kotlin.gradle.plugin.api)
+    compileOnly(libs.kotlin.gradle.plugin.main)
+    compileOnly(libs.kotlin.compiler.embeddable)
     // replace AGP dependency w/ gradle-api when we have source registering API available.
-    compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
+    compileOnly(libs.android.gradle.plugin)
     compileOnly(gradleApi())
     compileOnly(project(":kotlin-analysis-api"))
     // Ensure stdlib version is not inconsistent due to kotlin plugin version.
-    compileOnly(kotlin("stdlib", version = kotlinBaseVersion))
+    compileOnly(libs.kotlin.stdlib)
     implementation(project(":api"))
     implementation(project(":common-deps"))
     testImplementation(gradleApi())
     testImplementation(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("com.google.truth:truth:$googleTruthVersion")
+    testImplementation(libs.junit4)
+    testImplementation(libs.google.truth)
     testImplementation(gradleTestKit())
 
-    lintChecks("androidx.lint:lint-gradle:1.0.0-alpha05")
+    lintChecks(libs.androidx.lint.gradle)
 }
 
 kotlin {
@@ -104,14 +99,14 @@ val writeTestPropsTask = tasks.register<WriteProperties>("prepareTestConfigurati
     destinationFile = testPropsOutDir.map { it.file("testprops.properties") }
     property("kspVersion", version)
     property("mavenRepoDir", rootProject.layout.buildDirectory.dir("repos/test").get().asFile.absolutePath)
-    property("kspProjectRootDir", rootDir.absolutePath)
     property("processorClasspath", project.tasks["compileTestKotlin"].outputs.files.asPath)
+    property("kotlinBaseVersion", libs.versions.kotlin.base.get())
+    property("agpBaseVersion", libs.versions.agp.base.get())
 }
 
 normalization {
     runtimeClasspath {
         properties("**/testprops.properties") {
-            ignoreProperty("kspProjectRootDir")
             ignoreProperty("mavenRepoDir")
             ignoreProperty("processorClasspath")
         }
@@ -167,7 +162,7 @@ abstract class WriteVersionSrcTask : DefaultTask() {
 
 val writeVersionSrcTask = tasks.register<WriteVersionSrcTask>("generateKSPVersions") {
     kspVersion = version.toString()
-    coroutinesVersion = aaCoroutinesVersion
+    coroutinesVersion = libs.versions.aa.coroutines.get()
     outputSrcDir = layout.buildDirectory.dir("generated/ksp-versions")
 }
 

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/TestConfig.kt
@@ -25,10 +25,6 @@ import java.util.*
  */
 data class TestConfig(
     /**
-     * The root directory of the main KSP project
-     */
-    val kspProjectDir: File,
-    /**
      * The classpath that can be used to load processors.
      * The testing infra allows loading processors from the test classpath of the gradle-plugin.
      * This classpath is the output of the test compilation in the main KSP project.
@@ -41,23 +37,16 @@ data class TestConfig(
     /**
      * The version of KSP.
      */
-    val kspVersion: String
+    val kspVersion: String,
+    /**
+     * The version of Kotlin used by the integration test projects.
+     */
+    val kotlinBaseVersion: String,
+    /**
+     * The version of the Android Gradle Plugin used by the integration test projects.
+     */
+    val androidBaseVersion: String
 ) {
-    private val kspProjectProperties by lazy {
-        Properties().also { props ->
-            kspProjectDir.resolve("gradle.properties").inputStream().use {
-                props.load(it)
-            }
-        }
-    }
-    val kotlinBaseVersion by lazy {
-        kspProjectProperties["kotlinBaseVersion"] as String
-    }
-
-    val androidBaseVersion by lazy {
-        kspProjectProperties["agpBaseVersion"] as String
-    }
-
     val mavenRepoPath = mavenRepoDir.path.replace(File.separatorChar, '/')
 
     companion object {
@@ -70,10 +59,11 @@ data class TestConfig(
                 props.load(it)
             }
             return TestConfig(
-                kspProjectDir = File(props.get("kspProjectRootDir") as String),
                 processorClasspath = props.get("processorClasspath") as String,
                 mavenRepoDir = File(props.get("mavenRepoDir") as String),
-                kspVersion = props.get("kspVersion") as String
+                kspVersion = props.get("kspVersion") as String,
+                kotlinBaseVersion = props.get("kotlinBaseVersion") as String,
+                androidBaseVersion = props.get("agpBaseVersion") as String
             )
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,26 +2,4 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
-kotlinBaseVersion=2.3.20
-kotlinxSerializationVersion=1.6.3
-agpBaseVersion=9.3.0-alpha01
-junitVersion=4.13.1
-junit5Version=5.8.2
-junitPlatformVersion=1.8.2
-googleTruthVersion=1.4.5
-
-aaKotlinBaseVersion=2.4.20-dev-4664
-aaIntellijVersion=251.27812.49
-aaGuavaVersion=33.2.0-jre
-aaAsmVersion=9.0
-aaFastutilVersion=8.5.14-jb1
-aaStax2Version=4.2.1
-aaAaltoXmlVersion=1.3.0
-aaStreamexVersion=0.7.2
-aaCoroutinesVersion=1.10.2
-
 kotlin.jvm.target.validation.mode=warning
-
-# Build or runtime dependencies of this project
-buildKotlinVersion=2.3.20
-buildKspVersion=2.3.5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,118 @@
+[versions]
+kotlin-base = "2.3.20"
+build-kotlin = "2.3.20"
+ksp = "2.3.5"
+kotlinx-serialization = "1.6.3"
+agp-base = "9.3.0-alpha01"
+junit4 = "4.13.1"
+junit5 = "5.8.2"
+junit-platform = "1.8.2"
+google-truth = "1.4.5"
+aa-kotlin-base = "2.4.20-dev-4664"
+aa-intellij = "251.27812.49"
+aa-guava = "33.2.0-jre"
+aa-asm = "9.0"
+aa-fastutil = "8.5.14-jb1"
+aa-stax2 = "4.2.1"
+aa-aalto-xml = "1.3.0"
+aa-streamex = "0.7.2"
+aa-coroutines = "1.10.2"
+kotlinx-collections-immutable = "0.3.4"
+caffeine = "2.9.3"
+intellij-jna = "5.9.0.26"
+intellij-trove4j = "1.0.20200330"
+intellij-log4j = "1.2.17.2"
+intellij-jdom = "2.0.6"
+javaslang = "2.0.6"
+javax-inject = "1"
+kotlin-reflect-legacy = "1.6.10"
+lz4-java = "1.7.1"
+jetbrains-annotations = "24.1.0"
+opentelemetry-api = "1.34.1"
+androidx-lint-gradle = "1.0.0-alpha05"
+gradle-nexus-publish = "2.0.0"
+shadow = "8.3.9"
+dokka = "1.9.20"
+android-lint-plugin = "8.13.0"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin-base" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
+kotlin-gradle-plugin-main = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-base" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-base" }
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp-base" }
+androidx-lint-gradle = { module = "androidx.lint:lint-gradle", version.ref = "androidx-lint-gradle" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
+junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform" }
+google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+
+aa-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "aa-kotlin-base" }
+aa-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "aa-kotlin-base" }
+aa-kotlin-script-runtime = { module = "org.jetbrains.kotlin:kotlin-script-runtime", version.ref = "aa-kotlin-base" }
+aa-kotlin-stdlib-common = { module = "org.jetbrains.kotlin:kotlin-stdlib-common", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-main = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-internal-test-framework = { module = "org.jetbrains.kotlin:kotlin-compiler-internal-test-framework", version.ref = "aa-kotlin-base" }
+aa-analysis-api-test-framework = { module = "org.jetbrains.kotlin:analysis-api-test-framework", version.ref = "aa-kotlin-base" }
+aa-analysis-api-k2-ide = { module = "org.jetbrains.kotlin:analysis-api-k2-for-ide", version.ref = "aa-kotlin-base" }
+aa-analysis-api-ide = { module = "org.jetbrains.kotlin:analysis-api-for-ide", version.ref = "aa-kotlin-base" }
+aa-low-level-api-fir-ide = { module = "org.jetbrains.kotlin:low-level-api-fir-for-ide", version.ref = "aa-kotlin-base" }
+aa-analysis-api-platform-iface-ide = { module = "org.jetbrains.kotlin:analysis-api-platform-interface-for-ide", version.ref = "aa-kotlin-base" }
+aa-symbol-light-classes-ide = { module = "org.jetbrains.kotlin:symbol-light-classes-for-ide", version.ref = "aa-kotlin-base" }
+aa-analysis-api-standalone-ide = { module = "org.jetbrains.kotlin:analysis-api-standalone-for-ide", version.ref = "aa-kotlin-base" }
+aa-analysis-api-impl-base-ide = { module = "org.jetbrains.kotlin:analysis-api-impl-base-for-ide", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-common-ide = { module = "org.jetbrains.kotlin:kotlin-compiler-common-for-ide", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-fir-ide = { module = "org.jetbrains.kotlin:kotlin-compiler-fir-for-ide", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-fe10-ide = { module = "org.jetbrains.kotlin:kotlin-compiler-fe10-for-ide", version.ref = "aa-kotlin-base" }
+aa-kotlin-compiler-ir-ide = { module = "org.jetbrains.kotlin:kotlin-compiler-ir-for-ide", version.ref = "aa-kotlin-base" }
+aa-kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
+aa-kotlinx-coroutines-core-common = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "aa-coroutines" }
+
+intellij-platform-util-rt = { module = "com.jetbrains.intellij.platform:util-rt", version.ref = "aa-intellij" }
+intellij-platform-util-classloader = { module = "com.jetbrains.intellij.platform:util-class-loader", version.ref = "aa-intellij" }
+intellij-platform-util-text-matching = { module = "com.jetbrains.intellij.platform:util-text-matching", version.ref = "aa-intellij" }
+intellij-platform-util-core = { module = "com.jetbrains.intellij.platform:util", version.ref = "aa-intellij" }
+intellij-platform-util-base = { module = "com.jetbrains.intellij.platform:util-base", version.ref = "aa-intellij" }
+intellij-platform-util-coroutines = { module = "com.jetbrains.intellij.platform:util-coroutines", version.ref = "aa-intellij" }
+intellij-platform-util-xml-dom = { module = "com.jetbrains.intellij.platform:util-xml-dom", version.ref = "aa-intellij" }
+intellij-platform-core-main = { module = "com.jetbrains.intellij.platform:core", version.ref = "aa-intellij" }
+intellij-platform-core-impl = { module = "com.jetbrains.intellij.platform:core-impl", version.ref = "aa-intellij" }
+intellij-platform-extensions = { module = "com.jetbrains.intellij.platform:extensions", version.ref = "aa-intellij" }
+intellij-platform-diagnostic-main = { module = "com.jetbrains.intellij.platform:diagnostic", version.ref = "aa-intellij" }
+intellij-platform-diagnostic-telemetry = { module = "com.jetbrains.intellij.platform:diagnostic-telemetry", version.ref = "aa-intellij" }
+intellij-java-frontback-psi-main = { module = "com.jetbrains.intellij.java:java-frontback-psi", version.ref = "aa-intellij" }
+intellij-java-frontback-psi-impl = { module = "com.jetbrains.intellij.java:java-frontback-psi-impl", version.ref = "aa-intellij" }
+intellij-java-psi-main = { module = "com.jetbrains.intellij.java:java-psi", version.ref = "aa-intellij" }
+intellij-java-psi-impl = { module = "com.jetbrains.intellij.java:java-psi-impl", version.ref = "aa-intellij" }
+intellij-deps-asm-all = { module = "org.jetbrains.intellij.deps:asm-all", version.ref = "aa-asm" }
+intellij-deps-jna-core = { module = "org.jetbrains.intellij.deps.jna:jna", version.ref = "intellij-jna" }
+intellij-deps-jna-platform = { module = "org.jetbrains.intellij.deps.jna:jna-platform", version.ref = "intellij-jna" }
+intellij-deps-trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version.ref = "intellij-trove4j" }
+intellij-deps-log4j = { module = "org.jetbrains.intellij.deps:log4j", version.ref = "intellij-log4j" }
+intellij-deps-jdom = { module = "org.jetbrains.intellij.deps:jdom", version.ref = "intellij-jdom" }
+intellij-deps-fastutil = { module = "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil", version.ref = "aa-fastutil" }
+
+kotlinx-collections-immutable-jvm = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "kotlinx-collections-immutable" }
+guava = { module = "com.google.guava:guava", version.ref = "aa-guava" }
+streamex = { module = "one.util:streamex", version.ref = "aa-streamex" }
+stax2-api = { module = "org.codehaus.woodstox:stax2-api", version.ref = "aa-stax2" }
+aalto-xml = { module = "com.fasterxml:aalto-xml", version.ref = "aa-aalto-xml" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "caffeine" }
+javaslang = { module = "io.javaslang:javaslang", version.ref = "javaslang" }
+javax-inject = { module = "javax.inject:javax.inject", version.ref = "javax-inject" }
+kotlin-reflect-legacy = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin-reflect-legacy" }
+lz4-java = { module = "org.lz4:lz4-java", version.ref = "lz4-java" }
+jetbrains-annotations = { module = "org.jetbrains:annotations", version.ref = "jetbrains-annotations" }
+opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api", version.ref = "opentelemetry-api" }
+
+[plugins]
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "build-kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+gradle-nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "gradle-nexus-publish" }
+shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+android-lint = { id = "com.android.lint", version.ref = "android-lint-plugin" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -2,31 +2,25 @@ import com.google.devtools.ksp.RelativizingInternalPathProvider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import kotlin.math.max
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String by project
-
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
     testImplementation(gradleTestKit())
     testImplementation(project(":api"))
     testImplementation(project(":gradle-plugin"))
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    testImplementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.aa.kotlinx.coroutines.core.jvm)
 }
 
 fun Test.configureCommonSettings() {
     val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
     maxParallelForks = if (isWindows) 1 else max(1, Runtime.getRuntime().availableProcessors() / 2)
-    systemProperty("kotlinVersion", kotlinBaseVersion)
+    systemProperty("kotlinVersion", libs.versions.kotlin.base.get())
     systemProperty("kspVersion", version)
-    systemProperty("agpVersion", agpBaseVersion)
+    systemProperty("agpVersion", libs.versions.agp.base.get())
     jvmArgumentProviders.add(
         RelativizingInternalPathProvider(
             "testRepo",

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -1,6 +1,8 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.google.devtools.ksp.RelativizingInternalPathProvider
 import com.google.devtools.ksp.RelativizingPathProvider
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Provider
 import org.jetbrains.org.objectweb.asm.ClassReader
 import org.jetbrains.org.objectweb.asm.ClassWriter
 import org.jetbrains.org.objectweb.asm.commons.ClassRemapper
@@ -17,28 +19,15 @@ description = "Kotlin Symbol Processing implementation using Kotlin Analysis API
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
-val junitVersion: String by project
-val junit5Version: String by project
-val junitPlatformVersion: String by project
 val libsForTesting: Configuration by configurations.creating
 val libsForTestingCommon: Configuration by configurations.creating
 
-val aaKotlinBaseVersion: String by project
-val aaIntellijVersion: String by project
-val aaGuavaVersion: String by project
-val aaAsmVersion: String by project
-val aaFastutilVersion: String by project
-val aaStax2Version: String by project
-val aaAaltoXmlVersion: String by project
-val aaStreamexVersion: String by project
-val aaCoroutinesVersion: String by project
+val aaKotlinBaseVersion = libs.versions.aa.kotlin.base.get()
 
 plugins {
-    kotlin("jvm")
-    id("org.jetbrains.dokka")
-    id("com.gradleup.shadow")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.shadow)
     `maven-publish`
     signing
 }
@@ -124,108 +113,104 @@ val transformedIntellijDeps = tasks.register<TransformIntellijDeps>("transformed
 
 dependencies {
     listOf(
-        "com.jetbrains.intellij.platform:util-rt",
-        "com.jetbrains.intellij.platform:util-class-loader",
-        "com.jetbrains.intellij.platform:util-text-matching",
-        "com.jetbrains.intellij.platform:util",
-        "com.jetbrains.intellij.platform:util-base",
-        "com.jetbrains.intellij.platform:util-coroutines",
-        "com.jetbrains.intellij.platform:util-xml-dom",
-        "com.jetbrains.intellij.platform:core",
-        "com.jetbrains.intellij.platform:core-impl",
-        "com.jetbrains.intellij.platform:extensions",
-        "com.jetbrains.intellij.platform:diagnostic",
-        "com.jetbrains.intellij.platform:diagnostic-telemetry",
-        "com.jetbrains.intellij.java:java-frontback-psi",
-        "com.jetbrains.intellij.java:java-frontback-psi-impl",
-        "com.jetbrains.intellij.java:java-psi",
-        "com.jetbrains.intellij.java:java-psi-impl",
+        libs.intellij.platform.util.rt,
+        libs.intellij.platform.util.classloader,
+        libs.intellij.platform.util.text.matching,
+        libs.intellij.platform.util.core,
+        libs.intellij.platform.util.base,
+        libs.intellij.platform.util.coroutines,
+        libs.intellij.platform.util.xml.dom,
+        libs.intellij.platform.core.main,
+        libs.intellij.platform.core.impl,
+        libs.intellij.platform.extensions,
+        libs.intellij.platform.diagnostic.main,
+        libs.intellij.platform.diagnostic.telemetry,
+        libs.intellij.java.frontback.psi.main,
+        libs.intellij.java.frontback.psi.impl,
+        libs.intellij.java.psi.main,
+        libs.intellij.java.psi.impl,
     ).forEach {
-        intellijOriginal("$it:$aaIntellijVersion")
-        depSourceJars("$it:$aaIntellijVersion:sources") { isTransitive = false }
+        intellijOriginal(it)
+        depSourceJars(variantOf(it) { classifier("sources") }) { isTransitive = false }
     }
     implementation(files(transformedIntellijDeps.map { it.outputDir.asFileTree }))
 
     listOf(
-        "org.jetbrains.kotlin:analysis-api-k2-for-ide",
-        "org.jetbrains.kotlin:analysis-api-for-ide",
-        "org.jetbrains.kotlin:low-level-api-fir-for-ide",
-        "org.jetbrains.kotlin:analysis-api-platform-interface-for-ide",
-        "org.jetbrains.kotlin:symbol-light-classes-for-ide",
-        "org.jetbrains.kotlin:analysis-api-standalone-for-ide",
-        "org.jetbrains.kotlin:analysis-api-impl-base-for-ide",
-        "org.jetbrains.kotlin:kotlin-compiler-common-for-ide",
-        "org.jetbrains.kotlin:kotlin-compiler-fir-for-ide",
-        "org.jetbrains.kotlin:kotlin-compiler-fe10-for-ide",
-        "org.jetbrains.kotlin:kotlin-compiler-ir-for-ide",
+        libs.aa.analysis.api.k2.ide,
+        libs.aa.analysis.api.ide,
+        libs.aa.low.level.api.fir.ide,
+        libs.aa.analysis.api.platform.iface.ide,
+        libs.aa.symbol.light.classes.ide,
+        libs.aa.analysis.api.standalone.ide,
+        libs.aa.analysis.api.impl.base.ide,
+        libs.aa.kotlin.compiler.common.ide,
+        libs.aa.kotlin.compiler.fir.ide,
+        libs.aa.kotlin.compiler.fe10.ide,
+        libs.aa.kotlin.compiler.ir.ide,
     ).forEach {
-        implementation("$it:$aaKotlinBaseVersion") { isTransitive = false }
-        depSourceJars("$it:$aaKotlinBaseVersion:sources") { isTransitive = false }
+        implementation(it) { isTransitive = false }
+        depSourceJars(variantOf(it) { classifier("sources") }) { isTransitive = false }
     }
 
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
+    implementation(libs.kotlinx.collections.immutable.jvm)
+    implementation(libs.kotlinx.serialization.json)
+    compileOnly(libs.aa.kotlin.stdlib)
 
-    implementation("com.google.guava:guava:$aaGuavaVersion")
-    implementation("one.util:streamex:$aaStreamexVersion")
-    implementation("org.jetbrains.intellij.deps:asm-all:$aaAsmVersion")
-    implementation("org.codehaus.woodstox:stax2-api:$aaStax2Version") { isTransitive = false }
-    implementation("com.fasterxml:aalto-xml:$aaAaltoXmlVersion") { isTransitive = false }
-    implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
-    implementation("org.jetbrains.intellij.deps.jna:jna:5.9.0.26") { isTransitive = false }
-    implementation("org.jetbrains.intellij.deps.jna:jna-platform:5.9.0.26") { isTransitive = false }
-    implementation("org.jetbrains.intellij.deps:trove4j:1.0.20200330") { isTransitive = false }
-    originalLog4j("org.jetbrains.intellij.deps:log4j:1.2.17.2") { isTransitive = false }
+    implementation(libs.guava)
+    implementation(libs.streamex)
+    implementation(libs.intellij.deps.asm.all)
+    implementation(libs.stax2.api) { isTransitive = false }
+    implementation(libs.aalto.xml) { isTransitive = false }
+    implementation(libs.caffeine)
+    implementation(libs.intellij.deps.jna.core) { isTransitive = false }
+    implementation(libs.intellij.deps.jna.platform) { isTransitive = false }
+    implementation(libs.intellij.deps.trove4j) { isTransitive = false }
+    originalLog4j(libs.intellij.deps.log4j) { isTransitive = false }
     implementation(files(filteredLog4j))
-    implementation("org.jetbrains.intellij.deps:jdom:2.0.6") { isTransitive = false }
-    implementation("io.javaslang:javaslang:2.0.6")
-    implementation("javax.inject:javax.inject:1")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
-    implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
-    implementation(
-        "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil:$aaFastutilVersion"
-    ) {
-        isTransitive = false
-    }
-    implementation("org.jetbrains:annotations:24.1.0")
+    implementation(libs.intellij.deps.jdom) { isTransitive = false }
+    implementation(libs.javaslang)
+    implementation(libs.javax.inject)
+    implementation(libs.kotlin.reflect.legacy)
+    implementation(libs.lz4.java) { isTransitive = false }
+    compileOnly(libs.aa.kotlinx.coroutines.core.jvm)
+    compileOnly(libs.aa.kotlinx.coroutines.core.common)
+    implementation(libs.intellij.deps.fastutil) { isTransitive = false }
+    implementation(libs.jetbrains.annotations)
 
-    implementation("io.opentelemetry:opentelemetry-api:1.34.1") { isTransitive = false }
+    implementation(libs.opentelemetry.api) { isTransitive = false }
 
     compileOnly(project(":common-deps"))
 
     implementation(project(":api"))
     implementation(project(":common-util"))
 
-    testImplementation(kotlin("stdlib", aaKotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-params:$junit5Version")
-    testRuntimeOnly("org.junit.platform:junit-platform-suite:$junitPlatformVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-compiler:$aaKotlinBaseVersion")
-    testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$aaKotlinBaseVersion")
+    testImplementation(libs.aa.kotlin.stdlib)
+    testImplementation(libs.junit4)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.platform.suite)
+    testImplementation(libs.aa.kotlin.compiler.main)
+    testImplementation(libs.aa.kotlin.compiler.internal.test.framework)
     testImplementation(project(":common-deps"))
     testImplementation(project(":test-utils"))
-    testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$aaKotlinBaseVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    testImplementation(libs.aa.analysis.api.test.framework)
+    testImplementation(libs.aa.kotlinx.coroutines.core.jvm)
+    testImplementation(libs.aa.kotlinx.coroutines.core.common)
 
     // See AbstractKSPTest's init block if you change any of the `libsForTesting` or `libsForTestingCommon` dependencies.
-    libsForTesting(kotlin("stdlib", aaKotlinBaseVersion))
-    libsForTesting(kotlin("test", aaKotlinBaseVersion))
-    libsForTesting(kotlin("script-runtime", aaKotlinBaseVersion))
-    libsForTestingCommon(kotlin("stdlib-common", aaKotlinBaseVersion))
+    libsForTesting(libs.aa.kotlin.stdlib)
+    libsForTesting(libs.aa.kotlin.test)
+    libsForTesting(libs.aa.kotlin.script.runtime)
+    libsForTestingCommon(libs.aa.kotlin.stdlib.common)
 
-    depJarsForCheck("org.jetbrains.kotlin:kotlin-stdlib:$kotlinBaseVersion")
-    depJarsForCheck("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    depJarsForCheck("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    depJarsForCheck(libs.kotlin.stdlib)
+    depJarsForCheck(libs.aa.kotlinx.coroutines.core.jvm)
+    depJarsForCheck(libs.aa.kotlinx.coroutines.core.common)
     depJarsForCheck(project(":api"))
     depJarsForCheck(project(":common-deps"))
 
-    compilerJar("org.jetbrains.kotlin:kotlin-compiler-common-for-ide:$aaKotlinBaseVersion")
+    compilerJar(libs.aa.kotlin.compiler.common.ide)
 }
 
 sourceSets.main {
@@ -360,6 +345,19 @@ publishing {
                 description.set("KSP implementation on Kotlin Analysis API")
                 withXml {
                     fun groovy.util.Node.addDependency(
+                        dependency: Provider<MinimalExternalModuleDependency>,
+                        scope: String = "runtime"
+                    ) {
+                        val moduleDependency = dependency.get()
+                        appendNode("dependency").apply {
+                            appendNode("groupId", moduleDependency.module.group)
+                            appendNode("artifactId", moduleDependency.module.name)
+                            appendNode("version", moduleDependency.versionConstraint.requiredVersion)
+                            appendNode("scope", scope)
+                        }
+                    }
+
+                    fun groovy.util.Node.addDependency(
                         groupId: String,
                         artifactId: String,
                         version: String,
@@ -374,12 +372,8 @@ publishing {
                     }
 
                     asNode().appendNode("dependencies").apply {
-                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
-                        addDependency(
-                            "org.jetbrains.kotlinx",
-                            "kotlinx-coroutines-core-jvm",
-                            aaCoroutinesVersion
-                        )
+                        addDependency(libs.kotlin.stdlib)
+                        addDependency(libs.aa.kotlinx.coroutines.core.jvm)
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version, "compile")
                         addDependency(
                             "com.google.devtools.ksp",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,14 +1,6 @@
 rootProject.name = "ksp"
 
 pluginManagement {
-    val buildKotlinVersion: String by settings
-    val buildKspVersion: String by settings
-
-    plugins {
-        kotlin("jvm") version buildKotlinVersion apply false
-        id("com.google.devtools.ksp") version buildKspVersion apply false
-    }
-
     repositories {
         gradlePluginPortal()
         maven("https://redirector.kotlinlang.org/maven/bootstrap/")

--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -3,6 +3,8 @@ import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 import com.github.jengelman.gradle.plugins.shadow.transformers.TransformerContext
 import org.apache.tools.zip.ZipEntry
 import org.apache.tools.zip.ZipOutputStream
+import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.provider.Provider
 import org.gradle.jvm.tasks.Jar
 import java.io.InputStreamReader
 import java.util.zip.ZipFile
@@ -12,14 +14,9 @@ evaluationDependsOn(":kotlin-analysis-api")
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
-
-val aaKotlinBaseVersion: String by project
-val aaCoroutinesVersion: String by project
-
 plugins {
-    kotlin("jvm")
-    id("com.gradleup.shadow")
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.shadow)
     `maven-publish`
     signing
 }
@@ -28,7 +25,7 @@ val packedJars by configurations.creating
 
 dependencies {
     packedJars(project(":kotlin-analysis-api", "shadow")) { isTransitive = false }
-    packedJars("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion") { isTransitive = false }
+    packedJars(libs.aa.kotlinx.coroutines.core.jvm) { isTransitive = false }
 }
 
 tasks.withType(Jar::class.java).configureEach {
@@ -279,6 +276,19 @@ publishing {
                 description.set("KSP implementation on Kotlin Analysis API")
                 withXml {
                     fun groovy.util.Node.addDependency(
+                        dependency: Provider<MinimalExternalModuleDependency>,
+                        scope: String = "runtime"
+                    ) {
+                        val moduleDependency = dependency.get()
+                        appendNode("dependency").apply {
+                            appendNode("groupId", moduleDependency.module.group)
+                            appendNode("artifactId", moduleDependency.module.name)
+                            appendNode("version", moduleDependency.versionConstraint.requiredVersion)
+                            appendNode("scope", scope)
+                        }
+                    }
+
+                    fun groovy.util.Node.addDependency(
                         groupId: String,
                         artifactId: String,
                         version: String,
@@ -293,7 +303,7 @@ publishing {
                     }
 
                     asNode().appendNode("dependencies").apply {
-                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
+                        addDependency(libs.kotlin.stdlib)
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
                         addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version)
                     }
@@ -327,7 +337,7 @@ abstract class WriteVersionSrcTask : DefaultTask() {
 val writeVersionSrcTask = tasks.register<WriteVersionSrcTask>(
     "generateKSPVersions"
 ) {
-    kotlinVersion = aaKotlinBaseVersion
+    kotlinVersion = libs.versions.aa.kotlin.base.get()
     outputResDir = layout.buildDirectory.dir("generated/ksp-versions/META-INF")
 }
 

--- a/symbol-processing/build.gradle.kts
+++ b/symbol-processing/build.gradle.kts
@@ -4,7 +4,7 @@ val signingKey: String? by project
 val signingPassword: String? by project
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
     `maven-publish`
     signing
 }

--- a/test-utils/build.gradle.kts
+++ b/test-utils/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 plugins {
-    kotlin("jvm")
+    alias(libs.plugins.kotlin.jvm)
 }
 
 version = rootProject.extra.get("kspVersion") as String
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     implementation(project(":api"))
-    implementation(kotlin("reflect"))
+    implementation(libs.kotlin.reflect)
 }
 
 kotlin {


### PR DESCRIPTION
1. Moved all versions from gradle.properties into version catalog
2. Updated build files and TestConfig to use version catalog