### PR TITLE
Deprecate `-xjvm-flags` and `-language-version`

### DIFF
--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
@@ -58,7 +58,7 @@ abstract class KSPConfig(
         var removedSources: List<File> = emptyList()
         var changedClasses: List<String> = emptyList()
 
-        lateinit var languageVersion: String
+        var languageVersion: String = "2.0"
         lateinit var apiVersion: String
 
         var allWarningsAsErrors: Boolean = false

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -103,6 +103,13 @@ abstract class KspAATask @Inject constructor(
 
     @TaskAction
     fun execute(inputChanges: InputChanges) {
+        if (kspConfig.usedDeprecatedXJvmDefault.getOrElse(false)) {
+            logger.warn(
+                "Flag '-Xjvm-default' is deprecated. Please configure " +
+                    "'compilerOptions.jvmDefault' in Gradle DSL or use '-jvm-default' instead."
+            )
+        }
+
         // FIXME: Create a class loader with clean classpath instead of shadowing existing ones. It'll require either:
         //  1. passing arguments by data structures in stdlib, or
         //  2. hoisting and publishing KspGradleConfig into another package.
@@ -351,6 +358,7 @@ abstract class KspAATask @Inject constructor(
                             .map { it.toBoolean() }
                             .orElse(false)
                     )
+                    cfg.usedDeprecatedXJvmDefault.convention(false)
 
                     // Ref: https://github.com/JetBrains/kotlin/blob/6535f86dfe36effeba976802ebd56a5a56071f45/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt#L92
                     val moduleName = when (val compilationName = kotlinCompilation.name) {
@@ -375,6 +383,14 @@ abstract class KspAATask @Inject constructor(
                                 }
                                 .map { it.lastOrNull()?.substringAfter("=") ?: "undefined" }
                         }
+
+                        cfg.usedDeprecatedXJvmDefault.set(
+                            compileTask.flatMap { task ->
+                                task.compilerOptions.freeCompilerArgs.map { args ->
+                                    args.any { it.startsWith("-Xjvm-default=") }
+                                }
+                            }
+                        )
 
                         val compilerArgument = compileTask.flatMap { task ->
                             (task.compilerOptions as KotlinJvmCompilerOptions).jvmDefault.map { it.compilerArgument }
@@ -571,6 +587,10 @@ abstract class KspGradleConfig @Inject constructor() {
 
     @get:Input
     abstract val experimentalPsiResolution: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    abstract val usedDeprecatedXJvmDefault: Property<Boolean>
 
     @get:PathSensitive(PathSensitivity.NONE)
     @get:Incremental

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -425,4 +425,33 @@ class GradleCompilationTest(isExperimentalPsiResolution: Boolean) {
             .withArguments("tasks", "-Pandroid.experimental.enableTestFixturesKotlinSupport=true")
             .build()
     }
+
+    @Test
+    fun testDeprecatedXJvmDefaultWarning() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.buildFileAdditions.add(
+            """
+            tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+                compilerOptions.freeCompilerArgs.add("-Xjvm-default=all")
+            }
+            """.trimIndent()
+        )
+        testRule.appModule.dependencies.add(
+            module(configuration = "ksp", testRule.processorModule)
+        )
+        testRule.appModule.addSource(
+            "Foo.kt",
+            """
+            class Foo
+            """.trimIndent()
+        )
+        class DummyProcessor : SymbolProcessor {
+            override fun process(resolver: Resolver): List<KSAnnotated> = emptyList()
+        }
+        class Provider : TestSymbolProcessorProvider({ DummyProcessor() })
+        testRule.addProvider(Provider::class)
+
+        val result = testRule.runner().withArguments(":app:kspKotlin").build()
+        assertThat(result.output).contains("Flag '-Xjvm-default' is deprecated")
+    }
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/KSPCmdLineOptionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/KSPCmdLineOptionsIT.kt
@@ -74,10 +74,12 @@ class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
         )
     }
 
-    fun testKsp2(mainClassName: String, platformArgs: List<String>) {
+    fun testKsp2(mainClassName: String, platformArgs: List<String>, includeLanguageVersion: Boolean = true) {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
 
-        val sharedArgs = getKsp2SharedArgs()
+        val sharedArgs = getKsp2SharedArgs().let {
+            if (includeLanguageVersion) it else it.filterNot { arg -> arg.startsWith("-language-version") }
+        }
         val kspMain = getKsp2Main(mainClassName)
 
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
@@ -114,6 +116,41 @@ class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
                 "-jvm-target", "11",
             )
         )
+    }
+
+    @Test
+    fun testKSPJvmMainWithoutLanguageVersion() {
+        val outDir = "${project.root.path}/build/out"
+        testKsp2(
+            "com.google.devtools.ksp.cmdline.KSPJvmMain",
+            listOf(
+                "-java-output-dir", outDir,
+                "-jvm-target", "11",
+            ),
+            includeLanguageVersion = false
+        )
+    }
+
+    @Test
+    fun testKSPLanguageVersionDeprecationWarning() {
+        val outDir = "${project.root.path}/build/out"
+        val originalOut = System.out
+        val baos = java.io.ByteArrayOutputStream()
+        System.setOut(java.io.PrintStream(baos))
+        try {
+            testKsp2(
+                "com.google.devtools.ksp.cmdline.KSPJvmMain",
+                listOf(
+                    "-java-output-dir", outDir,
+                    "-jvm-target", "11",
+                ),
+                includeLanguageVersion = true
+            )
+            val output = baos.toString()
+            Assert.assertTrue("Flag '-language-version' is deprecated" in output)
+        } finally {
+            System.setOut(originalOut)
+        }
     }
 
     @Test

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -47,6 +47,10 @@ internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSP
 
     val logger = KspGradleLogger(loggingLevel)
 
+    if (args.any { it.startsWith("-language-version") }) {
+        logger.warn("Flag '-language-version' is deprecated.")
+    }
+
     val (config, classpath) = parse(args)
     val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
 


### PR DESCRIPTION
`-xjvm-default` and `-language-version` are now deprecated. A warning will be emitted if they are used.

Closes https://github.com/google/ksp/issues/2991