### PR TITLE
Enable progressive mode for Kotlin compilation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,7 @@ subprojects {
                 jvmTarget = JvmTarget.JVM_1_8
                 languageVersion.set(KotlinVersion.KOTLIN_2_3)
                 apiVersion.set(languageVersion)
+                progressiveMode.set(true)
             }
             jvmToolchain {
                 languageVersion = compileJavaVersion


### PR DESCRIPTION
Fixes #2984

Opts all subprojects into the Kotlin compiler's progressive mode via the central subprojects compiler options block, alongside the existing languageVersion and apiVersion pins.

Verified locally with ./gradlew compileKotlin compileTestKotlin across all modules. Progressive mode escalated nothing to an error and the only compiler output is preexisting deprecation warnings unrelated to the flag.