### PR TITLE
Add logging for dependency graph

### DIFF
--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/IncrementalContextLoggingOptions.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/IncrementalContextLoggingOptions.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp
+
+import java.io.Serializable
+
+/**
+ * Contains flags and configurations for incremental context logging.
+ */
+data class IncrementalContextLoggingOptions(
+    val incrementalLoggingEnabled: Boolean,
+    val dependencyGraphOriginName: String?
+) : Serializable

--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.processing
 
+import com.google.devtools.ksp.IncrementalContextLoggingOptions
 import java.io.File
 import java.io.Serializable
 
@@ -40,7 +41,7 @@ abstract class KSPConfig(
     val resourceOutputDir: File,
 
     val incremental: Boolean,
-    val incrementalLog: Boolean,
+    val incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     val modifiedSources: List<File>,
     val removedSources: List<File>,
     val changedClasses: List<String>,
@@ -71,6 +72,13 @@ abstract class KSPConfig(
 
         var incremental: Boolean = false
         var incrementalLog: Boolean = false
+        var incrementalLogGraphOrigin: String? = null
+            set(value) {
+                field = value
+                    ?.trim()
+                    ?.filterNot(::isInvalidGraphChar)
+            }
+
         var modifiedSources: List<File> = emptyList()
         var removedSources: List<File> = emptyList()
         var changedClasses: List<String> = emptyList()
@@ -81,6 +89,22 @@ abstract class KSPConfig(
         var allWarningsAsErrors: Boolean = false
         var mapAnnotationArgumentsInJava: Boolean = false
         var experimentalPsiResolution: Boolean = false
+
+        private companion object {
+            @JvmStatic
+            fun isInvalidGraphChar(char: Char): Boolean =
+                isEscape(char) || isQuote(char) || isWhiteSpace(char)
+
+            @JvmStatic
+            fun isWhiteSpace(char: Char): Boolean =
+                char == ' ' || char == '\n' || char == '\t' || char == '\r'
+
+            @JvmStatic
+            fun isEscape(char: Char): Boolean = char == '\\'
+
+            @JvmStatic
+            fun isQuote(char: Char): Boolean = char == '\'' || char == '"'
+        }
     }
 }
 
@@ -107,7 +131,7 @@ class KSPJvmConfig(
     resourceOutputDir: File,
 
     incremental: Boolean,
-    incrementalLog: Boolean,
+    incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
@@ -136,7 +160,7 @@ class KSPJvmConfig(
     resourceOutputDir,
 
     incremental,
-    incrementalLog,
+    incrementalContextLoggingOptions,
     modifiedSources,
     removedSources,
     changedClasses,
@@ -180,7 +204,10 @@ class KSPJvmConfig(
                 resourceOutputDir,
 
                 incremental,
-                incrementalLog,
+                IncrementalContextLoggingOptions(
+                    incrementalLog,
+                    incrementalLogGraphOrigin,
+                ),
                 modifiedSources,
                 removedSources,
                 changedClasses,
@@ -215,7 +242,7 @@ class KSPNativeConfig(
     resourceOutputDir: File,
 
     incremental: Boolean,
-    incrementalLog: Boolean,
+    incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
@@ -244,7 +271,7 @@ class KSPNativeConfig(
     resourceOutputDir,
 
     incremental,
-    incrementalLog,
+    incrementalContextLoggingOptions,
     modifiedSources,
     removedSources,
     changedClasses,
@@ -279,7 +306,10 @@ class KSPNativeConfig(
                 resourceOutputDir,
 
                 incremental,
-                incrementalLog,
+                IncrementalContextLoggingOptions(
+                    incrementalLog,
+                    incrementalLogGraphOrigin,
+                ),
                 modifiedSources,
                 removedSources,
                 changedClasses,
@@ -314,7 +344,7 @@ class KSPJsConfig(
     resourceOutputDir: File,
 
     incremental: Boolean,
-    incrementalLog: Boolean,
+    incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
@@ -343,7 +373,7 @@ class KSPJsConfig(
     resourceOutputDir,
 
     incremental,
-    incrementalLog,
+    incrementalContextLoggingOptions,
     modifiedSources,
     removedSources,
     changedClasses,
@@ -378,7 +408,10 @@ class KSPJsConfig(
                 resourceOutputDir,
 
                 incremental,
-                incrementalLog,
+                IncrementalContextLoggingOptions(
+                    incrementalLog,
+                    incrementalLogGraphOrigin,
+                ),
                 modifiedSources,
                 removedSources,
                 changedClasses,
@@ -418,7 +451,7 @@ class KSPCommonConfig(
     resourceOutputDir: File,
 
     incremental: Boolean,
-    incrementalLog: Boolean,
+    incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
@@ -447,7 +480,7 @@ class KSPCommonConfig(
     resourceOutputDir,
 
     incremental,
-    incrementalLog,
+    incrementalContextLoggingOptions,
     modifiedSources,
     removedSources,
     changedClasses,
@@ -482,7 +515,10 @@ class KSPCommonConfig(
                 resourceOutputDir,
 
                 incremental,
-                incrementalLog,
+                IncrementalContextLoggingOptions(
+                    incrementalLog,
+                    incrementalLogGraphOrigin,
+                ),
                 modifiedSources,
                 removedSources,
                 changedClasses,

--- a/common-deps/src/test/kotlin/com/google/devtools/ksp/CommandLineArgParserTest.kt
+++ b/common-deps/src/test/kotlin/com/google/devtools/ksp/CommandLineArgParserTest.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.ksp
 
 import com.google.devtools.ksp.processing.kspJvmArgParser
@@ -17,26 +34,28 @@ class CommandLineArgParserTest(private val isExperimentalPsiResolution: Boolean)
         fun params() = listOf(arrayOf(true), arrayOf(false))
     }
 
+    val sep = File.pathSeparator
+    fun mkDefaultArgs() = mutableListOf<String>(
+        "-module-name=MyModule",
+        "-source-roots", "/path/to/A$sep/path/to/B",
+        "/path/to/processorA.jar",
+        "-kotlin-output-dir=/path/to/output/kotlin",
+        "-java-output-dir=/path/to/output/java",
+        "-class-output-dir=/path/to/output/class",
+        "-resource-output-dir=/path/to/output/resource",
+        "-language-version=2.0",
+        "-api-version=2.0",
+        "-jvm-target", "21",
+        "-project-base-dir", "/path/to/base",
+        "-output-base-dir", "/path/to/output",
+        "-caches-dir", "/path/to/caches",
+        "-experimental-psi-resolution=$isExperimentalPsiResolution",
+        "/path/to/processorB.jar${sep}rel/to/processorC.jar",
+    )
+
     @Test
     fun testJvm() {
-        val sep = File.pathSeparator
-        val args = arrayListOf<String>(
-            "-module-name=MyModule",
-            "-source-roots", "/path/to/A$sep/path/to/B",
-            "/path/to/processorA.jar",
-            "-kotlin-output-dir=/path/to/output/kotlin",
-            "-java-output-dir=/path/to/output/java",
-            "-class-output-dir=/path/to/output/class",
-            "-resource-output-dir=/path/to/output/resource",
-            "-language-version=2.0",
-            "-api-version=2.0",
-            "-jvm-target", "21",
-            "-project-base-dir", "/path/to/base",
-            "-output-base-dir", "/path/to/output",
-            "-caches-dir", "/path/to/caches",
-            "-experimental-psi-resolution=$isExperimentalPsiResolution",
-            "/path/to/processorB.jar${sep}rel/to/processorC.jar",
-        ).toTypedArray()
+        val args = mkDefaultArgs().toTypedArray()
         val (config, classpath) = kspJvmArgParser(args)
         Assert.assertEquals(
             listOf("/path/to/A", "/path/to/B").map(::File),
@@ -64,5 +83,54 @@ class CommandLineArgParserTest(private val isExperimentalPsiResolution: Boolean)
         Assert.assertTrue("    -experimental-psi-resolution=Boolean" in helpMsg)
         Assert.assertTrue("*   <processor classpath>" in helpMsg)
         println(helpMsg)
+    }
+
+    fun mkDependencyGraphArg(value: String) = "-incremental-log-graph-origin=$value"
+
+    @Test
+    fun testIncrementalLoggingGraphOriginNull() {
+        val args = mkDefaultArgs()
+        val (config, _) = kspJvmArgParser(args.toTypedArray())
+        Assert.assertEquals(null, config.incrementalContextLoggingOptions.dependencyGraphOriginName)
+    }
+
+    @Test
+    fun testIncrementalLoggingGraphOriginValidName() {
+        val args = mkDefaultArgs()
+        args.add(
+            mkDependencyGraphArg("a.b.c.MyClass")
+        )
+        val (config, _) = kspJvmArgParser(args.toTypedArray())
+        Assert.assertEquals("a.b.c.MyClass", config.incrementalContextLoggingOptions.dependencyGraphOriginName)
+    }
+
+    @Test
+    fun testIncrementalLoggingGraphOriginEmptyQuotes() {
+        val args = mkDefaultArgs()
+        args.add(
+            mkDependencyGraphArg("\"\"")
+        )
+        val (config, _) = kspJvmArgParser(args.toTypedArray())
+        Assert.assertEquals("", config.incrementalContextLoggingOptions.dependencyGraphOriginName)
+    }
+
+    @Test
+    fun testIncrementalLoggingGraphOriginValidNameWithQuotes() {
+        val args = mkDefaultArgs()
+        args.add(
+            mkDependencyGraphArg("\"xyz.Something\"")
+        )
+        val (config, _) = kspJvmArgParser(args.toTypedArray())
+        Assert.assertEquals("xyz.Something", config.incrementalContextLoggingOptions.dependencyGraphOriginName)
+    }
+
+    @Test
+    fun testIncrementalLoggingGraphOriginInvalidChars() {
+        val args = mkDefaultArgs()
+        args.add(
+            mkDependencyGraphArg("\\\"xyz.Other")
+        )
+        val (config, _) = kspJvmArgParser(args.toTypedArray())
+        Assert.assertEquals("xyz.Other", config.incrementalContextLoggingOptions.dependencyGraphOriginName)
     }
 }

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalUtil.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalUtil.kt
@@ -30,7 +30,7 @@ abstract class KSVirtualFile(val baseDir: File, val name: String) : KSFile {
         get() = throw Exception("$name should not be used.")
 
     override val fileName: String
-        get() = "<$name is a virtual file; DO NOT USE.>"
+        get() = "$syntheticFileNamePrefix$name$SYNTHETIC_FILE_NAME_SUFFIX"
 
     override val filePath: String
         get() = File(baseDir, fileName).path
@@ -50,17 +50,71 @@ abstract class KSVirtualFile(val baseDir: File, val name: String) : KSFile {
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {
         throw Exception("$name should not be used.")
     }
+
+    abstract val syntheticFileNamePrefix: String
+
+    companion object {
+        const val SYNTHETIC_FILE_NAME_SUFFIX: String = " is a virtual file; DO NOT USE.>"
+    }
 }
 
 /**
  * Used when an output potentially depends on new information.
  */
-class AnyChanges(baseDir: File) : KSVirtualFile(baseDir, "AnyChanges")
+class AnyChanges(baseDir: File) : KSVirtualFile(baseDir, "AnyChanges") {
+    override val syntheticFileNamePrefix: String = SYNTHETIC_FILE_NAME_PREFIX
+
+    companion object {
+        fun isSyntheticFile(name: String, baseDir: File? = null): Boolean {
+            val anyChangesFile = baseDir?.let(::AnyChanges)
+            val processedName = name.removeSuffix(SYNTHETIC_FILE_NAME_SUFFIX)
+            return name == anyChangesFile?.fileName ||
+                name == anyChangesFile?.filePath ||
+                processedName.removePrefix(SYNTHETIC_FILE_NAME_PREFIX) == "AnyChanges"
+        }
+
+        const val SYNTHETIC_FILE_NAME_PREFIX: String = "<"
+    }
+}
 
 /**
  * Used for classes from classpath, i.e., classes without source files.
  */
-class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, "NoSourceFile for $fqn")
+class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, fqn) {
+    override val syntheticFileNamePrefix: String = SYNTHETIC_FILE_NAME_PREFIX
+
+    companion object {
+        fun isSyntheticFile(name: String, baseDir: File? = null): Boolean {
+
+            val noSourceFile = baseDir?.let { NoSourceFile(it, name) }
+
+            val processedName = name.removeSuffix(SYNTHETIC_FILE_NAME_SUFFIX)
+            return name == noSourceFile?.fileName ||
+                name == noSourceFile?.filePath ||
+                (
+                    name.startsWith(SYNTHETIC_FILE_NAME_PREFIX) &&
+                        name.endsWith(SYNTHETIC_FILE_NAME_SUFFIX)
+                    )
+        }
+
+        const val SYNTHETIC_FILE_NAME_PREFIX: String = "<NoSourceFile for "
+    }
+}
+
+fun isSyntheticFileName(name: String, baseDir: File? = null): Boolean {
+    return AnyChanges.isSyntheticFile(name, baseDir) || NoSourceFile.isSyntheticFile(name, baseDir)
+}
+
+/**
+ * Returns `a.b.c.MyClass` if `name` is a synthetic [NoSourceFile] file for `a.b.c.MyClass`.
+ */
+fun stripSyntheticFileNameModifiers(name: String, baseDir: File? = null): String {
+    require(
+        NoSourceFile.isSyntheticFile(name, baseDir),
+        { "Name '$name' must be recognized by NoSourceFile.isSyntheticFile" })
+    return name.removePrefix(NoSourceFile.SYNTHETIC_FILE_NAME_PREFIX)
+        .removeSuffix(KSVirtualFile.SYNTHETIC_FILE_NAME_SUFFIX)
+}
 
 // Copy recursively, including last-modified-time of file and its parent dirs.
 //

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -156,6 +156,7 @@ abstract class KspAATask @Inject constructor(
                         kspConfig.processorClasspath,
                     )
                 }
+
                 else -> {
                     if (
                         !inputChanges.isIncremental ||
@@ -373,6 +374,10 @@ abstract class KspAATask @Inject constructor(
                             .gradleProperty("ksp.incremental.log")
                             .map { it.toBoolean() }
                             .orElse(false)
+                    )
+                    cfg.incrementalGraphOrigin.value(
+                        project.providers
+                            .gradleProperty("ksp.incremental.log.graph.origin")
                     )
 
                     cfg.experimentalPsiResolution.value(
@@ -677,6 +682,10 @@ abstract class KspGradleConfig @Inject constructor() {
     abstract val incrementalLog: Property<Boolean>
 
     @get:Input
+    @get:Optional
+    abstract val incrementalGraphOrigin: Property<String>
+
+    @get:Input
     abstract val experimentalPsiResolution: Property<Boolean>
 
     @get:PathSensitive(PathSensitivity.NONE)
@@ -789,6 +798,7 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
 
             incremental = gradleCfg.incremental.get()
             incrementalLog = gradleCfg.incrementalLog.get()
+            incrementalLogGraphOrigin = gradleCfg.incrementalGraphOrigin.orNull
             experimentalPsiResolution = gradleCfg.experimentalPsiResolution.get()
 
             modifiedSources = parameters.modifiedSources

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/fixtures/TemporaryTestProject.kt
@@ -6,7 +6,8 @@ import java.io.File
 class TemporaryTestProject(
     projectName: String,
     baseProject: String? = null,
-    val experimentalPsiResolution: Boolean
+    val experimentalPsiResolution: Boolean,
+    val incrementalLogging: Boolean? = true,
 ) : TemporaryFolder() {
     private val testProjectSrc = File("src/test/resources", projectName)
     private val baseProjectSrc = baseProject?.let { File("src/test/resources", baseProject) }
@@ -31,7 +32,9 @@ class TemporaryTestProject(
         appendProperty("testRepo=$testRepo")
         appendProperty("org.gradle.configuration-cache=true")
         appendProperty("kotlin.jvm.target.validation.mode=warning")
-        appendProperty("ksp.incremental.log=true")
+        incrementalLogging?.let { value ->
+            appendProperty("ksp.incremental.log=$value")
+        }
         appendProperty("ksp.experimental.psi.resolution=$experimentalPsiResolution")
         appendProperty("android.useAndroidX=true")
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/IncrementalGraphOriginIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/IncrementalGraphOriginIT.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.test.secondary
+
+import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Assert
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class IncrementalGraphOriginIT(experimentalPsiResolution: Boolean) {
+    @Rule
+    @JvmField
+    val project: TemporaryTestProject = TemporaryTestProject(
+        "incremental",
+        experimentalPsiResolution = experimentalPsiResolution,
+        incrementalLogging = null, // Setting to null means the property is not declared
+    )
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Boolean> = listOf(true, false)
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToValidNameLoggingEnabled() {
+        project.appendProperty("ksp.incremental.log=true")
+        project.appendProperty("ksp.incremental.log.graph.origin=p1.TestK2K")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot to be generated", dotFiles.isNotEmpty())
+        val content = dotFiles.first().readText()
+        Assert.assertTrue("Expected digraph header in dot file", content.startsWith("digraph {"))
+        Assert.assertTrue("Expected p1.TestK2K origin in dot file", content.contains("\"p1.TestK2K\""))
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToValidNameLoggingDisabled() {
+        project.appendProperty("ksp.incremental.log=false")
+        project.appendProperty("ksp.incremental.log.graph.origin=p1.TestK2K")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot not to be generated: $dotFiles", dotFiles.isEmpty())
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToValidNameLoggingUnset() {
+        project.appendProperty("ksp.incremental.log.graph.origin=p1.TestK2K")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot not to be generated: $dotFiles", dotFiles.isEmpty())
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToInvalidNameLoggingEnabled() {
+        project.appendProperty("ksp.incremental.log=true")
+        val invalidName = "InvalidNameThatDoesNotExist"
+        project.appendProperty("ksp.incremental.log.graph.origin=$invalidName")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot to be generated", dotFiles.isNotEmpty())
+        val content = dotFiles.first().readText().trim()
+        val digraphContentForInvalidName =
+            """
+            digraph {
+              "$invalidName";
+            }
+            """.trimIndent()
+        Assert.assertEquals(digraphContentForInvalidName, content)
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToInvalidNameLoggingDisabled() {
+        project.appendProperty("ksp.incremental.log=false")
+        val invalidName = "InvalidNameThatDoesNotExist"
+        project.appendProperty("ksp.incremental.log.graph.origin=$invalidName")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot not to be generated: $dotFiles", dotFiles.isEmpty())
+    }
+
+    @Test
+    fun testGraphOriginOptionSetToInvalidNameLoggingUnset() {
+        val invalidName = "InvalidNameThatDoesNotExist"
+        project.appendProperty("ksp.incremental.log.graph.origin=$invalidName")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue("Expected kspLookupGraphOrigin.dot not to be generated: $dotFiles", dotFiles.isEmpty())
+    }
+
+    @Test
+    fun testGraphOriginOptionNotSetButLoggingEnabled() {
+        project.appendProperty("ksp.incremental.log=true")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue(
+            "Expected kspLookupGraphOrigin.dot NOT to be generated when option is unset $dotFiles",
+            dotFiles.isEmpty()
+        )
+    }
+
+    @Test
+    fun testGraphOriginOptionNotSetButLoggingDisabled() {
+        project.appendProperty("ksp.incremental.log=false")
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue(
+            "Expected kspLookupGraphOrigin.dot NOT to be generated when option is unset $dotFiles",
+            dotFiles.isEmpty()
+        )
+    }
+
+    @Test
+    fun testGraphOriginOptionNotSetLoggingUnset() {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", "assemble").build().let { result ->
+            Assert.assertEquals(TaskOutcome.SUCCESS, result.task(":workload:kspKotlin")?.outcome)
+        }
+
+        val dotFiles = project.root.walk().filter { it.name == "kspLookupGraphOrigin.dot" }.toList()
+        Assert.assertTrue(
+            "Expected kspLookupGraphOrigin.dot NOT to be generated when option is unset $dotFiles",
+            dotFiles.isEmpty()
+        )
+    }
+}

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -17,6 +17,7 @@
 
 package com.google.devtools.ksp.common
 
+import com.google.devtools.ksp.IncrementalContextLoggingOptions
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSDeclarationContainer
@@ -61,7 +62,7 @@ object SymbolCollector : KSDefaultVisitor<(LookupSymbolWrapper) -> Unit, Unit>()
 @Suppress("MemberVisibilityCanBePrivate", "CanBeParameter")
 abstract class IncrementalContextBase(
     protected val anyChangesWildcard: File,
-    protected val incrementalLog: Boolean,
+    protected val loggingOptions: IncrementalContextLoggingOptions,
     protected val baseDir: File,
     protected val cachesDir: File,
     protected val kspOutputDir: File,
@@ -70,7 +71,7 @@ abstract class IncrementalContextBase(
     protected val changedClasses: List<String>,
 ) {
     // Symbols defined in changed files. This is used to update symbolsMap in the end.
-    private val updatedSymbols = MultiMap.createSet<File, LookupSymbolWrapper>()
+    protected val updatedSymbols = MultiMap.createSet<File, LookupSymbolWrapper>()
 
     // Sealed classes / interfaces on which `getSealedSubclasses` is invoked.
     // This is used to update sealedMap in the end.
@@ -154,7 +155,7 @@ abstract class IncrementalContextBase(
     }
 
     private fun logSourceToOutputs(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
-        if (!incrementalLog)
+        if (!loggingOptions.incrementalLoggingEnabled)
             return
 
         mkLogFile("kspSourceToOutputs.log").bufferedWriter().use { logFile ->
@@ -193,8 +194,9 @@ abstract class IncrementalContextBase(
         dirtyFilesByNewSyms: Collection<File> = emptyList(),
         dirtyFilesBySealed: Collection<File> = emptyList(),
     ) {
-        if (!incrementalLog)
+        if (!loggingOptions.incrementalLoggingEnabled) {
             return
+        }
 
         mkLogFile("kspDirtySet.log").bufferedWriter().use { logFile ->
             logFile.write("All Files\n")
@@ -247,7 +249,6 @@ abstract class IncrementalContextBase(
         val dirtyFilesByNewSyms = newSyms.flatMap { newSym ->
             symbolLookupCache[newSym].map { it.toRelativeFile() }
         }
-
         val dirtyFilesBySealed = sealedMap.keys
 
         // Calculate dirty files by dirty classes in CP.
@@ -368,7 +369,11 @@ abstract class IncrementalContextBase(
         }
     }
 
-    private fun updateCaches(dirtyFiles: Collection<File>, outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
+    private fun updateCaches(
+        dirtyFiles: Collection<File>,
+        outputs: Set<File>,
+        sourceToOutputs: Map<File, Set<File>>
+    ) {
         // dirtyFiles may contain new files, which are unknown to sourceToOutputsMap.
         val oldOutputs = dirtyFiles.flatMap { sourceToOutputsMap[it] ?: emptyList() }.distinct()
         val removedOutputs = oldOutputs.filterNot { it in outputs }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
@@ -17,10 +17,14 @@
 
 package com.google.devtools.ksp.impl
 
+import com.google.devtools.ksp.IncrementalContextLoggingOptions
 import com.google.devtools.ksp.common.IncrementalContextBase
 import com.google.devtools.ksp.common.LookupStorageWrapper
 import com.google.devtools.ksp.common.LookupSymbolWrapper
 import com.google.devtools.ksp.common.LookupTrackerWrapper
+import com.google.devtools.ksp.common.NoSourceFile
+import com.google.devtools.ksp.common.isSyntheticFileName
+import com.google.devtools.ksp.common.stripSyntheticFileNameModifiers
 import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFileJavaImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSFunctionDeclarationImpl
@@ -66,7 +70,7 @@ class IncrementalContextAA(
     override val isIncremental: Boolean,
     lookupTracker: LookupTracker,
     anyChangesWildcard: File,
-    incrementalLog: Boolean,
+    loggingOptions: IncrementalContextLoggingOptions,
     baseDir: File,
     cachesDir: File,
     kspOutputDir: File,
@@ -75,7 +79,7 @@ class IncrementalContextAA(
     changedClasses: List<String>,
 ) : IncrementalContextBase(
     anyChangesWildcard,
-    incrementalLog,
+    loggingOptions,
     baseDir,
     cachesDir,
     kspOutputDir,
@@ -89,7 +93,7 @@ class IncrementalContextAA(
     private val symbolLookupCacheDir = File(cachesDir, "symbolLookups")
 
     private val symbolTrackerLogFile: Writer? =
-        if (this.incrementalLog) {
+        if (loggingOptions.incrementalLoggingEnabled) {
             mkLogFile("symbolTrackerTrace.log").bufferedWriter()
                 .also { logFiles.add(it) }
         } else {
@@ -97,7 +101,7 @@ class IncrementalContextAA(
         }
 
     private val classTrackerLogFile: Writer? =
-        if (this.incrementalLog) {
+        if (loggingOptions.incrementalLoggingEnabled) {
             mkLogFile("enumClassTrackerTrace.log").bufferedWriter()
                 .also { logFiles.add(it) }
         } else {
@@ -274,17 +278,95 @@ class IncrementalContextAA(
 
     override fun logBeforeCacheFlush(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
         super.logBeforeCacheFlush(outputs, sourceToOutputs)
-        logLookupGraph()
+        val lookupRecords = if (loggingOptions.incrementalLoggingEnabled) dumpLookupRecords() else emptyMap()
+        logLookupGraph(lookupRecords)
+        logDependencyGraphFrom(loggingOptions.dependencyGraphOriginName, lookupRecords)
         logFiles.forEach { it.close() }
     }
 
-    private fun logLookupGraph() {
-        if (!incrementalLog) {
+    /**
+     * Computes the dependency graph from [origin] using a normal BFS and logs it as a Graphviz `.dot` file.
+     */
+    private fun logDependencyGraphFrom(origin: String?, lookupRecords: Map<String, List<String>>) {
+        if (!loggingOptions.incrementalLoggingEnabled) {
+            return
+        }
+
+        if (origin == null) {
+            return
+        }
+
+        if (origin.isBlank()) {
+            return
+        }
+
+        val allDefinedSyms = mutableMapOf<File, MutableSet<LookupSymbolWrapper>>()
+        symbolsMap.forEach { (file, syms) ->
+            allDefinedSyms.getOrPut(file, ::mutableSetOf).addAll(syms)
+        }
+        updatedSymbols.keySet().forEach { file ->
+            allDefinedSyms.getOrPut(file, ::mutableSetOf).addAll(updatedSymbols[file])
+        }
+
+        // Prepare edges
+        val edges = mutableMapOf<String, MutableSet<String>>()
+        lookupRecords.forEach { (fqn, paths) ->
+            paths.forEach { path ->
+                if (NoSourceFile.isSyntheticFile(path)) {
+                    val fqnSource = stripSyntheticFileNameModifiers(path)
+                    edges.getOrPut(fqnSource, ::mutableSetOf).add(fqn)
+                } else {
+                    val file = File(path)
+                    val syms = allDefinedSyms[file]
+                    if (!syms.isNullOrEmpty()) {
+                        syms.forEach { sym ->
+                            val fqnSource = "${sym.scope}.${sym.name}"
+                            edges.getOrPut(fqnSource, ::mutableSetOf).add(fqn)
+                        }
+                    } else {
+                        // Default back to the path so we can visualize errors
+                        edges.getOrPut(path, ::mutableSetOf).add(fqn)
+                    }
+                }
+            }
+        }
+
+        // BFS
+        val visited = mutableSetOf<String>()
+        val queue = ArrayDeque<String>()
+        val bfsEdges = mutableSetOf<Pair<String, String>>()
+        if (edges.contains(origin)) {
+            visited.add(origin)
+            queue.add(origin)
+        }
+        while (queue.isNotEmpty()) {
+            val curr = queue.removeFirst()
+            edges[curr]?.forEach { next ->
+                bfsEdges.add(curr to next)
+                if (visited.add(next)) {
+                    queue.add(next)
+                }
+            }
+        }
+
+        // Log graph
+        mkFileInLogDir("kspLookupGraphOrigin.dot").bufferedWriter().use { logFile ->
+            logFile.write("digraph {\n")
+            // Always add origin vertex
+            logFile.write("  \"$origin\";\n")
+            bfsEdges.sortedWith(compareBy({ it.first }, { it.second })).forEach { (u, v) ->
+                logFile.write("  \"$u\" -> \"$v\";\n")
+            }
+            logFile.write("}\n")
+        }
+    }
+
+    private fun logLookupGraph(lookupRecords: Map<String, List<String>>) {
+        if (!loggingOptions.incrementalLoggingEnabled) {
             return
         }
 
         mkLogFile("kspLookupGraph.log").bufferedWriter().use { logFile ->
-            val lookupRecords = dumpLookupRecords()
             lookupRecords.forEach { (fqn, paths) ->
                 paths.forEach {
                     logFile.write("$it -> $fqn\n")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -514,7 +514,7 @@ class KotlinSymbolProcessing(
                 kspConfig.incremental,
                 dualLookupTracker,
                 File(anyChangesWildcard.filePath).relativeTo(kspConfig.projectBaseDir),
-                kspConfig.incrementalLog,
+                kspConfig.incrementalContextLoggingOptions,
                 kspConfig.projectBaseDir,
                 kspConfig.cachesDir,
                 kspConfig.outputBaseDir,


### PR DESCRIPTION
Adds a new Gradle property: `ksp.incremental.log.graph.origin=<String>` that takes a fully qualified name and if `ksp.incremental.log` is enabled/set to `true`, then it will output a Graphviz (`.dot`) file in the logs directory that contains the dependencies of the fully qualified name.

Closes https://github.com/google/ksp/issues/3015