### PR TITLE
Filter source file trees in KspAATask to restore NO-SOURCE skipping behaviour

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -212,9 +212,13 @@ abstract class KspAATask @Inject constructor(
                             sourceSet.kotlin.srcDirs.filter {
                                 !kotlinOut.asFile.isParentOf(it) && !javaOut.asFile.isParentOf(it) &&
                                     it !in kspExtension.excludedSources
-                            }.map {
+                            }.map { srcDir ->
                                 // @SkipWhenEmpty doesn't work well with File.
-                                project.objects.fileTree().from(it)
+                                // Filter to only include Kotlin/Java sources so that Gradle can correctly
+                                // skip the task as NO-SOURCE if the directories contain only non-source files.
+                                project.objects.fileTree().from(srcDir).matching {
+                                    it.include("**/*.kt", "**/*.kts", "**/*.java")
+                                }
                             }
                         }
                         cfg.sourceRoots.from(filtered)

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -411,4 +411,30 @@ class SourceSetConfigurationsTest(isExperimentalPsiResolution: Boolean) {
             testRule.runner().withArguments(":app:test", "--stacktrace").build()
         }
     }
+
+    @Test
+    fun testNoSourceSkippedWithNonSourceFiles() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.dependencies.add(
+            module("ksp", testRule.processorModule)
+        )
+        class Processor(val codeGenerator: CodeGenerator) : SymbolProcessor {
+            override fun process(resolver: Resolver): List<KSAnnotated> = emptyList()
+        }
+        class Provider : TestSymbolProcessorProvider({ env -> Processor(env.codeGenerator) })
+        testRule.addProvider(Provider::class)
+
+        // Create source directory but only add a non-source file
+        val srcDir = testRule.appModule.moduleRoot.resolve("src/main/kotlin")
+        srcDir.mkdirs()
+        srcDir.resolve("README.md").writeText("This is not a source file")
+
+        val result = testRule.runner()
+            .withArguments(":app:kspKotlin")
+            .build()
+
+        val kspTask = result.task(":app:kspKotlin")
+        require(kspTask != null)
+        assertThat(kspTask.outcome).isEqualTo(TaskOutcome.NO_SOURCE)
+    }
 }


### PR DESCRIPTION
By adding filters for Kotlin and Java files to the input file tree, Gradle can now properly skip these modules as NO-SOURCE. This saves a few hundred milliseconds of useless overhead per module during builds.

Fixes #2947