### PR TITLE
Allow test failures in non-primary tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,10 +84,12 @@ jobs:
 
     - name: Run secondary integration tests
       if: matrix.test-suite == 'integration-test-secondary'
+      continue-on-error: true
       run: ./gradlew :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
     - name: Run agp integration tests
       if: matrix.test-suite == 'integration-test-agp'
+      continue-on-error: true
       run: ./gradlew :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
     - name: Run remaining tests and checks

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/AndroidIT.kt
@@ -32,6 +32,7 @@ class AndroidIT(experimentalPsiResolution: Boolean) {
 
     @Test
     fun testPlaygroundAndroid() {
+        assert(false)
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
 
         gradleRunner.withArguments(


### PR DESCRIPTION
The `continue-on-error` that we have applied to entire job causes the matrix build to continue if one of the matrix instances fails. It does not apply to the job. This PR fixes that, so if the matrix instance with the secondary tests fails, then the workflow does not fail.

See https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepscontinue-on-error and https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idcontinue-on-error