### PR TITLE
Move integration-tests dependencies to the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,12 @@
 [versions]
 kotlin-base = "2.3.20"
+kotlinx-serialization = "1.6.3"
+agp-base = "9.3.0-alpha01"
 junit = "4.13.1"
+aa-coroutines = "1.10.2"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
 junit4 = { module = "junit:junit", version.ref = "junit" }

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -2,31 +2,25 @@ import com.google.devtools.ksp.RelativizingInternalPathProvider
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import kotlin.math.max
 
-val junitVersion: String by project
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String by project
-
 plugins {
     kotlin("jvm")
 }
 
 dependencies {
-    testImplementation("junit:junit:$junitVersion")
+    testImplementation(libs.junit4)
     testImplementation(gradleTestKit())
     testImplementation(project(":api"))
     testImplementation(project(":gradle-plugin"))
-    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
+    testImplementation(libs.kotlinx.serialization.json)
+    testImplementation(libs.kotlinx.coroutines.core.jvm)
 }
 
 fun Test.configureCommonSettings() {
     val isWindows = System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
     maxParallelForks = if (isWindows) 1 else max(1, Runtime.getRuntime().availableProcessors() / 2)
-    systemProperty("kotlinVersion", kotlinBaseVersion)
+    systemProperty("kotlinVersion", libs.versions.kotlin.base.get())
     systemProperty("kspVersion", version)
-    systemProperty("agpVersion", agpBaseVersion)
+    systemProperty("agpVersion", libs.versions.agp.base.get())
     jvmArgumentProviders.add(
         RelativizingInternalPathProvider(
             "testRepo",


### PR DESCRIPTION
Second slice of #2968, now that #3026 has landed. Thank you @hfmehmed and @jaschdoc for the quick review and merge.

The integration-tests module's junit, kotlinx-serialization, and coroutines dependencies move to catalog accessors, and the kotlinVersion and agpVersion test system properties now read from the catalog. Their gradle.properties entries stay because other modules still read them.

Verified that resolution is unchanged: ./gradlew :integration-tests:dependencies output for the compile, runtime, testCompile, and testRuntime classpaths is identical before and after this commit. :integration-tests:compileTestKotlin passes.