### PR TITLE
Move gradle-plugin dependencies to the version catalog

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -16,8 +16,8 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.gradle.plugin.api)
-    compileOnly(libs.kotlin.gradle.plugin.asProvider())
+    compileOnly(libs.kotlin.gradlePluginApi)
+    compileOnly(libs.kotlin.gradlePlugin)
     compileOnly(libs.kotlin.compiler.embeddable)
     // replace AGP dependency w/ gradle-api when we have source registering API available.
     compileOnly(libs.agp)

--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -3,11 +3,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 description = "Kotlin Symbol Processor"
 
-val kotlinBaseVersion: String by project
-val junitVersion: String by project
-val googleTruthVersion: String by project
-val agpBaseVersion: String by project
-val aaCoroutinesVersion: String? by project
 val signingKey: String? by project
 val signingPassword: String? by project
 
@@ -21,21 +16,21 @@ plugins {
 }
 
 dependencies {
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin-api:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinBaseVersion")
-    compileOnly("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinBaseVersion")
+    compileOnly(libs.kotlin.gradle.plugin.api)
+    compileOnly(libs.kotlin.gradle.plugin.asProvider())
+    compileOnly(libs.kotlin.compiler.embeddable)
     // replace AGP dependency w/ gradle-api when we have source registering API available.
-    compileOnly("com.android.tools.build:gradle:$agpBaseVersion")
+    compileOnly(libs.agp)
     compileOnly(gradleApi())
     compileOnly(project(":kotlin-analysis-api"))
     // Ensure stdlib version is not inconsistent due to kotlin plugin version.
-    compileOnly(kotlin("stdlib", version = kotlinBaseVersion))
+    compileOnly(libs.kotlin.stdlib)
     implementation(project(":api"))
     implementation(project(":common-deps"))
     testImplementation(gradleApi())
     testImplementation(project(":api"))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("com.google.truth:truth:$googleTruthVersion")
+    testImplementation(libs.junit4)
+    testImplementation(libs.google.truth)
     testImplementation(gradleTestKit())
 
     lintChecks("androidx.lint:lint-gradle:1.0.0-alpha05")
@@ -167,7 +162,7 @@ abstract class WriteVersionSrcTask : DefaultTask() {
 
 val writeVersionSrcTask = tasks.register<WriteVersionSrcTask>("generateKSPVersions") {
     kspVersion = version.toString()
-    coroutinesVersion = aaCoroutinesVersion
+    coroutinesVersion = libs.versions.aa.coroutines.get()
     outputSrcDir = layout.buildDirectory.dir("generated/ksp-versions")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,6 @@ agpBaseVersion=9.3.0-alpha01
 junitVersion=4.13.1
 junit5Version=5.8.2
 junitPlatformVersion=1.8.2
-googleTruthVersion=1.4.5
 
 aaKotlinBaseVersion=2.4.20-dev-6138
 aaIntellijVersion=251.27812.49

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,10 +3,16 @@ kotlin-base = "2.3.20"
 kotlinx-serialization = "1.6.3"
 agp-base = "9.3.0-alpha01"
 junit = "4.13.1"
+google-truth = "1.4.5"
 aa-coroutines = "1.10.2"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-base" }
+kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
+kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-base" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
+agp = { module = "com.android.tools.build:gradle", version.ref = "agp-base" }
 junit4 = { module = "junit:junit", version.ref = "junit" }
+google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ aa-coroutines = "1.10.2"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-base" }
-kotlin-gradle-plugin-api = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-base" }
+kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-base" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }


### PR DESCRIPTION
Third slice of #2968, following #3026 and #3031.

The Kotlin Gradle plugin artifacts, kotlin-compiler-embeddable, AGP, and Truth move to catalog accessors, and the generateKSPVersions task reads the coroutines version from the catalog. googleTruthVersion is removed from gradle.properties since gradle-plugin was its last consumer. kotlinBaseVersion stays because TestConfig loads gradle.properties directly at test runtime.

Verified that resolution is unchanged: ./gradlew :gradle-plugin:dependencies output for the compile, runtime, testCompile, and testRuntime classpaths is identical before and after this commit. :gradle-plugin:compileTestKotlin passes.