### PR TITLE
Move kotlin-analysis-api test dependencies to the version catalog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,10 +5,6 @@ org.gradle.parallel=true
 kotlinBaseVersion=2.3.20
 kotlinxSerializationVersion=1.6.3
 agpBaseVersion=9.3.0-alpha01
-junitVersion=4.13.1
-junit5Version=5.8.2
-junitPlatformVersion=1.8.2
-
 aaKotlinBaseVersion=2.4.20-dev-6138
 aaIntellijVersion=251.27812.49
 aaGuavaVersion=33.2.0-jre

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,8 @@ kotlin-base = "2.3.20"
 kotlinx-serialization = "1.6.3"
 agp-base = "9.3.0-alpha01"
 junit = "4.13.1"
+junit5 = "5.8.2"
+junit-platform = "1.8.2"
 google-truth = "1.4.5"
 aa-kotlin-base = "2.4.20-dev-6138"
 aa-coroutines = "1.10.2"
@@ -16,4 +18,8 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp-base" }
 junit4 = { module = "junit:junit", version.ref = "junit" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
+junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform" }
 google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -19,9 +19,6 @@ val signingPassword: String? by project
 
 val kotlinBaseVersion: String by project
 val kotlinxSerializationVersion: String by project
-val junitVersion: String by project
-val junit5Version: String by project
-val junitPlatformVersion: String by project
 val libsForTesting: Configuration by configurations.creating
 val libsForTestingCommon: Configuration by configurations.creating
 
@@ -200,11 +197,11 @@ dependencies {
     implementation(project(":common-util"))
 
     testImplementation(kotlin("stdlib", aaKotlinBaseVersion))
-    testImplementation("junit:junit:$junitVersion")
-    testImplementation("org.junit.jupiter:junit-jupiter-api:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junit5Version")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-params:$junit5Version")
-    testRuntimeOnly("org.junit.platform:junit-platform-suite:$junitPlatformVersion")
+    testImplementation(libs.junit4)
+    testImplementation(libs.junit.jupiter.api)
+    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junit.jupiter.params)
+    testRuntimeOnly(libs.junit.platform.suite)
     testImplementation("org.jetbrains.kotlin:kotlin-compiler:$aaKotlinBaseVersion")
     testImplementation("org.jetbrains.kotlin:kotlin-compiler-internal-test-framework:$aaKotlinBaseVersion")
     testImplementation(project(":common-deps"))


### PR DESCRIPTION
Fifth slice of #2968 and the first of three for kotlin-analysis-api, following #3026, #3031, #3033, and #3040.

The JUnit 5 and JUnit Platform test artifacts move to catalog accessors. junitVersion, junit5Version, and junitPlatformVersion are removed from gradle.properties since this module was their last reader, which I verified by grepping every build file including the integration test fixtures.

Verified that resolution is unchanged: ./gradlew :kotlin-analysis-api:dependencies output for the testCompile and testRuntime classpaths is identical before and after this commit, 254 lines compared. :kotlin-analysis-api:compileTestKotlin passes.