### PR TITLE
Add regression test for annotation array value type

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
@@ -25,8 +25,8 @@ class AnnotationArrayValueTypeProcessor : AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        logAnnotationArrayValue(resolver, "JavaAnnotated")
-        logAnnotationArrayValue(resolver, "KotlinAnnotated")
+        logAnnotationArrayValues(resolver, "JavaAnnotated")
+        logAnnotationArrayValues(resolver, "KotlinAnnotated")
         return emptyList()
     }
 
@@ -34,14 +34,16 @@ class AnnotationArrayValueTypeProcessor : AbstractTestProcessor() {
         return results
     }
 
-    private fun logAnnotationArrayValue(resolver: Resolver, className: String) {
+    private fun logAnnotationArrayValues(resolver: Resolver, className: String) {
         val annotated = resolver.getClassDeclarationByName(className)!!
-        val annotation = annotated.annotations.single { it.shortName.asString() == "JavaAnnotation" }
-        val argument = annotation.arguments.single()
-        val value = argument.value
-        val argumentName = argument.name?.asString()
-        results.add("$className $argumentName is Array<*>: ${value is Array<*>}")
-        results.add("$className $argumentName size: ${value.sizeOrNull()}")
+        listOf("JavaAnnotation", "KotlinAnnotation").forEach { annotationName ->
+            val annotation = annotated.annotations.single { it.shortName.asString() == annotationName }
+            val argument = annotation.arguments.single()
+            val value = argument.value
+            val argumentName = argument.name?.asString()
+            results.add("$className $annotationName $argumentName is Array<*>: ${value is Array<*>}")
+            results.add("$className $annotationName $argumentName size: ${value.sizeOrNull()}")
+        }
     }
 
     private fun Any?.sizeOrNull(): Int? {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
@@ -25,17 +25,23 @@ class AnnotationArrayValueTypeProcessor : AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val annotated = resolver.getClassDeclarationByName("JavaAnnotated")!!
-        val annotation = annotated.annotations.single { it.shortName.asString() == "JavaAnnotation" }
-        val argument = annotation.arguments.single()
-        val value = argument.value
-        results.add("${argument.name?.asString()} is Array<*>: ${value is Array<*>}")
-        results.add("${argument.name?.asString()} size: ${value.sizeOrNull()}")
+        logAnnotationArrayValue(resolver, "JavaAnnotated")
+        logAnnotationArrayValue(resolver, "KotlinAnnotated")
         return emptyList()
     }
 
     override fun toResult(): List<String> {
         return results
+    }
+
+    private fun logAnnotationArrayValue(resolver: Resolver, className: String) {
+        val annotated = resolver.getClassDeclarationByName(className)!!
+        val annotation = annotated.annotations.single { it.shortName.asString() == "JavaAnnotation" }
+        val argument = annotation.arguments.single()
+        val value = argument.value
+        val argumentName = argument.name?.asString()
+        results.add("$className $argumentName is Array<*>: ${value is Array<*>}")
+        results.add("$className $argumentName size: ${value.sizeOrNull()}")
     }
 
     private fun Any?.sizeOrNull(): Int? {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -28,6 +28,12 @@ class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = f
         runTest("$AA_PATH/getSymbolsWithAnnotation/aliasedAnnotation.kt")
     }
 
+    @TestMetadata("annotationArrayValueType.kt")
+    @Test
+    override fun testAnnotationArrayValueType() {
+        runFailingTest("$AA_PATH/annotationArrayValueType.kt")
+    }
+
     @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
     override fun testAllUseSiteTargetAppliedToAnnotationList() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -152,6 +152,9 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/annotationWithArrayValue.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/3008", BugState.OPEN)
+    abstract fun testAnnotationArrayValueType()
+
     @TestMetadata("annotationWithDefault.kt")
     @Test
     fun testAnnotationWithDefault() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -28,6 +28,12 @@ class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = 
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/aliasedAnnotation.kt")
     }
 
+    @TestMetadata("annotationArrayValueType.kt")
+    @Test
+    override fun testAnnotationArrayValueType() {
+        runFailingTest("$AA_PATH/annotationArrayValueType.kt")
+    }
+
     @TestMetadata("allUseSiteTargetAppliedToAnnotationList.kt")
     @Test
     override fun testAllUseSiteTargetAppliedToAnnotationList() {

--- a/kotlin-analysis-api/testData/annotationArrayValueType.kt
+++ b/kotlin-analysis-api/testData/annotationArrayValueType.kt
@@ -16,10 +16,14 @@
  */
 // TEST PROCESSOR: AnnotationArrayValueTypeProcessor
 // EXPECTED:
-// JavaAnnotated args is Array<*>: true
-// JavaAnnotated args size: 2
-// KotlinAnnotated args is Array<*>: true
-// KotlinAnnotated args size: 2
+// JavaAnnotated JavaAnnotation args is Array<*>: true
+// JavaAnnotated JavaAnnotation args size: 2
+// JavaAnnotated KotlinAnnotation args is Array<*>: true
+// JavaAnnotated KotlinAnnotation args size: 2
+// KotlinAnnotated JavaAnnotation args is Array<*>: true
+// KotlinAnnotated JavaAnnotation args size: 2
+// KotlinAnnotated KotlinAnnotation args is Array<*>: true
+// KotlinAnnotated KotlinAnnotation args size: 2
 // END
 // FILE: JavaAnnotation.java
 public @interface JavaAnnotation {
@@ -33,8 +37,14 @@ public @interface NestedAnnotation {
 
 // FILE: JavaAnnotated.java
 @JavaAnnotation(args = {@NestedAnnotation(value = "one"), @NestedAnnotation(value = "two")})
+@KotlinAnnotation(args = {@KotlinNestedAnnotation(value = "one"), @KotlinNestedAnnotation(value = "two")})
 class JavaAnnotated {}
 
 // FILE: KotlinAnnotated.kt
+annotation class KotlinAnnotation(val args: Array<KotlinNestedAnnotation>)
+
+annotation class KotlinNestedAnnotation(val value: String)
+
 @JavaAnnotation(args = [NestedAnnotation(value = "one"), NestedAnnotation(value = "two")])
+@KotlinAnnotation(args = [KotlinNestedAnnotation(value = "one"), KotlinNestedAnnotation(value = "two")])
 class KotlinAnnotated

--- a/kotlin-analysis-api/testData/annotationArrayValueType.kt
+++ b/kotlin-analysis-api/testData/annotationArrayValueType.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// TEST PROCESSOR: AnnotationArrayValueTypeProcessor
+// EXPECTED:
+// args is Array<*>: true
+// args size: 2
+// END
+// FILE: JavaAnnotation.java
+public @interface JavaAnnotation {
+    NestedAnnotation[] args();
+}
+
+// FILE: NestedAnnotation.java
+public @interface NestedAnnotation {
+    String value();
+}
+
+// FILE: JavaAnnotated.java
+@JavaAnnotation(args = {@NestedAnnotation(value = "one"), @NestedAnnotation(value = "two")})
+class JavaAnnotated {}

--- a/kotlin-analysis-api/testData/annotationArrayValueType.kt
+++ b/kotlin-analysis-api/testData/annotationArrayValueType.kt
@@ -16,8 +16,10 @@
  */
 // TEST PROCESSOR: AnnotationArrayValueTypeProcessor
 // EXPECTED:
-// args is Array<*>: true
-// args size: 2
+// JavaAnnotated args is Array<*>: true
+// JavaAnnotated args size: 2
+// KotlinAnnotated args is Array<*>: true
+// KotlinAnnotated args size: 2
 // END
 // FILE: JavaAnnotation.java
 public @interface JavaAnnotation {
@@ -32,3 +34,7 @@ public @interface NestedAnnotation {
 // FILE: JavaAnnotated.java
 @JavaAnnotation(args = {@NestedAnnotation(value = "one"), @NestedAnnotation(value = "two")})
 class JavaAnnotated {}
+
+// FILE: KotlinAnnotated.kt
+@JavaAnnotation(args = [NestedAnnotation(value = "one"), NestedAnnotation(value = "two")])
+class KotlinAnnotated

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class AnnotationArrayValueTypeProcessor : AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val annotated = resolver.getClassDeclarationByName("JavaAnnotated")!!
+        val annotation = annotated.annotations.single { it.shortName.asString() == "JavaAnnotation" }
+        val argument = annotation.arguments.single()
+        val value = argument.value
+        results.add("${argument.name?.asString()} is Array<*>: ${value is Array<*>}")
+        results.add("${argument.name?.asString()} size: ${value.sizeOrNull()}")
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    private fun Any?.sizeOrNull(): Int? {
+        return when (this) {
+            is Array<*> -> size
+            is Collection<*> -> size
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
Adds a failing regression test for Java annotation array arguments.

The test covers a Java source annotation usage where a Java annotation array argument is read through `KSValueArgument.value`. It verifies that the value should be exposed as `Array<*>`, matching the KSP API contract.

The test is currently registered with `runFailingTest` in both AA and PSI configured suites to document the existing incorrect behavior before implementing the fix.

Refs #3008

Verified locally:

```bash
./gradlew :kotlin-analysis-api:test \
  --tests com.google.devtools.ksp.test.AAConfiguredUnitTestSuite.testAnnotationArrayValueType \
  --tests com.google.devtools.ksp.test.PsiConfiguredUnitTestSuite.testAnnotationArrayValueType
```

```text
AAConfiguredUnitTestSuite > testAnnotationArrayValueType() PASSED
PsiConfiguredUnitTestSuite > testAnnotationArrayValueType() PASSED
BUILD SUCCESSFUL
```
