### PR TITLE
Raise JVM bytecode target from 8 to 11 #2966

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -104,12 +104,12 @@ subprojects {
     pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
         configure<JavaPluginExtension> {
             toolchain.languageVersion.set(compileJavaVersion)
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
         }
         configure<KotlinJvmProjectExtension> {
             compilerOptions {
-                jvmTarget = JvmTarget.JVM_1_8
+                jvmTarget = JvmTarget.JVM_11
                 languageVersion.set(KotlinVersion.KOTLIN_2_3)
                 apiVersion.set(languageVersion)
             }


### PR DESCRIPTION
I run following tests to verify migration:

```
:api:checkApi    
:kotlin-analysis-api:test 
:integration-tests:primaryTest  
:integration-tests:secondaryTest
:integration-tests:agpTest
:gradle-plugin:test
```

I didn't update benchmark project to 11, since it's not working with it's wrapper since commit a8c7e9e12096593006d6ee19d4657f05d5a224b2, I'm updating benchmark project in a separate branch 