### PR TITLE
Fix KSP crash for missing parent declaration in incremental compilation

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
@@ -18,7 +18,6 @@
 package com.google.devtools.ksp.impl
 
 import com.google.devtools.ksp.IncrementalContextLoggingOptions
-import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.common.IncrementalContextBase
 import com.google.devtools.ksp.common.LookupStorageWrapper
 import com.google.devtools.ksp.common.LookupSymbolWrapper
@@ -36,9 +35,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.separateQualifierAndName
 import com.google.devtools.ksp.impl.symbol.kotlin.typeArguments
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
-import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSNode
-import com.google.devtools.ksp.symbol.KSValueArgument
 import com.google.devtools.ksp.symbol.Origin
 import com.intellij.psi.PsiJavaFile
 import com.intellij.util.containers.MultiMap
@@ -191,9 +188,10 @@ class IncrementalContextAA(
      * Records a reference to `MyClass::class`.
      * 
      * @param type the referenced type, e.g., `MyClass`
-     * @param context the parent of [type], i.e., where the reference occurs.
+     * @param declaration the closest enclosing declaration where the reference occurs.
+     *                    Callers can use [KSNode.findParentDeclaration] to obtain the enclosing declaration.
      */
-    fun recordClassReferenceLookup(type: KaType, context: KSNode) {
+    fun recordClassReferenceLookup(type: KaType, declaration: KSDeclaration) {
         if (!isIncremental) {
             return
         }
@@ -202,66 +200,47 @@ class IncrementalContextAA(
             ?: type.getFqn()
             ?: return
 
-        recordClassReferenceLookup(fqn, context)
+        recordClassReferenceLookup(fqn, declaration)
     }
 
     /**
      * Records a reference to `MyClass::class`.
      * 
      * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of `MyClass`.
-     * @param context the parent of [fqn], i.e., where the reference occurs.
+     * @param declaration the closest enclosing declaration where the reference occurs.
+     *                    Callers can use [KSNode.findParentDeclaration] to obtain the enclosing declaration.
      */
-    fun recordClassReferenceLookup(fqn: String, context: KSNode) {
+    fun recordClassReferenceLookup(fqn: String, declaration: KSDeclaration) {
         if (!isIncremental) {
             return
         }
 
         val (scope, name) = separateQualifierAndName(fqn)
 
-        symbolLookupTracker.record(filePathFor(context), scope, name)
+        symbolLookupTracker.record(filePathFor(declaration), scope, name)
     }
 
     /**
-     * Returns a string representing a file path for [context].
+     * Returns a string representing a file path for [declaration].
      *
      * If the filepath is already available, it is returned. Otherwise, a synthetic filepath is generated.
      */
-    private fun filePathFor(context: KSNode): String {
+    private fun filePathFor(declaration: KSDeclaration): String {
         // Try directly getting the filepath
-        val maybeAvailableFilePath = context.containingFile?.filePath
+        val maybeAvailableFilePath = declaration.containingFile?.filePath
         if (maybeAvailableFilePath != null) {
             return maybeAvailableFilePath
         }
 
         // Construct synthetic filepath
-        val closestParentDeclaration = context.findFirstParentDeclaration() ?: throw InternalKSPException(
-            // N.B.: Check that context is a KSValueArgument, since its toString method depends on its `value`
-            //       property, which depends on this function, thus causing a stack overflow.
-            when (context) {
-                is KSName -> context.asString()
-                is KSValueArgument -> context.name?.asString()
-                else -> context
-            }.let { ctx ->
-                "Unexpected missing parent declaration for KSNode '$ctx'"
-            },
-            context.location,
-            context.javaClass
-        )
-
-        val parentDeclarationName = closestParentDeclaration.qualifiedName?.asString()
-            ?: (
-                closestParentDeclaration.packageName.asString()
-                    + "."
-                    + closestParentDeclaration.simpleName.asString()
-                )
+        val parentDeclarationName = declaration.qualifiedName?.asString()
+            ?: buildString {
+                append(declaration.packageName.asString())
+                append('.')
+                append(declaration.simpleName.asString())
+            }
 
         return NoSourceFile(baseDir, parentDeclarationName).filePath
-    }
-
-    /** Returns the nearest parent declaration if it exists */
-    private fun KSNode.findFirstParentDeclaration(): KSDeclaration? = when (this) {
-        is KSDeclaration -> this
-        else -> parent?.findFirstParentDeclaration()
     }
 
     @OptIn(KaExperimentalApi::class)
@@ -465,19 +444,22 @@ internal fun recordLookup(ktType: KaType, context: KSNode?) =
  * Records a reference to `MyClass::class`.
  * 
  * @param ktType the referenced type, e.g., `MyClass`
- * @param context the parent of [ktType], i.e., where the reference occurs.
+ * @param declaration the closest enclosing declaration where the reference occurs.
+ *                    Callers can use [KSNode.findParentDeclaration] to obtain the enclosing declaration.
  */
-internal fun recordClassReferenceLookup(ktType: KaType, context: KSNode) =
-    ResolverAAImpl.instance.incrementalContext.recordClassReferenceLookup(ktType, context)
+internal fun recordClassReferenceLookup(ktType: KaType, declaration: KSDeclaration) =
+    ResolverAAImpl.instance.incrementalContext.recordClassReferenceLookup(ktType, declaration)
 
 /**
  * Records a reference to `MyClass::class`.
  * 
  * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of `MyClass`.
- * @param context the parent of [fqn], i.e., where the reference occurs.
+ * @param declaration the closest enclosing declaration where the reference occurs.
+ *                    Callers can use [KSNode.findParentDeclaration] to obtain the enclosing declaration.
+ *
  */
-internal fun recordClassReferenceLookup(fqn: String, context: KSNode) =
-    ResolverAAImpl.instance.incrementalContext.recordClassReferenceLookup(fqn, context)
+internal fun recordClassReferenceLookup(fqn: String, declaration: KSDeclaration) =
+    ResolverAAImpl.instance.incrementalContext.recordClassReferenceLookup(fqn, declaration)
 
 internal fun recordLookupWithSupertypes(ktType: KaType, extra: (KaType, PsiJavaFile) -> Unit = { _, _ -> }) =
     ResolverAAImpl.instance.incrementalContext.recordLookupWithSupertypes(ktType, mutableSetOf(), extra)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -10,6 +10,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.KSErrorType
 import com.google.devtools.ksp.impl.symbol.kotlin.KSValueArgumentImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.analyze
 import com.google.devtools.ksp.impl.symbol.kotlin.classifierSymbol
+import com.google.devtools.ksp.impl.symbol.kotlin.findParentDeclaration
 import com.google.devtools.ksp.impl.symbol.kotlin.getDefaultValue
 import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolvedImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.toKaType
@@ -141,7 +142,9 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
                         symbol.valueParameters.mapNotNull { valueParameterSymbol ->
                             val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
                             if (constantValue is KaAnnotationValue.ClassLiteralValue) {
-                                recordClassReferenceLookup(constantValue.type, this@KSAnnotationJavaImpl)
+                                this@KSAnnotationJavaImpl.findParentDeclaration()?.let { decl ->
+                                    recordClassReferenceLookup(constantValue.type, decl)
+                                }
                             }
                             KSValueArgumentImpl.getCached(
                                 KaBaseNamedAnnotationValue(
@@ -181,10 +184,12 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
     }
 }
 
-fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode): Any? {
+fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode?): Any? {
     if (value is PsiAnnotation) {
         value.qualifiedName?.let { fqn ->
-            recordClassReferenceLookup(fqn, parent)
+            parent?.findParentDeclaration()?.let { decl ->
+                recordClassReferenceLookup(fqn, decl)
+            }
         }
         return KSAnnotationJavaImpl.getCached(value, null)
     }
@@ -218,7 +223,9 @@ fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode): Any? {
                         .getClassDeclarationByName(component.canonicalText)?.asStarProjectedType()
                         ?.also { ksType ->
                             ksType.toKaType()?.let { kaType ->
-                                recordClassReferenceLookup(kaType, parent)
+                                parent?.findParentDeclaration()?.let { decl ->
+                                    recordClassReferenceLookup(kaType, decl)
+                                }
                             }
                         }
                         ?: KSErrorType(component.canonicalText)
@@ -235,7 +242,9 @@ fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode): Any? {
                 .getClassDeclarationByName(result.canonicalText)?.asStarProjectedType()
                 ?.also { ksType ->
                     ksType.toKaType()?.let { kaType ->
-                        recordClassReferenceLookup(kaType, parent)
+                        parent?.findParentDeclaration()?.let { decl ->
+                            recordClassReferenceLookup(kaType, decl)
+                        }
                     }
                 }
                 ?: KSErrorType(result.canonicalText)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -6,10 +6,12 @@ import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.impl.recordClassReferenceLookup
 import com.google.devtools.ksp.impl.symbol.java.KSValueArgumentLiteImpl
 import com.google.devtools.ksp.impl.symbol.java.calcValue
-import com.google.devtools.ksp.impl.symbol.kotlin.*
+import com.google.devtools.ksp.impl.symbol.kotlin.KSValueArgumentImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.analyze
+import com.google.devtools.ksp.impl.symbol.kotlin.findParentDeclaration
 import com.google.devtools.ksp.impl.symbol.kotlin.getDefaultValue
 import com.google.devtools.ksp.impl.symbol.kotlin.toKtClassSymbol
+import com.google.devtools.ksp.impl.symbol.kotlin.toLocation
 import com.google.devtools.ksp.symbol.AnnotationUseSiteTarget
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSName
@@ -29,7 +31,16 @@ import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotation
 import org.jetbrains.kotlin.analysis.api.annotations.KaAnnotationValue
 import org.jetbrains.kotlin.analysis.api.impl.base.annotations.KaBaseNamedAnnotationValue
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
-import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.ALL
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.CONSTRUCTOR_PARAMETER
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FIELD
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.FILE
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_DELEGATE_FIELD
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_GETTER
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.PROPERTY_SETTER
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.RECEIVER
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.SETTER_PARAMETER
 import org.jetbrains.kotlin.psi.KtFile
 
 class KSAnnotationResolvedImpl private constructor(
@@ -109,7 +120,9 @@ class KSAnnotationResolvedImpl private constructor(
                         it.valueParameters.mapNotNull { valueParameterSymbol ->
                             val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
                             if (constantValue is KaAnnotationValue.ClassLiteralValue) {
-                                recordClassReferenceLookup(constantValue.type, this@KSAnnotationResolvedImpl)
+                                this@KSAnnotationResolvedImpl.findParentDeclaration()?.let { decl ->
+                                    recordClassReferenceLookup(constantValue.type, decl)
+                                }
                             }
                             KSValueArgumentImpl.getCached(
                                 KaBaseNamedAnnotationValue(

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -732,6 +732,19 @@ internal inline fun <reified T : KSNode> KSNode.findParentOfType(): KSNode? {
     return result
 }
 
+/**
+ * Find the closest enclosing [KSDeclaration] of a [KSNode], or self if this node is already a [KSDeclaration].
+ *
+ * @return The enclosing [KSDeclaration], or `null` if no enclosing declaration exists.
+ */
+internal fun KSNode.findParentDeclaration(): KSDeclaration? {
+    var current: KSNode? = this
+    while (current != null && current !is KSDeclaration) {
+        current = current.parent
+    }
+    return current
+}
+
 internal fun KaAnnotationValue.toValue(parent: KSNode? = null, origin: Origin? = null): Any? = when (this) {
     is KaAnnotationValue.ArrayValue -> this.values.map { it.toValue(parent, origin) }
     is KaAnnotationValue.NestedAnnotationValue -> KSAnnotationResolvedImpl.getCached(this.annotation, parent, origin)
@@ -747,8 +760,8 @@ internal fun KaAnnotationValue.toValue(parent: KSNode? = null, origin: Origin? =
     } ?: KSErrorType
 
     is KaAnnotationValue.ClassLiteralValue -> {
-        parent?.let { ctx ->
-            recordClassReferenceLookup(type, ctx)
+        parent?.findParentDeclaration()?.let { decl ->
+            recordClassReferenceLookup(type, decl)
         }
         KSTypeImpl.getCached(type)
     }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -902,13 +902,13 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("typeAnnotationClassReference.kt")
     @Test
-    @Bug("https://github.com/google/ksp/issues/3030", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3030", BugState.FIXED)
     @Bug(
         "https://github.com/google/ksp/issues/3036",
         BugState.FIXED,
         "The toString method of KSValueArgument has a circular call chain leading to a stack overflow."
     )
     fun testTypeAnnotationClassReference() {
-        runThrowingTest("$AA_PATH/typeAnnotationClassReference.kt")
+        runTest("$AA_PATH/typeAnnotationClassReference.kt")
     }
 }


### PR DESCRIPTION
This PR removes the internal KSP exception that can happen when recording class reference dependencies in incremental compilation, and moves the responsibility of obtain the parent declaration to call sites. That way, a dependency is safely recorded if there is a parent declaration available (the crash could happen for `KSTypeImpl` which does not have a parent declaration for its annotations, since `KSType` is not a `KSNode` or a `KSDeclaration`).

Depends on https://github.com/google/ksp/pull/3034
Fixes https://github.com/google/ksp/issues/3030