### PR TITLE
Fix R-class resolution in KSP when AGP 9 built-in Kotlin is enabled

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("InternalAgpApiUsage")
+
 package com.google.devtools.ksp.gradle
 
 import com.android.build.api.artifact.ScopedArtifact
@@ -25,6 +27,7 @@ import com.android.build.api.variant.impl.FlatSourceDirectoriesForJavaImpl
 import com.android.build.api.variant.impl.FlatSourceDirectoriesImpl
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.SourceKind
+import com.android.build.gradle.internal.component.ComponentCreationConfig
 import com.google.devtools.ksp.gradle.utils.canUseAddGeneratedSourceDirectoriesApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
@@ -89,6 +92,18 @@ object AndroidPluginIntegration {
                 kspTaskProvider.configure { task ->
                     task.kspConfig.javaSourceRoots.from(javaSources)
                     task.kspConfig.javaSourceRoots.from(kotlinSources)
+                }
+
+                val isKaptApplied = project.plugins.hasPlugin("com.android.legacy-kapt")
+                if (isKaptApplied) {
+                    (androidComponent as? ComponentCreationConfig)
+                        ?.androidResourcesCreationConfig
+                        ?.compiledRClassArtifact
+                        ?.let { compiledRClassArtifact ->
+                            kspTaskProvider.configure { task ->
+                                task.kspConfig.libraries.from(project.files(compiledRClassArtifact))
+                            }
+                        }
                 }
             } else {
                 throw RuntimeException(

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -31,6 +31,7 @@ import com.android.build.gradle.internal.component.ComponentCreationConfig
 import com.google.devtools.ksp.gradle.utils.canUseAddGeneratedSourceDirectoriesApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
+import com.google.devtools.ksp.gradle.utils.isLegacyKaptPluginApplied
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
@@ -94,8 +95,7 @@ object AndroidPluginIntegration {
                     task.kspConfig.javaSourceRoots.from(kotlinSources)
                 }
 
-                val isKaptApplied = project.plugins.hasPlugin("com.android.legacy-kapt")
-                if (isKaptApplied) {
+                if (project.isLegacyKaptPluginApplied()) {
                     (androidComponent as? ComponentCreationConfig)
                         ?.androidResourcesCreationConfig
                         ?.compiledRClassArtifact

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -22,6 +22,7 @@ import com.google.devtools.ksp.gradle.utils.allKotlinSourceSetsObservable
 import com.google.devtools.ksp.gradle.utils.canUseGeneratedKotlinApi
 import com.google.devtools.ksp.gradle.utils.enableProjectIsolationCompatibleCodepath
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
+import com.google.devtools.ksp.gradle.utils.isLegacyKaptPluginApplied
 import com.google.devtools.ksp.impl.KotlinSymbolProcessing
 import com.google.devtools.ksp.processing.ExitCode
 import com.google.devtools.ksp.processing.KSPCommonConfig
@@ -235,9 +236,8 @@ abstract class KspAATask @Inject constructor(
                         if (project.isAgpBuiltInKotlinUsed()) {
                             val androidComponents =
                                 project.extensions.getByType(AndroidComponentsExtension::class.java)
-                            val isKaptApplied = project.plugins.hasPlugin("com.android.legacy-kapt")
 
-                            if (isKaptApplied) {
+                            if (project.isLegacyKaptPluginApplied()) {
                                 // Fallback to workaround to avoid circular dependency with KAPT.
                                 cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
                                 cfg.libraries.from(

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -233,22 +233,29 @@ abstract class KspAATask @Inject constructor(
 
                     if (kotlinCompilation is KotlinJvmAndroidCompilation) {
                         if (project.isAgpBuiltInKotlinUsed()) {
-                            // when legacy-kapt plugin is applied, we can't use KotlinCompile.libraries directly
-                            // because it contains the kapt output classes dir leading to circular dependency
-                            val androidComponents = project.extensions.getByType(AndroidComponentsExtension::class.java)
-                            cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
-                            cfg.libraries.from(
-                                project.provider {
-                                    val configuration = project.configurations.getByName(
-                                        kotlinCompilation.compileDependencyConfigurationName
-                                    )
-                                    configuration.incoming.artifactView { config ->
-                                        config.attributes.attribute(
-                                            Attribute.of("artifactType", String::class.java), "android-classes-jar"
+                            val androidComponents =
+                                project.extensions.getByType(AndroidComponentsExtension::class.java)
+                            val isKaptApplied = project.plugins.hasPlugin("com.android.legacy-kapt")
+
+                            if (isKaptApplied) {
+                                // Fallback to workaround to avoid circular dependency with KAPT.
+                                cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
+                                cfg.libraries.from(
+                                    project.provider {
+                                        val configuration = project.configurations.getByName(
+                                            kotlinCompilation.compileDependencyConfigurationName
                                         )
-                                    }.files
-                                }
-                            )
+                                        configuration.incoming.artifactView { config ->
+                                            config.attributes.attribute(
+                                                Attribute.of("artifactType", String::class.java), "android-classes-jar"
+                                            )
+                                        }.files
+                                    }
+                                )
+                            } else {
+                                cfg.libraries.from(kotlinCompileProvider.get().libraries)
+                                cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
+                            }
                         } else {
                             val kaptGeneratedClassesDir = getKaptGeneratedClassesDir(project, sourceSetName)
                             val kspOutputDir = KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -19,6 +19,8 @@ fun Project.isKotlinBaseApiPluginApplied() = plugins.withType(KotlinBaseApiPlugi
 
 fun Project.isKotlinAndroidPluginApplied() = pluginManager.hasPlugin("org.jetbrains.kotlin.android")
 
+fun Project.isLegacyKaptPluginApplied() = pluginManager.hasPlugin("com.android.legacy-kapt")
+
 fun Project.canUseGeneratedKotlinApi(): Boolean {
     val kotlinVersion = KotlinToolingVersion(getKotlinPluginVersion())
     return kotlinVersion >= KotlinToolingVersion("2.3.0-Beta2")

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/AndroidBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/AndroidBuiltInKotlinIT.kt
@@ -171,4 +171,105 @@ class AndroidBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
             assert("w: [ksp] [workload] Mangled name for internalFun: internalFun\$workload" in outputs)
         }
     }
+
+    @Test
+    fun testRClassResolutionWithBuiltInKotlin() {
+        val resDir = File(project.root, "workload/src/main/res/values")
+        resDir.mkdirs()
+        File(resDir, "strings.xml").writeText(
+            """
+            <resources>
+                <string name="sample_label">Sample Label</string>
+            </resources>
+            """.trimIndent()
+        )
+
+        val javaDir = File(project.root, "workload/src/main/java/com/example")
+        javaDir.mkdirs()
+        File(javaDir, "RUsage.kt").writeText(
+            """
+            package com.example
+            import com.example.annotation.Builder
+            import com.example.myapplication.R
+
+            @Builder
+            class RUsage {
+                val label = R.string.sample_label
+            }
+            """.trimIndent()
+        )
+
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(
+            "clean", "build", "--configuration-cache", "--info", "--stacktrace"
+        ).build().let { result ->
+            val classesJar = File(
+                project.root,
+                "workload/build/intermediates/compile_app_classes_jar/debug/bundleDebugClassesToCompileJar/classes.jar"
+            )
+            JarFile(classesJar).use { jarFile ->
+                jarFile.assertContainsNonNullEntry("com/example/RUsageBuilder.class")
+            }
+        }
+    }
+
+    @Test
+    fun testRClassResolutionWithBuiltInKotlinAndKapt() {
+        val settingsGradle = File(project.root, "settings.gradle.kts")
+        val settingsContent = settingsGradle.readText()
+        val updatedSettingsContent = settingsContent.replace(
+            "id(\"com.android.application\") version agpVersion apply false",
+            "id(\"com.android.application\") version agpVersion apply false\n        " +
+                "id(\"com.android.legacy-kapt\") version agpVersion apply false"
+        )
+        settingsGradle.writeText(updatedSettingsContent)
+
+        val buildGradle = File(project.root, "workload/build.gradle.kts")
+        val content = buildGradle.readText()
+        val updatedContent = content.replace(
+            "id(\"com.android.application\")",
+            "id(\"com.android.application\")\n    id(\"com.android.legacy-kapt\")"
+        )
+        buildGradle.writeText(updatedContent)
+
+        val resDir = File(project.root, "workload/src/main/res/values")
+        resDir.mkdirs()
+        File(resDir, "strings.xml").writeText(
+            """
+            <resources>
+                <string name="sample_label">Sample Label</string>
+            </resources>
+            """.trimIndent()
+        )
+
+        val javaDir = File(project.root, "workload/src/main/java/com/example")
+        javaDir.mkdirs()
+        File(javaDir, "RUsage.kt").writeText(
+            """
+            package com.example
+            import com.example.annotation.Builder
+            import com.example.myapplication.R
+
+            @Builder
+            class RUsage {
+                val label = R.string.sample_label
+            }
+            """.trimIndent()
+        )
+
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(
+            "clean", "build", "--configuration-cache", "--info", "--stacktrace"
+        ).build().let { result ->
+            val classesJar = File(
+                project.root,
+                "workload/build/intermediates/compile_app_classes_jar/debug/bundleDebugClassesToCompileJar/classes.jar"
+            )
+            JarFile(classesJar).use { jarFile ->
+                jarFile.assertContainsNonNullEntry("com/example/RUsageBuilder.class")
+            }
+        }
+    }
 }


### PR DESCRIPTION
This change resolves a KSP regression where generated Android R classes fail to resolve when `android.builtInKotlin=true` is enabled. 

The fix is targeted based on whether KAPT is enabled or not.

If KAPT is not applied, KSP now safely wires the kotlinCompile libraries directly. If KAPT (specifically com.android.legacy-kapt) is applied, we fall back to a restricted classpath but wire the compiledRClassArtifact using AGP 9's ComponentCreationConfig API to restore R class visibility. Internal AGP API usage warnings have been suppressed at the file level in AndroidPluginIntegration.kt to satisfy lint checks. 

Fixes #2857