### PR TITLE
Move common-util and common-deps dependencies to a version catalog

### DIFF
--- a/common-deps/build.gradle.kts
+++ b/common-deps/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processor"
 
-val junitVersion: String by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -16,7 +15,7 @@ plugins {
 
 dependencies {
     compileOnly(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
 
     ksp(project(":cmdline-parser-gen"))
 }

--- a/common-util/build.gradle.kts
+++ b/common-util/build.gradle.kts
@@ -2,9 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
 
 description = "Kotlin Symbol Processing Util"
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-
 plugins {
     kotlin("jvm")
     id("org.jetbrains.dokka")
@@ -12,8 +9,8 @@ plugins {
 
 dependencies {
     implementation(project(":api"))
-    implementation(kotlin("stdlib", kotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
+    implementation(libs.kotlin.stdlib)
+    testImplementation(libs.junit4)
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+kotlin-base = "2.3.20"
+junit = "4.13.1"
+
+[libraries]
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
+junit4 = { module = "junit:junit", version.ref = "junit" }


### PR DESCRIPTION
First slice of #2968, following the guidance in #3025 and #2989 to migrate module by module with only a couple of dependencies at a time.

This introduces gradle/libs.versions.toml with kotlin-stdlib and junit, and switches common-util and common-deps to catalog accessors. Nothing is removed from gradle.properties yet because other modules still read those properties.

Verified locally with ./gradlew :common-util:compileTestKotlin :common-deps:compileTestKotlin.

The remaining modules are prepared as equally small follow-up slices and I will submit them one at a time as each PR lands, so every review stays small.