### PR TITLE
Move symbol-processing-aa-embeddable dependencies to the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ kotlinx-serialization = "1.6.3"
 agp-base = "9.3.0-alpha01"
 junit = "4.13.1"
 google-truth = "1.4.5"
+aa-kotlin-base = "2.4.20-dev-6138"
 aa-coroutines = "1.10.2"
 
 [libraries]

--- a/symbol-processing-aa-embeddable/build.gradle.kts
+++ b/symbol-processing-aa-embeddable/build.gradle.kts
@@ -12,10 +12,8 @@ evaluationDependsOn(":kotlin-analysis-api")
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
 
-val aaKotlinBaseVersion: String by project
-val aaCoroutinesVersion: String by project
+val aaKotlinBaseVersion = libs.versions.aa.kotlin.base.get()
 
 plugins {
     kotlin("jvm")
@@ -28,7 +26,7 @@ val packedJars by configurations.creating
 
 dependencies {
     packedJars(project(":kotlin-analysis-api", "shadow")) { isTransitive = false }
-    packedJars("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion") { isTransitive = false }
+    packedJars(libs.kotlinx.coroutines.core.jvm) { isTransitive = false }
 }
 
 tasks.withType(Jar::class.java).configureEach {
@@ -293,7 +291,7 @@ publishing {
                     }
 
                     asNode().appendNode("dependencies").apply {
-                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", kotlinBaseVersion)
+                        addDependency("org.jetbrains.kotlin", "kotlin-stdlib", libs.versions.kotlin.base.get())
                         addDependency("com.google.devtools.ksp", "symbol-processing-api", version)
                         addDependency("com.google.devtools.ksp", "symbol-processing-common-deps", version)
                     }


### PR DESCRIPTION
Fourth slice of #2968, following #3026, #3031, and #3033.

The packed coroutines jar moves to a catalog accessor and the aa Kotlin base version becomes a catalog sourced value used by the packed jar renaming and the generated version metadata. aaKotlinBaseVersion and aaCoroutinesVersion stay in gradle.properties while kotlin-analysis-api still reads them.

Verified that resolution is unchanged: ./gradlew :symbol-processing-aa-embeddable:dependencies output for the compile, runtime, and packedJars configurations is identical before and after this commit. :symbol-processing-aa-embeddable:compileKotlin passes.