### PR TITLE
Add negative test for incremental compilation

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/IncrementalAnnotationArgumentClassReferences.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/IncrementalAnnotationArgumentClassReferences.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.test.secondary
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.File
+
+@RunWith(Parameterized::class)
+class IncrementalAnnotationArgumentClassReferences(experimentalPsiResolution: Boolean) {
+
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental-annotation-argument-class-references",
+        experimentalPsiResolution = experimentalPsiResolution
+    )
+
+    companion object {
+
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+
+        private const val TARGET: String = "downstream"
+        private const val KSP_KOTLIN: String = ":$TARGET:kspKotlin"
+        private const val ASSEMBLE: String = "assemble"
+        private const val CLEAN: String = "clean"
+        private const val PROCESSOR_LABEL: String = "[TestProcessor]"
+    }
+
+    @Test
+    fun testUpToDate() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+
+        gradleRunner.withArguments(CLEAN, ASSEMBLE).build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":$TARGET:assemble")?.outcome)
+        }
+
+        gradleRunner.withArguments(ASSEMBLE).build().let { result ->
+            Assert.assertEquals(TaskOutcome.UP_TO_DATE, result.task(KSP_KOTLIN)?.outcome)
+        }
+    }
+
+    @Test
+    fun testProcessorChange() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        // 1. Clean build
+        val expected = mutableListOf<String>()
+        gradleRunner.withArguments(CLEAN, ASSEMBLE).build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(KSP_KOTLIN)?.outcome)
+            val processedClasses = result.output.lines().filter { it.startsWith(PROCESSOR_LABEL) }
+            expected.addAll(processedClasses)
+            Assert.assertTrue("Expected processed classes, but found none", expected.isNotEmpty())
+        }
+
+        // 2. Apply change to upstream class
+        val fileToChange = "upstream/src/main/kotlin/UpstreamChanges.kt"
+        val change = "{ val prop2 = false }"
+        File(project.root, fileToChange).appendText(change)
+
+        // 3. Rebuild
+        gradleRunner.withArguments(ASSEMBLE).build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(KSP_KOTLIN)?.outcome)
+            val actual = result.output.lines().filter { it.startsWith(PROCESSOR_LABEL) }
+            Assert.assertNotEquals(
+                "\n${expected.joinToString("\n")}\n[SEPARATOR]\n${actual.joinToString("\n")}",
+                expected,
+                actual
+            )
+        }
+    }
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/build.gradle.kts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    kotlin("jvm")
+}
+
+repositories {
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    mavenCentral()
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/downstream/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/downstream/build.gradle.kts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    mavenCentral()
+}
+
+dependencies {
+    implementation(project(":upstream"))
+    ksp(project(":processor"))
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/downstream/src/main/kotlin/DownstreamClass.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/downstream/src/main/kotlin/DownstreamClass.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ExampleReference(UpstreamEntryPoint::class)
+class DownstreamClass

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/build.gradle.kts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val kspVersion: String by project
+val testRepo: String by project
+
+plugins {
+    kotlin("jvm")
+}
+
+group = "com.example"
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.google.devtools.ksp:symbol-processing-api:$kspVersion")
+}
+
+sourceSets.main {
+    java.srcDirs("src/main/kotlin")
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/kotlin/TestProcessor.kt
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSType
+
+class TestProcessor(val environment: SymbolProcessorEnvironment) : SymbolProcessor {
+    private val createdFiles = mutableSetOf<String>()
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getSymbolsWithAnnotation("ExampleReference")
+            .filterIsInstance<KSClassDeclaration>().forEach { sym ->
+                // Follow dependencies to let KSP capture dependency graph
+                followSym(sym)
+
+                val fileName = "${sym.simpleName.asString()}Generated"
+
+                if (!createdFiles.contains(fileName)) {
+                    createdFiles.add(fileName)
+                    val file = environment.codeGenerator.createNewFile(
+                        Dependencies(false, sym.containingFile!!),
+                        "",
+                        fileName
+                    )
+                    file.write("class ${sym.simpleName.asString()}Generated".toByteArray())
+                }
+            }
+        // Do not keep KSNodes across rounds
+        seen.clear()
+        return emptyList()
+    }
+
+    private val seen = mutableListOf<KSNode>()
+    private val queue = mutableListOf<KSNode>()
+
+    private fun followSym(sym: KSAnnotated) {
+        if (!seen.contains(sym)) {
+            queue.add(sym)
+        }
+        while (queue.isNotEmpty()) {
+            val node = queue.removeFirst()
+            log("Processing $node")
+            seen.add(node)
+            when (node) {
+                is KSDeclaration -> {
+                    followAnnotations(node)
+                    followDeclaration(node)
+                }
+
+                is KSAnnotated -> {
+                    followAnnotations(node)
+                }
+
+                else -> Unit
+            }
+        }
+    }
+
+    private fun followAnnotations(sym: KSAnnotated) {
+        sym.annotations.forEach { anno ->
+            anno.arguments.forEach { annoArg ->
+                annoArg.value?.let { value ->
+                    when (value) {
+                        is List<*> -> {
+                            value.filterIsInstance<KSType>()
+                                .map { ksType -> ksType.declaration }
+                                .filterNot(seen::contains)
+                                .forEach(queue::add)
+                        }
+
+                        is KSType -> {
+                            val decl = value.declaration
+                            if (!seen.contains(decl)) {
+                                queue.add(decl)
+                            }
+                        }
+
+                        else -> {
+                            return@forEach
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun followDeclaration(ksDecl: KSDeclaration): Unit = when (ksDecl) {
+        is KSClassDeclaration -> {
+            ksDecl.declarations
+                .filterNot(seen::contains)
+                .filter { it !is KSPropertyDeclaration }
+                .forEach(queue::add)
+        }
+
+        is KSFunctionDeclaration -> {
+            ksDecl.returnType?.resolve()?.declaration?.let {
+                if (!seen.contains(it)) {
+                    queue.add(it)
+                }
+            }
+            ksDecl.parameters
+                .map { it.type.resolve().declaration }
+                .filterNot(seen::contains)
+                .forEach(queue::add)
+        }
+
+        else -> Unit
+    }
+
+    private fun log(msg: Any) {
+        println("[TestProcessor] $msg")
+    }
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/kotlin/TestProcessorProvider.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/kotlin/TestProcessorProvider.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+class TestProcessorProvider : SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return TestProcessor(environment)
+    }
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/processor/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -1,0 +1,1 @@
+TestProcessorProvider

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/settings.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/settings.gradle.kts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pluginManagement {
+    val kspVersion: String by settings
+    val kotlinVersion: String by settings
+    val testRepo: String by settings
+    plugins {
+        id("com.google.devtools.ksp") version kspVersion
+        kotlin("jvm") version kotlinVersion
+    }
+    repositories {
+        maven(testRepo)
+        gradlePluginPortal()
+        maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    }
+}
+
+rootProject.name = "incremental-test-annotation-argument-class-references"
+
+include(":downstream")
+include(":upstream")
+include(":processor")

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/build.gradle.kts
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/build.gradle.kts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+val testRepo: String by project
+
+plugins {
+    id("com.google.devtools.ksp")
+    kotlin("jvm")
+}
+
+version = "1.0-SNAPSHOT"
+
+repositories {
+    maven(testRepo)
+    maven("https://redirector.kotlinlang.org/maven/bootstrap/")
+    mavenCentral()
+}
+
+dependencies {
+    ksp(project(":processor"))
+}

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/ExampleReference.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/ExampleReference.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import kotlin.reflect.KClass
+
+annotation class ExampleReference(val value: KClass<*>)

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/UpstreamChanges.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/UpstreamChanges.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+class UpstreamChanges(val prop: Int)

--- a/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/UpstreamEntryPoint.kt
+++ b/integration-tests/src/test/resources/incremental-annotation-argument-class-references/upstream/src/main/kotlin/UpstreamEntryPoint.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@ExampleReference(UpstreamChanges::class)
+class UpstreamEntryPoint


### PR DESCRIPTION
This test shows the presence of the bug where KSP does not capture transitive dependencies of class references, e.g., `MyClass::class`.

Related to #3011 