### PR TITLE
Use Gradle version catalog for dependency declarations

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle.properties') }}-${{ hashFiles('**/libs.versions.toml') }}
           # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
           restore-keys: |
             ${{ runner.os }}-gradle-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
       uses: actions/cache@v5
       with:
         path: ~/.gradle/caches
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle.properties') }}
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}-${{ hashFiles('**/gradle.properties') }}-${{ hashFiles('**/libs.versions.toml') }}
         # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
         restore-keys: |
           ${{ runner.os }}-gradle-

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,11 +23,11 @@ repositories {
 
 plugins {
     kotlin("jvm")
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
+    alias(libs.plugins.nexus.publish)
     // Adding plugins used in multiple places to the classpath for centralized version control
-    id("com.gradleup.shadow") version "8.3.9" apply false
-    id("org.jetbrains.dokka") version "1.9.20" apply false
-    id("com.android.lint") version "8.13.0" apply false
+    alias(libs.plugins.shadow) apply false
+    alias(libs.plugins.dokka) apply false
+    alias(libs.plugins.android.lint) apply false
 }
 
 nexusPublishing {

--- a/common-deps/build.gradle.kts
+++ b/common-deps/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processor"
 
-val junitVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -16,7 +15,7 @@ plugins {
 
 dependencies {
     compileOnly(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
 
     ksp(project(":cmdline-parser-gen"))
 }

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -2,9 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processing Util"
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-
 plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
@@ -12,8 +9,8 @@ plugins {
 
 dependencies {
     implementation(project(":api"))
-    implementation(kotlin("stdlib", kotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
+    implementation(libs.kotlin.stdlib)
+    testImplementation(libs.junit4)
 }
 
 kotlin {

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -3,11 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 description = "Kotlin Symbol Processor"
 
-val kotlinBaseVersion: String by project
-val junitVersion: String by project
-val googleTruthVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String? by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -21,21 +16,21 @@ plugins {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
+    compileOnly(libs.kotlin.gradle.plugin.api)
+    compileOnly(libs.kotlin.gradle.plugin.asProvider())
+    compileOnly(libs.kotlin.compiler.embeddable)
     // replace AGP dependency w/ gradle-api when we have source registering API available.
-    compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
+    compileOnly(libs.agp)
     compileOnly(gradleApi())
     compileOnly(project(":kotlin-analysis-api"))
     // Ensure stdlib version is not inconsistent due to kotlin plugin version.
-    compileOnly(kotlin("stdlib", version = kotlinBaseVersion))
+    compileOnly(libs.kotlin.stdlib)
     implementation(project(":api"))
     implementation(project(":common-deps"))
     testImplementation(gradleApi())
     testImplementation(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("com.google.truth:truth:$googleTruthVersion")
+    testImplementation(libs.junit4)
+    testImplementation(libs.google.truth)
     testImplementation(gradleTestKit())
 
     lintChecks("androidx.lint:lint-gradle:1.0.0-alpha05")
@@ -167,7 +162,7 @@ abstract class WriteVersionSrcTask : DefaultTask() {
 
 val writeVersionSrcTask = tasks.register<WriteVersionSrcTask>("generateKSPVersions") {
     kspVersion = version.toString()
-    coroutinesVersion = aaCoroutinesVersion
+    coroutinesVersion = libs.versions.aa.coroutines.get()
     outputSrcDir = layout.buildDirectory.dir("generated/ksp-versions")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,23 +2,11 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
+# Dependency versions live in gradle/libs.versions.toml. The two properties below are kept
+# in sync with kotlin-base / agp-base there, because gradle-plugin tests (TestConfig.kt)
+# read them from this file at runtime.
 kotlinBaseVersion=2.3.20
-kotlinxSerializationVersion=1.6.3
 agpBaseVersion=9.3.0-alpha01
-junitVersion=4.13.1
-junit5Version=5.8.2
-junitPlatformVersion=1.8.2
-googleTruthVersion=1.4.5
-
-aaKotlinBaseVersion=2.4.20-dev-6138
-aaIntellijVersion=251.27812.49
-aaGuavaVersion=33.2.0-jre
-aaAsmVersion=9.0
-aaFastutilVersion=8.5.14-jb1
-aaStax2Version=4.2.1
-aaAaltoXmlVersion=1.3.0
-aaStreamexVersion=0.7.2
-aaCoroutinesVersion=1.10.2
 
 kotlin.jvm.target.validation.mode=warning
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,45 @@
+[versions]
+kotlin-base = "2.3.20"
+kotlinx-serialization = "1.6.3"
+agp-base = "9.3.0-alpha01"
+junit = "4.13.1"
+junit5 = "5.8.2"
+junit-platform = "1.8.2"
+google-truth = "1.4.5"
+aa-kotlin-base = "2.4.20-dev-6138"
+aa-intellij = "251.27812.49"
+aa-guava = "33.2.0-jre"
+aa-asm = "9.0"
+aa-fastutil = "8.5.14-jb1"
+aa-stax2 = "4.2.1"
+aa-aalto-xml = "1.3.0"
+aa-streamex = "0.7.2"
+aa-coroutines = "1.10.2"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-base" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-base" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "aa-coroutines" }
+kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
+agp = { module = "com.android.tools.build:gradle", version.ref = "agp-base" }
+junit4 = { module = "junit:junit", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
+junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform" }
+google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }
+aa-guava = { module = "com.google.guava:guava", version.ref = "aa-guava" }
+aa-asm = { module = "org.jetbrains.intellij.deps:asm-all", version.ref = "aa-asm" }
+aa-fastutil = { module = "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil", version.ref = "aa-fastutil" }
+aa-stax2 = { module = "org.codehaus.woodstox:stax2-api", version.ref = "aa-stax2" }
+aa-aalto-xml = { module = "com.fasterxml:aalto-xml", version.ref = "aa-aalto-xml" }
+aa-streamex = { module = "one.util:streamex", version.ref = "aa-streamex" }
+
+[plugins]
+nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
+shadow = { id = "com.gradleup.shadow", version = "8.3.9" }
+dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
+android-lint = { id = "com.android.lint", version = "8.13.0" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -2,31 +2,25 @@ import com.google.devtools.ksp.RelativizingInternalPathProvider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import kotlin.math.max
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String by project
-
 plugins {
     kotlin("jvm")
 }
 
 dependencies {
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
     testImplementation(gradleTestKit())
     testImplementation(project(":api"))
     testImplementation(project(":gradle-plugin"))
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    testImplementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.kotlinx.coroutines.core.jvm)
 }
 
 fun Test.configureCommonSettings() {
     val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
     maxParallelForks = if (isWindows) 1 else max(1, Runtime.getRuntime().availableProcessors() / 2)
-    systemProperty("kotlinVersion", kotlinBaseVersion)
+    systemProperty("kotlinVersion", libs.versions.kotlin.base.get())
     systemProperty("kspVersion", version)
-    systemProperty("agpVersion", agpBaseVersion)
+    systemProperty("agpVersion", libs.versions.agp.base.get())
     jvmArgumentProviders.add(
         RelativizingInternalPathProvider(
             "testRepo",

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -17,23 +17,11 @@ description = "Kotlin Symbol Processing implementation using Kotlin Analysis API
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
-val junitVersion: String by project
-val junit5Version: String by project
-val junitPlatformVersion: String by project
 val libsForTesting: Configuration by configurations.creating
 val libsForTestingCommon: Configuration by configurations.creating
 
-val aaKotlinBaseVersion: String by project
-val aaIntellijVersion: String by project
-val aaGuavaVersion: String by project
-val aaAsmVersion: String by project
-val aaFastutilVersion: String by project
-val aaStax2Version: String by project
-val aaAaltoXmlVersion: String by project
-val aaStreamexVersion: String by project
-val aaCoroutinesVersion: String by project
+val aaKotlinBaseVersion = libs.versions.aa.kotlin.base.get()
+val aaIntellijVersion = libs.versions.aa.intellij.get()
 
 plugins {
     kotlin("jvm")
@@ -164,14 +152,14 @@ dependencies {
     }
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    implementation(libs.kotlinx.serialization.json)
     compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
 
-    implementation("com.google.guava:guava:$aaGuavaVersion")
-    implementation("one.util:streamex:$aaStreamexVersion")
-    implementation("org.jetbrains.intellij.deps:asm-all:$aaAsmVersion")
-    implementation("org.codehaus.woodstox:stax2-api:$aaStax2Version") { isTransitive = false }
-    implementation("com.fasterxml:aalto-xml:$aaAaltoXmlVersion") { isTransitive = false }
+    implementation(libs.aa.guava)
+    implementation(libs.aa.streamex)
+    implementation(libs.aa.asm)
+    implementation(libs.aa.stax2) { isTransitive = false }
+    implementation(libs.aa.aalto.xml) { isTransitive = false }
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
     implementation("org.jetbrains.intellij.deps.jna:jna:5.9.0.26") { isTransitive = false }
     implementation("org.jetbrains.intellij.deps.jna:jna-platform:5.9.0.26") { isTransitive = false }
@@ -183,11 +171,9 @@ dependencies {
     implementation("javax.inject:javax.inject:1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
     implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
-    implementation(
-        "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil:$aaFastutilVersion"
-    ) {
+    compileOnly(libs.kotlinx.coroutines.core.jvm)
+    compileOnly(libs.kotlinx.coroutines.core.asProvider())
+    implementation(libs.aa.fastutil) {
         isTransitive = false
     }
     implementation("org.jetbrains:annotations:24.1.0")
@@ -200,18 +186,18 @@ dependencies {
     implementation(project(":common-util"))
 
     testImplementation(kotlin("stdlib", aaKotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-params:$junit5Version")
-    testRuntimeOnly("org.junit.platform:junit-platform-suite:$junitPlatformVersion")
+    testImplementation(libs.junit4)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.platform.suite)
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$aaKotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$aaKotlinBaseVersion")
     testImplementation(project(":common-deps"))
     testImplementation(project(":test-utils"))
     testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$aaKotlinBaseVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    testImplementation(libs.kotlinx.coroutines.core.jvm)
+    testImplementation(libs.kotlinx.coroutines.core.asProvider())
 
     // See AbstractKSPTest's init block if you change any of the `libsForTesting` or `libsForTestingCommon` dependencies.
     libsForTesting(kotlin("stdlib", aaKotlinBaseVersion))
@@ -219,9 +205,9 @@ dependencies {
     libsForTesting(kotlin("script-runtime", aaKotlinBaseVersion))
     libsForTestingCommon(kotlin("stdlib-common", aaKotlinBaseVersion))
 
-    depJarsForCheck("org.jetbrains.kotlin:kotlin-stdlib:$kotlinBaseVersion")
-    depJarsForCheck("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    depJarsForCheck("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    depJarsForCheck(libs.kotlin.stdlib)
+    depJarsForCheck(libs.kotlinx.coroutines.core.jvm)
+    depJarsForCheck(libs.kotlinx.coroutines.core.asProvider())
     depJarsForCheck(project(":api"))
     depJarsForCheck(project(":common-deps"))
 
@@ -374,11 +360,15 @@ publishing {
                     }
 
                     asNode().appendNode("dependencies").apply {
-                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
+                        addDependency(
+                            "org.jetbrains.kotlin",
+                            "kotlin-stdlib",
+                            libs.versions.kotlin.base.get()
+                        )
                         addDependency(
                             "org.jetbrains.kotlinx",
                             "kotlinx-coroutines-core-jvm",
-                            aaCoroutinesVersion
+                            libs.versions.aa.coroutines.get()
                         )
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version, "compile")
                         addDependency(

--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -12,11 +12,6 @@ evaluationDependsOn(":kotlin-analysis-api")
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
-
-val aaKotlinBaseVersion: String by project
-val aaCoroutinesVersion: String by project
-
 plugins {
     kotlin("jvm")
     id("com.gradleup.shadow")
@@ -28,7 +23,7 @@ val packedJars by configurations.creating
 
 dependencies {
     packedJars(project(":kotlin-analysis-api", "shadow")) { isTransitive = false }
-    packedJars("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion") { isTransitive = false }
+    packedJars(libs.kotlinx.coroutines.core.jvm) { isTransitive = false }
 }
 
 tasks.withType(Jar::class.java).configureEach {
@@ -293,7 +288,11 @@ publishing {
                     }
 
                     asNode().appendNode("dependencies").apply {
-                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
+                        addDependency(
+                            "org.jetbrains.kotlin",
+                            "kotlin-stdlib",
+                            libs.versions.kotlin.base.get()
+                        )
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
                         addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version)
                     }
@@ -327,7 +326,7 @@ abstract class WriteVersionSrcTask : DefaultTask() {
 val writeVersionSrcTask = tasks.register<WriteVersionSrcTask>(
     "generateKSPVersions"
 ) {
-    kotlinVersion = aaKotlinBaseVersion
+    kotlinVersion = libs.versions.aa.kotlin.base.get()
     outputResDir = layout.buildDirectory.dir("generated/ksp-versions/META-INF")
 }
 


### PR DESCRIPTION
Fixes #2968

Moves dependency and plugin versions into `gradle/libs.versions.toml` and replaces interpolated dependency strings with catalog accessors across the module build files (`api` and other modules without version properties are untouched).

## Scope decisions

- **Test-project fixtures under `integration-tests/src/test/resources/` and `examples/` are intentionally NOT migrated** — they are spawned as separate Gradle builds by the test harness and receive versions via `-P` properties, which a root catalog cannot reach.
- **`kotlinBaseVersion` and `agpBaseVersion` remain in `gradle.properties`** (with a comment explaining why): `gradle-plugin`'s `TestConfig` loads the root `gradle.properties` file directly at test runtime. Build files no longer read them. A follow-up could route these through the existing `prepareTestConfiguration` task to eliminate the duplication — happy to do that here if preferred.
- In `kotlin-analysis-api`, `aaKotlinBaseVersion`/`aaIntellijVersion` stay as local `val`s sourced from `libs.versions.*` since they version loop-generated coordinates, `kotlin(...)` helper calls, and jar-rename regexes that catalog accessors can't express.
- CI cache keys in `main.yml`/`auto-merge.yml` now also hash `**/libs.versions.toml`.

## Verification

- `./gradlew compileKotlin compileTestKotlin`: BUILD SUCCESSFUL across all modules.
- `./gradlew :gradle-plugin:test`: 41 pass; the 12 failing tests are the Android TestKit tests, which fail identically on a clean checkout of main on this machine (no Android SDK) — unrelated to this change.