### PR TITLE
Format implementation files

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -18,9 +18,7 @@ package com.google.devtools.ksp.visitor
 
 import com.google.devtools.ksp.symbol.*
 
-/**
- * A visitor that delegates to super types for methods that are not overridden.
- */
+/** A visitor that delegates to super types for methods that are not overridden. */
 abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     override fun visitDynamicReference(reference: KSDynamicReference, data: D): R {
         this.visitReferenceElement(reference, data)
@@ -133,7 +131,10 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
         return super.visitAnnotation(annotation, data)
     }
 
-    override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: D): R {
+    override fun visitDeclarationContainer(
+        declarationContainer: KSDeclarationContainer,
+        data: D,
+    ): R {
         this.visitNode(declarationContainer, data)
         return super.visitDeclarationContainer(declarationContainer, data)
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -18,9 +18,7 @@ package com.google.devtools.ksp.visitor
 
 import com.google.devtools.ksp.symbol.*
 
-/**
- * A visitor that methods fall back to [defaultHandler] if not overridden.
- */
+/** A visitor that methods fall back to [defaultHandler] if not overridden. */
 abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
     abstract fun defaultHandler(node: KSNode, data: D): R
 
@@ -44,7 +42,10 @@ abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
         return defaultHandler(declaration, data)
     }
 
-    override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: D): R {
+    override fun visitDeclarationContainer(
+        declarationContainer: KSDeclarationContainer,
+        data: D,
+    ): R {
         return defaultHandler(declarationContainer, data)
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -27,6 +27,7 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
     private fun Sequence<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }
+
     private fun List<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }
@@ -56,7 +57,10 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
         return super.visitDeclaration(declaration, data)
     }
 
-    override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: D): R {
+    override fun visitDeclarationContainer(
+        declarationContainer: KSDeclarationContainer,
+        data: D,
+    ): R {
         declarationContainer.declarations.accept(data)
         return super.visitDeclarationContainer(declarationContainer, data)
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -2,9 +2,8 @@ package com.google.devtools.ksp.visitor
 
 import com.google.devtools.ksp.symbol.*
 
-open class KSValidateVisitor(
-    private val predicate: (KSNode?, KSNode) -> Boolean
-) : KSDefaultVisitor<KSNode?, Boolean>() {
+open class KSValidateVisitor(private val predicate: (KSNode?, KSNode) -> Boolean) :
+    KSDefaultVisitor<KSNode?, Boolean>() {
     private fun validateType(type: KSType): Boolean {
         return !type.isError && !type.arguments.any { it.type?.accept(this, null) == false }
     }
@@ -23,21 +22,27 @@ open class KSValidateVisitor(
         return this.visitAnnotated(declaration, data)
     }
 
-    override fun visitDeclarationContainer(declarationContainer: KSDeclarationContainer, data: KSNode?): Boolean {
+    override fun visitDeclarationContainer(
+        declarationContainer: KSDeclarationContainer,
+        data: KSNode?,
+    ): Boolean {
         return declarationContainer.declarations.all {
-            !predicate(declarationContainer, it) || it.accept(
-                this,
-                declarationContainer
-            )
+            !predicate(declarationContainer, it) ||
+                it.accept(
+                    this,
+                    declarationContainer,
+                )
         }
     }
 
     override fun visitTypeParameter(typeParameter: KSTypeParameter, data: KSNode?): Boolean {
-        return !predicate(data, typeParameter) || typeParameter.bounds.all { it.accept(this, typeParameter) }
+        return !predicate(data, typeParameter) ||
+            typeParameter.bounds.all { it.accept(this, typeParameter) }
     }
 
     override fun visitAnnotated(annotated: KSAnnotated, data: KSNode?): Boolean {
-        return !predicate(data, annotated) || annotated.annotations.all { it.accept(this, annotated) }
+        return !predicate(data, annotated) ||
+            annotated.annotations.all { it.accept(this, annotated) }
     }
 
     override fun visitAnnotation(annotation: KSAnnotation, data: KSNode?): Boolean {
@@ -57,7 +62,10 @@ open class KSValidateVisitor(
         return validateType(typeReference.resolve())
     }
 
-    override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: KSNode?): Boolean {
+    override fun visitClassDeclaration(
+        classDeclaration: KSClassDeclaration,
+        data: KSNode?,
+    ): Boolean {
         if (classDeclaration.asStarProjectedType().isError) {
             return false
         }
@@ -74,8 +82,10 @@ open class KSValidateVisitor(
     }
 
     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: KSNode?): Boolean {
-        if (function.returnType != null &&
-            predicate(function, function.returnType!!) && !function.returnType!!.accept(this, data)
+        if (
+            function.returnType != null &&
+                predicate(function, function.returnType!!) &&
+                !function.returnType!!.accept(this, data)
         ) {
             return false
         }
@@ -99,12 +109,13 @@ open class KSValidateVisitor(
     }
 
     override fun visitValueArgument(valueArgument: KSValueArgument, data: KSNode?): Boolean {
-        fun visitValue(value: Any?): Boolean = when (value) {
-            is KSType -> this.validateType(value)
-            is KSAnnotation -> this.visitAnnotation(value, data)
-            is List<*> -> value.all { visitValue(it) }
-            else -> true
-        }
+        fun visitValue(value: Any?): Boolean =
+            when (value) {
+                is KSType -> this.validateType(value)
+                is KSAnnotation -> this.visitAnnotation(value, data)
+                is List<*> -> value.all { visitValue(it) }
+                else -> true
+            }
         return visitValue(valueArgument.value)
     }
 

--- a/cmdline-parser-gen/src/main/kotlin/CmdlineParserGenerator.kt
+++ b/cmdline-parser-gen/src/main/kotlin/CmdlineParserGenerator.kt
@@ -28,122 +28,153 @@ private fun OutputStream.appendLine(str: String = "") {
 }
 
 // modueName => -module-name
-private fun String.camelToOptionName(): String = fold(StringBuilder()) { acc, c ->
-    acc.let {
-        val lower = c.lowercase()
-        acc.append(if (acc.isEmpty() || c.isUpperCase()) "-$lower" else lower)
-    }
-}.toString()
+private fun String.camelToOptionName(): String =
+    fold(StringBuilder()) { acc, c ->
+            acc.let {
+                val lower = c.lowercase()
+                acc.append(if (acc.isEmpty() || c.isUpperCase()) "-$lower" else lower)
+            }
+        }
+        .toString()
 
 class CmdlineParserGenerator(
     val codeGenerator: CodeGenerator,
     val logger: KSPLogger,
-    val options: Map<String, String>
+    val options: Map<String, String>,
 ) : SymbolProcessor {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val annotationName = "com.google.devtools.ksp.processing.KSPArgParserGen"
-        val kspConfigBuilders =
-            resolver.getSymbolsWithAnnotation(annotationName)
+        val kspConfigBuilders = resolver.getSymbolsWithAnnotation(annotationName)
 
         kspConfigBuilders.filterIsInstance<KSClassDeclaration>().forEach { builderClass ->
-            val parserName = builderClass.annotations.single {
-                it.annotationType.resolve().declaration.qualifiedName?.asString() == annotationName
-            }.arguments.single().value as String
-            val configClass = builderClass.parentDeclaration as KSClassDeclaration
-            val builderName = "${configClass.simpleName.asString()}.${builderClass.simpleName.asString()}"
-            codeGenerator.createNewFile(
-                Dependencies(false, builderClass.containingFile!!),
-                builderClass.packageName.asString(),
-                parserName
-            ).use { os ->
-                os.appendLine("package ${builderClass.packageName.asString()}")
-                os.appendLine()
-                os.appendLine(
-                    "fun $parserName(args: Array<String>): Pair<${configClass.simpleName.asString()}, List<String>> {"
-                )
-                os.appendLine("  val processorClasspath = mutableListOf<String>()")
-                os.appendLine("  return Pair($builderName().apply {")
-                os.appendLine("    var i = 0")
-                os.appendLine("    while (i < args.size) {")
-                os.appendLine("      val arg = args[i++]")
-                os.appendLine("      when {")
-
-                builderClass.getAllProperties().filter { it.setter != null }.forEach { prop ->
-                    val type = prop.type.resolve()
-                    val typeName = type.declaration.simpleName.asString()
-                    val propName = prop.simpleName.asString()
-                    val optionName = propName.camelToOptionName()
-                    val optionNameLen = optionName.length
-                    when (typeName) {
-                        "String", "Boolean", "File" -> {
-                            os.appendLine(
-                                "        arg == \"$optionName\" -> " +
-                                    "$propName = parse$typeName(getArg(args, i++))"
-                            )
-                            os.appendLine(
-                                "        arg.startsWith(\"$optionName=\") -> " +
-                                    "$propName = parse$typeName(arg.substring(${optionNameLen + 1}))"
-                            )
-                        }
-                        "List", "Map" -> {
-                            val elementTypeName =
-                                type.arguments.last().type!!.resolve().declaration.simpleName.asString()
-                            os.appendLine(
-                                "        arg == \"$optionName\" -> " +
-                                    "$propName = parse$typeName(getArg(args, i++), ::parse$elementTypeName)"
-                            )
-                            os.appendLine(
-                                "        arg.startsWith(\"$optionName=\") -> " +
-                                    "$propName = parse$typeName(arg.substring(${optionNameLen + 1}), " +
-                                    "::parse$elementTypeName)"
-                            )
-                        }
-                        else -> {
-                            throw IllegalArgumentException("Unknown type of option `$propName: ${prop.type}`")
-                        }
+            val parserName =
+                builderClass.annotations
+                    .single {
+                        it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+                            annotationName
                     }
-                }
-
-                // Free args are processor classpath
-                os.appendLine("        else -> {")
-                os.appendLine("          processorClasspath.addAll(parseList(arg, ::parseString))")
-                os.appendLine("        }")
-                os.appendLine("      }")
-                os.appendLine("    }")
-                os.appendLine("  }.build(), processorClasspath)")
-                os.appendLine("}")
-            }
-
-            codeGenerator.createNewFile(
-                Dependencies(false, builderClass.containingFile!!),
-                builderClass.packageName.asString(),
-                parserName + "Help"
-            ).use { os ->
-                os.appendLine("package ${builderClass.packageName.asString()}")
-                os.appendLine()
-                os.appendLine(
-                    "fun ${parserName}Help(): String = \"\"\""
+                    .arguments
+                    .single()
+                    .value as String
+            val configClass = builderClass.parentDeclaration as KSClassDeclaration
+            val builderName =
+                "${configClass.simpleName.asString()}.${builderClass.simpleName.asString()}"
+            codeGenerator
+                .createNewFile(
+                    Dependencies(false, builderClass.containingFile!!),
+                    builderClass.packageName.asString(),
+                    parserName,
                 )
-                builderClass.getAllProperties().filter { it.setter != null }.forEach { prop ->
-                    val type = prop.type.resolve()
-                    val typeName = type.toString()
-                    val propName = prop.simpleName.asString()
-                    val optionName = propName.camelToOptionName()
-                    val prefix = if (Modifier.LATEINIT in prop.modifiers) "*" else " "
-                    os.appendLine("$prefix   $optionName=$typeName")
+                .use { os ->
+                    os.appendLine("package ${builderClass.packageName.asString()}")
+                    os.appendLine()
+                    os.appendLine(
+                        "fun $parserName(args: Array<String>): Pair<${configClass.simpleName.asString()}, List<String>> {"
+                    )
+                    os.appendLine("  val processorClasspath = mutableListOf<String>()")
+                    os.appendLine("  return Pair($builderName().apply {")
+                    os.appendLine("    var i = 0")
+                    os.appendLine("    while (i < args.size) {")
+                    os.appendLine("      val arg = args[i++]")
+                    os.appendLine("      when {")
+
+                    builderClass
+                        .getAllProperties()
+                        .filter { it.setter != null }
+                        .forEach { prop ->
+                            val type = prop.type.resolve()
+                            val typeName = type.declaration.simpleName.asString()
+                            val propName = prop.simpleName.asString()
+                            val optionName = propName.camelToOptionName()
+                            val optionNameLen = optionName.length
+                            when (typeName) {
+                                "String",
+                                "Boolean",
+                                "File" -> {
+                                    os.appendLine(
+                                        "        arg == \"$optionName\" -> " +
+                                            "$propName = parse$typeName(getArg(args, i++))"
+                                    )
+                                    os.appendLine(
+                                        "        arg.startsWith(\"$optionName=\") -> " +
+                                            "$propName = parse$typeName(arg.substring(${optionNameLen + 1}))"
+                                    )
+                                }
+                                "List",
+                                "Map" -> {
+                                    val elementTypeName =
+                                        type.arguments
+                                            .last()
+                                            .type!!
+                                            .resolve()
+                                            .declaration
+                                            .simpleName
+                                            .asString()
+                                    os.appendLine(
+                                        "        arg == \"$optionName\" -> " +
+                                            "$propName = parse$typeName(getArg(args, i++), ::parse$elementTypeName)"
+                                    )
+                                    os.appendLine(
+                                        "        arg.startsWith(\"$optionName=\") -> " +
+                                            "$propName = parse$typeName(arg.substring(${optionNameLen + 1}), " +
+                                            "::parse$elementTypeName)"
+                                    )
+                                }
+                                else -> {
+                                    throw IllegalArgumentException(
+                                        "Unknown type of option `$propName: ${prop.type}`"
+                                    )
+                                }
+                            }
+                        }
+
+                    // Free args are processor classpath
+                    os.appendLine("        else -> {")
+                    os.appendLine(
+                        "          processorClasspath.addAll(parseList(arg, ::parseString))"
+                    )
+                    os.appendLine("        }")
+                    os.appendLine("      }")
+                    os.appendLine("    }")
+                    os.appendLine("  }.build(), processorClasspath)")
+                    os.appendLine("}")
                 }
-                os.appendLine("*   <processor classpath>")
-                os.appendLine("\"\"\"")
-            }
+
+            codeGenerator
+                .createNewFile(
+                    Dependencies(false, builderClass.containingFile!!),
+                    builderClass.packageName.asString(),
+                    parserName + "Help",
+                )
+                .use { os ->
+                    os.appendLine("package ${builderClass.packageName.asString()}")
+                    os.appendLine()
+                    os.appendLine("fun ${parserName}Help(): String = \"\"\"")
+                    builderClass
+                        .getAllProperties()
+                        .filter { it.setter != null }
+                        .forEach { prop ->
+                            val type = prop.type.resolve()
+                            val typeName = type.toString()
+                            val propName = prop.simpleName.asString()
+                            val optionName = propName.camelToOptionName()
+                            val prefix = if (Modifier.LATEINIT in prop.modifiers) "*" else " "
+                            os.appendLine("$prefix   $optionName=$typeName")
+                        }
+                    os.appendLine("*   <processor classpath>")
+                    os.appendLine("\"\"\"")
+                }
         }
         return emptyList()
     }
 }
 
 class CmdlineParserGeneratorProvider : SymbolProcessorProvider {
-    override fun create(
-        environment: SymbolProcessorEnvironment
-    ): SymbolProcessor {
-        return CmdlineParserGenerator(environment.codeGenerator, environment.logger, environment.options)
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return CmdlineParserGenerator(
+            environment.codeGenerator,
+            environment.logger,
+            environment.options,
+        )
     }
 }

--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/IncrementalContextLoggingOptions.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/IncrementalContextLoggingOptions.kt
@@ -19,10 +19,8 @@ package com.google.devtools.ksp
 
 import java.io.Serializable
 
-/**
- * Contains flags and configurations for incremental context logging.
- */
+/** Contains flags and configurations for incremental context logging. */
 data class IncrementalContextLoggingOptions(
     val incrementalLoggingEnabled: Boolean,
-    val dependencyGraphOriginName: String?
+    val dependencyGraphOriginName: String?,
 ) : Serializable

--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KSPConfig.kt
@@ -29,26 +29,20 @@ abstract class KSPConfig(
     val commonSourceRoots: List<File>,
     val libraries: List<File>,
     val friends: List<File>,
-
     val processorOptions: Map<String, String>,
-
     val projectBaseDir: File,
     val outputBaseDir: File,
     val cachesDir: File,
-
     val classOutputDir: File,
     val kotlinOutputDir: File,
     val resourceOutputDir: File,
-
     val incremental: Boolean,
     val incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     val modifiedSources: List<File>,
     val removedSources: List<File>,
     val changedClasses: List<String>,
-
     val languageVersion: String,
     val apiVersion: String,
-
     val allWarningsAsErrors: Boolean,
     val mapAnnotationArgumentsInJava: Boolean,
     val experimentalPsiResolution: Boolean,
@@ -74,9 +68,7 @@ abstract class KSPConfig(
         var incrementalLog: Boolean = false
         var incrementalLogGraphOrigin: String? = null
             set(value) {
-                field = value
-                    ?.trim()
-                    ?.filterNot(::isInvalidGraphChar)
+                field = value?.trim()?.filterNot(::isInvalidGraphChar)
             }
 
         var modifiedSources: List<File> = emptyList()
@@ -99,11 +91,9 @@ abstract class KSPConfig(
             fun isWhiteSpace(char: Char): Boolean =
                 char == ' ' || char == '\n' || char == '\t' || char == '\r'
 
-            @JvmStatic
-            fun isEscape(char: Char): Boolean = char == '\\'
+            @JvmStatic fun isEscape(char: Char): Boolean = char == '\\'
 
-            @JvmStatic
-            fun isQuote(char: Char): Boolean = char == '\'' || char == '"'
+            @JvmStatic fun isQuote(char: Char): Boolean = char == '\'' || char == '"'
         }
     }
 }
@@ -119,59 +109,48 @@ class KSPJvmConfig(
     commonSourceRoots: List<File>,
     libraries: List<File>,
     friends: List<File>,
-
     processorOptions: Map<String, String>,
-
     projectBaseDir: File,
     outputBaseDir: File,
     cachesDir: File,
-
     classOutputDir: File,
     kotlinOutputDir: File,
     resourceOutputDir: File,
-
     incremental: Boolean,
     incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
-
     languageVersion: String,
     apiVersion: String,
-
     allWarningsAsErrors: Boolean,
     mapAnnotationArgumentsInJava: Boolean,
     experimentalPsiResolution: Boolean,
-) : KSPConfig(
-    moduleName,
-    sourceRoots,
-    commonSourceRoots,
-    libraries,
-    friends,
-
-    processorOptions,
-
-    projectBaseDir,
-    outputBaseDir,
-    cachesDir,
-
-    classOutputDir,
-    kotlinOutputDir,
-    resourceOutputDir,
-
-    incremental,
-    incrementalContextLoggingOptions,
-    modifiedSources,
-    removedSources,
-    changedClasses,
-
-    languageVersion,
-    apiVersion,
-
-    allWarningsAsErrors,
-    mapAnnotationArgumentsInJava,
-    experimentalPsiResolution,
-) {
+) :
+    KSPConfig(
+        moduleName,
+        sourceRoots,
+        commonSourceRoots,
+        libraries,
+        friends,
+        processorOptions,
+        projectBaseDir,
+        outputBaseDir,
+        cachesDir,
+        classOutputDir,
+        kotlinOutputDir,
+        resourceOutputDir,
+        incremental,
+        incrementalContextLoggingOptions,
+        modifiedSources,
+        removedSources,
+        changedClasses,
+        languageVersion,
+        apiVersion,
+        allWarningsAsErrors,
+        mapAnnotationArgumentsInJava,
+        experimentalPsiResolution,
+    ) {
     @KSPArgParserGen(name = "kspJvmArgParser")
     class Builder : KSPConfig.Builder(), Serializable {
         var javaSourceRoots: List<File> = emptyList()
@@ -187,22 +166,18 @@ class KSPJvmConfig(
                 jdkHome,
                 jvmTarget,
                 jvmDefaultMode,
-
                 moduleName,
                 sourceRoots,
                 commonSourceRoots,
                 libraries,
                 friends,
-
                 processorOptions,
-
                 projectBaseDir,
                 outputBaseDir,
                 cachesDir,
                 classOutputDir,
                 kotlinOutputDir,
                 resourceOutputDir,
-
                 incremental,
                 IncrementalContextLoggingOptions(
                     incrementalLog,
@@ -211,13 +186,11 @@ class KSPJvmConfig(
                 modifiedSources,
                 removedSources,
                 changedClasses,
-
                 languageVersion,
                 apiVersion,
-
                 allWarningsAsErrors,
                 mapAnnotationArgumentsInJava,
-                experimentalPsiResolution
+                experimentalPsiResolution,
             )
         }
     }
@@ -230,59 +203,48 @@ class KSPNativeConfig(
     commonSourceRoots: List<File>,
     libraries: List<File>,
     friends: List<File>,
-
     processorOptions: Map<String, String>,
-
     projectBaseDir: File,
     outputBaseDir: File,
     cachesDir: File,
-
     classOutputDir: File,
     kotlinOutputDir: File,
     resourceOutputDir: File,
-
     incremental: Boolean,
     incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
-
     languageVersion: String,
     apiVersion: String,
-
     allWarningsAsErrors: Boolean,
     mapAnnotationArgumentsInJava: Boolean,
     experimentalPsiResolution: Boolean,
-) : KSPConfig(
-    moduleName,
-    sourceRoots,
-    commonSourceRoots,
-    libraries,
-    friends,
-
-    processorOptions,
-
-    projectBaseDir,
-    outputBaseDir,
-    cachesDir,
-
-    classOutputDir,
-    kotlinOutputDir,
-    resourceOutputDir,
-
-    incremental,
-    incrementalContextLoggingOptions,
-    modifiedSources,
-    removedSources,
-    changedClasses,
-
-    languageVersion,
-    apiVersion,
-
-    allWarningsAsErrors,
-    mapAnnotationArgumentsInJava,
-    experimentalPsiResolution,
-) {
+) :
+    KSPConfig(
+        moduleName,
+        sourceRoots,
+        commonSourceRoots,
+        libraries,
+        friends,
+        processorOptions,
+        projectBaseDir,
+        outputBaseDir,
+        cachesDir,
+        classOutputDir,
+        kotlinOutputDir,
+        resourceOutputDir,
+        incremental,
+        incrementalContextLoggingOptions,
+        modifiedSources,
+        removedSources,
+        changedClasses,
+        languageVersion,
+        apiVersion,
+        allWarningsAsErrors,
+        mapAnnotationArgumentsInJava,
+        experimentalPsiResolution,
+    ) {
     @KSPArgParserGen(name = "kspNativeArgParser")
     class Builder : KSPConfig.Builder(), Serializable {
         lateinit var target: String
@@ -295,16 +257,13 @@ class KSPNativeConfig(
                 commonSourceRoots,
                 libraries,
                 friends,
-
                 processorOptions,
-
                 projectBaseDir,
                 outputBaseDir,
                 cachesDir,
                 classOutputDir,
                 kotlinOutputDir,
                 resourceOutputDir,
-
                 incremental,
                 IncrementalContextLoggingOptions(
                     incrementalLog,
@@ -313,13 +272,11 @@ class KSPNativeConfig(
                 modifiedSources,
                 removedSources,
                 changedClasses,
-
                 languageVersion,
                 apiVersion,
-
                 allWarningsAsErrors,
                 mapAnnotationArgumentsInJava,
-                experimentalPsiResolution
+                experimentalPsiResolution,
             )
         }
     }
@@ -332,59 +289,48 @@ class KSPJsConfig(
     commonSourceRoots: List<File>,
     libraries: List<File>,
     friends: List<File>,
-
     processorOptions: Map<String, String>,
-
     projectBaseDir: File,
     outputBaseDir: File,
     cachesDir: File,
-
     classOutputDir: File,
     kotlinOutputDir: File,
     resourceOutputDir: File,
-
     incremental: Boolean,
     incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
-
     languageVersion: String,
     apiVersion: String,
-
     allWarningsAsErrors: Boolean,
     mapAnnotationArgumentsInJava: Boolean,
     experimentalPsiResolution: Boolean,
-) : KSPConfig(
-    moduleName,
-    sourceRoots,
-    commonSourceRoots,
-    libraries,
-    friends,
-
-    processorOptions,
-
-    projectBaseDir,
-    outputBaseDir,
-    cachesDir,
-
-    classOutputDir,
-    kotlinOutputDir,
-    resourceOutputDir,
-
-    incremental,
-    incrementalContextLoggingOptions,
-    modifiedSources,
-    removedSources,
-    changedClasses,
-
-    languageVersion,
-    apiVersion,
-
-    allWarningsAsErrors,
-    mapAnnotationArgumentsInJava,
-    experimentalPsiResolution,
-) {
+) :
+    KSPConfig(
+        moduleName,
+        sourceRoots,
+        commonSourceRoots,
+        libraries,
+        friends,
+        processorOptions,
+        projectBaseDir,
+        outputBaseDir,
+        cachesDir,
+        classOutputDir,
+        kotlinOutputDir,
+        resourceOutputDir,
+        incremental,
+        incrementalContextLoggingOptions,
+        modifiedSources,
+        removedSources,
+        changedClasses,
+        languageVersion,
+        apiVersion,
+        allWarningsAsErrors,
+        mapAnnotationArgumentsInJava,
+        experimentalPsiResolution,
+    ) {
     @KSPArgParserGen(name = "kspJsArgParser")
     class Builder : KSPConfig.Builder(), Serializable {
         lateinit var backend: String
@@ -397,16 +343,13 @@ class KSPJsConfig(
                 commonSourceRoots,
                 libraries,
                 friends,
-
                 processorOptions,
-
                 projectBaseDir,
                 outputBaseDir,
                 cachesDir,
                 classOutputDir,
                 kotlinOutputDir,
                 resourceOutputDir,
-
                 incremental,
                 IncrementalContextLoggingOptions(
                     incrementalLog,
@@ -415,13 +358,11 @@ class KSPJsConfig(
                 modifiedSources,
                 removedSources,
                 changedClasses,
-
                 languageVersion,
                 apiVersion,
-
                 allWarningsAsErrors,
                 mapAnnotationArgumentsInJava,
-                experimentalPsiResolution
+                experimentalPsiResolution,
             )
         }
     }
@@ -429,7 +370,7 @@ class KSPJsConfig(
 
 data class Target(
     val platform: String,
-    val args: Map<String, String>
+    val args: Map<String, String>,
 )
 
 class KSPCommonConfig(
@@ -439,59 +380,48 @@ class KSPCommonConfig(
     commonSourceRoots: List<File>,
     libraries: List<File>,
     friends: List<File>,
-
     processorOptions: Map<String, String>,
-
     projectBaseDir: File,
     outputBaseDir: File,
     cachesDir: File,
-
     classOutputDir: File,
     kotlinOutputDir: File,
     resourceOutputDir: File,
-
     incremental: Boolean,
     incrementalContextLoggingOptions: IncrementalContextLoggingOptions,
     modifiedSources: List<File>,
     removedSources: List<File>,
     changedClasses: List<String>,
-
     languageVersion: String,
     apiVersion: String,
-
     allWarningsAsErrors: Boolean,
     mapAnnotationArgumentsInJava: Boolean,
     experimentalPsiResolution: Boolean,
-) : KSPConfig(
-    moduleName,
-    sourceRoots,
-    commonSourceRoots,
-    libraries,
-    friends,
-
-    processorOptions,
-
-    projectBaseDir,
-    outputBaseDir,
-    cachesDir,
-
-    classOutputDir,
-    kotlinOutputDir,
-    resourceOutputDir,
-
-    incremental,
-    incrementalContextLoggingOptions,
-    modifiedSources,
-    removedSources,
-    changedClasses,
-
-    languageVersion,
-    apiVersion,
-
-    allWarningsAsErrors,
-    mapAnnotationArgumentsInJava,
-    experimentalPsiResolution,
-) {
+) :
+    KSPConfig(
+        moduleName,
+        sourceRoots,
+        commonSourceRoots,
+        libraries,
+        friends,
+        processorOptions,
+        projectBaseDir,
+        outputBaseDir,
+        cachesDir,
+        classOutputDir,
+        kotlinOutputDir,
+        resourceOutputDir,
+        incremental,
+        incrementalContextLoggingOptions,
+        modifiedSources,
+        removedSources,
+        changedClasses,
+        languageVersion,
+        apiVersion,
+        allWarningsAsErrors,
+        mapAnnotationArgumentsInJava,
+        experimentalPsiResolution,
+    ) {
     @KSPArgParserGen(name = "kspCommonArgParser")
     class Builder : KSPConfig.Builder(), Serializable {
         lateinit var targets: List<Target>
@@ -504,16 +434,13 @@ class KSPCommonConfig(
                 commonSourceRoots,
                 libraries,
                 friends,
-
                 processorOptions,
-
                 projectBaseDir,
                 outputBaseDir,
                 cachesDir,
                 classOutputDir,
                 kotlinOutputDir,
                 resourceOutputDir,
-
                 incremental,
                 IncrementalContextLoggingOptions(
                     incrementalLog,
@@ -522,13 +449,11 @@ class KSPCommonConfig(
                 modifiedSources,
                 removedSources,
                 changedClasses,
-
                 languageVersion,
                 apiVersion,
-
                 allWarningsAsErrors,
                 mapAnnotationArgumentsInJava,
-                experimentalPsiResolution
+                experimentalPsiResolution,
             )
         }
     }
@@ -561,10 +486,12 @@ fun <T> parseList(arg: String, transform: (String) -> T): List<T> {
 fun <T> parseMap(arg: String, transform: (String) -> T): Map<String, T> {
     if (arg.length > 0 && arg[0] == '-')
         throw IllegalArgumentException("expecting a Map but got $arg")
-    return arg.split(File.pathSeparatorChar).map {
-        val (k, v) = it.split('=')
-        k to transform(v)
-    }.toMap()
+    return arg.split(File.pathSeparatorChar)
+        .map {
+            val (k, v) = it.split('=')
+            k to transform(v)
+        }
+        .toMap()
 }
 
 fun parseTarget(arg: String): Target {

--- a/common-deps/src/main/kotlin/com/google/devtools/ksp/KspGradleLogger.kt
+++ b/common-deps/src/main/kotlin/com/google/devtools/ksp/KspGradleLogger.kt
@@ -26,7 +26,8 @@ class KspGradleLogger(val loglevel: Int) : KSPLogger {
     private fun decorateMessage(message: String, symbol: KSNode?): String =
         when (val location = symbol?.location) {
             is FileLocation -> "${location.filePath}:${location.lineNumber}: $message"
-            is NonExistLocation, null -> message
+            is NonExistLocation,
+            null -> message
         }
 
     override fun logging(message: String, symbol: KSNode?) {
@@ -50,8 +51,7 @@ class KspGradleLogger(val loglevel: Int) : KSPLogger {
     }
 
     override fun exception(e: Throwable) {
-        if (loglevel <= LOGGING_LEVEL_ERROR)
-            messager.println("e: [ksp] $e")
+        if (loglevel <= LOGGING_LEVEL_ERROR) messager.println("e: [ksp] $e")
     }
 
     companion object {

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/ErrorTypeUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/ErrorTypeUtils.kt
@@ -20,7 +20,8 @@ package com.google.devtools.ksp.common
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeArgument
 
-// This does not work when the type is already error AND args are either empty or matches actual size.
+// This does not work when the type is already error AND args are either empty or matches actual
+// size.
 inline fun <E> errorTypeOnInconsistentArguments(
     arguments: List<KSTypeArgument>,
     placeholdersProvider: () -> List<KSTypeArgument>,

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalUtil.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/IncrementalUtil.kt
@@ -58,9 +58,7 @@ abstract class KSVirtualFile(val baseDir: File, val name: String) : KSFile {
     }
 }
 
-/**
- * Used when an output potentially depends on new information.
- */
+/** Used when an output potentially depends on new information. */
 class AnyChanges(baseDir: File) : KSVirtualFile(baseDir, "AnyChanges") {
     override val syntheticFileNamePrefix: String = SYNTHETIC_FILE_NAME_PREFIX
 
@@ -77,9 +75,7 @@ class AnyChanges(baseDir: File) : KSVirtualFile(baseDir, "AnyChanges") {
     }
 }
 
-/**
- * Used for classes from classpath, i.e., classes without source files.
- */
+/** Used for classes from classpath, i.e., classes without source files. */
 class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, fqn) {
     override val syntheticFileNamePrefix: String = SYNTHETIC_FILE_NAME_PREFIX
 
@@ -91,10 +87,8 @@ class NoSourceFile(baseDir: File, val fqn: String) : KSVirtualFile(baseDir, fqn)
             val processedName = name.removeSuffix(SYNTHETIC_FILE_NAME_SUFFIX)
             return name == noSourceFile?.fileName ||
                 name == noSourceFile?.filePath ||
-                (
-                    name.startsWith(SYNTHETIC_FILE_NAME_PREFIX) &&
-                        name.endsWith(SYNTHETIC_FILE_NAME_SUFFIX)
-                    )
+                (name.startsWith(SYNTHETIC_FILE_NAME_PREFIX) &&
+                    name.endsWith(SYNTHETIC_FILE_NAME_SUFFIX))
         }
 
         const val SYNTHETIC_FILE_NAME_PREFIX: String = "<NoSourceFile for "
@@ -105,30 +99,30 @@ fun isSyntheticFileName(name: String, baseDir: File? = null): Boolean {
     return AnyChanges.isSyntheticFile(name, baseDir) || NoSourceFile.isSyntheticFile(name, baseDir)
 }
 
-/**
- * Returns `a.b.c.MyClass` if `name` is a synthetic [NoSourceFile] file for `a.b.c.MyClass`.
- */
+/** Returns `a.b.c.MyClass` if `name` is a synthetic [NoSourceFile] file for `a.b.c.MyClass`. */
 fun stripSyntheticFileNameModifiers(name: String, baseDir: File? = null): String {
     require(
         NoSourceFile.isSyntheticFile(name, baseDir),
-        { "Name '$name' must be recognized by NoSourceFile.isSyntheticFile" })
-    return name.removePrefix(NoSourceFile.SYNTHETIC_FILE_NAME_PREFIX)
+        { "Name '$name' must be recognized by NoSourceFile.isSyntheticFile" },
+    )
+    return name
+        .removePrefix(NoSourceFile.SYNTHETIC_FILE_NAME_PREFIX)
         .removeSuffix(KSVirtualFile.SYNTHETIC_FILE_NAME_SUFFIX)
 }
 
 // Copy recursively, including last-modified-time of file and its parent dirs.
 //
-// `java.nio.file.Files.copy(path1, path2, options...)` keeps last-modified-time (if supported) according to
+// `java.nio.file.Files.copy(path1, path2, options...)` keeps last-modified-time (if supported)
+// according to
 // https://docs.oracle.com/javase/7/docs/api/java/nio/file/Files.html
 fun copyWithTimestamp(src: File, dst: File, overwrite: Boolean) {
-    if (!dst.parentFile.exists())
-        copyWithTimestamp(src.parentFile, dst.parentFile, false)
+    if (!dst.parentFile.exists()) copyWithTimestamp(src.parentFile, dst.parentFile, false)
     if (overwrite) {
         Files.copy(
             src.toPath(),
             dst.toPath(),
             StandardCopyOption.COPY_ATTRIBUTES,
-            StandardCopyOption.REPLACE_EXISTING
+            StandardCopyOption.REPLACE_EXISTING,
         )
     } else {
         Files.copy(src.toPath(), dst.toPath(), StandardCopyOption.COPY_ATTRIBUTES)

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSObjectCacheManager.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSObjectCacheManager.kt
@@ -19,15 +19,17 @@ package com.google.devtools.ksp.common
 
 class KSObjectCacheManager {
     companion object {
-        private val caches_prop = object : ThreadLocal<ArrayList<KSObjectCache<*, *>>>() {
-            override fun initialValue(): ArrayList<KSObjectCache<*, *>> {
-                return ArrayList()
+        private val caches_prop =
+            object : ThreadLocal<ArrayList<KSObjectCache<*, *>>>() {
+                override fun initialValue(): ArrayList<KSObjectCache<*, *>> {
+                    return ArrayList()
+                }
             }
-        }
         val caches
             get() = caches_prop.get()
 
         fun register(cache: KSObjectCache<*, *>) = caches.add(cache)
+
         fun clear() {
             caches.forEach { it.clear() }
             caches_prop.remove()

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSPUtils.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/KSPUtils.kt
@@ -3,24 +3,28 @@ package com.google.devtools.ksp.common
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSType
 
-@Suppress("NOTHING_TO_INLINE")
-private inline fun Any?.idHashCode() = System.identityHashCode(this)
+@Suppress("NOTHING_TO_INLINE") private inline fun Any?.idHashCode() = System.identityHashCode(this)
 
 class IdKey<T>(private val k: T) {
     override fun equals(other: Any?): Boolean = if (other is IdKey<*>) k === other.k else false
+
     override fun hashCode(): Int = k.idHashCode()
 }
 
 class IdKeyPair<T, P>(private val k1: T, private val k2: P) {
-    override fun equals(other: Any?): Boolean = if (other is IdKeyPair<*, *>) k1 === other.k1 &&
-        k2 === other.k2 else false
+    override fun equals(other: Any?): Boolean =
+        if (other is IdKeyPair<*, *>) k1 === other.k1 && k2 === other.k2 else false
+
     override fun hashCode(): Int = k1.idHashCode() * 31 + k2.idHashCode()
 }
 
 class IdKeyTriple<T, P, Q>(private val k1: T, private val k2: P, private val k3: Q) {
-    override fun equals(other: Any?): Boolean = if (other is IdKeyTriple<*, *, *>) k1 === other.k1 &&
-        k2 === other.k2 && k3 === other.k3 else false
-    override fun hashCode(): Int = k1.idHashCode() * 31 * 31 + k2.idHashCode() * 31 + k3.idHashCode()
+    override fun equals(other: Any?): Boolean =
+        if (other is IdKeyTriple<*, *, *>) k1 === other.k1 && k2 === other.k2 && k3 === other.k3
+        else false
+
+    override fun hashCode(): Int =
+        k1.idHashCode() * 31 * 31 + k2.idHashCode() * 31 + k3.idHashCode()
 }
 
 @Suppress("UNCHECKED_CAST")
@@ -29,9 +33,10 @@ fun extractThrowsAnnotation(annotated: KSAnnotated): Sequence<KSType> {
         .singleOrNull {
             it.shortName.asString() == "Throws" &&
                 it.annotationType.resolve().declaration.qualifiedName?.asString()?.let {
-                it == "kotlin.jvm.Throws" || it == "kotlin.Throws"
-            } ?: false
-        }?.arguments
+                    it == "kotlin.jvm.Throws" || it == "kotlin.Throws"
+                } ?: false
+        }
+        ?.arguments
         ?.singleOrNull()
         ?.let { it.value as? ArrayList<KSType> }
         ?.asSequence() ?: emptySequence()

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/MemoizedSequence.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/MemoizedSequence.kt
@@ -28,6 +28,7 @@ class MemoizedSequence<T>(sequence: Sequence<T>) : Sequence<T> {
 
     private inner class CachedIterator() : Iterator<T> {
         var idx = 0
+
         override fun hasNext(): Boolean {
             return idx < cache.size || iter.hasNext()
         }

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/CodeGeneratorImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/CodeGeneratorImpl.kt
@@ -37,7 +37,7 @@ class CodeGeneratorImpl(
     private val projectBase: File,
     private val anyChangesWildcard: KSFile,
     private val allSources: List<KSFile>,
-    private val isIncremental: Boolean
+    private val isIncremental: Boolean,
 ) : CodeGenerator {
     private val fileMap = mutableMapOf<String, File>()
     private val fileOutputStreamMap = mutableMapOf<String, FileOutputStream>()
@@ -46,7 +46,8 @@ class CodeGeneratorImpl(
 
     val sourceToOutputs: MutableMap<File, MutableSet<File>> = mutableMapOf()
 
-    // This function will also clear `fileOutputStreamMap` which will change the result of `generatedFile`
+    // This function will also clear `fileOutputStreamMap` which will change the result of
+    // `generatedFile`
     fun closeFiles() {
         fileOutputStreamMap.keys.forEach {
             fileOutputStreamMap[it]!!.close()
@@ -55,7 +56,9 @@ class CodeGeneratorImpl(
     }
 
     fun pathOf(packageName: String, fileName: String, extensionName: String): String {
-        val packageDirs = if (packageName != "") "${packageName.split(".").joinToString(separator)}$separator" else ""
+        val packageDirs =
+            if (packageName != "") "${packageName.split(".").joinToString(separator)}$separator"
+            else ""
         val extension = if (extensionName != "") ".$extensionName" else ""
         return "$packageDirs$fileName$extension"
     }
@@ -64,22 +67,35 @@ class CodeGeneratorImpl(
         dependencies: Dependencies,
         packageName: String,
         fileName: String,
-        extensionName: String
+        extensionName: String,
     ): OutputStream {
         return createNewFile(
             dependencies,
             pathOf(packageName, fileName, extensionName),
-            extensionToDirectory(extensionName)
+            extensionToDirectory(extensionName),
         )
     }
 
-    override fun createNewFileByPath(dependencies: Dependencies, path: String, extensionName: String): OutputStream {
+    override fun createNewFileByPath(
+        dependencies: Dependencies,
+        path: String,
+        extensionName: String,
+    ): OutputStream {
         val extension = if (extensionName != "") ".$extensionName" else ""
         return createNewFile(dependencies, path + extension, extensionToDirectory(extensionName))
     }
 
-    override fun associate(sources: List<KSFile>, packageName: String, fileName: String, extensionName: String) {
-        associate(sources, pathOf(packageName, fileName, extensionName), extensionToDirectory(extensionName))
+    override fun associate(
+        sources: List<KSFile>,
+        packageName: String,
+        fileName: String,
+        extensionName: String,
+    ) {
+        associate(
+            sources,
+            pathOf(packageName, fileName, extensionName),
+            extensionToDirectory(extensionName),
+        )
     }
 
     override fun associateByPath(sources: List<KSFile>, path: String, extensionName: String) {
@@ -91,7 +107,7 @@ class CodeGeneratorImpl(
         classes: List<KSClassDeclaration>,
         packageName: String,
         fileName: String,
-        extensionName: String
+        extensionName: String,
     ) {
         val path = pathOf(packageName, fileName, extensionName)
         val files = classes.map {
@@ -101,15 +117,17 @@ class CodeGeneratorImpl(
     }
 
     // FIXME: associate with the containing FileKt.
-    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin metadata.
-    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of interest.
+    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin
+    // metadata.
+    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of
+    // interest.
     //
     // This implementation associates anyChangesWildcard, which is an overkill.
     override fun associateWithFunctions(
         functions: List<KSFunctionDeclaration>,
         packageName: String,
         fileName: String,
-        extensionName: String
+        extensionName: String,
     ) {
         val path = pathOf(packageName, fileName, extensionName)
         val files = functions.map {
@@ -119,15 +137,17 @@ class CodeGeneratorImpl(
     }
 
     // FIXME: associate with the containing FileKt.
-    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin metadata.
-    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of interest.
+    // The containing FileKt is unfortunately a backend thing and is not available in Kotlin
+    // metadata.
+    // Therefore, the only way to get it seems to be traversing bytecode and find the functions of
+    // interest.
     //
     // This implementation associates anyChangesWildcard, which is an overkill.
     override fun associateWithProperties(
         properties: List<KSPropertyDeclaration>,
         packageName: String,
         fileName: String,
-        extensionName: String
+        extensionName: String,
     ) {
         val path = pathOf(packageName, fileName, extensionName)
         val files = properties.map {
@@ -145,10 +165,16 @@ class CodeGeneratorImpl(
         }
     }
 
-    private fun createNewFile(dependencies: Dependencies, path: String, baseDir: File): OutputStream {
+    private fun createNewFile(
+        dependencies: Dependencies,
+        path: String,
+        baseDir: File,
+    ): OutputStream {
         val file = File(baseDir, path)
         if (!isWithinBaseDir(baseDir, file)) {
-            throw IllegalStateException("requested path is outside the bounds of the required directory")
+            throw IllegalStateException(
+                "requested path is outside the bounds of the required directory"
+            )
         }
         if (path in fileMap) {
             throw FileAlreadyExistsException(file)
@@ -159,15 +185,16 @@ class CodeGeneratorImpl(
         }
         file.writeText("")
         fileMap[path] = file
-        val sources = if (dependencies.isAllSources) {
-            allSources + anyChangesWildcard
-        } else {
-            if (dependencies.aggregating) {
-                dependencies.originatingFiles + anyChangesWildcard
+        val sources =
+            if (dependencies.isAllSources) {
+                allSources + anyChangesWildcard
             } else {
-                dependencies.originatingFiles
+                if (dependencies.aggregating) {
+                    dependencies.originatingFiles + anyChangesWildcard
+                } else {
+                    dependencies.originatingFiles
+                }
             }
-        }
         associate(sources, file)
         fileOutputStreamMap[path] = fileMap[path]!!.outputStream()
         return fileOutputStreamMap[path]!!
@@ -186,18 +213,21 @@ class CodeGeneratorImpl(
     private fun associate(sources: List<KSFile>, path: String, baseDir: File) {
         val file = File(baseDir, path)
         if (!isWithinBaseDir(baseDir, file)) {
-            throw IllegalStateException("requested path is outside the bounds of the required directory")
+            throw IllegalStateException(
+                "requested path is outside the bounds of the required directory"
+            )
         }
         associate(sources, file)
     }
 
     private fun associate(sources: List<KSFile>, outputPath: File) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val output = outputPath.relativeTo(projectBase)
         sources.forEach { source ->
-            sourceToOutputs.getOrPut(File(source.filePath).relativeTo(projectBase)) { mutableSetOf() }.add(output)
+            sourceToOutputs
+                .getOrPut(File(source.filePath).relativeTo(projectBase)) { mutableSetOf() }
+                .add(output)
         }
     }
 

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/KSTypeReferenceSyntheticImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/KSTypeReferenceSyntheticImpl.kt
@@ -13,10 +13,13 @@ import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
 
-class KSTypeReferenceSyntheticImpl(val ksType: KSType, override val parent: KSNode?) : KSTypeReference {
+class KSTypeReferenceSyntheticImpl(val ksType: KSType, override val parent: KSNode?) :
+    KSTypeReference {
     companion object : KSObjectCache<Pair<IdKey<KSType>, KSNode?>, KSTypeReferenceSyntheticImpl>() {
-        fun getCached(ksType: KSType, parent: KSNode?) = KSTypeReferenceSyntheticImpl.cache
-            .getOrPut(Pair(IdKey(ksType), parent)) { KSTypeReferenceSyntheticImpl(ksType, parent) }
+        fun getCached(ksType: KSType, parent: KSNode?) =
+            KSTypeReferenceSyntheticImpl.cache.getOrPut(Pair(IdKey(ksType), parent)) {
+                KSTypeReferenceSyntheticImpl(ksType, parent)
+            }
     }
 
     override val annotations: Sequence<KSAnnotation> = emptySequence()

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/PlatformInfoImpl.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/PlatformInfoImpl.kt
@@ -25,26 +25,22 @@ import com.google.devtools.ksp.processing.UnknownPlatformInfo
 class JvmPlatformInfoImpl(
     override val platformName: String,
     override val jvmTarget: String,
-    override val jvmDefaultMode: String
+    override val jvmDefaultMode: String,
 ) : JvmPlatformInfo {
     override fun toString() = "$platformName ($jvmTarget)"
 }
 
-class JsPlatformInfoImpl(
-    override val platformName: String
-) : JsPlatformInfo {
+class JsPlatformInfoImpl(override val platformName: String) : JsPlatformInfo {
     override fun toString() = platformName
 }
 
 class NativePlatformInfoImpl(
     override val platformName: String,
-    override val targetName: String
+    override val targetName: String,
 ) : NativePlatformInfo {
     override fun toString() = "$platformName ($targetName)"
 }
 
-class UnknownPlatformInfoImpl(
-    override val platformName: String
-) : UnknownPlatformInfo {
+class UnknownPlatformInfoImpl(override val platformName: String) : UnknownPlatformInfo {
     override fun toString() = platformName
 }

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/RefPosition.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/impl/RefPosition.kt
@@ -14,39 +14,42 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 enum class RefPosition {
     PARAMETER_TYPE,
     RETURN_TYPE,
-    SUPER_TYPE
+    SUPER_TYPE,
 }
 
 // TODO: Strict mode for catching unhandled cases.
-fun findRefPosition(ref: KSTypeReference): RefPosition = when (val parent = ref.parent) {
-    is KSCallableReference -> when (ref) {
-        parent.returnType -> RefPosition.RETURN_TYPE
+fun findRefPosition(ref: KSTypeReference): RefPosition =
+    when (val parent = ref.parent) {
+        is KSCallableReference ->
+            when (ref) {
+                parent.returnType -> RefPosition.RETURN_TYPE
+                else -> RefPosition.PARAMETER_TYPE
+            }
+        is KSFunctionDeclaration ->
+            when (ref) {
+                parent.returnType -> RefPosition.RETURN_TYPE
+                else -> RefPosition.PARAMETER_TYPE
+            }
+        is KSPropertyGetter -> RefPosition.RETURN_TYPE
+        is KSPropertyDeclaration ->
+            when (ref) {
+                parent.type -> RefPosition.RETURN_TYPE
+                else -> RefPosition.PARAMETER_TYPE
+            }
+        is KSClassDeclaration -> RefPosition.SUPER_TYPE
+        // is KSTypeArgument -> RefPosition.PARAMETER_TYPE
+        // is KSAnnotation -> RefPosition.PARAMETER_TYPE
+        // is KSTypeAlias -> RefPosition.PARAMETER_TYPE
+        // is KSValueParameter -> RefPosition.PARAMETER_TYPE
+        // is KSTypeParameter -> RefPosition.PARAMETER_TYPE
         else -> RefPosition.PARAMETER_TYPE
     }
-    is KSFunctionDeclaration -> when (ref) {
-        parent.returnType -> RefPosition.RETURN_TYPE
-        else -> RefPosition.PARAMETER_TYPE
-    }
-    is KSPropertyGetter -> RefPosition.RETURN_TYPE
-    is KSPropertyDeclaration -> when (ref) {
-        parent.type -> RefPosition.RETURN_TYPE
-        else -> RefPosition.PARAMETER_TYPE
-    }
-    is KSClassDeclaration -> RefPosition.SUPER_TYPE
-    // is KSTypeArgument -> RefPosition.PARAMETER_TYPE
-    // is KSAnnotation -> RefPosition.PARAMETER_TYPE
-    // is KSTypeAlias -> RefPosition.PARAMETER_TYPE
-    // is KSValueParameter -> RefPosition.PARAMETER_TYPE
-    // is KSTypeParameter -> RefPosition.PARAMETER_TYPE
-    else -> RefPosition.PARAMETER_TYPE
-}
 
 // Search in self and parents for the first type reference that is not part of a type argument.
 fun KSTypeReference.findOuterMostRef(): Pair<KSTypeReference, List<Int>> {
     fun KSNode.findParentRef(): KSTypeReference? {
         var parent = parent
-        while (parent != null && parent !is KSTypeReference)
-            parent = parent.parent
+        while (parent != null && parent !is KSTypeReference) parent = parent.parent
         return parent
     }
 
@@ -67,7 +70,6 @@ fun KSTypeReference.findOuterMostRef(): Pair<KSTypeReference, List<Int>> {
 
 fun KSTypeReference.isReturnTypeOfAnnotationMethod(): Boolean {
     var candidate = this.parent
-    while (candidate !is KSClassDeclaration && candidate != null)
-        candidate = candidate.parent
+    while (candidate !is KSClassDeclaration && candidate != null) candidate = candidate.parent
     return candidate?.classKind == ClassKind.ANNOTATION_CLASS
 }

--- a/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
+++ b/common-util/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsVisitor.kt
@@ -34,8 +34,7 @@ class CollectAnnotatedSymbolsVisitor(private val inDepth: Boolean) : KSVisitorVo
     val symbols = arrayListOf<KSAnnotated>()
 
     override fun visitAnnotated(annotated: KSAnnotated, data: Unit) {
-        if (annotated.annotations.any())
-            symbols.add(annotated)
+        if (annotated.annotations.any()) symbols.add(annotated)
     }
 
     override fun visitFile(file: KSFile, data: Unit) {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -32,6 +32,7 @@ import com.google.devtools.ksp.gradle.utils.canUseAddGeneratedSourceDirectoriesA
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
 import com.google.devtools.ksp.gradle.utils.isLegacyKaptPluginApplied
+import java.util.concurrent.Callable
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.Directory
@@ -40,14 +41,13 @@ import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.internal.KaptTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.util.capitalizeDecapitalize.capitalizeAsciiOnly
-import java.util.concurrent.Callable
 
 /**
- * This helper class handles communication with the android plugin.
- * It is isolated in a separate class to avoid adding dependency on the android plugin.
- * Instead, we add a compileOnly dependency to the Android Plugin, which means we can still function
- * without the Android plugin. The downside is that we need to ensure never to access Android
- * plugin APIs directly without checking its existence (we have tests covering that case).
+ * This helper class handles communication with the android plugin. It is isolated in a separate
+ * class to avoid adding dependency on the android plugin. Instead, we add a compileOnly dependency
+ * to the Android Plugin, which means we can still function without the Android plugin. The downside
+ * is that we need to ensure never to access Android plugin APIs directly without checking its
+ * existence (we have tests covering that case).
  */
 object AndroidPluginIntegration {
 
@@ -59,11 +59,12 @@ object AndroidPluginIntegration {
     }
 
     private fun decorateAndroidExtension(project: Project, onSourceSet: (String) -> Unit) {
-        val sourceSets = when (val androidExt = project.extensions.getByName("android")) {
-            is BaseExtension -> androidExt.sourceSets
-            is CommonExtension -> androidExt.sourceSets
-            else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
-        }
+        val sourceSets =
+            when (val androidExt = project.extensions.getByName("android")) {
+                is BaseExtension -> androidExt.sourceSets
+                is CommonExtension -> androidExt.sourceSets
+                else -> throw RuntimeException("Unsupported Android Gradle plugin version.")
+            }
         sourceSets.configureEach {
             onSourceSet(it.name)
         }
@@ -73,9 +74,7 @@ object AndroidPluginIntegration {
         return kotlinCompilation.androidVariant?.sourceSets?.map { it.name } ?: emptyList()
     }
 
-    /**
-     * Support KspTaskJvm and KspAATask tasks
-     */
+    /** Support KspTaskJvm and KspAATask tasks */
     @Suppress("DEPRECATION")
     private fun tryUpdateKspWithAndroidSourceSets(
         project: Project,
@@ -86,7 +85,8 @@ object AndroidPluginIntegration {
         if (androidComponent != null && project.isAgpBuiltInKotlinUsed()) {
             if (project.canUseInternalKspApis()) {
                 val javaSources =
-                    (androidComponent.sources.java as? FlatSourceDirectoriesForJavaImpl)?.allButKspAndKaptGenerators()
+                    (androidComponent.sources.java as? FlatSourceDirectoriesForJavaImpl)
+                        ?.allButKspAndKaptGenerators()
 
                 val kotlinSources = androidComponent.sources.kotlin?.all
 
@@ -158,61 +158,66 @@ object AndroidPluginIntegration {
         resourcesOutputDir: Provider<Directory>,
         androidComponent: Component?,
     ) {
-        if (androidComponent != null &&
-            project.canUseAddGeneratedSourceDirectoriesApi() &&
-            project.isAgpBuiltInKotlinUsed()
+        if (
+            androidComponent != null &&
+                project.canUseAddGeneratedSourceDirectoriesApi() &&
+                project.isAgpBuiltInKotlinUsed()
         ) {
             if (project.canUseInternalKspApis()) {
-                (androidComponent.sources.java as? FlatSourceDirectoriesImpl)?.addGeneratedSourceDirectory(
-                    taskProvider = kspTaskProvider,
-                    wiredWith = { task -> task.kspConfig.javaOutputDir },
-                    DirectoryEntry.Kind.KSP
-                )
+                (androidComponent.sources.java as? FlatSourceDirectoriesImpl)
+                    ?.addGeneratedSourceDirectory(
+                        taskProvider = kspTaskProvider,
+                        wiredWith = { task -> task.kspConfig.javaOutputDir },
+                        DirectoryEntry.Kind.KSP,
+                    )
 
-                (androidComponent.sources.java as? FlatSourceDirectoriesImpl)?.addGeneratedSourceDirectory(
-                    taskProvider = kspTaskProvider,
-                    wiredWith = { task -> task.kspConfig.kotlinOutputDir },
-                    DirectoryEntry.Kind.KSP
-                )
+                (androidComponent.sources.java as? FlatSourceDirectoriesImpl)
+                    ?.addGeneratedSourceDirectory(
+                        taskProvider = kspTaskProvider,
+                        wiredWith = { task -> task.kspConfig.kotlinOutputDir },
+                        DirectoryEntry.Kind.KSP,
+                    )
             } else {
                 androidComponent.sources.java?.addGeneratedSourceDirectory(
                     taskProvider = kspTaskProvider,
-                    wiredWith = { task -> task.kspConfig.javaOutputDir }
+                    wiredWith = { task -> task.kspConfig.javaOutputDir },
                 )
 
                 androidComponent.sources.java?.addGeneratedSourceDirectory(
                     taskProvider = kspTaskProvider,
-                    wiredWith = { task -> task.kspConfig.kotlinOutputDir }
+                    wiredWith = { task -> task.kspConfig.kotlinOutputDir },
                 )
             }
 
             androidComponent.sources.resources?.addGeneratedSourceDirectory(
                 taskProvider = kspTaskProvider,
-                wiredWith = { task -> task.kspConfig.resourceOutputDir }
+                wiredWith = { task -> task.kspConfig.resourceOutputDir },
             )
 
-            // this is a bit of a hack because merge*GeneratedProguardFiles in AGP looks in the CLASSES artifacts
+            // this is a bit of a hack because merge*GeneratedProguardFiles in AGP looks in the
+            // CLASSES artifacts
             // for the KSP generated proguard files
             // todo: remove this once the issues is amended in AGP
             androidComponent.artifacts
                 .forScope(ScopedArtifacts.Scope.PROJECT)
                 .use(kspTaskProvider)
-                .toAppend(
-                    ScopedArtifact.CLASSES
-                ) { task -> project.objects.directoryProperty().also { it.set(resourcesOutputDir) } }
+                .toAppend(ScopedArtifact.CLASSES) { task ->
+                    project.objects.directoryProperty().also { it.set(resourcesOutputDir) }
+                }
 
             androidComponent.artifacts
                 .forScope(ScopedArtifacts.Scope.PROJECT)
                 .use(kspTaskProvider)
-                .toAppend(
-                    ScopedArtifact.CLASSES
-                ) { task -> project.objects.directoryProperty().also { it.set(classOutputDir) } }
+                .toAppend(ScopedArtifact.CLASSES) { task ->
+                    project.objects.directoryProperty().also { it.set(classOutputDir) }
+                }
         } else {
             val kspJavaOutput = project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
             val kspKotlinOutput = project.fileTree(kotlinOutputDir).builtBy(kspTaskProvider)
             val kspClassOutput = project.fileTree(classOutputDir).builtBy(kspTaskProvider)
             // PostJavacGeneratedBytecode will be used by bundleLibRuntimeToJar*
-            // We need add ksp task dependency for this output to avoid bundleLib task run before KSP
+            // We need add ksp task dependency for this output to avoid bundleLib task run before
+            // KSP
             val resourcesOutput = project.files(resourcesOutputDir).builtBy(kspTaskProvider)
 
             kspJavaOutput.include("**/*.java")
@@ -268,12 +273,12 @@ object AndroidPluginIntegration {
         if (androidComponent != null) {
             androidComponent.sources.java?.addGeneratedSourceDirectory(
                 taskProvider = kspTaskProvider,
-                wiredWith = { task -> task.kspConfig.javaOutputDir }
+                wiredWith = { task -> task.kspConfig.javaOutputDir },
             )
 
             androidComponent.sources.kotlin?.addGeneratedSourceDirectory(
                 taskProvider = kspTaskProvider,
-                wiredWith = { task -> task.kspConfig.kotlinOutputDir }
+                wiredWith = { task -> task.kspConfig.kotlinOutputDir },
             )
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/IsolatedClassLoaderCacheBuildService.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/IsolatedClassLoaderCacheBuildService.kt
@@ -16,11 +16,11 @@
 
 package com.google.devtools.ksp.gradle
 
-import org.gradle.api.services.BuildService
-import org.gradle.api.services.BuildServiceParameters
 import java.net.URLClassLoader
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
 
 object IsolatedClassLoaderCache {
     val cache = ConcurrentHashMap<String, URLClassLoader>()
@@ -30,14 +30,16 @@ object IsolatedClassLoaderCache {
             try {
                 classLoader.close()
             } catch (e: Exception) {
-                // Ignore exceptions during cleanup, but we could log them if a logger was available.
+                // Ignore exceptions during cleanup, but we could log them if a logger was
+                // available.
             }
         }
         cache.clear()
     }
 }
 
-abstract class IsolatedClassLoaderCacheBuildService : BuildService<BuildServiceParameters.None>, AutoCloseable {
+abstract class IsolatedClassLoaderCacheBuildService :
+    BuildService<BuildServiceParameters.None>, AutoCloseable {
     companion object {
         val KEY = "IsolatedClassLoaderCacheBuildService_" + UUID.randomUUID().toString()
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -31,6 +31,15 @@ import com.google.devtools.ksp.processing.KSPJsConfig
 import com.google.devtools.ksp.processing.KSPJvmConfig
 import com.google.devtools.ksp.processing.KSPNativeConfig
 import com.google.devtools.ksp.processing.KspGradleLogger
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.ObjectOutputStream
+import java.lang.reflect.InvocationTargetException
+import java.net.URLClassLoader
+import java.nio.file.Paths
+import java.util.*
+import java.util.concurrent.Callable
+import javax.inject.Inject
 import org.gradle.api.DefaultTask
 import org.gradle.api.JavaVersion
 import org.gradle.api.Project
@@ -82,28 +91,15 @@ import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
 import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
-import java.io.ByteArrayOutputStream
-import java.io.File
-import java.io.ObjectOutputStream
-import java.lang.reflect.InvocationTargetException
-import java.net.URLClassLoader
-import java.nio.file.Paths
-import java.util.*
-import java.util.concurrent.Callable
-import javax.inject.Inject
 
 @CacheableTask
-abstract class KspAATask @Inject constructor(
-    private val workerExecutor: WorkerExecutor,
-) : DefaultTask() {
-    @get:Classpath
-    abstract val kspClasspath: ConfigurableFileCollection
+abstract class KspAATask @Inject constructor(private val workerExecutor: WorkerExecutor) :
+    DefaultTask() {
+    @get:Classpath abstract val kspClasspath: ConfigurableFileCollection
 
-    @get:Nested
-    abstract val kspConfig: KspGradleConfig
+    @get:Nested abstract val kspConfig: KspGradleConfig
 
-    @get:Nested
-    abstract val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
+    @get:Nested abstract val commandLineArgumentProviders: ListProperty<CommandLineArgumentProvider>
 
     // Metadata JSONs from dependencies indicating cross-compilation support.
     // Declared as input so Gradle runs the exporting tasks before this task executes.
@@ -113,11 +109,13 @@ abstract class KspAATask @Inject constructor(
     abstract val crossCompilationMetadata: ConfigurableFileCollection
 
     @get:ServiceReference
-    abstract val isolatedClassLoaderCacheBuildService: Property<IsolatedClassLoaderCacheBuildService>
+    abstract val isolatedClassLoaderCacheBuildService:
+        Property<IsolatedClassLoaderCacheBuildService>
 
     @TaskAction
     fun execute(inputChanges: InputChanges) {
-        // FIXME: Create a class loader with clean classpath instead of shadowing existing ones. It'll require either:
+        // FIXME: Create a class loader with clean classpath instead of shadowing existing ones.
+        // It'll require either:
         //  1. passing arguments by data structures in stdlib, or
         //  2. hoisting and publishing KspGradleConfig into another package.
 
@@ -126,50 +124,57 @@ abstract class KspAATask @Inject constructor(
 
         if (inputChanges.isIncremental) {
             listOf(
-                kspConfig.sourceRoots,
-                kspConfig.javaSourceRoots,
-                kspConfig.commonSourceRoots
-            ).forEach { fileCollection ->
-                inputChanges.getFileChanges(fileCollection).forEach {
-                    when (it.changeType) {
-                        ChangeType.ADDED, ChangeType.MODIFIED -> modifiedSources.add(it.file)
-                        ChangeType.REMOVED -> removedSources.add(it.file)
+                    kspConfig.sourceRoots,
+                    kspConfig.javaSourceRoots,
+                    kspConfig.commonSourceRoots,
+                )
+                .forEach { fileCollection ->
+                    inputChanges.getFileChanges(fileCollection).forEach {
+                        when (it.changeType) {
+                            ChangeType.ADDED,
+                            ChangeType.MODIFIED -> modifiedSources.add(it.file)
+                            ChangeType.REMOVED -> removedSources.add(it.file)
+                        }
                     }
                 }
-            }
         }
 
-        val changedClasses = if (kspConfig.incremental.get()) {
-            when (kspConfig.platformType.get()) {
-                KotlinPlatformType.jvm, KotlinPlatformType.androidJvm -> {
-                    getCPChanges(
-                        inputChanges,
-                        listOf(
-                            kspConfig.sourceRoots,
-                            kspConfig.javaSourceRoots,
-                            kspConfig.commonSourceRoots,
+        val changedClasses =
+            if (kspConfig.incremental.get()) {
+                when (kspConfig.platformType.get()) {
+                    KotlinPlatformType.jvm,
+                    KotlinPlatformType.androidJvm -> {
+                        getCPChanges(
+                            inputChanges,
+                            listOf(
+                                kspConfig.sourceRoots,
+                                kspConfig.javaSourceRoots,
+                                kspConfig.commonSourceRoots,
+                                kspConfig.classpathStructure,
+                            ),
+                            kspConfig.cachesDir.asFile.get(),
                             kspConfig.classpathStructure,
-                        ),
-                        kspConfig.cachesDir.asFile.get(),
-                        kspConfig.classpathStructure,
-                        kspConfig.libraries,
-                        kspConfig.processorClasspath,
-                    )
-                }
+                            kspConfig.libraries,
+                            kspConfig.processorClasspath,
+                        )
+                    }
 
-                else -> {
-                    if (
-                        !inputChanges.isIncremental ||
-                        inputChanges.getFileChanges(kspConfig.nonJvmLibraries).iterator().hasNext()
-                    )
-                        kspConfig.cachesDir.get().asFile.deleteRecursively()
-                    emptyList()
+                    else -> {
+                        if (
+                            !inputChanges.isIncremental ||
+                                inputChanges
+                                    .getFileChanges(kspConfig.nonJvmLibraries)
+                                    .iterator()
+                                    .hasNext()
+                        )
+                            kspConfig.cachesDir.get().asFile.deleteRecursively()
+                        emptyList()
+                    }
                 }
+            } else {
+                kspConfig.cachesDir.get().asFile.deleteRecursively()
+                emptyList()
             }
-        } else {
-            kspConfig.cachesDir.get().asFile.deleteRecursively()
-            emptyList()
-        }
 
         val workerQueue = workerExecutor.noIsolation()
         workerQueue.submit(KspAAWorkerAction::class.java) {
@@ -190,308 +195,401 @@ abstract class KspAATask @Inject constructor(
             kspExtension: KspExtension,
         ): TaskProvider<KspAATask> {
             val project = kotlinCompilation.target.project
-            val isolatedClassLoaderCacheBuildServiceProvider = project.gradle.sharedServices.registerIfAbsent(
-                IsolatedClassLoaderCacheBuildService.KEY,
-                IsolatedClassLoaderCacheBuildService::class.java
-            ) {}
+            val isolatedClassLoaderCacheBuildServiceProvider =
+                project.gradle.sharedServices.registerIfAbsent(
+                    IsolatedClassLoaderCacheBuildService.KEY,
+                    IsolatedClassLoaderCacheBuildService::class.java,
+                ) {}
 
             val target = kotlinCompilation.target.name
             val sourceSetName = kotlinCompilation.defaultSourceSet.name
             val kspTaskName = kotlinCompileProvider.name.replaceFirst("compile", "ksp")
-            val kspAADepCfg = project.configurations.detachedConfiguration(
-                project.dependencies.create("${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-api:$KSP_VERSION"),
-                project.dependencies.create(
-                    "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-common-deps:$KSP_VERSION"
-                ),
-                project.dependencies.create(
-                    "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-aa-embeddable:$KSP_VERSION"
-                ),
-                project.dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:${project.getKotlinPluginVersion()}"),
-                project.dependencies.create(
-                    "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$KSP_COROUTINES_VERSION"
-                ),
-            ).apply {
-                isTransitive = false
-            }
-            val incomingProcessors = processorClasspath.incoming.artifactView { }.files
-            val kspTaskProvider = project.tasks.register(kspTaskName, KspAATask::class.java) { kspAATask ->
-                kspAATask.onlyIf {
-                    !incomingProcessors.isEmpty
-                }
-                kspAATask.usesService(isolatedClassLoaderCacheBuildServiceProvider)
-                kspAATask.isolatedClassLoaderCacheBuildService.set(isolatedClassLoaderCacheBuildServiceProvider)
-                kspAATask.kspClasspath.from(kspAADepCfg.incoming.artifactView { }.files)
-                kspAATask.kspConfig.let { cfg ->
-                    cfg.processorClasspath.from(incomingProcessors)
-                    val kotlinOutputDir = KspGradleSubplugin.getKspKotlinOutputDir(project, sourceSetName, target)
-                    val javaOutputDir = KspGradleSubplugin.getKspJavaOutputDir(project, sourceSetName, target)
-                    val filteredTasks = if (kspExtension.excludedSources.isEmpty.not()) {
-                        kspExtension.excludedSources.buildDependencies.getDependencies(null).map { it.name }
-                    } else emptyList()
-                    kotlinCompilation.allKotlinSourceSetsObservable.forAll { sourceSet ->
-                        val filtered = kotlinOutputDir.zip(javaOutputDir) { kotlinOut, javaOut ->
-                            sourceSet.kotlin.srcDirs.filter {
-                                !kotlinOut.asFile.isParentOf(it) && !javaOut.asFile.isParentOf(it) &&
-                                    it !in kspExtension.excludedSources
-                            }.map { srcDir ->
-                                // @SkipWhenEmpty doesn't work well with File.
-                                // Filter to only include Kotlin/Java sources so that Gradle can correctly
-                                // skip the task as NO-SOURCE if the directories contain only non-source files.
-                                project.objects.fileTree().from(srcDir).matching {
-                                    it.include("**/*.kt", "**/*.kts", "**/*.java")
+            val kspAADepCfg =
+                project.configurations
+                    .detachedConfiguration(
+                        project.dependencies.create(
+                            "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-api:$KSP_VERSION"
+                        ),
+                        project.dependencies.create(
+                            "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-common-deps:$KSP_VERSION"
+                        ),
+                        project.dependencies.create(
+                            "${KspGradleSubplugin.KSP_GROUP_ID}:symbol-processing-aa-embeddable:$KSP_VERSION"
+                        ),
+                        project.dependencies.create(
+                            "org.jetbrains.kotlin:kotlin-stdlib:${project.getKotlinPluginVersion()}"
+                        ),
+                        project.dependencies.create(
+                            "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$KSP_COROUTINES_VERSION"
+                        ),
+                    )
+                    .apply {
+                        isTransitive = false
+                    }
+            val incomingProcessors = processorClasspath.incoming.artifactView {}.files
+            val kspTaskProvider =
+                project.tasks.register(kspTaskName, KspAATask::class.java) { kspAATask ->
+                    kspAATask.onlyIf {
+                        !incomingProcessors.isEmpty
+                    }
+                    kspAATask.usesService(isolatedClassLoaderCacheBuildServiceProvider)
+                    kspAATask.isolatedClassLoaderCacheBuildService.set(
+                        isolatedClassLoaderCacheBuildServiceProvider
+                    )
+                    kspAATask.kspClasspath.from(kspAADepCfg.incoming.artifactView {}.files)
+                    kspAATask.kspConfig.let { cfg ->
+                        cfg.processorClasspath.from(incomingProcessors)
+                        val kotlinOutputDir =
+                            KspGradleSubplugin.getKspKotlinOutputDir(project, sourceSetName, target)
+                        val javaOutputDir =
+                            KspGradleSubplugin.getKspJavaOutputDir(project, sourceSetName, target)
+                        val filteredTasks =
+                            if (kspExtension.excludedSources.isEmpty.not()) {
+                                kspExtension.excludedSources.buildDependencies
+                                    .getDependencies(null)
+                                    .map { it.name }
+                            } else emptyList()
+                        kotlinCompilation.allKotlinSourceSetsObservable.forAll { sourceSet ->
+                            val filtered =
+                                kotlinOutputDir.zip(javaOutputDir) { kotlinOut, javaOut ->
+                                    sourceSet.kotlin.srcDirs
+                                        .filter {
+                                            !kotlinOut.asFile.isParentOf(it) &&
+                                                !javaOut.asFile.isParentOf(it) &&
+                                                it !in kspExtension.excludedSources
+                                        }
+                                        .map { srcDir ->
+                                            // @SkipWhenEmpty doesn't work well with File.
+                                            // Filter to only include Kotlin/Java sources so that
+                                            // Gradle can correctly
+                                            // skip the task as NO-SOURCE if the directories contain
+                                            // only non-source files.
+                                            project.objects.fileTree().from(srcDir).matching {
+                                                it.include("**/*.kt", "**/*.kts", "**/*.java")
+                                            }
+                                        }
                                 }
-                            }
-                        }
-                        cfg.sourceRoots.from(filtered)
-                        cfg.javaSourceRoots.from(filtered)
-                        if (project.canUseGeneratedKotlinApi() && project.enableProjectIsolationCompatibleCodepath()) {
-                            kspAATask.dependsOn(sourceSet.kotlin.buildDependencies)
-                        } else {
-                            kspAATask.dependsOn(
-                                sourceSet.kotlin.nonSelfDeps(kspTaskName).filter { it.name !in filteredTasks }
-                            )
-                        }
-                    }
-                    if (kotlinCompilation is KotlinCommonCompilation) {
-                        cfg.commonSourceRoots.from(kotlinCompilation.defaultSourceSet.kotlin)
-                    }
-
-                    if (kotlinCompilation is KotlinJvmAndroidCompilation) {
-                        if (project.isAgpBuiltInKotlinUsed()) {
-                            val androidComponents =
-                                project.extensions.getByType(AndroidComponentsExtension::class.java)
-
-                            if (project.isLegacyKaptPluginApplied()) {
-                                // Fallback to workaround to avoid circular dependency with KAPT.
-                                cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
-                                cfg.libraries.from(
-                                    project.provider {
-                                        val configuration = project.configurations.getByName(
-                                            kotlinCompilation.compileDependencyConfigurationName
-                                        )
-                                        configuration.incoming.artifactView { config ->
-                                            config.attributes.attribute(
-                                                Attribute.of("artifactType", String::class.java), "android-classes-jar"
-                                            )
-                                        }.files
-                                    }
-                                )
+                            cfg.sourceRoots.from(filtered)
+                            cfg.javaSourceRoots.from(filtered)
+                            if (
+                                project.canUseGeneratedKotlinApi() &&
+                                    project.enableProjectIsolationCompatibleCodepath()
+                            ) {
+                                kspAATask.dependsOn(sourceSet.kotlin.buildDependencies)
                             } else {
-                                cfg.libraries.from(kotlinCompileProvider.get().libraries)
-                                cfg.libraries.from(androidComponents.sdkComponents.bootClasspath)
-                            }
-                        } else {
-                            val kaptGeneratedClassesDir = getKaptGeneratedClassesDir(project, sourceSetName)
-                            val kspOutputDir = KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target)
-                            cfg.libraries.from(
-                                project.files(
-                                    Callable {
-                                        kotlinCompileProvider.get().libraries.filter {
-                                            !kspOutputDir.get().asFile.isParentOf(it) &&
-                                                !kaptGeneratedClassesDir.isParentOf(it) &&
-                                                !(it.isDirectory && it.listFiles()?.isEmpty() == true)
-                                        }
+                                kspAATask.dependsOn(
+                                    sourceSet.kotlin.nonSelfDeps(kspTaskName).filter {
+                                        it.name !in filteredTasks
                                     }
                                 )
+                            }
+                        }
+                        if (kotlinCompilation is KotlinCommonCompilation) {
+                            cfg.commonSourceRoots.from(kotlinCompilation.defaultSourceSet.kotlin)
+                        }
+
+                        if (kotlinCompilation is KotlinJvmAndroidCompilation) {
+                            if (project.isAgpBuiltInKotlinUsed()) {
+                                val androidComponents =
+                                    project.extensions.getByType(
+                                        AndroidComponentsExtension::class.java
+                                    )
+
+                                if (project.isLegacyKaptPluginApplied()) {
+                                    // Fallback to workaround to avoid circular dependency with
+                                    // KAPT.
+                                    cfg.libraries.from(
+                                        androidComponents.sdkComponents.bootClasspath
+                                    )
+                                    cfg.libraries.from(
+                                        project.provider {
+                                            val configuration =
+                                                project.configurations.getByName(
+                                                    kotlinCompilation
+                                                        .compileDependencyConfigurationName
+                                                )
+                                            configuration.incoming
+                                                .artifactView { config ->
+                                                    config.attributes.attribute(
+                                                        Attribute.of(
+                                                            "artifactType",
+                                                            String::class.java,
+                                                        ),
+                                                        "android-classes-jar",
+                                                    )
+                                                }
+                                                .files
+                                        }
+                                    )
+                                } else {
+                                    cfg.libraries.from(kotlinCompileProvider.get().libraries)
+                                    cfg.libraries.from(
+                                        androidComponents.sdkComponents.bootClasspath
+                                    )
+                                }
+                            } else {
+                                val kaptGeneratedClassesDir =
+                                    getKaptGeneratedClassesDir(project, sourceSetName)
+                                val kspOutputDir =
+                                    KspGradleSubplugin.getKspOutputDir(
+                                        project,
+                                        sourceSetName,
+                                        target,
+                                    )
+                                cfg.libraries.from(
+                                    project.files(
+                                        Callable {
+                                            kotlinCompileProvider.get().libraries.filter {
+                                                !kspOutputDir.get().asFile.isParentOf(it) &&
+                                                    !kaptGeneratedClassesDir.isParentOf(it) &&
+                                                    !(it.isDirectory &&
+                                                        it.listFiles()?.isEmpty() == true)
+                                            }
+                                        }
+                                    )
+                                )
+                            }
+                        } else {
+                            cfg.libraries.from(
+                                project.provider {
+                                    kotlinCompilation.compileDependencyFiles
+                                }
                             )
                         }
-                    } else {
-                        cfg.libraries.from(
-                            project.provider {
-                                kotlinCompilation.compileDependencyFiles
+
+                        val classOutputDir =
+                            KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target)
+                        val compileTask = kotlinCompilation.compileTaskProvider
+                        val defaultKotlinVersion =
+                            project
+                                .getKotlinPluginVersion()
+                                .split('.', '-')
+                                .take(2)
+                                .joinToString(".")
+
+                        cfg.languageVersion.set(
+                            compileTask.flatMap { task ->
+                                task.compilerOptions.languageVersion
+                                    .map { it.version }
+                                    .orElse(defaultKotlinVersion)
                             }
                         )
-                    }
 
-                    val classOutputDir = KspGradleSubplugin.getKspClassOutputDir(project, sourceSetName, target)
-                    val compileTask = kotlinCompilation.compileTaskProvider
-                    val defaultKotlinVersion = project.getKotlinPluginVersion()
-                        .split('.', '-')
-                        .take(2)
-                        .joinToString(".")
-
-                    cfg.languageVersion.set(
-                        compileTask.flatMap { task ->
-                            task.compilerOptions.languageVersion.map { it.version }.orElse(defaultKotlinVersion)
-                        }
-                    )
-
-                    cfg.apiVersion.set(
-                        compileTask.flatMap { task ->
-                            task.compilerOptions.apiVersion.map { it.version }.orElse(defaultKotlinVersion)
-                        }
-                    )
-
-                    cfg.projectBaseDir.set(project.layout.projectDirectory)
-                    cfg.cachesDir.set(KspGradleSubplugin.getKspCachesDir(project, sourceSetName, target))
-                    cfg.outputBaseDir.set(KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target))
-                    cfg.kotlinOutputDir.set(kotlinOutputDir)
-                    cfg.javaOutputDir.set(javaOutputDir)
-                    cfg.classOutputDir.set(classOutputDir)
-                    cfg.resourceOutputDir.set(
-                        KspGradleSubplugin.getKspResourceOutputDir(
-                            project,
-                            sourceSetName,
-                            target
+                        cfg.apiVersion.set(
+                            compileTask.flatMap { task ->
+                                task.compilerOptions.apiVersion
+                                    .map { it.version }
+                                    .orElse(defaultKotlinVersion)
+                            }
                         )
-                    )
-                    cfg.processorOptions.putAll(kspExtension.apOptions)
-                    cfg.apOptions.putAll(kspExtension.apOptions)
 
-                    fun ListProperty<CommandLineArgumentProvider>.mapArgProviders() =
-                        map { providers ->
-                            buildMap {
-                                for (provider in providers) {
-                                    provider.asArguments().forEach { argument ->
-                                        val kv = Regex("(\\S+)=(\\S+)").matchEntire(argument)?.groupValues
-                                        require(kv != null && kv.size == 3) {
-                                            "Processor arguments not in the format \\S+=\\S+: $argument"
+                        cfg.projectBaseDir.set(project.layout.projectDirectory)
+                        cfg.cachesDir.set(
+                            KspGradleSubplugin.getKspCachesDir(project, sourceSetName, target)
+                        )
+                        cfg.outputBaseDir.set(
+                            KspGradleSubplugin.getKspOutputDir(project, sourceSetName, target)
+                        )
+                        cfg.kotlinOutputDir.set(kotlinOutputDir)
+                        cfg.javaOutputDir.set(javaOutputDir)
+                        cfg.classOutputDir.set(classOutputDir)
+                        cfg.resourceOutputDir.set(
+                            KspGradleSubplugin.getKspResourceOutputDir(
+                                project,
+                                sourceSetName,
+                                target,
+                            )
+                        )
+                        cfg.processorOptions.putAll(kspExtension.apOptions)
+                        cfg.apOptions.putAll(kspExtension.apOptions)
+
+                        fun ListProperty<CommandLineArgumentProvider>.mapArgProviders() =
+                            map { providers ->
+                                buildMap {
+                                    for (provider in providers) {
+                                        provider.asArguments().forEach { argument ->
+                                            val kv =
+                                                Regex("(\\S+)=(\\S+)")
+                                                    .matchEntire(argument)
+                                                    ?.groupValues
+                                            require(kv != null && kv.size == 3) {
+                                                "Processor arguments not in the format \\S+=\\S+: $argument"
+                                            }
+                                            put(kv[1], kv[2])
                                         }
-                                        put(kv[1], kv[2])
                                     }
                                 }
                             }
-                        }
 
-                    kspAATask.commandLineArgumentProviders.addAll(kspExtension.commandLineArgumentProviders)
-                    cfg.processorOptions.putAll(kspAATask.commandLineArgumentProviders.mapArgProviders())
+                        kspAATask.commandLineArgumentProviders.addAll(
+                            kspExtension.commandLineArgumentProviders
+                        )
+                        cfg.processorOptions.putAll(
+                            kspAATask.commandLineArgumentProviders.mapArgProviders()
+                        )
 
-                    val logLevel = LogLevel.entries.first {
-                        project.logger.isEnabled(it)
-                    }
-                    cfg.logLevel.value(logLevel)
-                    cfg.allWarningsAsErrors.value(kspExtension.allWarningsAsErrors)
-                    cfg.excludedProcessors.value(kspExtension.excludedProcessors)
+                        val logLevel =
+                            LogLevel.entries.first {
+                                project.logger.isEnabled(it)
+                            }
+                        cfg.logLevel.value(logLevel)
+                        cfg.allWarningsAsErrors.value(kspExtension.allWarningsAsErrors)
+                        cfg.excludedProcessors.value(kspExtension.excludedProcessors)
 
-                    cfg.incremental.value(
-                        project.providers
-                            .gradleProperty("ksp.incremental")
-                            .map { it.toBoolean() }
-                            .orElse(true)
-                    )
-                    cfg.incrementalLog.value(
-                        project.providers
-                            .gradleProperty("ksp.incremental.log")
-                            .map { it.toBoolean() }
-                            .orElse(false)
-                    )
-                    cfg.incrementalGraphOrigin.value(
-                        project.providers
-                            .gradleProperty("ksp.incremental.log.graph.origin")
-                    )
+                        cfg.incremental.value(
+                            project.providers
+                                .gradleProperty("ksp.incremental")
+                                .map { it.toBoolean() }
+                                .orElse(true)
+                        )
+                        cfg.incrementalLog.value(
+                            project.providers
+                                .gradleProperty("ksp.incremental.log")
+                                .map { it.toBoolean() }
+                                .orElse(false)
+                        )
+                        cfg.incrementalGraphOrigin.value(
+                            project.providers.gradleProperty("ksp.incremental.log.graph.origin")
+                        )
 
-                    cfg.experimentalPsiResolution.value(
-                        project.providers
-                            .gradleProperty("ksp.experimental.psi.resolution")
-                            .map { it.toBoolean() }
-                            .orElse(false)
-                    )
+                        cfg.experimentalPsiResolution.value(
+                            project.providers
+                                .gradleProperty("ksp.experimental.psi.resolution")
+                                .map { it.toBoolean() }
+                                .orElse(false)
+                        )
 
-                    // Ref: https://github.com/JetBrains/kotlin/blob/6535f86dfe36effeba976802ebd56a5a56071f45/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt#L92
-                    val moduleName = when (val compilationName = kotlinCompilation.name) {
-                        KotlinCompilation.MAIN_COMPILATION_NAME -> project.name
-                        else -> "${project.name}_$compilationName"
-                    }
+                        // Ref:
+                        // https://github.com/JetBrains/kotlin/blob/6535f86dfe36effeba976802ebd56a5a56071f45/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/mpp/kotlinCompilations.kt#L92
+                        val moduleName =
+                            when (val compilationName = kotlinCompilation.name) {
+                                KotlinCompilation.MAIN_COMPILATION_NAME -> project.name
+                                else -> "${project.name}_$compilationName"
+                            }
 
-                    if (kotlinCompilation.platformType == KotlinPlatformType.jvm ||
-                        kotlinCompilation.platformType == KotlinPlatformType.androidJvm
-                    ) {
-                        cfg.jdkHome.set(File(System.getProperty("java.home")))
-                        val javaVersion = JavaVersion.toVersion(System.getProperty("java.version"))
-                        cfg.jdkVersion.value(javaVersion.majorVersion.toInt())
+                        if (
+                            kotlinCompilation.platformType == KotlinPlatformType.jvm ||
+                                kotlinCompilation.platformType == KotlinPlatformType.androidJvm
+                        ) {
+                            cfg.jdkHome.set(File(System.getProperty("java.home")))
+                            val javaVersion =
+                                JavaVersion.toVersion(System.getProperty("java.version"))
+                            cfg.jdkVersion.value(javaVersion.majorVersion.toInt())
 
-                        val oldJvmDefaultMode = compileTask.flatMap { task ->
-                            task.compilerOptions.freeCompilerArgs
-                                .map { args ->
-                                    args.filter {
-                                        // Support both new and deprecated arguments (-Xjvm-* is deprecated)
-                                        it.startsWith("-jvm-default=") || it.startsWith("-Xjvm-default=")
+                            val oldJvmDefaultMode = compileTask.flatMap { task ->
+                                task.compilerOptions.freeCompilerArgs
+                                    .map { args ->
+                                        args.filter {
+                                            // Support both new and deprecated arguments (-Xjvm-* is
+                                            // deprecated)
+                                            it.startsWith("-jvm-default=") ||
+                                                it.startsWith("-Xjvm-default=")
+                                        }
+                                    }
+                                    .map { it.lastOrNull()?.substringAfter("=") ?: "undefined" }
+                            }
+
+                            val compilerArgument = compileTask.flatMap { task ->
+                                (task.compilerOptions as KotlinJvmCompilerOptions)
+                                    .jvmDefault
+                                    .map { it.compilerArgument }
+                                    .orElse(JvmDefaultMode.ENABLE.compilerArgument)
+                            }
+
+                            cfg.jvmDefaultMode.value(
+                                project.provider {
+                                    when (oldJvmDefaultMode.get()) {
+                                        "all" -> "no-compatibility"
+                                        "all-compatibility" -> "enable"
+                                        "disable" -> "disable"
+                                        else -> compilerArgument.get()
                                     }
                                 }
-                                .map { it.lastOrNull()?.substringAfter("=") ?: "undefined" }
-                        }
+                            )
 
-                        val compilerArgument = compileTask.flatMap { task ->
-                            (task.compilerOptions as KotlinJvmCompilerOptions).jvmDefault.map { it.compilerArgument }
-                                .orElse(JvmDefaultMode.ENABLE.compilerArgument)
-                        }
-
-                        cfg.jvmDefaultMode.value(
-                            project.provider {
-                                when (oldJvmDefaultMode.get()) {
-                                    "all" -> "no-compatibility"
-                                    "all-compatibility" -> "enable"
-                                    "disable" -> "disable"
-                                    else -> compilerArgument.get()
+                            cfg.jvmTarget.value(
+                                compileTask.flatMap { task ->
+                                    (task.compilerOptions as KotlinJvmCompilerOptions)
+                                        .jvmTarget
+                                        .map { it.target }
                                 }
-                            }
-                        )
+                            )
 
-                        cfg.jvmTarget.value(
-                            compileTask.flatMap { task ->
-                                (task.compilerOptions as KotlinJvmCompilerOptions).jvmTarget.map { it.target }
-                            }
-                        )
+                            cfg.classpathStructure.from(
+                                getClassStructureFiles(project, cfg.libraries)
+                            )
 
-                        cfg.classpathStructure.from(getClassStructureFiles(project, cfg.libraries))
+                            // Don't support binary generation for non-JVM platforms yet.
+                            // FIXME: figure out how to add user generated libraries.
+                            kotlinCompilation.output.classesDirs.from(classOutputDir)
 
-                        // Don't support binary generation for non-JVM platforms yet.
-                        // FIXME: figure out how to add user generated libraries.
-                        kotlinCompilation.output.classesDirs.from(classOutputDir)
-
-                        cfg.moduleName.set(
-                            compileTask.flatMap { task ->
-                                (task.compilerOptions as KotlinJvmCompilerOptions).moduleName.orElse(moduleName)
-                            }
-                        )
-                    } else {
-                        cfg.nonJvmLibraries.from(cfg.libraries)
-                        cfg.moduleName.value(moduleName)
-                    }
-
-                    cfg.platformType.value(kotlinCompilation.platformType)
-                    if (kotlinCompilation is KotlinNativeCompilation) {
-                        val konanTargetName = kotlinCompilation.target.konanTarget.name
-                        cfg.konanTargetName.value(konanTargetName)
-                        cfg.konanHome.set(kotlinCompileProvider.flatMap { (it as KotlinNativeCompile).konanHome })
-
-                        val isHostSupported = HostManager().enabled.any {
-                            it.name == konanTargetName
+                            cfg.moduleName.set(
+                                compileTask.flatMap { task ->
+                                    (task.compilerOptions as KotlinJvmCompilerOptions)
+                                        .moduleName
+                                        .orElse(moduleName)
+                                }
+                            )
+                        } else {
+                            cfg.nonJvmLibraries.from(cfg.libraries)
+                            cfg.moduleName.value(moduleName)
                         }
-                        if (!isHostSupported) {
-                            configureCrossCompilationSkipCondition(project, kotlinCompilation, kspAATask)
-                        }
-                    }
 
-                    cfg.profilingMode.value(
-                        project.providers
-                            .gradleProperty("ksp.ksp2.profiling.mode")
-                            .map { it.toBoolean() }
-                            .orElse(false)
-                    )
-                    // TODO: pass targets of common
+                        cfg.platformType.value(kotlinCompilation.platformType)
+                        if (kotlinCompilation is KotlinNativeCompilation) {
+                            val konanTargetName = kotlinCompilation.target.konanTarget.name
+                            cfg.konanTargetName.value(konanTargetName)
+                            cfg.konanHome.set(
+                                kotlinCompileProvider.flatMap {
+                                    (it as KotlinNativeCompile).konanHome
+                                }
+                            )
+
+                            val isHostSupported =
+                                HostManager().enabled.any {
+                                    it.name == konanTargetName
+                                }
+                            if (!isHostSupported) {
+                                configureCrossCompilationSkipCondition(
+                                    project,
+                                    kotlinCompilation,
+                                    kspAATask,
+                                )
+                            }
+                        }
+
+                        cfg.profilingMode.value(
+                            project.providers
+                                .gradleProperty("ksp.ksp2.profiling.mode")
+                                .map { it.toBoolean() }
+                                .orElse(false)
+                        )
+                        // TODO: pass targets of common
+                    }
                 }
-            }
 
             return kspTaskProvider
         }
 
-        private const val ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY = "kotlin.native.enableKlibsCrossCompilation"
+        private const val ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY =
+            "kotlin.native.enableKlibsCrossCompilation"
         private const val CROSS_COMPILATION_SHARED_DATA_KEY = "crossCompilationMetadata"
         private val KOTLIN_PROJECT_SHARED_DATA_ATTRIBUTE =
             Attribute.of("org.jetbrains.kotlin.project-shared-data", String::class.java)
 
         /**
-         * Configures [kspAATask] to skip when cross-compilation is not possible on the current host,
-         * mirroring how KGP skips compile tasks (see KGP's KotlinCreateNativeCompileTasksSideEffect).
+         * Configures [kspAATask] to skip when cross-compilation is not possible on the current
+         * host, mirroring how KGP skips compile tasks (see KGP's
+         * KotlinCreateNativeCompileTasksSideEffect).
          *
          * To remain compatible with the Configuration Cache, we split KGP's check:
-         *  1. Target-level check (evaluated during configuration): Checks host compatibility,
-         *     cross-compilation properties, and cinterops.
-         *  2. Dependency-level check (evaluated during execution): Reads shared metadata JSONs
-         *     from project dependencies (declared as task inputs to ensure correct task ordering).
+         * 1. Target-level check (evaluated during configuration): Checks host compatibility,
+         *    cross-compilation properties, and cinterops.
+         * 2. Dependency-level check (evaluated during execution): Reads shared metadata JSONs from
+         *    project dependencies (declared as task inputs to ensure correct task ordering).
          *
-         * TODO(https://youtrack.jetbrains.com/issue/KT-87411): Replace with the public KGP API once available.
+         * TODO(https://youtrack.jetbrains.com/issue/KT-87411): Replace with the public KGP API once
+         *   available.
          */
         private fun configureCrossCompilationSkipCondition(
             project: Project,
@@ -517,79 +615,95 @@ abstract class KspAATask @Inject constructor(
                 }
             }
 
-            val isTargetCrossCompilationPossible = isKlibCrossCompilationEnabled.zip(hasCinterops) { klibCrossCompilationEnabled, targetHasCinterops ->
-                HostManager.hostOrNull != null &&
-                    klibCrossCompilationEnabled &&
-                    !targetHasCinterops
-            }
+            val isTargetCrossCompilationPossible =
+                isKlibCrossCompilationEnabled.zip(hasCinterops) {
+                    klibCrossCompilationEnabled,
+                    targetHasCinterops ->
+                    HostManager.hostOrNull != null &&
+                        klibCrossCompilationEnabled &&
+                        !targetHasCinterops
+                }
             kspAATask.onlyIf("Cross compilation should be supported on host") {
                 isTargetCrossCompilationPossible.get()
             }
 
             val metadataFiles = getCrossCompilationMetadataFiles(project, kotlinCompilation)
             kspAATask.crossCompilationMetadata.from(metadataFiles)
-            kspAATask.onlyIf("Cross compilation should be possible with project dependencies") { task ->
-                (task as KspAATask).crossCompilationMetadata.files.all(::isCrossCompilationSupportedBy)
+            kspAATask.onlyIf("Cross compilation should be possible with project dependencies") {
+                task ->
+                (task as KspAATask)
+                    .crossCompilationMetadata
+                    .files
+                    .all(::isCrossCompilationSupportedBy)
             }
         }
 
         private fun getKlibCrossCompilationEnabledProvider(project: Project): Provider<Boolean> {
-            val gradlePropertiesSetting = project.providers.gradleProperty(ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY)
-                .map { it.toBoolean() }
-                .orElse(true)
+            val gradlePropertiesSetting =
+                project.providers
+                    .gradleProperty(ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY)
+                    .map { it.toBoolean() }
+                    .orElse(true)
 
-            val subprojectPropertiesSetting = project.providers
-                .fileContents(project.layout.projectDirectory.file("gradle.properties"))
-                .asText
-                .map { text ->
-                    val props = Properties().apply { load(java.io.StringReader(text)) }
-                    props.getProperty(ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY)?.toBoolean()
-                }
+            val subprojectPropertiesSetting =
+                project.providers
+                    .fileContents(project.layout.projectDirectory.file("gradle.properties"))
+                    .asText
+                    .map { text ->
+                        val props = Properties().apply { load(java.io.StringReader(text)) }
+                        props.getProperty(ENABLE_KLIBS_CROSSCOMPILATION_PROPERTY)?.toBoolean()
+                    }
 
             return subprojectPropertiesSetting.orElse(gradlePropertiesSetting)
         }
 
         private fun getCrossCompilationMetadataFiles(
             project: Project,
-            kotlinCompilation: KotlinNativeCompilation
+            kotlinCompilation: KotlinNativeCompilation,
         ): FileCollection {
-            val configurationProvider = project.configurations.named(kotlinCompilation.compileDependencyConfigurationName)
-            val sharedDataUsage = project.objects.named(Usage::class.java, "kotlin-project-shared-data")
+            val configurationProvider =
+                project.configurations.named(kotlinCompilation.compileDependencyConfigurationName)
+            val sharedDataUsage =
+                project.objects.named(Usage::class.java, "kotlin-project-shared-data")
             val filesProvider = configurationProvider.map { configuration ->
-                configuration.incoming.artifactView { view ->
-                    view.isLenient = true
-                    view.attributes.attribute(Usage.USAGE_ATTRIBUTE, sharedDataUsage)
-                    view.attributes.attribute(KOTLIN_PROJECT_SHARED_DATA_ATTRIBUTE, CROSS_COMPILATION_SHARED_DATA_KEY)
-                    view.attributes.attribute(
-                        Attribute.of("artifactType", String::class.java),
-                        "kotlin-project-shared-data-$CROSS_COMPILATION_SHARED_DATA_KEY"
-                    )
-                }.files
+                configuration.incoming
+                    .artifactView { view ->
+                        view.isLenient = true
+                        view.attributes.attribute(Usage.USAGE_ATTRIBUTE, sharedDataUsage)
+                        view.attributes.attribute(
+                            KOTLIN_PROJECT_SHARED_DATA_ATTRIBUTE,
+                            CROSS_COMPILATION_SHARED_DATA_KEY,
+                        )
+                        view.attributes.attribute(
+                            Attribute.of("artifactType", String::class.java),
+                            "kotlin-project-shared-data-$CROSS_COMPILATION_SHARED_DATA_KEY",
+                        )
+                    }
+                    .files
             }
             return project.files(filesProvider)
         }
 
         /**
-         * Parses the cross-compilation metadata JSON exported by KGP.
-         * Missing or malformed files default to supported (matching KGP's parser).
+         * Parses the cross-compilation metadata JSON exported by KGP. Missing or malformed files
+         * default to supported (matching KGP's parser).
          */
         private fun isCrossCompilationSupportedBy(metadataFile: File): Boolean {
             val content = runCatching { metadataFile.readText() }.getOrNull() ?: return true
             return runCatching {
-                val parser = groovy.json.JsonSlurper()
-                val map = parser.parseText(content) as Map<*, *>
-                map["crossCompilationSupported"] as? Boolean
-            }.getOrNull() ?: true
+                    val parser = groovy.json.JsonSlurper()
+                    val map = parser.parseText(content) as Map<*, *>
+                    map["crossCompilationSupported"] as? Boolean
+                }
+                .getOrNull() ?: true
         }
     }
 }
 
 abstract class KspGradleConfig @Inject constructor() {
-    @get:Classpath
-    abstract val processorClasspath: ConfigurableFileCollection
+    @get:Classpath abstract val processorClasspath: ConfigurableFileCollection
 
-    @get:Input
-    abstract val moduleName: Property<String>
+    @get:Input abstract val moduleName: Property<String>
 
     @get:InputFiles
     @get:SkipWhenEmpty
@@ -614,79 +728,52 @@ abstract class KspGradleConfig @Inject constructor() {
 
     // Marked as Internal for compilation avoidance.
     // classpathStructure has the needed incremental properties.
-    @get:Internal
-    abstract val libraries: ConfigurableFileCollection
+    @get:Internal abstract val libraries: ConfigurableFileCollection
 
-    @get:Internal
-    abstract val jdkHome: DirectoryProperty
+    @get:Internal abstract val jdkHome: DirectoryProperty
 
-    @get:Input
-    @get:Optional
-    abstract val jdkVersion: Property<Int>
+    @get:Input @get:Optional abstract val jdkVersion: Property<Int>
 
-    @get:Internal
-    abstract val projectBaseDir: DirectoryProperty
+    @get:Internal abstract val projectBaseDir: DirectoryProperty
 
-    @get:Internal
-    abstract val outputBaseDir: DirectoryProperty
+    @get:Internal abstract val outputBaseDir: DirectoryProperty
 
-    @get:LocalState
-    abstract val cachesDir: DirectoryProperty
+    @get:LocalState abstract val cachesDir: DirectoryProperty
 
-    @get:OutputDirectory
-    abstract val kotlinOutputDir: DirectoryProperty
+    @get:OutputDirectory abstract val kotlinOutputDir: DirectoryProperty
 
-    @get:OutputDirectory
-    abstract val javaOutputDir: DirectoryProperty
+    @get:OutputDirectory abstract val javaOutputDir: DirectoryProperty
 
-    @get:OutputDirectory
-    abstract val classOutputDir: DirectoryProperty
+    @get:OutputDirectory abstract val classOutputDir: DirectoryProperty
 
-    @get:OutputDirectory
-    abstract val resourceOutputDir: DirectoryProperty
+    @get:OutputDirectory abstract val resourceOutputDir: DirectoryProperty
 
-    @get:Input
-    abstract val languageVersion: Property<String>
+    @get:Input abstract val languageVersion: Property<String>
 
-    @get:Input
-    abstract val apiVersion: Property<String>
+    @get:Input abstract val apiVersion: Property<String>
 
-    @get:Internal
-    abstract val processorOptions: MapProperty<String, String>
+    @get:Internal abstract val processorOptions: MapProperty<String, String>
 
-    @get:Input
-    abstract val apOptions: MapProperty<String, String>
+    @get:Input abstract val apOptions: MapProperty<String, String>
 
     // Unfortunately, passing project.logger over is not possible.
-    @get:Input
-    abstract val logLevel: Property<LogLevel>
+    @get:Input abstract val logLevel: Property<LogLevel>
 
-    @get:Input
-    abstract val allWarningsAsErrors: Property<Boolean>
+    @get:Input abstract val allWarningsAsErrors: Property<Boolean>
 
-    @get:Input
-    abstract val excludedProcessors: SetProperty<String>
+    @get:Input abstract val excludedProcessors: SetProperty<String>
 
-    @get:Input
-    @get:Optional
-    abstract val jvmTarget: Property<String>
+    @get:Input @get:Optional abstract val jvmTarget: Property<String>
 
-    @get:Input
-    @get:Optional
-    abstract val jvmDefaultMode: Property<String>
+    @get:Input @get:Optional abstract val jvmDefaultMode: Property<String>
 
-    @get:Input
-    abstract val incremental: Property<Boolean>
+    @get:Input abstract val incremental: Property<Boolean>
 
-    @get:Input
-    abstract val incrementalLog: Property<Boolean>
+    @get:Input abstract val incrementalLog: Property<Boolean>
 
-    @get:Input
-    @get:Optional
-    abstract val incrementalGraphOrigin: Property<String>
+    @get:Input @get:Optional abstract val incrementalGraphOrigin: Property<String>
 
-    @get:Input
-    abstract val experimentalPsiResolution: Property<Boolean>
+    @get:Input abstract val experimentalPsiResolution: Property<Boolean>
 
     @get:PathSensitive(PathSensitivity.NONE)
     @get:Incremental
@@ -704,19 +791,13 @@ abstract class KspGradleConfig @Inject constructor() {
     @get:InputFiles
     abstract val nonJvmLibraries: ConfigurableFileCollection
 
-    @get:Input
-    abstract val platformType: Property<KotlinPlatformType>
+    @get:Input abstract val platformType: Property<KotlinPlatformType>
 
-    @get:Input
-    @get:Optional
-    abstract val konanTargetName: Property<String>
+    @get:Input @get:Optional abstract val konanTargetName: Property<String>
 
-    @get:Input
-    @get:Optional
-    abstract val konanHome: Property<String>
+    @get:Input @get:Optional abstract val konanHome: Property<String>
 
-    @get:Internal
-    abstract val profilingMode: Property<Boolean>
+    @get:Internal abstract val profilingMode: Property<Boolean>
 }
 
 interface KspAAWorkParameter : WorkParameters {
@@ -735,21 +816,23 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
         val kspClasspath = parameters.kspClasspath
         val isolatedClassLoaderCache = IsolatedClassLoaderCache.cache
         val key = kspClasspath.files.map { it.toURI().toURL() }.joinToString { it.path }
-        val isolatedClassLoader = isolatedClassLoaderCache.computeIfAbsent(key) {
-            URLClassLoader(
-                kspClasspath.files.map { it.toURI().toURL() }.toTypedArray(),
-                ClassLoader.getPlatformClassLoader()
-            )
-        }
+        val isolatedClassLoader =
+            isolatedClassLoaderCache.computeIfAbsent(key) {
+                URLClassLoader(
+                    kspClasspath.files.map { it.toURI().toURL() }.toTypedArray(),
+                    ClassLoader.getPlatformClassLoader(),
+                )
+            }
 
         // Clean stale files for now.
         // TODO: support incremental processing.
         gradleCfg.outputBaseDir.get().asFile.deleteRecursively()
 
-        val processorClassloader = URLClassLoader(
-            gradleCfg.processorClasspath.files.map { it.toURI().toURL() }.toTypedArray(),
-            isolatedClassLoader
-        )
+        val processorClassloader =
+            URLClassLoader(
+                gradleCfg.processorClasspath.files.map { it.toURI().toURL() }.toTypedArray(),
+                isolatedClassLoader,
+            )
         if (gradleCfg.profilingMode.get()) {
             doNotGC.add(processorClassloader)
         } else {
@@ -757,22 +840,31 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
         }
 
         val excludedProcessors = gradleCfg.excludedProcessors.get()
-        val processorProviders = ServiceLoader.load(
-            processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
-            processorClassloader
-        ).filter {
-            it.javaClass.name !in excludedProcessors
-        }.toList()
+        val processorProviders =
+            ServiceLoader.load(
+                    processorClassloader.loadClass(
+                        "com.google.devtools.ksp.processing.SymbolProcessorProvider"
+                    ),
+                    processorClassloader,
+                )
+                .filter {
+                    it.javaClass.name !in excludedProcessors
+                }
+                .toList()
 
         val kspGradleLogger = KspGradleLogger(gradleCfg.logLevel.get().ordinal)
 
         if (processorProviders.isEmpty()) {
             kspGradleLogger.error("No providers found in processor classpath.")
-            throw Exception("KSP failed with exit code: ${KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR}")
+            throw Exception(
+                "KSP failed with exit code: ${KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR}"
+            )
         } else {
             kspGradleLogger.info(
                 "loaded provider(s): " +
-                    processorProviders.joinToString(separator = ", ", prefix = "[", postfix = "]") { it.javaClass.name }
+                    processorProviders.joinToString(separator = ", ", prefix = "[", postfix = "]") {
+                        it.javaClass.name
+                    }
             )
         }
 
@@ -791,7 +883,8 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
             languageVersion = gradleCfg.languageVersion.get()
             apiVersion = gradleCfg.apiVersion.get()
 
-            // Gradle's MapProperty returns a Guava map and forces the deserializer to depend on Guava.
+            // Gradle's MapProperty returns a Guava map and forces the deserializer to depend on
+            // Guava.
             // Let's convert to Kotlin's choice of map instead.
             processorOptions = gradleCfg.processorOptions.get().toMap()
             allWarningsAsErrors = gradleCfg.allWarningsAsErrors.get()
@@ -806,79 +899,94 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
             changedClasses = parameters.changedClasses
         }
 
-        val kspConfig = when (val platformType = gradleCfg.platformType.get()) {
-            KotlinPlatformType.jvm, KotlinPlatformType.androidJvm -> {
-                KSPJvmConfig.Builder().apply {
-                    this.setupSuper()
-                    javaSourceRoots = gradleCfg.javaSourceRoots.files.toList()
-                    jdkHome = gradleCfg.jdkHome.get().asFile
-                    javaOutputDir = gradleCfg.javaOutputDir.get().asFile
-                    jvmTarget = gradleCfg.jvmTarget.get()
-                    jvmDefaultMode = gradleCfg.jvmDefaultMode.get()
-                }.build()
-            }
+        val kspConfig =
+            when (val platformType = gradleCfg.platformType.get()) {
+                KotlinPlatformType.jvm,
+                KotlinPlatformType.androidJvm -> {
+                    KSPJvmConfig.Builder()
+                        .apply {
+                            this.setupSuper()
+                            javaSourceRoots = gradleCfg.javaSourceRoots.files.toList()
+                            jdkHome = gradleCfg.jdkHome.get().asFile
+                            javaOutputDir = gradleCfg.javaOutputDir.get().asFile
+                            jvmTarget = gradleCfg.jvmTarget.get()
+                            jvmDefaultMode = gradleCfg.jvmDefaultMode.get()
+                        }
+                        .build()
+                }
 
-            KotlinPlatformType.js, KotlinPlatformType.wasm -> {
-                KSPJsConfig.Builder().apply {
-                    this.setupSuper()
-                    backend = if (platformType == KotlinPlatformType.js) "JS" else "WASM"
-                }.build()
-            }
+                KotlinPlatformType.js,
+                KotlinPlatformType.wasm -> {
+                    KSPJsConfig.Builder()
+                        .apply {
+                            this.setupSuper()
+                            backend = if (platformType == KotlinPlatformType.js) "JS" else "WASM"
+                        }
+                        .build()
+                }
 
-            KotlinPlatformType.native -> {
-                KSPNativeConfig.Builder().apply {
-                    this.setupSuper()
-                    target = gradleCfg.konanTargetName.get()
+                KotlinPlatformType.native -> {
+                    KSPNativeConfig.Builder()
+                        .apply {
+                            this.setupSuper()
+                            target = gradleCfg.konanTargetName.get()
 
-                    // Unlike other platforms, K/N sets up stdlib in the compiler, not KGP,
-                    // meaning that KotlinNativeCompile doesn't have stdlib.
-                    // FIXME: find a solution with KGP, K/N and AA owners
-                    val konanHome = File(gradleCfg.konanHome.get())
-                    val klib = File(konanHome, "klib")
-                    val common = File(klib, "common")
-                    val stdlib = File(common, "stdlib")
-                    libraries += stdlib
-                    val platform = File(klib, "platform")
-                    val targetLibDir = File(platform, target)
-                    targetLibDir.listFiles()?.let {
-                        libraries += it
-                    }
-                }.build()
-            }
+                            // Unlike other platforms, K/N sets up stdlib in the compiler, not KGP,
+                            // meaning that KotlinNativeCompile doesn't have stdlib.
+                            // FIXME: find a solution with KGP, K/N and AA owners
+                            val konanHome = File(gradleCfg.konanHome.get())
+                            val klib = File(konanHome, "klib")
+                            val common = File(klib, "common")
+                            val stdlib = File(common, "stdlib")
+                            libraries += stdlib
+                            val platform = File(klib, "platform")
+                            val targetLibDir = File(platform, target)
+                            targetLibDir.listFiles()?.let {
+                                libraries += it
+                            }
+                        }
+                        .build()
+                }
 
-            KotlinPlatformType.common -> {
-                KSPCommonConfig.Builder().apply {
-                    this.setupSuper()
-                    // FIXME: targets
-                    targets = emptyList()
-                }.build()
+                KotlinPlatformType.common -> {
+                    KSPCommonConfig.Builder()
+                        .apply {
+                            this.setupSuper()
+                            // FIXME: targets
+                            targets = emptyList()
+                        }
+                        .build()
+                }
             }
-        }
         val byteArrayOutputStream = ByteArrayOutputStream()
         val objectOutputStream = ObjectOutputStream(byteArrayOutputStream)
         objectOutputStream.writeObject(kspConfig)
 
-        val exitCode = try {
-            val kspLoaderClass = isolatedClassLoader.loadClass("com.google.devtools.ksp.impl.KSPLoader")
-            val runMethod = kspLoaderClass.getMethod(
-                "loadAndRunKSP",
-                ByteArray::class.java,
-                List::class.java,
-                Int::class.java
-            )
-            val returnCode = runMethod.invoke(
-                null,
-                byteArrayOutputStream.toByteArray(),
-                processorProviders,
-                gradleCfg.logLevel.get().ordinal
-            ) as Int
-            ExitCode.entries[returnCode]
-        } catch (e: InvocationTargetException) {
-            kspGradleLogger.exception(e.targetException)
-            throw e.targetException
-        } finally {
-            processorClassloader.close()
-        }
+        val exitCode =
+            try {
+                val kspLoaderClass =
+                    isolatedClassLoader.loadClass("com.google.devtools.ksp.impl.KSPLoader")
+                val runMethod =
+                    kspLoaderClass.getMethod(
+                        "loadAndRunKSP",
+                        ByteArray::class.java,
+                        List::class.java,
+                        Int::class.java,
+                    )
+                val returnCode =
+                    runMethod.invoke(
+                        null,
+                        byteArrayOutputStream.toByteArray(),
+                        processorProviders,
+                        gradleCfg.logLevel.get().ordinal,
+                    ) as Int
+                ExitCode.entries[returnCode]
+            } catch (e: InvocationTargetException) {
+                kspGradleLogger.exception(e.targetException)
+                throw e.targetException
+            } finally {
+                processorClassloader.close()
+            }
 
         if (exitCode != ExitCode.OK) {
             throw Exception("KSP failed with exit code: $exitCode")

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt
@@ -12,36 +12,33 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinCommonCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 
-/**
- * Creates and retrieves ksp-related configurations.
- */
+/** Creates and retrieves ksp-related configurations. */
 class KspConfigurations(private val project: Project) {
     companion object {
         private const val PREFIX = "ksp"
     }
 
     internal val allowAllTargetConfiguration =
-        project.providers.gradleProperty("ksp.allow.all.target.configuration")
-            .orNull
-            ?.toBoolean()
+        project.providers.gradleProperty("ksp.allow.all.target.configuration").orNull?.toBoolean()
             ?: false
 
     // The "ksp" configuration, applied to every compilation.
-    private val configurationForAll = project.configurations.create(PREFIX).apply {
-        isCanBeConsumed = false
-        isCanBeResolved = false
-        isVisible = false
-    }
+    private val configurationForAll =
+        project.configurations.create(PREFIX).apply {
+            isCanBeConsumed = false
+            isCanBeResolved = false
+            isVisible = false
+        }
 
     private fun configurationNameOf(vararg parts: String): String {
-        return parts.joinToString("") { part ->
-            part.replaceFirstChar { it.uppercase() }
-        }.replaceFirstChar { it.lowercase() }
+        return parts
+            .joinToString("") { part ->
+                part.replaceFirstChar { it.uppercase() }
+            }
+            .replaceFirstChar { it.lowercase() }
     }
 
-    /**
-     * Returns a new or existing [Configuration] with the given [name], with applied properties.
-     */
+    /** Returns a new or existing [Configuration] with the given [name], with applied properties. */
     private fun createConfiguration(
         name: String,
         readableSetName: String,
@@ -55,40 +52,53 @@ class KspConfigurations(private val project: Project) {
     }
 
     /**
-     * Returns the Android sourceSet-specific KSP configuration name given a [kotlinTarget] and [sourceSet].
+     * Returns the Android sourceSet-specific KSP configuration name given a [kotlinTarget] and
+     * [sourceSet].
      *
      * For single-platform, [kotlinTarget] can be null.
      */
-    private fun getAndroidConfigurationName(kotlinTarget: KotlinTarget?, sourceSet: String): String {
+    private fun getAndroidConfigurationName(
+        kotlinTarget: KotlinTarget?,
+        sourceSet: String,
+    ): String {
         val isMain = sourceSet.endsWith("main", ignoreCase = true)
-        val nameWithoutMain = when {
-            isMain -> sourceSet.substring(0, sourceSet.length - 4)
-            else -> sourceSet
-        }
+        val nameWithoutMain =
+            when {
+                isMain -> sourceSet.substring(0, sourceSet.length - 4)
+                else -> sourceSet
+            }
         // Note: on single-platform, target name is conveniently set to "".
         return configurationNameOf(PREFIX, kotlinTarget?.name ?: "", nameWithoutMain)
     }
 
-    private fun getKotlinConfigurationName(compilation: KotlinCompilation<*>, sourceSet: KotlinSourceSet): String {
+    private fun getKotlinConfigurationName(
+        compilation: KotlinCompilation<*>,
+        sourceSet: KotlinSourceSet,
+    ): String {
         val isMain = compilation.name == KotlinCompilation.MAIN_COMPILATION_NAME
-        val isDefault = sourceSet.name == compilation.defaultSourceSet.name && compilation !is KotlinCommonCompilation
+        val isDefault =
+            sourceSet.name == compilation.defaultSourceSet.name &&
+                compilation !is KotlinCommonCompilation
         // Note: on single-platform, target name is conveniently set to "".
-        val name = if (isMain && isDefault) {
-            // For js(IR), js(LEGACY), the target "js" is created.
-            //
-            // When js(BOTH) is used, target "jsLegacy" and "jsIr" are created.
-            // Both targets share the same source set. Therefore, configurations other than main compilation
-            // are shared. E.g., "kspJsTest".
-            // For simplicity and consistency, let's not distinguish them.
-            when (val targetName = compilation.target.name) {
-                "jsLegacy", "jsIr" -> "js"
-                else -> targetName
+        val name =
+            if (isMain && isDefault) {
+                // For js(IR), js(LEGACY), the target "js" is created.
+                //
+                // When js(BOTH) is used, target "jsLegacy" and "jsIr" are created.
+                // Both targets share the same source set. Therefore, configurations other than main
+                // compilation
+                // are shared. E.g., "kspJsTest".
+                // For simplicity and consistency, let's not distinguish them.
+                when (val targetName = compilation.target.name) {
+                    "jsLegacy",
+                    "jsIr" -> "js"
+                    else -> targetName
+                }
+            } else if (compilation is KotlinCommonCompilation) {
+                sourceSet.name + compilation.target.name.replaceFirstChar(Char::uppercaseChar)
+            } else {
+                sourceSet.name
             }
-        } else if (compilation is KotlinCommonCompilation) {
-            sourceSet.name + compilation.target.name.replaceFirstChar(Char::uppercaseChar)
-        } else {
-            sourceSet.name
-        }
         return configurationNameOf(PREFIX, name)
     }
 
@@ -97,10 +107,12 @@ class KspConfigurations(private val project: Project) {
             decorateKotlinProject(project.kotlinExtension, project)
         }
 
-        // Create sourceSet-specific KSP configurations for the case when the KotlinBaseApiPlugin is applied instead
+        // Create sourceSet-specific KSP configurations for the case when the KotlinBaseApiPlugin is
+        // applied instead
         // of the KotlinBasePluginWrapper (e.g., when AGP's built-in Kotlin support is enabled).
         project.plugins.withType(KotlinBaseApiPlugin::class.java).configureEach {
-            // FIXME: After KT-70897 is fixed and AGP's built-in Kotlin support adds a `kotlin` extension, call
+            // FIXME: After KT-70897 is fixed and AGP's built-in Kotlin support adds a `kotlin`
+            // extension, call
             //  decorateKotlinProject here instead.
             createAndroidSourceSetConfigurations(project, kotlinTarget = null)
         }
@@ -111,23 +123,29 @@ class KspConfigurations(private val project: Project) {
                     project.extensions.findByType(
                         com.android.build.api.variant.AndroidComponentsExtension::class.java
                     )
-                androidComponents?.addKspConfigurations(useGlobalConfiguration = allowAllTargetConfiguration)
+                androidComponents?.addKspConfigurations(
+                    useGlobalConfiguration = allowAllTargetConfiguration
+                )
             }
         }
     }
 
     private fun decorateKotlinProject(kotlin: KotlinProjectExtension, project: Project) {
         when (kotlin) {
-            is KotlinSingleTargetExtension<*> -> decorateKotlinTarget(kotlin.target, isKotlinMultiplatform = false)
+            is KotlinSingleTargetExtension<*> ->
+                decorateKotlinTarget(kotlin.target, isKotlinMultiplatform = false)
             is KotlinMultiplatformExtension -> {
-                kotlin.targets.configureEach { decorateKotlinTarget(it, isKotlinMultiplatform = true) }
+                kotlin.targets.configureEach {
+                    decorateKotlinTarget(it, isKotlinMultiplatform = true)
+                }
 
                 var reported = false
                 configurationForAll.dependencies.whenObjectAdded {
                     if (!reported) {
                         reported = true
-                        val msg = "The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. " +
-                            "Please use target-specific configurations like 'kspJvm' instead."
+                        val msg =
+                            "The 'ksp' configuration is deprecated in Kotlin Multiplatform projects. " +
+                                "Please use target-specific configurations like 'kspJvm' instead."
 
                         if (allowAllTargetConfiguration) {
                             project.logger.warn(msg)
@@ -141,15 +159,16 @@ class KspConfigurations(private val project: Project) {
     }
 
     /**
-     * Decorate the [KotlinSourceSet]s belonging to [target] to create one KSP configuration per source set,
-     * named ksp<SourceSet>. The only exception is the main source set, for which we avoid using the
-     * "main" suffix (so what would be "kspJvmMain" becomes "kspJvm").
+     * Decorate the [KotlinSourceSet]s belonging to [target] to create one KSP configuration per
+     * source set, named ksp<SourceSet>. The only exception is the main source set, for which we
+     * avoid using the "main" suffix (so what would be "kspJvmMain" becomes "kspJvm").
      *
-     * For Android, we prefer to use AndroidSourceSets from AGP rather than [KotlinSourceSet]s.
-     * Even though the Kotlin Plugin does create [KotlinSourceSet]s out of AndroidSourceSets
-     * ( https://kotlinlang.org/docs/mpp-configure-compilations.html#compilation-of-the-source-set-hierarchy ),
-     * there are slight differences between the two - Kotlin creates some extra sets with unexpected word ordering,
-     * and things get worse when you add product flavors. So, we use AGP sets as the source of truth.
+     * For Android, we prefer to use AndroidSourceSets from AGP rather than [KotlinSourceSet]s. Even
+     * though the Kotlin Plugin does create [KotlinSourceSet]s out of AndroidSourceSets (
+     * https://kotlinlang.org/docs/mpp-configure-compilations.html#compilation-of-the-source-set-hierarchy
+     * ), there are slight differences between the two - Kotlin creates some extra sets with
+     * unexpected word ordering, and things get worse when you add product flavors. So, we use AGP
+     * sets as the source of truth.
      */
     private fun decorateKotlinTarget(target: KotlinTarget, isKotlinMultiplatform: Boolean) {
         if (isPlainAndroidTarget(target) || isOldKmpAndroidTarget(target)) {
@@ -161,23 +180,26 @@ class KspConfigurations(private val project: Project) {
                 compilation.kotlinSourceSetsObservable.forAll { sourceSet ->
                     createConfiguration(
                         name = getKotlinConfigurationName(compilation, sourceSet),
-                        readableSetName = sourceSet.name
+                        readableSetName = sourceSet.name,
                     )
                 }
             }
         }
     }
 
-    // check if this target is the old implementation of android kmp target (using com.android.library)
+    // check if this target is the old implementation of android kmp target (using
+    // com.android.library)
     // org.jetbrains.kotlin.gradle.plugin.mpp.KotlinAndroidTarget
     private fun isOldKmpAndroidTarget(target: KotlinTarget): Boolean {
-        val isKotlinAndroidTargetClass = try {
-            target is KotlinAndroidTarget
-        } catch (e: Throwable) {
-            false
-        }
+        val isKotlinAndroidTargetClass =
+            try {
+                target is KotlinAndroidTarget
+            } catch (e: Throwable) {
+                false
+            }
         return target.platformType == KotlinPlatformType.androidJvm &&
-            isMppProject() && isKotlinAndroidTargetClass
+            isMppProject() &&
+            isKotlinAndroidTargetClass
     }
 
     private fun isPlainAndroidTarget(target: KotlinTarget): Boolean {
@@ -185,15 +207,18 @@ class KspConfigurations(private val project: Project) {
     }
 
     private fun isMppProject() = project.pluginManager.hasPlugin("kotlin-multiplatform")
+
     /**
-     * Returns the user-facing configurations involved in the given compilation.
-     * We use [KotlinCompilation.kotlinSourceSets], not [KotlinCompilation.allKotlinSourceSets] for a few reasons:
-     * 1) consistency with how we created the configurations. For example, all* can return user-defined sets
-     *    that don't belong to any compilation, like user-defined intermediate source sets (e.g. iosMain).
-     *    These do not currently have their own ksp configuration.
+     * Returns the user-facing configurations involved in the given compilation. We use
+     * [KotlinCompilation.kotlinSourceSets], not [KotlinCompilation.allKotlinSourceSets] for a few
+     * reasons:
+     * 1) consistency with how we created the configurations. For example, all* can return
+     *    user-defined sets that don't belong to any compilation, like user-defined intermediate
+     *    source sets (e.g. iosMain). These do not currently have their own ksp configuration.
      * 2) all* can return sets belonging to other [KotlinCompilation]s
      *
-     * See test: SourceSetConfigurationsTest.configurationsForMultiplatformApp_doesNotCrossCompilationBoundaries
+     * See test:
+     * SourceSetConfigurationsTest.configurationsForMultiplatformApp_doesNotCrossCompilationBoundaries
      */
     fun find(compilation: KotlinCompilation<*>): Set<Configuration> {
         val results = mutableListOf<String>()
@@ -216,21 +241,27 @@ class KspConfigurations(private val project: Project) {
             results.add(configurationForAll.name)
         }
 
-        return results.mapNotNull {
-            compilation.target.project.configurations.findByName(it)
-        }.toSet()
+        return results
+            .mapNotNull {
+                compilation.target.project.configurations.findByName(it)
+            }
+            .toSet()
     }
 
     /**
-     * Creates the Android sourceSet-specific KSP configurations for the given [project] and [kotlinTarget]
+     * Creates the Android sourceSet-specific KSP configurations for the given [project] and
+     * [kotlinTarget]
      *
      * For single-platform, [kotlinTarget] can be null.
      */
-    private fun createAndroidSourceSetConfigurations(project: Project, kotlinTarget: KotlinTarget?) {
+    private fun createAndroidSourceSetConfigurations(
+        project: Project,
+        kotlinTarget: KotlinTarget?,
+    ) {
         AndroidPluginIntegration.forEachAndroidSourceSet(project) { sourceSet ->
             createConfiguration(
                 name = getAndroidConfigurationName(kotlinTarget, sourceSet),
-                readableSetName = "$sourceSet (Android)"
+                readableSetName = "$sourceSet (Android)",
             )
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspExtension.kt
@@ -18,45 +18,42 @@
 package com.google.devtools.ksp.gradle
 
 import com.google.devtools.ksp.KspExperimental
+import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.process.CommandLineArgumentProvider
-import javax.inject.Inject
 
 abstract class KspExtension @Inject constructor(project: Project) {
     /**
-     * KSP1 is removed now so KSP2 is the only option
-     * This is kept for backwards compatibility in the meantime
-     * Setting this value to `false` will have no impact
+     * KSP1 is removed now so KSP2 is the only option This is kept for backwards compatibility in
+     * the meantime Setting this value to `false` will have no impact
      */
-    @KspExperimental
-    abstract val useKsp2: Property<Boolean>
+    @KspExperimental abstract val useKsp2: Property<Boolean>
 
     internal val apOptions = project.objects.mapProperty(String::class.java, String::class.java)
-    internal val commandLineArgumentProviders = project.objects.listProperty(CommandLineArgumentProvider::class.java)
-        .also { it.finalizeValueOnRead() }
-    internal val excludedProcessors = project.objects.setProperty(String::class.java)
-        .also { it.finalizeValueOnRead() }
+    internal val commandLineArgumentProviders =
+        project.objects.listProperty(CommandLineArgumentProvider::class.java).also {
+            it.finalizeValueOnRead()
+        }
+    internal val excludedProcessors =
+        project.objects.setProperty(String::class.java).also { it.finalizeValueOnRead() }
 
     /**
      * Sources that should be excluded from processing by Kotlin Symbol Processors.
      *
-     * If you have a task that generates sources, you can call `ksp.excludedSources.from(task)` for those sources
-     * to be added to the file collection.
+     * If you have a task that generates sources, you can call `ksp.excludedSources.from(task)` for
+     * those sources to be added to the file collection.
      */
     abstract val excludedSources: ConfigurableFileCollection
 
-    /**
-     * Returns a map with key/value arguments passed to Kotlin Symbol Processors.
-     */
-    open val arguments: Map<String, String> get() = apOptions.get()
+    /** Returns a map with key/value arguments passed to Kotlin Symbol Processors. */
+    open val arguments: Map<String, String>
+        get() = apOptions.get()
 
-    /**
-     * Add a key/value pair to pass an argument to the processors.
-     */
+    /** Add a key/value pair to pass an argument to the processors. */
     open fun arg(k: String, v: String) {
         if ('=' in k) {
             throw GradleException("'=' is not allowed in custom option's name.")
@@ -64,9 +61,7 @@ abstract class KspExtension @Inject constructor(project: Project) {
         apOptions.put(k, v)
     }
 
-    /**
-     * Add a key/value pair to pass an argument to the processors.
-     */
+    /** Add a key/value pair to pass an argument to the processors. */
     open fun arg(k: String, v: Provider<String>) {
         if ('=' in k) {
             throw GradleException("'=' is not allowed in custom option's name.")
@@ -74,9 +69,7 @@ abstract class KspExtension @Inject constructor(project: Project) {
         apOptions.put(k, v)
     }
 
-    /**
-     * Add an argument in a form of "key=value" to pass to the processors.
-     */
+    /** Add an argument in a form of "key=value" to pass to the processors. */
     open fun arg(arg: CommandLineArgumentProvider) {
         commandLineArgumentProviders.add(arg)
     }
@@ -85,19 +78,21 @@ abstract class KspExtension @Inject constructor(project: Project) {
     open var blockOtherCompilerPlugins: Boolean = true
 
     // Instruct KSP to pickup sources from compile tasks, instead of source sets.
-    // Note that it depends on behaviors of other Gradle plugins, that may bring surprises and can be hard to debug.
+    // Note that it depends on behaviors of other Gradle plugins, that may bring surprises and can
+    // be hard to debug.
     // Use your discretion.
-    @Deprecated("This feature is broken in recent versions of Gradle and is no longer supported in KSP2.")
+    @Deprecated(
+        "This feature is broken in recent versions of Gradle and is no longer supported in KSP2."
+    )
     open var allowSourcesFromOtherPlugins: Boolean = false
 
-    /**
-     * Treat all warnings as errors.
-     */
+    /** Treat all warnings as errors. */
     open var allWarningsAsErrors: Boolean = false
 
     /**
-     * Exclude calling the processor provider with given class with [fullyQualifiedName]. By default, all
-     * `com.google.devtools.ksp.processing.SymbolProcessorProvider` on the processor classpath are called.
+     * Exclude calling the processor provider with given class with [fullyQualifiedName]. By
+     * default, all `com.google.devtools.ksp.processing.SymbolProcessorProvider` on the processor
+     * classpath are called.
      *
      * Note, the excluded providers will still be loaded, but not called.
      */

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -25,6 +25,9 @@ import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.checkMinimumAgpVersion
 import com.google.devtools.ksp.gradle.utils.enableProjectIsolationCompatibleCodepath
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -62,45 +65,69 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinSharedNativeCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinWithJavaCompilation
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompile
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
-import java.io.File
-import java.util.concurrent.ConcurrentHashMap
-import javax.inject.Inject
 
 @OptIn(KspExperimental::class)
-class KspGradleSubplugin @Inject internal constructor(private val registry: ToolingModelBuilderRegistry) :
+class KspGradleSubplugin
+@Inject
+internal constructor(private val registry: ToolingModelBuilderRegistry) :
     KotlinCompilerPluginSupportPlugin {
     companion object {
         const val KSP_PLUGIN_ID = "com.google.devtools.ksp.symbol-processing"
         const val KSP_API_ID = "symbol-processing-api"
         const val KSP_GROUP_ID = "com.google.devtools.ksp"
         const val KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME = "kspPluginClasspath"
-        const val KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME_NON_EMBEDDABLE = "kspPluginClasspathNonEmbeddable"
+        const val KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME_NON_EMBEDDABLE =
+            "kspPluginClasspathNonEmbeddable"
 
         const val agpBasePluginId = "com.android.base"
         const val agpKmpPluginId = "com.android.kotlin.multiplatform.library"
 
         @JvmStatic
-        fun getKspOutputDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspOutputDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             project.layout.buildDirectory.dir("generated/ksp/$target/$sourceSetName")
 
         @JvmStatic
-        fun getKspClassOutputDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspClassOutputDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             getKspOutputDir(project, sourceSetName, target).map { it.dir("classes") }
 
         @JvmStatic
-        fun getKspJavaOutputDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspJavaOutputDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             getKspOutputDir(project, sourceSetName, target).map { it.dir("java") }
 
         @JvmStatic
-        fun getKspKotlinOutputDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspKotlinOutputDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             getKspOutputDir(project, sourceSetName, target).map { it.dir("kotlin") }
 
         @JvmStatic
-        fun getKspResourceOutputDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspResourceOutputDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             getKspOutputDir(project, sourceSetName, target).map { it.dir("resources") }
 
         @JvmStatic
-        fun getKspCachesDir(project: Project, sourceSetName: String, target: String): Provider<Directory> =
+        fun getKspCachesDir(
+            project: Project,
+            sourceSetName: String,
+            target: String,
+        ): Provider<Directory> =
             project.layout.buildDirectory.dir("kspCaches/$target/$sourceSetName")
     }
 
@@ -111,10 +138,7 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
     override fun apply(target: Project) {
         val ksp = target.extensions.create("ksp", KspExtension::class.java)
         ksp.useKsp2.convention(
-            target.providers
-                .gradleProperty("ksp.useKSP2")
-                .map { it.toBoolean() }
-                .orElse(true)
+            target.providers.gradleProperty("ksp.useKSP2").map { it.toBoolean() }.orElse(true)
         )
         kspConfigurations = KspConfigurations(target)
         registry.register(KspModelBuilder())
@@ -122,8 +146,12 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         listOf(agpBasePluginId, agpKmpPluginId).forEach { pluginId ->
             target.plugins.withId(pluginId) {
                 val componentsExtension =
-                    target.extensions.findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
-                        ?: throw GradleException("Could not find the Android Gradle Plugin (AGP) extension.")
+                    target.extensions.findByType(
+                        com.android.build.api.variant.AndroidComponentsExtension::class.java
+                    )
+                        ?: throw GradleException(
+                            "Could not find the Android Gradle Plugin (AGP) extension."
+                        )
 
                 checkMinimumAgpVersion(componentsExtension.pluginVersion)
                 val selector = componentsExtension.selector().all()
@@ -151,27 +179,33 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         return true
     }
 
-    override fun applyToCompilation(kotlinCompilation: KotlinCompilation<*>): Provider<List<SubpluginOption>> {
+    override fun applyToCompilation(
+        kotlinCompilation: KotlinCompilation<*>
+    ): Provider<List<SubpluginOption>> {
         val project = kotlinCompilation.target.project
         val kotlinCompileProvider: TaskProvider<AbstractKotlinCompileTool<*>> =
-            project.locateTask(kotlinCompilation.compileKotlinTaskName) ?: return project.provider { emptyList() }
+            project.locateTask(kotlinCompilation.compileKotlinTaskName)
+                ?: return project.provider { emptyList() }
         val kspExtension = project.extensions.getByType(KspExtension::class.java)
         if (kotlinCompileProvider.name == "compileKotlinMetadata") {
             return project.provider { emptyList() }
         }
-        if ((kotlinCompilation as? KotlinSharedNativeCompilation)?.platformType == KotlinPlatformType.common) {
+        if (
+            (kotlinCompilation as? KotlinSharedNativeCompilation)?.platformType ==
+                KotlinPlatformType.common
+        ) {
             return project.provider { emptyList() }
         }
         assert(kotlinCompileProvider.name.startsWith("compile"))
         val kspTaskName = kotlinCompileProvider.name.replaceFirst("compile", "ksp")
         val processorClasspath =
             project.configurations.maybeCreate("${kspTaskName}ProcessorClasspath").markResolvable()
-        if (kotlinCompilation.platformType != KotlinPlatformType.androidJvm ||
-            project.pluginManager.hasPlugin("kotlin-multiplatform")
+        if (
+            kotlinCompilation.platformType != KotlinPlatformType.androidJvm ||
+                project.pluginManager.hasPlugin("kotlin-multiplatform")
         ) {
             val nonEmptyKspConfigurations =
-                kspConfigurations.find(kotlinCompilation)
-                    .filter { it.allDependencies.isNotEmpty() }
+                kspConfigurations.find(kotlinCompilation).filter { it.allDependencies.isNotEmpty() }
             processorClasspath.extendsFrom(*nonEmptyKspConfigurations.toTypedArray())
         }
 
@@ -182,63 +216,77 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         val kotlinOutputDir = getKspKotlinOutputDir(project, sourceSetName, target)
         val resourceOutputDir = getKspResourceOutputDir(project, sourceSetName, target)
 
-        val kspClasspathCfg = project.configurations.maybeCreate(
-            KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME
-        ).markResolvable()
+        val kspClasspathCfg =
+            project.configurations
+                .maybeCreate(KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME)
+                .markResolvable()
         project.dependencies.add(
             kspClasspathCfg.name,
-            "$KSP_GROUP_ID:$KSP_API_ID:$KSP_VERSION"
+            "$KSP_GROUP_ID:$KSP_API_ID:$KSP_VERSION",
         )
 
-        val kspClasspathCfgNonEmbeddable = project.configurations.maybeCreate(
-            KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME_NON_EMBEDDABLE
-        ).markResolvable()
+        val kspClasspathCfgNonEmbeddable =
+            project.configurations
+                .maybeCreate(KSP_PLUGIN_CLASSPATH_CONFIGURATION_NAME_NON_EMBEDDABLE)
+                .markResolvable()
         project.dependencies.add(
             kspClasspathCfgNonEmbeddable.name,
-            "$KSP_GROUP_ID:$KSP_API_ID:$KSP_VERSION"
+            "$KSP_GROUP_ID:$KSP_API_ID:$KSP_VERSION",
         )
 
         // Create and configure KSP tasks.
-        val kspTaskProvider = KspAATask.registerKspAATask(
-            kotlinCompilation,
-            kotlinCompileProvider,
-            processorClasspath,
-            kspExtension,
-        )
+        val kspTaskProvider =
+            KspAATask.registerKspAATask(
+                kotlinCompilation,
+                kotlinCompileProvider,
+                processorClasspath,
+                kspExtension,
+            )
 
-        val generatedSources = arrayOf(
-            project.files(kotlinOutputDir).builtBy(kspTaskProvider),
-            project.files(javaOutputDir).builtBy(kspTaskProvider),
-        )
+        val generatedSources =
+            arrayOf(
+                project.files(kotlinOutputDir).builtBy(kspTaskProvider),
+                project.files(javaOutputDir).builtBy(kspTaskProvider),
+            )
         if (kotlinCompilation is KotlinCommonCompilation) {
             // Do not add generated sources to common source sets.
             // They will be observed by downstreams and violate current build scheme.
             kotlinCompileProvider.configure { it.source(*generatedSources) }
         } else {
-            val skipAddingSources = kotlinCompilation is KotlinJvmAndroidCompilation &&
-                project.isAgpBuiltInKotlinUsed() && project.canUseInternalKspApis()
+            val skipAddingSources =
+                kotlinCompilation is KotlinJvmAndroidCompilation &&
+                    project.isAgpBuiltInKotlinUsed() &&
+                    project.canUseInternalKspApis()
 
             if (!skipAddingSources) {
-                registerOutputWithKotlinSrcdirs(project, kotlinCompilation, kspTaskProvider, *generatedSources)
+                registerOutputWithKotlinSrcdirs(
+                    project,
+                    kotlinCompilation,
+                    kspTaskProvider,
+                    *generatedSources,
+                )
             }
         }
 
         kotlinCompileProvider.configure { kotlinCompile ->
             when (kotlinCompile) {
-                is AbstractKotlinCompile<*> -> kotlinCompile.libraries.from(project.files(classOutputDir))
-                // is KotlinNativeCompile -> TODO: support binary generation?
+                is AbstractKotlinCompile<*> ->
+                    kotlinCompile.libraries.from(project.files(classOutputDir))
+            // is KotlinNativeCompile -> TODO: support binary generation?
             }
         }
 
         findJavaTaskForKotlinCompilation(kotlinCompilation)?.configure { javaCompile ->
-            val generatedJavaSources = javaCompile.project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
+            val generatedJavaSources =
+                javaCompile.project.fileTree(javaOutputDir).builtBy(kspTaskProvider)
             generatedJavaSources.include("**/*.java")
             javaCompile.source(generatedJavaSources)
             javaCompile.classpath += project.files(classOutputDir)
         }
 
         val processResourcesTaskName =
-            (kotlinCompilation as? KotlinCompilationWithResources)?.processResourcesTaskName ?: "processResources"
+            (kotlinCompilation as? KotlinCompilationWithResources)?.processResourcesTaskName
+                ?: "processResources"
         project.locateTask<ProcessResources>(processResourcesTaskName)?.let { provider ->
             provider.configure { resourcesTask ->
                 resourcesTask.from(project.files(resourceOutputDir).builtBy(kspTaskProvider))
@@ -256,21 +304,26 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
                 resourcesOutputDir = resourceOutputDir,
                 androidComponent = component,
             )
-            if (!kspConfigurations.allowAllTargetConfiguration &&
-                project.pluginManager.hasPlugin("kotlin-multiplatform")
+            if (
+                !kspConfigurations.allowAllTargetConfiguration &&
+                    project.pluginManager.hasPlugin("kotlin-multiplatform")
             ) {
                 project.configurations.findByName("ksp")?.let { kspConfig ->
-                    processorClasspath.setExtendsFrom(processorClasspath.extendsFrom.filter { it != kspConfig })
+                    processorClasspath.setExtendsFrom(
+                        processorClasspath.extendsFrom.filter { it != kspConfig }
+                    )
                 }
             }
         }
 
         // The variant API in KMP runs after KotlinCompilerPluginSupportPlugin.applyToCompilation()
-        // afterEvaluate is needed here to ensure the Variant API onVariants callback has run and populated the
+        // afterEvaluate is needed here to ensure the Variant API onVariants callback has run and
+        // populated the
         // androidComponentCache, before we attempt to query for the Component object
         project.afterEvaluate {
-            if (project.isAndroidKmpProject() &&
-                kotlinCompilation is KotlinMultiplatformAndroidCompilation
+            if (
+                project.isAndroidKmpProject() &&
+                    kotlinCompilation is KotlinMultiplatformAndroidCompilation
             ) {
                 val component = androidComponentCache.get(kotlinCompilation.componentName)
                 AndroidPluginIntegration.registerGeneratedSourcesKmp(
@@ -287,9 +340,11 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         project: Project,
         kotlinCompilation: KotlinCompilation<*>,
         kspTaskProvider: TaskProvider<KspAATask>,
-        vararg generatedSources: FileCollection
+        vararg generatedSources: FileCollection,
     ) {
-        if (project.canUseGeneratedKotlinApi() && project.enableProjectIsolationCompatibleCodepath()) {
+        if (
+            project.canUseGeneratedKotlinApi() && project.enableProjectIsolationCompatibleCodepath()
+        ) {
             kotlinCompilation.defaultSourceSet.generatedKotlin.srcDir(
                 kspTaskProvider.map { task -> task.kspConfig.kotlinOutputDir }
             )
@@ -303,11 +358,12 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
     }
 
     override fun getCompilerPluginId() = KSP_PLUGIN_ID
+
     override fun getPluginArtifact(): SubpluginArtifact =
         SubpluginArtifact(
             groupId = KSP_GROUP_ID,
             artifactId = KSP_API_ID,
-            version = KSP_VERSION
+            version = KSP_VERSION,
         )
 }
 
@@ -320,25 +376,27 @@ internal inline fun <reified T : Task> Project.locateTask(name: String): TaskPro
     }
 
 // Copied from kotlin-gradle-plugin, because they are internal.
-internal fun findJavaTaskForKotlinCompilation(compilation: KotlinCompilation<*>): TaskProvider<out JavaCompile>? =
+internal fun findJavaTaskForKotlinCompilation(
+    compilation: KotlinCompilation<*>
+): TaskProvider<out JavaCompile>? =
     when (compilation) {
         is KotlinJvmAndroidCompilation -> compilation.compileJavaTaskProvider
         is KotlinWithJavaCompilation<*, *> -> compilation.compileJavaTaskProvider
-        is KotlinJvmCompilation -> compilation.compileJavaTaskProvider // may be null for Kotlin-only JVM target in MPP
+        is KotlinJvmCompilation ->
+            compilation.compileJavaTaskProvider // may be null for Kotlin-only JVM target in MPP
         else -> null
     }
 
 internal val artifactType = Attribute.of("artifactType", String::class.java)
 
 internal fun maybeRegisterTransform(project: Project) {
-    // Use the same flag with KAPT, so as to share the same transformation in case KAPT and KSP are both enabled.
+    // Use the same flag with KAPT, so as to share the same transformation in case KAPT and KSP are
+    // both enabled.
     if (!project.extensions.extraProperties.has("KaptStructureTransformAdded")) {
         val transformActionClass =
             if (GradleVersion.current() >= GradleVersion.version("5.4"))
                 StructureTransformAction::class.java
-            else
-
-                StructureTransformLegacyAction::class.java
+            else StructureTransformLegacyAction::class.java
         project.dependencies.registerTransform(transformActionClass) { transformSpec ->
             transformSpec.from.attribute(artifactType, "jar")
             transformSpec.to.attribute(artifactType, CLASS_STRUCTURE_ARTIFACT_TYPE)
@@ -359,13 +417,18 @@ internal fun getClassStructureFiles(
 ): FileCollection {
     maybeRegisterTransform(project)
 
-    val classStructureIfIncremental = project.configurations.detachedConfiguration(
-        project.dependencies.create(project.files(project.provider { libraries }))
-    ).markResolvable()
+    val classStructureIfIncremental =
+        project.configurations
+            .detachedConfiguration(
+                project.dependencies.create(project.files(project.provider { libraries }))
+            )
+            .markResolvable()
 
-    return classStructureIfIncremental.incoming.artifactView { viewConfig ->
-        viewConfig.attributes.attribute(artifactType, CLASS_STRUCTURE_ARTIFACT_TYPE)
-    }.files
+    return classStructureIfIncremental.incoming
+        .artifactView { viewConfig ->
+            viewConfig.attributes.attribute(artifactType, CLASS_STRUCTURE_ARTIFACT_TYPE)
+        }
+        .files
 }
 
 // Reuse Kapt's infrastructure to compute affected names in classpath.
@@ -380,32 +443,39 @@ internal fun findClasspathChanges(
     cacheDir.mkdirs()
 
     val changedFiles =
-        (changes as? SourcesChanges.Known)?.let { it.modifiedFiles + it.removedFiles }?.toSet() ?: allDataFiles
+        (changes as? SourcesChanges.Known)?.let { it.modifiedFiles + it.removedFiles }?.toSet()
+            ?: allDataFiles
 
     val loadedPrevious = ClasspathSnapshot.ClasspathSnapshotFactory.loadFrom(cacheDir)
     val previousAndCurrentDataFiles = lazy { loadedPrevious.getAllDataFiles() + allDataFiles }
     val allChangesRecognized = changedFiles.all {
         val extension = it.extension
-        if (extension.isEmpty() || extension == "kt" || extension == "java" || extension == "jar" ||
-            extension == "class"
+        if (
+            extension.isEmpty() ||
+                extension == "kt" ||
+                extension == "java" ||
+                extension == "jar" ||
+                extension == "class"
         ) {
             return@all true
         }
-        // if not a directory, Java source file, jar, or class, it has to be a structure file, in order to understand changes
+        // if not a directory, Java source file, jar, or class, it has to be a structure file, in
+        // order to understand changes
         it in previousAndCurrentDataFiles.value
     }
-    val previousSnapshot = if (allChangesRecognized) {
-        loadedPrevious
-    } else {
-        ClasspathSnapshot.ClasspathSnapshotFactory.getEmptySnapshot()
-    }
+    val previousSnapshot =
+        if (allChangesRecognized) {
+            loadedPrevious
+        } else {
+            ClasspathSnapshot.ClasspathSnapshotFactory.getEmptySnapshot()
+        }
 
     val currentSnapshot =
         ClasspathSnapshot.ClasspathSnapshotFactory.createCurrent(
             cacheDir,
             libs,
             processorCP,
-            allDataFiles
+            allDataFiles,
         )
 
     val classpathChanges = currentSnapshot.diff(previousSnapshot, changedFiles)
@@ -427,28 +497,33 @@ internal fun getCPChanges(
     processorCP: FileCollection,
 ): List<String> {
     val apClasspath = processorCP.files.toList()
-    val changedFiles = if (!inputChanges.isIncremental) {
-        SourcesChanges.Unknown
-    } else {
-        incrementalProps.fold(mutableListOf<File>() to mutableListOf<File>()) { (modified, removed), prop ->
-            inputChanges.getFileChanges(prop).forEach {
-                when (it.changeType) {
-                    ChangeType.ADDED, ChangeType.MODIFIED -> modified.add(it.file)
-                    ChangeType.REMOVED -> removed.add(it.file)
+    val changedFiles =
+        if (!inputChanges.isIncremental) {
+            SourcesChanges.Unknown
+        } else {
+            incrementalProps
+                .fold(mutableListOf<File>() to mutableListOf<File>()) { (modified, removed), prop ->
+                    inputChanges.getFileChanges(prop).forEach {
+                        when (it.changeType) {
+                            ChangeType.ADDED,
+                            ChangeType.MODIFIED -> modified.add(it.file)
+                            ChangeType.REMOVED -> removed.add(it.file)
+                        }
+                    }
+                    modified to removed
                 }
-            }
-            modified to removed
-        }.run {
-            SourcesChanges.Known(first, second)
+                .run {
+                    SourcesChanges.Known(first, second)
+                }
         }
-    }
-    val classpathChanges = findClasspathChanges(
-        changedFiles,
-        cacheDir,
-        classpathStructure.files,
-        libraries.files.toList(),
-        apClasspath
-    )
+    val classpathChanges =
+        findClasspathChanges(
+            changedFiles,
+            cacheDir,
+            classpathStructure.files,
+            libraries.files.toList(),
+            apClasspath,
+        )
     return if (classpathChanges is KaptClasspathChanges.Known) {
         classpathChanges.names.map {
             it.replace('/', '.').replace('$', '.')
@@ -464,27 +539,27 @@ internal fun Configuration.markResolvable(): Configuration = apply {
     isVisible = false
 }
 
-/**
- * A [SubpluginOption] that returns the joined path for files in the given [fileCollection].
- */
+/** A [SubpluginOption] that returns the joined path for files in the given [fileCollection]. */
 internal class FileCollectionSubpluginOption(
     key: String,
-    val fileCollection: FileCollection
-) : SubpluginOption(
-    key = key,
-    lazyValue = lazy {
-        val files = fileCollection.files
-        files.joinToString(File.pathSeparator) { it.normalize().absolutePath }
-    }
-) {
+    val fileCollection: FileCollection,
+) :
+    SubpluginOption(
+        key = key,
+        lazyValue =
+            lazy {
+                val files = fileCollection.files
+                files.joinToString(File.pathSeparator) { it.normalize().absolutePath }
+            },
+    ) {
     companion object {
         fun create(
             name: String,
-            classpath: Configuration
+            classpath: Configuration,
         ): FileCollectionSubpluginOption {
             return FileCollectionSubpluginOption(
                 key = name,
-                fileCollection = classpath.incoming.artifactView { }.files
+                fileCollection = classpath.incoming.artifactView {}.files,
             )
         }
     }

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/Ksp.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/Ksp.kt
@@ -18,14 +18,13 @@
 package com.google.devtools.ksp.gradle.model
 
 /**
- * Entry point for Kotlin Ksp models.
- * Represents the description of annotations interpreted by 'kotlin-ksp-gradle' plugin.
+ * Entry point for Kotlin Ksp models. Represents the description of annotations interpreted by
+ * 'kotlin-ksp-gradle' plugin.
  */
 interface Ksp {
 
     /**
-     * Return a number representing the version of this API.
-     * Always increasing if changed.
+     * Return a number representing the version of this API. Always increasing if changed.
      *
      * @return the version of this model.
      */

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/builder/KspModelBuilder.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/builder/KspModelBuilder.kt
@@ -23,8 +23,8 @@ import org.gradle.api.Project
 import org.gradle.tooling.provider.model.ToolingModelBuilder
 
 /**
- * [ToolingModelBuilder] for [Ksp] models.
- * This model builder is registered for Kotlin All Open sub-plugin.
+ * [ToolingModelBuilder] for [Ksp] models. This model builder is registered for Kotlin All Open
+ * sub-plugin.
  */
 class KspModelBuilder : ToolingModelBuilder {
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/impl/KspImpl.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/model/impl/KspImpl.kt
@@ -20,12 +20,8 @@ package com.google.devtools.ksp.gradle.model.impl
 import com.google.devtools.ksp.gradle.model.Ksp
 import java.io.Serializable
 
-/**
- * Implementation of the [Ksp] interface.
- */
-data class KspImpl(
-    override val name: String
-) : Ksp, Serializable {
+/** Implementation of the [Ksp] interface. */
+data class KspImpl(override val name: String) : Ksp, Serializable {
 
     override val modelVersion = serialVersionUID
 

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -3,19 +3,21 @@ package com.google.devtools.ksp.gradle.utils
 import com.android.build.api.AndroidPluginVersion
 import org.gradle.api.Project
 
-fun Project.getAgpVersion(): AndroidPluginVersion? = try {
-    this.extensions
-        .findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
-        ?.pluginVersion
-} catch (e: NoClassDefFoundError) {
-    // AGP not applied
-    null
-} catch (e: Exception) {
-    // Perhaps a version of AGP before pluginVersion API was added.
-    null
-}
+fun Project.getAgpVersion(): AndroidPluginVersion? =
+    try {
+        this.extensions
+            .findByType(com.android.build.api.variant.AndroidComponentsExtension::class.java)
+            ?.pluginVersion
+    } catch (e: NoClassDefFoundError) {
+        // AGP not applied
+        null
+    } catch (e: Exception) {
+        // Perhaps a version of AGP before pluginVersion API was added.
+        null
+    }
 
-fun Project.isAgpBuiltInKotlinUsed() = isKotlinBaseApiPluginApplied() && isKotlinAndroidPluginApplied().not()
+fun Project.isAgpBuiltInKotlinUsed() =
+    isKotlinBaseApiPluginApplied() && isKotlinAndroidPluginApplied().not()
 
 fun checkMinimumAgpVersion(pluginVersion: AndroidPluginVersion) {
     if (pluginVersion < MINIMUM_SUPPORTED_AGP_VERSION) {
@@ -27,8 +29,8 @@ fun checkMinimumAgpVersion(pluginVersion: AndroidPluginVersion) {
 }
 
 /**
- * Returns true for AGP version is 8.12.0-alpha06 or higher.
- * That is the version where addGeneratedSourceDirectories API was fixed
+ * Returns true for AGP version is 8.12.0-alpha06 or higher. That is the version where
+ * addGeneratedSourceDirectories API was fixed
  */
 fun Project.canUseAddGeneratedSourceDirectoriesApi(): Boolean {
     val agpVersion = project.getAgpVersion() ?: return false
@@ -43,7 +45,7 @@ fun Project.canUseInternalKspApis(): Boolean {
 /**
  * Defines the minimum supported Android Gradle Plugin (AGP) version.
  *
- * KSP aims to support AGP versions released approximately within the last year
- * from the current KSP release date.
+ * KSP aims to support AGP versions released approximately within the last year from the current KSP
+ * release date.
  */
 val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 10, 0)

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -8,14 +8,16 @@ import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import org.jetbrains.kotlin.gradle.utils.ObservableSet
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 
-// NOTE: for AGP with built in kotlin enabled and android.disallowKotlinSourceSets=true, this returns empty set
+// NOTE: for AGP with built in kotlin enabled and android.disallowKotlinSourceSets=true, this
+// returns empty set
 internal val KotlinCompilation<*>.allKotlinSourceSetsObservable
     get() = this.allKotlinSourceSets as ObservableSet<KotlinSourceSet>
 
 internal val KotlinCompilation<*>.kotlinSourceSetsObservable
     get() = this.kotlinSourceSets as ObservableSet<KotlinSourceSet>
 
-fun Project.isKotlinBaseApiPluginApplied() = plugins.withType(KotlinBaseApiPlugin::class.java).firstOrNull() != null
+fun Project.isKotlinBaseApiPluginApplied() =
+    plugins.withType(KotlinBaseApiPlugin::class.java).firstOrNull() != null
 
 fun Project.isKotlinAndroidPluginApplied() = pluginManager.hasPlugin("org.jetbrains.kotlin.android")
 

--- a/kotlin-analysis-api/src/main/java/com/intellij/util/IntelliJCoroutinesFacade.kt
+++ b/kotlin-analysis-api/src/main/java/com/intellij/util/IntelliJCoroutinesFacade.kt
@@ -1,11 +1,12 @@
-// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license.
+// Copyright 2000-2025 JetBrains s.r.o. and contributors. Use of this source code is governed by the
+// Apache 2.0 license.
 package com.intellij.util
 
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.annotations.ApiStatus
-import kotlin.coroutines.CoroutineContext
-import kotlin.time.Duration
 
 @ApiStatus.Internal
 object IntelliJCoroutinesFacade {
@@ -22,7 +23,7 @@ object IntelliJCoroutinesFacade {
     @Throws(InterruptedException::class)
     fun <T> runBlockingWithParallelismCompensation(
         context: CoroutineContext,
-        block: suspend CoroutineScope.() -> T
+        block: suspend CoroutineScope.() -> T,
     ): T {
         @Suppress("RAW_RUN_BLOCKING")
         return runBlocking(context, block)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
@@ -24,33 +24,34 @@ import com.google.devtools.ksp.symbol.NonExistLocation
 /**
  * Internal exception that signals a bug in KSP.
  *
- * Copy of InternalKSPException in API package which is also marked
- * internal to avoid users depending on the type.
- * Importantly, this class is in a different package than in the API module
+ * Copy of InternalKSPException in API package which is also marked internal to avoid users
+ * depending on the type. Importantly, this class is in a different package than in the API module
  * to avoid classpath collisions/shadowing.
  */
 internal class InternalKSPException(
     message: String,
     val location: Location,
-    val originatingClass: Class<*>
-) : Exception(
-    buildString {
-        appendLine(">>> Internal KSP Error")
-        appendLine("   | *** THIS IS A BUG IN KSP ***")
-        appendLine("   |")
-        message.lines().forEach { messageLine ->
-            appendLine("   | $messageLine")
+    val originatingClass: Class<*>,
+) :
+    Exception(
+        buildString {
+            appendLine(">>> Internal KSP Error")
+            appendLine("   | *** THIS IS A BUG IN KSP ***")
+            appendLine("   |")
+            message.lines().forEach { messageLine ->
+                appendLine("   | $messageLine")
+            }
+            appendLine("   |")
+            appendLine("   | Location           : ${location.render()}")
+            appendLine("   | Class at occurrence: $originatingClass")
+            appendLine("   |")
+            appendLine("   | You can report it at https://github.com/google/ksp/issues/new")
+            appendLine("   |")
         }
-        appendLine("   |")
-        appendLine("   | Location           : ${location.render()}")
-        appendLine("   | Class at occurrence: $originatingClass")
-        appendLine("   |")
-        appendLine("   | You can report it at https://github.com/google/ksp/issues/new")
-        appendLine("   |")
-    }
-) {
+    ) {
     override fun toString(): String {
-        // N.B.: Override the toString method to prevent the big error message being printed in the stack trace.
+        // N.B.: Override the toString method to prevent the big error message being printed in the
+        // stack trace.
         return buildString {
             append(javaClass.name)
             append(": ")

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -29,34 +29,45 @@ internal fun printHelpMsg(optionsList: String) {
     println(optionsList)
     println("where:")
     println(" * is required")
-    println(" List is <path-separator> separated. E.g., arg1:arg2:arg3 on Linux/Mac, or arg1;arg2;arg3 on Windows")
-    println(" Map is in the form key1=value1:key2=value2 on Linux/Mac or key1=value1;key2=value2 on Windows")
+    println(
+        " List is <path-separator> separated. E.g., arg1:arg2:arg3 on Linux/Mac, or arg1;arg2;arg3 on Windows"
+    )
+    println(
+        " Map is in the form key1=value1:key2=value2 on Linux/Mac or key1=value1;key2=value2 on Windows"
+    )
 }
 
-internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSPConfig, List<String>>) {
+internal fun runWithArgs(
+    args: Array<String>,
+    parse: (Array<String>) -> Pair<KSPConfig, List<String>>,
+) {
 
     val loggingVerbosity = System.getProperty("ksp.logging", "warn")
-    val loggingLevel = when (loggingVerbosity.lowercase()) {
-        "error" -> KspGradleLogger.LOGGING_LEVEL_ERROR
-        "warn" -> KspGradleLogger.LOGGING_LEVEL_WARN
-        "warning" -> KspGradleLogger.LOGGING_LEVEL_WARN
-        "info" -> KspGradleLogger.LOGGING_LEVEL_INFO
-        "debug" -> KspGradleLogger.LOGGING_LEVEL_LOGGING
-        else -> KspGradleLogger.LOGGING_LEVEL_WARN
-    }
+    val loggingLevel =
+        when (loggingVerbosity.lowercase()) {
+            "error" -> KspGradleLogger.LOGGING_LEVEL_ERROR
+            "warn" -> KspGradleLogger.LOGGING_LEVEL_WARN
+            "warning" -> KspGradleLogger.LOGGING_LEVEL_WARN
+            "info" -> KspGradleLogger.LOGGING_LEVEL_INFO
+            "debug" -> KspGradleLogger.LOGGING_LEVEL_LOGGING
+            else -> KspGradleLogger.LOGGING_LEVEL_WARN
+        }
 
     val logger = KspGradleLogger(loggingLevel)
 
     val (config, classpath) = parse(args)
-    val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
+    val processorClassloader =
+        URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
 
     @Suppress("UNCHECKED_CAST")
-    val processorProviders = ServiceLoader
-        .load(
-            processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
-            processorClassloader
-        )
-        .toList() as List<SymbolProcessorProvider>
+    val processorProviders =
+        ServiceLoader.load(
+                processorClassloader.loadClass(
+                    "com.google.devtools.ksp.processing.SymbolProcessorProvider"
+                ),
+                processorClassloader,
+            )
+            .toList() as List<SymbolProcessorProvider>
 
     val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
     exitProcess(exitCode.code)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -41,18 +41,18 @@ object SymbolCollector : KSDefaultVisitor<(LookupSymbolWrapper) -> Unit, Unit>()
     override fun visitDeclaration(declaration: KSDeclaration, data: (LookupSymbolWrapper) -> Unit) {
         val name = declaration.simpleName.asString()
         val scope =
-            declaration.qualifiedName?.asString()?.let { it.substring(0, Math.max(it.length - name.length - 1, 0)) }
-                ?: return
+            declaration.qualifiedName?.asString()?.let {
+                it.substring(0, Math.max(it.length - name.length - 1, 0))
+            } ?: return
         data(LookupSymbolWrapper(name, scope))
     }
 
     override fun visitDeclarationContainer(
         declarationContainer: KSDeclarationContainer,
-        data: (LookupSymbolWrapper) -> Unit
+        data: (LookupSymbolWrapper) -> Unit,
     ) {
         // Local declarations aren't visible to other files / classes.
-        if (declarationContainer is KSFunctionDeclaration)
-            return
+        if (declarationContainer is KSFunctionDeclaration) return
 
         declarationContainer.declarations.forEach {
             it.accept(this, data)
@@ -156,8 +156,7 @@ abstract class IncrementalContextBase(
     }
 
     private fun logSourceToOutputs(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
-        if (!loggingOptions.incrementalLoggingEnabled)
-            return
+        if (!loggingOptions.incrementalLoggingEnabled) return
 
         mkLogFile("kspSourceToOutputs.log").bufferedWriter().use { logFile ->
             logFile.write("Accumulated source to outputs map\n")
@@ -240,12 +239,14 @@ abstract class IncrementalContextBase(
         val newSyms = mutableSetOf<LookupSymbolWrapper>()
 
         // Parse and add newly defined symbols in modified files.
-        ksFiles.filter { it.relativeFile in modified }.forEach { file ->
-            file.accept(SymbolCollector) {
-                updatedSymbols.putValue(file.relativeFile, it)
-                newSyms.add(it)
+        ksFiles
+            .filter { it.relativeFile in modified }
+            .forEach { file ->
+                file.accept(SymbolCollector) {
+                    updatedSymbols.putValue(file.relativeFile, it)
+                    newSyms.add(it)
+                }
             }
-        }
 
         val dirtyFilesByNewSyms = newSyms.flatMap { newSym ->
             symbolLookupCache[newSym].map { it.toRelativeFile() }
@@ -253,18 +254,26 @@ abstract class IncrementalContextBase(
         val dirtyFilesBySealed = sealedMap.keys
 
         // Calculate dirty files by dirty classes in CP.
-        val dirtyFilesByCP = changedClasses.flatMap { fqn ->
-            val (scope, name) = separateQualifierAndName(fqn)
-            classLookupCache[LookupSymbolWrapper(name, scope)].map { it.toRelativeFile() } +
-                symbolLookupCache[LookupSymbolWrapper(name, scope)].map { it.toRelativeFile() }
-        }.toSet()
+        val dirtyFilesByCP =
+            changedClasses
+                .flatMap { fqn ->
+                    val (scope, name) = separateQualifierAndName(fqn)
+                    classLookupCache[LookupSymbolWrapper(name, scope)].map { it.toRelativeFile() } +
+                        symbolLookupCache[LookupSymbolWrapper(name, scope)].map {
+                            it.toRelativeFile()
+                        }
+                }
+                .toSet()
 
         // output files that exist in CURR~2 but not in CURR~1
         val removedOutputs = sourceToOutputsMap[removedOutputsKey] ?: emptyList()
 
-        val noSourceFiles = changedClasses.map { fqn ->
-            NoSourceFile(baseDir, fqn).filePath.toRelativeFile()
-        }.toSet()
+        val noSourceFiles =
+            changedClasses
+                .map { fqn ->
+                    NoSourceFile(baseDir, fqn).filePath.toRelativeFile()
+                }
+                .toSet()
 
         val initialSet = mutableSetOf<File>()
         initialSet.addAll(modified)
@@ -277,13 +286,15 @@ abstract class IncrementalContextBase(
 
         initialSet.add(anyChangesWildcard)
 
-        val dirtyFiles = DirtinessPropagator(
-            symbolLookupCache,
-            symbolsMap,
-            sourceToOutputsMap,
-            anyChangesWildcard,
-            removedOutputsKey
-        ).propagate(initialSet)
+        val dirtyFiles =
+            DirtinessPropagator(
+                    symbolLookupCache,
+                    symbolsMap,
+                    sourceToOutputsMap,
+                    anyChangesWildcard,
+                    removedOutputsKey,
+                )
+                .propagate(initialSet)
 
         updateFromRemovedOutputs()
 
@@ -295,7 +306,7 @@ abstract class IncrementalContextBase(
             removedOutputs,
             dirtyFilesByCP,
             dirtyFilesByNewSyms,
-            dirtyFilesBySealed
+            dirtyFilesBySealed,
         )
         return@closeFilesOnException dirtyKSFiles
     }
@@ -319,9 +330,11 @@ abstract class IncrementalContextBase(
             sourceToOutputsMap.removeRecursively(it)
         }
 
-        dirtyFiles.filterNot { sourceToOutputs.containsKey(it) }.forEach {
-            sourceToOutputsMap.removeRecursively(it)
-        }
+        dirtyFiles
+            .filterNot { sourceToOutputs.containsKey(it) }
+            .forEach {
+                sourceToOutputsMap.removeRecursively(it)
+            }
 
         removedOutputs.forEach {
             sourceToOutputsMap.removeRecursively(it)
@@ -351,7 +364,8 @@ abstract class IncrementalContextBase(
         //    Untouched outputs need to be restore.
         //
         //    TODO: need a change in upstream to not clean files in gradle plugin.
-        //    Not cleaning files in gradle plugin has potentially fewer copies when processing succeeds.
+        //    Not cleaning files in gradle plugin has potentially fewer copies when processing
+        // succeeds.
         //
         // 2. Even if outputs are left from last compilation / processing, processors can still
         //    fail and the outputs will need to be restored.
@@ -372,7 +386,7 @@ abstract class IncrementalContextBase(
     private fun updateCaches(
         dirtyFiles: Collection<File>,
         outputs: Set<File>,
-        sourceToOutputs: Map<File, Set<File>>
+        sourceToOutputs: Map<File, Set<File>>,
     ) {
         // dirtyFiles may contain new files, which are unknown to sourceToOutputsMap.
         val oldOutputs = dirtyFiles.flatMap { sourceToOutputsMap[it] ?: emptyList() }.distinct()
@@ -388,7 +402,10 @@ abstract class IncrementalContextBase(
             }
         }
 
-        fun <K : Comparable<K>, V> remove(m: PersistentMap<K, List<V>>, removedKeys: Collection<K>) {
+        fun <K : Comparable<K>, V> remove(
+            m: PersistentMap<K, List<V>>,
+            removedKeys: Collection<K>,
+        ) {
             // Remove symbol caches from removed files.
             removedKeys.forEach {
                 m.remove(it)
@@ -413,8 +430,7 @@ abstract class IncrementalContextBase(
     }
 
     fun registerGeneratedFiles(newFiles: Collection<KSFile>) = closeFilesOnException {
-        if (!isIncremental)
-            return@closeFilesOnException
+        if (!isIncremental) return@closeFilesOnException
 
         collectDefinedSymbols(newFiles)
     }
@@ -444,8 +460,7 @@ abstract class IncrementalContextBase(
         outputs: Set<File>,
         sourceToOutputs: Map<File, Set<File>>,
     ) = closeFilesOnException {
-        if (!isIncremental)
-            return@closeFilesOnException
+        if (!isIncremental) return@closeFilesOnException
 
         cachesUpToDateFile.delete()
         assert(!cachesUpToDateFile.exists())
@@ -454,12 +469,16 @@ abstract class IncrementalContextBase(
 
         // Throw away results from clean inputs.
         //
-        // One common misuse of incremental APIs is associating a non-root source, instead of the ones obtained from
-        // root functions (e.g., getSymbolsWithAnnotation), to an output. This non-root source can be reached and
-        // reprocessed even when it is clean. Because it is clean, it is not available via root functions. As a result,
+        // One common misuse of incremental APIs is associating a non-root source, instead of the
+        // ones obtained from
+        // root functions (e.g., getSymbolsWithAnnotation), to an output. This non-root source can
+        // be reached and
+        // reprocessed even when it is clean. Because it is clean, it is not available via root
+        // functions. As a result,
         // other outputs that are solely based on it won't be re-generated and is deemed as removed.
         //
-        // Assuming that the processors are deterministic, we are throwing away outputs from clean inputs, and
+        // Assuming that the processors are deterministic, we are throwing away outputs from clean
+        // inputs, and
         // recovering them from the backup as a workaround for processors.
 
         val relativeOutputs = outputs.map { it.toRelativeFile() }.toSet()
@@ -496,8 +515,7 @@ abstract class IncrementalContextBase(
 
         val cleanOutputs = mutableSetOf<File>()
         sourceToOutputsMap.keys.forEach { source ->
-            if (!isDirty(source))
-                cleanOutputs.addAll(sourceToOutputsMap[source]!!)
+            if (!isDirty(source)) cleanOutputs.addAll(sourceToOutputsMap[source]!!)
         }
         sourceToOutputsMap.flush()
         updateOutputs(dirtyOutputs, cleanOutputs)
@@ -507,25 +525,23 @@ abstract class IncrementalContextBase(
     }
 
     /**
-     * Insert Java file -> names lookup records.
-     * In other words, it inserts the names of symbols that may invalidate the [psiFile].
-     * There are several cases where that may happen:
-     * - If `fqn` has been looked up in the file, then `fqn` may invalidate the file
-     * (`fqn` may come from the same file or out of file).
+     * Insert Java file -> names lookup records. In other words, it inserts the names of symbols
+     * that may invalidate the [psiFile]. There are several cases where that may happen:
+     * - If `fqn` has been looked up in the file, then `fqn` may invalidate the file (`fqn` may come
+     *   from the same file or out of file).
      * - If `sym` is a named import, then `sym` may invalidate the file.
      * - If `sym` is an on-demand import, then `sym` may invalidate the file.
-     * - If `sym` is an implicit import, i.e., from the same package, then `sym` may invalidate the file.
+     * - If `sym` is an implicit import, i.e., from the same package, then `sym` may invalidate the
+     *   file.
      */
     fun recordLookup(psiFile: PsiJavaFile, fqn: String) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val path = psiFile.virtualFile.path
         val (scope, name) = separateQualifierAndName(fqn)
 
         // Java types are classes. Therefore lookups only happen in packages.
-        fun record(scope: String, name: String) =
-            symbolLookupTracker.record(path, scope, name)
+        fun record(scope: String, name: String) = symbolLookupTracker.record(path, scope, name)
 
         record(scope, name)
 
@@ -533,9 +549,12 @@ abstract class IncrementalContextBase(
         // Therefore, the potential providers all need to be inserted. They are
         //   1. definition of the name in the same package
         //   2. other * imports
-        val onDemandImports = onDemandImportsCache.getOrPut(psiFile) {
-            psiFile.getOnDemandImports().mapNotNull { (it.importReference?.resolve() as? PsiPackage)?.qualifiedName }
-        }
+        val onDemandImports =
+            onDemandImportsCache.getOrPut(psiFile) {
+                psiFile.getOnDemandImports().mapNotNull {
+                    (it.importReference?.resolve() as? PsiPackage)?.qualifiedName
+                }
+            }
         if (scope in onDemandImports) {
             record(psiFile.packageName, name)
             onDemandImports.forEach {
@@ -544,38 +563,40 @@ abstract class IncrementalContextBase(
         }
     }
 
-    /**
-     * Returns all on-demand imports for `this`, i.e., `import X.*`.
-     */
+    /** Returns all on-demand imports for `this`, i.e., `import X.*`. */
     private fun PsiJavaFile.getOnDemandImports(): List<PsiImportStatement> =
-        this.importList?.importStatements
-            ?.filter { it.isOnDemand }
-            ?: emptyList()
+        this.importList?.importStatements?.filter { it.isOnDemand } ?: emptyList()
 
     fun recordGetSealedSubclasses(classDeclaration: KSClassDeclaration) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val name = classDeclaration.simpleName.asString()
-        val scope = classDeclaration.qualifiedName?.asString()
-            ?.let { it.substring(0, (it.length - name.length - 1).coerceAtLeast(0)) } ?: return
-        updatedSealed.putValue(classDeclaration.containingFile!!.relativeFile, LookupSymbolWrapper(name, scope))
+        val scope =
+            classDeclaration.qualifiedName?.asString()?.let {
+                it.substring(0, (it.length - name.length - 1).coerceAtLeast(0))
+            } ?: return
+        updatedSealed.putValue(
+            classDeclaration.containingFile!!.relativeFile,
+            LookupSymbolWrapper(name, scope),
+        )
     }
 
-    protected open fun logBeforeCacheFlush(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
+    protected open fun logBeforeCacheFlush(
+        outputs: Set<File>,
+        sourceToOutputs: Map<File, Set<File>>,
+    ) {
         logSourceToOutputs(outputs, sourceToOutputs)
     }
 
     protected fun mkFileInLogDir(fileName: String): File =
-        File(logsDir, fileName)
-            .also {
-                if (it.delete()) {
-                    it.createNewFile()
-                }
+        File(logsDir, fileName).also {
+            if (it.delete()) {
+                it.createNewFile()
             }
+        }
 
-    protected fun mkLogFile(fileName: String): File = mkFileInLogDir(fileName)
-        .also { it.appendText("=== Build $buildTime ===\n") }
+    protected fun mkLogFile(fileName: String): File =
+        mkFileInLogDir(fileName).also { it.appendText("=== Build $buildTime ===\n") }
 }
 
 internal class DirtinessPropagator(
@@ -583,24 +604,24 @@ internal class DirtinessPropagator(
     private val symbolsMap: FileToSymbolsMap,
     private val sourceToOutputs: FileToFilesMap,
     private val anyChangesWildcard: File,
-    private val removedOutputsKey: File
+    private val removedOutputsKey: File,
 ) {
     private val visitedFiles = mutableSetOf<File>()
     private val visitedSyms = mutableSetOf<LookupSymbolWrapper>()
 
-    private val outputToSources = mutableMapOf<File, MutableSet<File>>().apply {
-        sourceToOutputs.keys.forEach { source ->
-            if (source != anyChangesWildcard && source != removedOutputsKey) {
-                sourceToOutputs[source]!!.forEach { output ->
-                    getOrPut(output) { mutableSetOf() }.add(source)
+    private val outputToSources =
+        mutableMapOf<File, MutableSet<File>>().apply {
+            sourceToOutputs.keys.forEach { source ->
+                if (source != anyChangesWildcard && source != removedOutputsKey) {
+                    sourceToOutputs[source]!!.forEach { output ->
+                        getOrPut(output) { mutableSetOf() }.add(source)
+                    }
                 }
             }
         }
-    }
 
     private fun visit(sym: LookupSymbolWrapper) {
-        if (sym in visitedSyms)
-            return
+        if (sym in visitedSyms) return
         visitedSyms.add(sym)
 
         lookupCache[sym].forEach {
@@ -609,8 +630,7 @@ internal class DirtinessPropagator(
     }
 
     private fun visit(file: File) {
-        if (file in visitedFiles)
-            return
+        if (file in visitedFiles) return
         visitedFiles.add(file)
 
         // Propagate by dependencies
@@ -627,7 +647,8 @@ internal class DirtinessPropagator(
         // Propagate by input-output relations
         // Given (..., I, ...) -> O:
         // 1) if I is dirty, then O is dirty.
-        // 2) if O is dirty, then O must be regenerated, which requires all of its inputs to be reprocessed.
+        // 2) if O is dirty, then O must be regenerated, which requires all of its inputs to be
+        // reprocessed.
         sourceToOutputs[file]?.forEach {
             visit(it)
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalWrapperBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalWrapperBase.kt
@@ -24,13 +24,14 @@ interface LookupTrackerWrapper {
     fun record(
         filePath: String,
         scopeFqName: String,
-        name: String
+        name: String,
     )
 
     val lookups: MultiMap<LookupSymbolWrapper, String>
 }
 
-data class LookupSymbolWrapper(val name: String, val scope: String) : Comparable<LookupSymbolWrapper> {
+data class LookupSymbolWrapper(val name: String, val scope: String) :
+    Comparable<LookupSymbolWrapper> {
     override fun compareTo(other: LookupSymbolWrapper): Int {
         val scopeCompare = scope.compareTo(other.scope)
         if (scopeCompare != 0) return scopeCompare
@@ -41,8 +42,16 @@ data class LookupSymbolWrapper(val name: String, val scope: String) : Comparable
 
 interface LookupStorageWrapper {
     fun removeLookupsFrom(files: Sequence<File>)
-    fun update(lookupTracker: LookupTrackerWrapper, filesToCompile: Iterable<File>, removedFiles: Iterable<File>)
+
+    fun update(
+        lookupTracker: LookupTrackerWrapper,
+        filesToCompile: Iterable<File>,
+        removedFiles: Iterable<File>,
+    )
+
     fun flush()
+
     fun close()
+
     operator fun get(lookupSymbol: LookupSymbolWrapper): Collection<String>
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/MapUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/MapUtils.kt
@@ -18,15 +18,13 @@
 package com.google.devtools.ksp.common
 
 /**
- * Applies [transform] to each key-value pair, where the value is a collection,
- * and merges the resulting collections of values.
+ * Applies [transform] to each key-value pair, where the value is a collection, and merges the
+ * resulting collections of values.
  *
  * It will exclude any key-value pair where `transform(key)` is `null`.
  *
- * In other words, if `k1 -> [a, b, c], k2 -> [c, d, e]` and
- * `transform(k1) = transform(k2) = k3`, then the result is
- * `k3 -> [a, b, c, d, e]`.
- * Note the list is deduplicated.
+ * In other words, if `k1 -> [a, b, c], k2 -> [c, d, e]` and `transform(k1) = transform(k2) = k3`,
+ * then the result is `k3 -> [a, b, c, d, e]`. Note the list is deduplicated.
  */
 internal fun <K, V, R> Map<K, Lazy<Collection<V>>>.mergeMapNotNullKeys(
     transform: (K) -> R?

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PersistentMap.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PersistentMap.kt
@@ -1,5 +1,7 @@
 package com.google.devtools.ksp.common
 
+import java.io.BufferedInputStream
+import java.io.File
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.builtins.ListSerializer
@@ -12,20 +14,23 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
-import java.io.BufferedInputStream
-import java.io.File
 
 private object FileSerializer : KSerializer<File> {
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("File", PrimitiveKind.STRING)
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("File", PrimitiveKind.STRING)
+
     override fun serialize(encoder: Encoder, value: File) = encoder.encodeString(value.path)
+
     override fun deserialize(decoder: Decoder): File = File(decoder.decodeString())
 }
 
 private object SymbolSerializer : KSerializer<LookupSymbolWrapper> {
     override val descriptor: SerialDescriptor =
         PrimitiveSerialDescriptor("LookupSymbolWrapper", PrimitiveKind.STRING)
+
     override fun serialize(encoder: Encoder, value: LookupSymbolWrapper) =
         encoder.encodeString("${value.name}:${value.scope}")
+
     override fun deserialize(decoder: Decoder): LookupSymbolWrapper {
         val (name, scope) = decoder.decodeString().split(':')
         return LookupSymbolWrapper(name, scope)
@@ -33,7 +38,8 @@ private object SymbolSerializer : KSerializer<LookupSymbolWrapper> {
 }
 
 private val fileToFilesMapSerializer = MapSerializer(FileSerializer, ListSerializer(FileSerializer))
-private val fileToSymbolsMapSerializer = MapSerializer(FileSerializer, ListSerializer(SymbolSerializer))
+private val fileToSymbolsMapSerializer =
+    MapSerializer(FileSerializer, ListSerializer(SymbolSerializer))
 
 abstract class PersistentMap<K, V>(
     private val serializer: KSerializer<Map<K, V>>,
@@ -47,12 +53,16 @@ abstract class PersistentMap<K, V>(
             Json.encodeToStream(serializer, m.toMap(), it)
         }
     }
+
     override fun toString() = m.toString()
 
     companion object {
         @JvmStatic
         @OptIn(ExperimentalSerializationApi::class)
-        protected fun <K, V> deserialize(serializer: KSerializer<Map<K, V>>, storage: File): MutableMap<K, V> {
+        protected fun <K, V> deserialize(
+            serializer: KSerializer<Map<K, V>>,
+            storage: File,
+        ): MutableMap<K, V> {
             return if (storage.exists()) {
                 BufferedInputStream(storage.inputStream()).use {
                     Json.decodeFromStream(serializer, it).toMutableMap()
@@ -64,14 +74,16 @@ abstract class PersistentMap<K, V>(
     }
 }
 
-class FileToFilesMap(
-    storage: File
-) : PersistentMap<File, List<File>>(fileToFilesMapSerializer, storage, deserialize(fileToFilesMapSerializer, storage))
+class FileToFilesMap(storage: File) :
+    PersistentMap<File, List<File>>(
+        fileToFilesMapSerializer,
+        storage,
+        deserialize(fileToFilesMapSerializer, storage),
+    )
 
-class FileToSymbolsMap(
-    storage: File
-) : PersistentMap<File, List<LookupSymbolWrapper>>(
-    fileToSymbolsMapSerializer,
-    storage,
-    deserialize(fileToSymbolsMapSerializer, storage)
-)
+class FileToSymbolsMap(storage: File) :
+    PersistentMap<File, List<LookupSymbolWrapper>>(
+        fileToSymbolsMapSerializer,
+        storage,
+        deserialize(fileToSymbolsMapSerializer, storage),
+    )

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/PsiUtils.kt
@@ -26,41 +26,41 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.PsiModifierListOwner
 
-val jvmModifierMap = mapOf(
-    JvmModifier.PUBLIC to Modifier.PUBLIC,
-    JvmModifier.PRIVATE to Modifier.PRIVATE,
-    JvmModifier.ABSTRACT to Modifier.ABSTRACT,
-    JvmModifier.FINAL to Modifier.FINAL,
-    JvmModifier.PROTECTED to Modifier.PROTECTED,
-    JvmModifier.STATIC to Modifier.JAVA_STATIC,
-    JvmModifier.STRICTFP to Modifier.JAVA_STRICT,
-    JvmModifier.NATIVE to Modifier.JAVA_NATIVE,
-    JvmModifier.SYNCHRONIZED to Modifier.JAVA_SYNCHRONIZED,
-    JvmModifier.TRANSIENT to Modifier.JAVA_TRANSIENT,
-    JvmModifier.VOLATILE to Modifier.JAVA_VOLATILE
-)
+val jvmModifierMap =
+    mapOf(
+        JvmModifier.PUBLIC to Modifier.PUBLIC,
+        JvmModifier.PRIVATE to Modifier.PRIVATE,
+        JvmModifier.ABSTRACT to Modifier.ABSTRACT,
+        JvmModifier.FINAL to Modifier.FINAL,
+        JvmModifier.PROTECTED to Modifier.PROTECTED,
+        JvmModifier.STATIC to Modifier.JAVA_STATIC,
+        JvmModifier.STRICTFP to Modifier.JAVA_STRICT,
+        JvmModifier.NATIVE to Modifier.JAVA_NATIVE,
+        JvmModifier.SYNCHRONIZED to Modifier.JAVA_SYNCHRONIZED,
+        JvmModifier.TRANSIENT to Modifier.JAVA_TRANSIENT,
+        JvmModifier.VOLATILE to Modifier.JAVA_VOLATILE,
+    )
 
-val javaModifiers = setOf(
-    Modifier.ABSTRACT,
-    Modifier.FINAL,
-    Modifier.JAVA_DEFAULT,
-    Modifier.JAVA_NATIVE,
-    Modifier.JAVA_STATIC,
-    Modifier.JAVA_STRICT,
-    Modifier.JAVA_SYNCHRONIZED,
-    Modifier.JAVA_TRANSIENT,
-    Modifier.JAVA_VOLATILE,
-    Modifier.PRIVATE,
-    Modifier.PROTECTED,
-    Modifier.PUBLIC,
-)
+val javaModifiers =
+    setOf(
+        Modifier.ABSTRACT,
+        Modifier.FINAL,
+        Modifier.JAVA_DEFAULT,
+        Modifier.JAVA_NATIVE,
+        Modifier.JAVA_STATIC,
+        Modifier.JAVA_STRICT,
+        Modifier.JAVA_SYNCHRONIZED,
+        Modifier.JAVA_TRANSIENT,
+        Modifier.JAVA_VOLATILE,
+        Modifier.PRIVATE,
+        Modifier.PROTECTED,
+        Modifier.PUBLIC,
+    )
 
 fun PsiModifierListOwner.toKSModifiers(): Set<Modifier> {
     val modifiers = mutableSetOf<Modifier>()
     modifiers.addAll(
-        jvmModifierMap.entries.filter { this.hasModifier(it.key) }
-            .map { it.value }
-            .toSet()
+        jvmModifierMap.entries.filter { this.hasModifier(it.key) }.map { it.value }.toSet()
     )
     if (this.modifierList?.hasExplicitModifier("default") == true) {
         modifiers.add(Modifier.JAVA_DEFAULT)
@@ -78,8 +78,7 @@ fun Project.findLocationString(file: PsiFile, offset: Int): String {
 
 private fun parseDocString(raw: String): String? {
     val t1 = raw.trim()
-    if (!t1.startsWith("/**") || !t1.endsWith("*/"))
-        return null
+    if (!t1.startsWith("/**") || !t1.endsWith("*/")) return null
     val lineSep = t1.findAnyOf(listOf("\r\n", "\n", "\r"))?.second ?: ""
     return t1.trim('/').trim('*').lines().joinToString(lineSep) {
         it.trimStart().trimStart('*')
@@ -96,17 +95,15 @@ inline fun <reified T> PsiElement.findParentOfType(): T? {
 
 fun <T> Sequence<T>.memoized() = MemoizedSequence(this)
 
-inline fun <T> lazyMemoizedSequence(crossinline initializer: () -> Sequence<T>): Lazy<Sequence<T>> = lazy {
-    val value = initializer()
-    if (value is MemoizedSequence<T>)
-        value
-    else
-        value.memoized()
-}
+inline fun <T> lazyMemoizedSequence(crossinline initializer: () -> Sequence<T>): Lazy<Sequence<T>> =
+    lazy {
+        val value = initializer()
+        if (value is MemoizedSequence<T>) value else value.memoized()
+    }
 
 /**
- * Returns `true` if this [PsiMethod] represents one of the public instance methods
- * from `java.lang.Object` (i.e., `equals`, `hashCode`, or `toString`).
+ * Returns `true` if this [PsiMethod] represents one of the public instance methods from
+ * `java.lang.Object` (i.e., `equals`, `hashCode`, or `toString`).
  */
 fun PsiMethod.isObjectOverride(): Boolean {
     if (parameterList.parametersCount == 0) {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
@@ -31,19 +31,19 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import org.jetbrains.kotlin.analysis.api.types.symbol
 
-/**
- * An [AnnotationResolutionStrategy] that uses the Kotlin Analysis API to resolve all symbols.
- */
+/** An [AnnotationResolutionStrategy] that uses the Kotlin Analysis API to resolve all symbols. */
 class AAResolutionStrategy(
     override val newKSFiles: List<KSFile>,
-    override val deferredSymbols: Map<SymbolProcessor, List<Restorable>>
+    override val deferredSymbols: Map<SymbolProcessor, List<Restorable>>,
 ) : AnnotationResolutionStrategy {
 
-    override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> =
+    override fun getSymbolsWithAnnotation(
+        annotationName: String,
+        inDepth: Boolean,
+    ): Sequence<KSAnnotated> =
         if (inDepth)
             annotationToSymbolsWithLocalsCache[annotationName]?.asSequence() ?: emptySequence()
-        else
-            annotationToSymbolsCache[annotationName]?.asSequence() ?: emptySequence()
+        else annotationToSymbolsCache[annotationName]?.asSequence() ?: emptySequence()
 
     private val annotationToSymbolsCache: Map<String, Collection<KSAnnotated>> by lazy {
         mapAnnotatedSymbols(false)
@@ -69,8 +69,10 @@ class AAResolutionStrategy(
         return mutableMapOf<String, MutableCollection<KSAnnotated>>().apply {
             withDeferred.forEach { annotated ->
                 for (annotation in annotated.annotations) {
-                    val kaType = (annotation.annotationType.resolve() as? KSTypeImpl)?.type ?: continue
-                    val annotationFqN = kaType.fullyExpand().symbol?.classId?.asFqNameString() ?: continue
+                    val kaType =
+                        (annotation.annotationType.resolve() as? KSTypeImpl)?.type ?: continue
+                    val annotationFqN =
+                        kaType.fullyExpand().symbol?.classId?.asFqNameString() ?: continue
                     val annotatedTarget = annotation.useSiteTarget.findTargetedSymbolFor(annotated)
                     getOrPut(annotationFqN, ::mutableSetOf).addAll(annotatedTarget)
                 }
@@ -82,34 +84,38 @@ class AAResolutionStrategy(
         deferredSymbols.values.flatten().mapNotNull { it.restore() }.toSet()
     }
 
-    /**
-     * Returns the symbol(s) in [annotated], targeted by the [AnnotationUseSiteTarget].
-     */
-    private fun AnnotationUseSiteTarget?.findTargetedSymbolFor(annotated: KSAnnotated): Collection<KSAnnotated> =
-        buildList {
-            when (this@findTargetedSymbolFor) {
-                null -> add(annotated)
-                AnnotationUseSiteTarget.FILE -> when (annotated) {
+    /** Returns the symbol(s) in [annotated], targeted by the [AnnotationUseSiteTarget]. */
+    private fun AnnotationUseSiteTarget?.findTargetedSymbolFor(
+        annotated: KSAnnotated
+    ): Collection<KSAnnotated> = buildList {
+        when (this@findTargetedSymbolFor) {
+            null -> add(annotated)
+            AnnotationUseSiteTarget.FILE ->
+                when (annotated) {
                     is KSFile -> add(annotated)
                     else -> annotated.containingFile?.let { add(it) }
                 }
 
-                AnnotationUseSiteTarget.PROPERTY -> add(annotated)
-                AnnotationUseSiteTarget.FIELD -> add(annotated)
-                AnnotationUseSiteTarget.GET -> add(annotated)
-                AnnotationUseSiteTarget.SET -> add(annotated)
-                AnnotationUseSiteTarget.RECEIVER -> when (annotated) {
+            AnnotationUseSiteTarget.PROPERTY -> add(annotated)
+            AnnotationUseSiteTarget.FIELD -> add(annotated)
+            AnnotationUseSiteTarget.GET -> add(annotated)
+            AnnotationUseSiteTarget.SET -> add(annotated)
+            AnnotationUseSiteTarget.RECEIVER ->
+                when (annotated) {
                     is KSPropertyDeclaration -> annotated.extensionReceiver?.let { add(it) }
                     is KSFunctionDeclaration -> annotated.extensionReceiver?.let { add(it) }
                 }
 
-                AnnotationUseSiteTarget.PARAM -> (annotated as? KSValueParameter)?.let { add(it) }
-                AnnotationUseSiteTarget.SETPARAM -> add(annotated)
-                AnnotationUseSiteTarget.DELEGATE -> add(annotated) // TODO: Add proper support for backing fields.
-                AnnotationUseSiteTarget.ALL -> when (annotated) {
+            AnnotationUseSiteTarget.PARAM -> (annotated as? KSValueParameter)?.let { add(it) }
+            AnnotationUseSiteTarget.SETPARAM -> add(annotated)
+            AnnotationUseSiteTarget.DELEGATE ->
+                add(annotated) // TODO: Add proper support for backing fields.
+            AnnotationUseSiteTarget.ALL ->
+                when (annotated) {
                     is KSValueParameter -> add(annotated)
                     is KSPropertyDeclaration -> {
-                        // TODO: Add proper support for backing fields, the ALL use site target also targets the field
+                        // TODO: Add proper support for backing fields, the ALL use site target also
+                        // targets the field
                         // TODO: Add support for JvmRecord annotation according to KEEP 402
                         add(annotated)
                         annotated.getter?.let { add(it) }
@@ -117,6 +123,6 @@ class AAResolutionStrategy(
                         annotated.setter?.parameter?.let { add(it) }
                     }
                 }
-            }
         }
+    }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
@@ -22,29 +22,25 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 
-/**
- * Represents a strategy for resolving annotated symbols.
- */
+/** Represents a strategy for resolving annotated symbols. */
 interface AnnotationResolutionStrategy {
 
-    /**
-     * Files that are new in the current round of processing.
-     */
+    /** Files that are new in the current round of processing. */
     val newKSFiles: List<KSFile>
 
-    /**
-     * Symbols that were deferred by symbol processors in the previous round.
-     */
+    /** Symbols that were deferred by symbol processors in the previous round. */
     val deferredSymbols: Map<SymbolProcessor, List<Restorable>>
 
     /**
-     * Get all symbols with specified annotation in the current compilation unit.
-     * Note that in multiple round processing, only symbols from deferred symbols of last round and symbols from newly generated files will be returned in this function.
+     * Get all symbols with specified annotation in the current compilation unit. Note that in
+     * multiple round processing, only symbols from deferred symbols of last round and symbols from
+     * newly generated files will be returned in this function.
      *
-     * @param annotationName is the fully qualified name of the fully expanded type (i.e. no type alias); using '.' as separator.
-     * @param inDepth whether to check symbols in depth, i.e. check symbols from local declarations. Operation can be expensive if true.
+     * @param annotationName is the fully qualified name of the fully expanded type (i.e. no type
+     *   alias); using '.' as separator.
+     * @param inDepth whether to check symbols in depth, i.e. check symbols from local declarations.
+     *   Operation can be expensive if true.
      * @return Elements annotated with the specified annotation.
-     *
      */
     fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated>
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/KSPCompilationError.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/KSPCompilationError.kt
@@ -20,4 +20,5 @@ package com.google.devtools.ksp.common.impl
 import com.intellij.psi.PsiFile
 
 // PsiElement.toLocation() isn't available before ResolveImpl is initialized.
-class KSPCompilationError(val file: PsiFile, val offset: Int, override val message: String) : Exception()
+class KSPCompilationError(val file: PsiFile, val offset: Int, override val message: String) :
+    Exception()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -57,6 +57,7 @@ import com.intellij.psi.PsiParameter
 import com.intellij.psi.PsiTypeParameter
 import com.intellij.psi.PsiTypeParameterList
 import com.intellij.util.containers.addIfNotNull
+import kotlin.collections.mapValues
 import org.jetbrains.kotlin.analysis.api.resolution.KaAnnotationCall
 import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -74,65 +75,57 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.psiUtil.parameterIndex
 import org.jetbrains.kotlin.utils.addToStdlib.flatGroupBy
-import kotlin.collections.mapValues
 
 /**
- * An [AnnotationResolutionStrategy] that uses a combination of Psi and Kotlin's Analysis API to resolve
- * annotated symbols.
+ * An [AnnotationResolutionStrategy] that uses a combination of Psi and Kotlin's Analysis API to
+ * resolve annotated symbols.
  *
  * This strategy is experimental, but should be faster than the default [AAResolutionStrategy].
  */
 class PsiResolutionStrategy(
     override val newKSFiles: List<KSFile>,
-    override val deferredSymbols: Map<SymbolProcessor, List<Restorable>>
+    override val deferredSymbols: Map<SymbolProcessor, List<Restorable>>,
 ) : AnnotationResolutionStrategy {
 
-    /**
-     * Returns all symbols annotated with [annotationName].
-     */
-    override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> =
-        if (inDepth)
-            aaResolutionStrategy.getSymbolsWithAnnotation(annotationName, inDepth = true)
-        else
-            getAnnotatedSymbols(annotationName)
+    /** Returns all symbols annotated with [annotationName]. */
+    override fun getSymbolsWithAnnotation(
+        annotationName: String,
+        inDepth: Boolean,
+    ): Sequence<KSAnnotated> =
+        if (inDepth) aaResolutionStrategy.getSymbolsWithAnnotation(annotationName, inDepth = true)
+        else getAnnotatedSymbols(annotationName)
 
     /**
-     * Calls to [getSymbolsWithAnnotation] with `inDepth = true` are
-     * delegated to the [AAResolutionStrategy].
-     * It is stored in a lazy val to ensure it is only initialized if
-     * needed and to cache its results.
+     * Calls to [getSymbolsWithAnnotation] with `inDepth = true` are delegated to the
+     * [AAResolutionStrategy]. It is stored in a lazy val to ensure it is only initialized if needed
+     * and to cache its results.
      */
     private val aaResolutionStrategy: AAResolutionStrategy by lazy {
         AAResolutionStrategy(newKSFiles, deferredSymbols)
     }
 
-    /**
-     * Returns the symbols annotated with the fully qualified name [annotationName].
-     */
+    /** Returns the symbols annotated with the fully qualified name [annotationName]. */
     private fun getAnnotatedSymbols(annotationName: String): Sequence<KSAnnotated> =
         getAnnotatedJavaSymbols(annotationName) +
             getAnnotatedKotlinSymbols(annotationName) +
             getRestoredSymbols(annotationName)
 
-    /**
-     * Returns the Kotlin symbols annotated with the fully qualified name [annotationName].
-     */
+    /** Returns the Kotlin symbols annotated with the fully qualified name [annotationName]. */
     private fun getAnnotatedKotlinSymbols(annotationName: String): Sequence<KSAnnotated> {
-        val newKotlinSymbols = annotatedKotlinElementsByFullyQualifiedName[annotationName]?.value ?: emptyList()
+        val newKotlinSymbols =
+            annotatedKotlinElementsByFullyQualifiedName[annotationName]?.value ?: emptyList()
         return newKotlinSymbols.asSequence()
     }
 
-    /**
-     * Returns the Java symbols annotated with the fully qualified name [annotationName].
-     */
+    /** Returns the Java symbols annotated with the fully qualified name [annotationName]. */
     private fun getAnnotatedJavaSymbols(annotationName: String): Sequence<KSAnnotated> =
-        annotatedJavaElementsByFullyQualifiedName.getOrPut(annotationName) {
-            resolveJavaAnnotationByShortName(annotationName)
-        }.asSequence()
+        annotatedJavaElementsByFullyQualifiedName
+            .getOrPut(annotationName) {
+                resolveJavaAnnotationByShortName(annotationName)
+            }
+            .asSequence()
 
-    /**
-     * Returns the [deferredSymbols] that are annotated with [annotationName].
-     */
+    /** Returns the [deferredSymbols] that are annotated with [annotationName]. */
     private fun getRestoredSymbols(annotationName: String): Sequence<KSAnnotated> =
         deferredSymbolsGroupedByAnnotations[annotationName]?.asSequence() ?: emptySequence()
 
@@ -142,35 +135,39 @@ class PsiResolutionStrategy(
      * See [annotatedKotlinElementsByFullyQualifiedName] for an example of the grouping.
      */
     private val deferredSymbolsGroupedByAnnotations: Map<String, Collection<KSAnnotated>> by lazy {
-        deferredSymbols.values.flatten().mapNotNull { it.restore() }.distinct()
+        deferredSymbols.values
+            .flatten()
+            .mapNotNull { it.restore() }
+            .distinct()
             .flatGroupBy { sym -> sym.annotations.mapNotNull { it.getFqn() }.toSet() }
     }
 
     /**
-     * Returns the Java symbols annotated with the fully qualified name [annotationName].
-     * The function only considers the subset of annotations in the program that share the same
-     * short name / unqualified name.
+     * Returns the Java symbols annotated with the fully qualified name [annotationName]. The
+     * function only considers the subset of annotations in the program that share the same short
+     * name / unqualified name.
      */
     private fun resolveJavaAnnotationByShortName(annotationName: String): Collection<KSAnnotated> {
         val annotationShortName = annotationName.substringAfterLast('.')
-        return annotatedJavaElementsByShortName[annotationShortName]?.filter { element ->
-            val annotationsForElement = fullyQualifiedJavaAnnotationNamesByElements[element] ?: emptyMap()
-            annotationsForElement[annotationShortName]?.value?.contains(annotationName) ?: false
-        }?.flatMap {
-            it.resolveToKSAnnotated()
-        } ?: emptyList()
+        return annotatedJavaElementsByShortName[annotationShortName]
+            ?.filter { element ->
+                val annotationsForElement =
+                    fullyQualifiedJavaAnnotationNamesByElements[element] ?: emptyMap()
+                annotationsForElement[annotationShortName]?.value?.contains(annotationName) ?: false
+            }
+            ?.flatMap {
+                it.resolveToKSAnnotated()
+            } ?: emptyList()
     }
 
-    /**
-     * All annotated [PsiElement]s in [newKSFiles] from both Kotlin and Java sources.
-     */
+    /** All annotated [PsiElement]s in [newKSFiles] from both Kotlin and Java sources. */
     private val annotatedPsiElements: Collection<PsiElement> by lazy {
         newKSFiles.flatMap { collectAnnotatedPsiElementsIn(it) }
     }
 
     /**
-     * Returns all [PsiElement]s that are annotated in [file] except for declarations
-     * in function bodies or property accessors.
+     * Returns all [PsiElement]s that are annotated in [file] except for declarations in function
+     * bodies or property accessors.
      */
     private fun collectAnnotatedPsiElementsIn(file: KSFile): Collection<PsiElement> {
         val visitor = CollectAnnotatedSymbolsPsiVisitor()
@@ -178,16 +175,12 @@ class PsiResolutionStrategy(
         return visitor.result
     }
 
-    /**
-     * All annotated Java elements.
-     */
+    /** All annotated Java elements. */
     private val annotatedJavaElements: List<PsiModifierListOwner> by lazy {
         annotatedPsiElements.filterIsInstance<PsiModifierListOwner>()
     }
 
-    /**
-     * Groups [annotatedJavaElements] by the short names of their annotations.
-     */
+    /** Groups [annotatedJavaElements] by the short names of their annotations. */
     private val annotatedJavaElementsByShortName: Map<String, Collection<PsiElement>> by lazy {
         annotatedJavaElements.flatGroupBy { element ->
             // N.B.: deduplicate by converting to a set, since
@@ -199,39 +192,42 @@ class PsiResolutionStrategy(
     /**
      * A map from Java elements to their annotations' fully qualified names, indexed by short name.
      */
-    private val fullyQualifiedJavaAnnotationNamesByElements: Map<PsiElement, Map<String, Lazy<Set<String>>>> by lazy {
+    private val fullyQualifiedJavaAnnotationNamesByElements:
+        Map<PsiElement, Map<String, Lazy<Set<String>>>> by lazy {
         annotatedJavaElements.associate { element ->
-            // N.B.: Performance: Lazily compute the set of qualified names to avoid resolution until requested
+            // N.B.: Performance: Lazily compute the set of qualified names to avoid resolution
+            // until requested
             //  for a specific annotation.
-            element to buildMap<String, Lazy<MutableSet<String>>> {
-                element.annotations.forEach { anno ->
-                    val lazyFullyQualifiedNames = this[anno.shortName]
-                    if (lazyFullyQualifiedNames == null) {
-                        this[anno.shortName] = lazy {
-                            mutableSetOf(
-                                anno.qualifiedName
-                                    ?: throw InternalKSPException(
-                                        "Unexpected unqualified name",
-                                        anno.toLocation(),
-                                        anno.javaClass
-                                    )
-                            )
-                        }
-                    } else {
-                        this[anno.shortName] = lazy {
-                            lazyFullyQualifiedNames.value.add(
-                                anno.qualifiedName
-                                    ?: throw InternalKSPException(
-                                        "Unexpected unqualified name",
-                                        anno.toLocation(),
-                                        anno.javaClass
-                                    )
-                            )
-                            lazyFullyQualifiedNames.value
+            element to
+                buildMap<String, Lazy<MutableSet<String>>> {
+                    element.annotations.forEach { anno ->
+                        val lazyFullyQualifiedNames = this[anno.shortName]
+                        if (lazyFullyQualifiedNames == null) {
+                            this[anno.shortName] = lazy {
+                                mutableSetOf(
+                                    anno.qualifiedName
+                                        ?: throw InternalKSPException(
+                                            "Unexpected unqualified name",
+                                            anno.toLocation(),
+                                            anno.javaClass,
+                                        )
+                                )
+                            }
+                        } else {
+                            this[anno.shortName] = lazy {
+                                lazyFullyQualifiedNames.value.add(
+                                    anno.qualifiedName
+                                        ?: throw InternalKSPException(
+                                            "Unexpected unqualified name",
+                                            anno.toLocation(),
+                                            anno.javaClass,
+                                        )
+                                )
+                                lazyFullyQualifiedNames.value
+                            }
                         }
                     }
                 }
-            }
         }
     }
 
@@ -240,12 +236,11 @@ class PsiResolutionStrategy(
      *
      * @see [annotatedKotlinElementsByFullyQualifiedName] for further explanation.
      */
-    private val annotatedJavaElementsByFullyQualifiedName: MutableMap<String, Collection<KSAnnotated>> =
+    private val annotatedJavaElementsByFullyQualifiedName:
+        MutableMap<String, Collection<KSAnnotated>> =
         mutableMapOf()
 
-    /**
-     * All annotated Kotlin elements.
-     */
+    /** All annotated Kotlin elements. */
     private val annotatedKotlinElements: List<KtAnnotated> by lazy {
         annotatedPsiElements.filterIsInstance<KtAnnotated>()
     }
@@ -259,6 +254,7 @@ class PsiResolutionStrategy(
      * @Annotation1 @Annotation2 fun fun2
      * @Annotation2 @Annotation3 fun fun3
      * ```
+     *
      * Then the result is
      *
      * ```
@@ -267,47 +263,59 @@ class PsiResolutionStrategy(
      * "Annotation3" -> [fun3]
      * ```
      */
-    private val annotatedKotlinElementsByFullyQualifiedName: Map<String, Lazy<List<KSAnnotated>>> by lazy {
+    private val annotatedKotlinElementsByFullyQualifiedName:
+        Map<String, Lazy<List<KSAnnotated>>> by lazy {
         buildMap {
-            val fileCaches = mutableMapOf<KtFile, FileCache>()
-            annotatedKotlinElements.forEach { annotated ->
-                val file = annotated.containingKtFile
-                annotated.annotationEntries.forEach { annotationEntry ->
-                    // TODO: Cache (file, annotation.shortName) -> classId. Shadowing is a problem
-                    //  so we should only cache for known unique declarations in the file.
-                    //  See test shadowingAnnotations.kt
-                    val fileCache = fileCaches.getOrPut(file) { FileCache(file) }
-                    val classId = resolveAnnotationEntryClassId(annotationEntry, fileCache)
-                    // N.B.: Skip nullable qualified names without error. This is what the AA-based implementation does.
-                    //   For now, this is the intended behavior. If it is changed in the future, then it is an API change.
-                    val fqn = classId?.asFqNameString() ?: return@forEach
-                    getOrPut(fqn, ::mutableListOf)
-                        .add(annotated to annotationEntry)
+                val fileCaches = mutableMapOf<KtFile, FileCache>()
+                annotatedKotlinElements.forEach { annotated ->
+                    val file = annotated.containingKtFile
+                    annotated.annotationEntries.forEach { annotationEntry ->
+                        // TODO: Cache (file, annotation.shortName) -> classId. Shadowing is a
+                        // problem
+                        //  so we should only cache for known unique declarations in the file.
+                        //  See test shadowingAnnotations.kt
+                        val fileCache = fileCaches.getOrPut(file) { FileCache(file) }
+                        val classId = resolveAnnotationEntryClassId(annotationEntry, fileCache)
+                        // N.B.: Skip nullable qualified names without error. This is what the
+                        // AA-based implementation does.
+                        //   For now, this is the intended behavior. If it is changed in the future,
+                        // then it is an API change.
+                        val fqn = classId?.asFqNameString() ?: return@forEach
+                        getOrPut(fqn, ::mutableListOf).add(annotated to annotationEntry)
+                    }
                 }
             }
-        }.mapValues { entry ->
-            lazy {
-                entry.value.flatMap { (annotated, annotationEntry) ->
-                    annotated.resolveToKSAnnotated(annotationEntry)
-                }.distinct()
+            .mapValues { entry ->
+                lazy {
+                    entry.value
+                        .flatMap { (annotated, annotationEntry) ->
+                            annotated.resolveToKSAnnotated(annotationEntry)
+                        }
+                        .distinct()
+                }
             }
-        }
     }
 
     /**
      * Resolves the [ClassId] for a given [KtAnnotationEntry].
      *
-     * It first attempts a [fastResolveClassId] and falls back to [slowResolveClassId] if that fails.
+     * It first attempts a [fastResolveClassId] and falls back to [slowResolveClassId] if that
+     * fails.
      */
-    private fun resolveAnnotationEntryClassId(annotationEntry: KtAnnotationEntry, fileCache: FileCache): ClassId? =
-        fastResolveClassId(annotationEntry, fileCache)
-            ?: slowResolveClassId(annotationEntry)
+    private fun resolveAnnotationEntryClassId(
+        annotationEntry: KtAnnotationEntry,
+        fileCache: FileCache,
+    ): ClassId? =
+        fastResolveClassId(annotationEntry, fileCache) ?: slowResolveClassId(annotationEntry)
 
     /**
-     * Attempts to resolve the [ClassId] of an [annotationEntry] without full type resolution,
-     * by trying to guess the [ClassId] and asking the Analysis API if it is a type alias.
+     * Attempts to resolve the [ClassId] of an [annotationEntry] without full type resolution, by
+     * trying to guess the [ClassId] and asking the Analysis API if it is a type alias.
      */
-    private fun fastResolveClassId(annotationEntry: KtAnnotationEntry, fileCache: FileCache): ClassId? {
+    private fun fastResolveClassId(
+        annotationEntry: KtAnnotationEntry,
+        fileCache: FileCache,
+    ): ClassId? {
         val shortName = annotationEntry.shortName?.asString() ?: return null
         val unresolvedTypeName = annotationEntry.typeReference?.text ?: return null
 
@@ -322,17 +330,20 @@ class PsiResolutionStrategy(
 
         // Check for explicit name import.
         // If it exists, we have found the name, otherwise fall back to checking other candidates.
-        val candidateClassIds = fileCache.explicitImports[shortName]?.let { explicitFqn ->
-            // Direct name import found. Do not consider other imports.
-            listOf((ClassId.topLevel(explicitFqn)))
-        } ?: buildList {
-            // No direct name import found. Consider package imports, star imports, and default imports.
-            add(mkClassId(fileCache.packageName, shortName))
-            fileCache.starImports.forEach { add(mkClassId(it, shortName)) }
-            FileCache.DEFAULT_IMPORTS.forEach {
-                add(mkClassId(FqName(it), shortName))
+        val candidateClassIds =
+            fileCache.explicitImports[shortName]?.let { explicitFqn ->
+                // Direct name import found. Do not consider other imports.
+                listOf((ClassId.topLevel(explicitFqn)))
             }
-        }
+                ?: buildList {
+                    // No direct name import found. Consider package imports, star imports, and
+                    // default imports.
+                    add(mkClassId(fileCache.packageName, shortName))
+                    fileCache.starImports.forEach { add(mkClassId(it, shortName)) }
+                    FileCache.DEFAULT_IMPORTS.forEach {
+                        add(mkClassId(FqName(it), shortName))
+                    }
+                }
 
         return analyze {
             candidateClassIds.firstNotNullOfOrNull { classId ->
@@ -353,9 +364,7 @@ class PsiResolutionStrategy(
         }
     }
 
-    /**
-     * Creates a [ClassId] from a package name and a top-level class name.
-     */
+    /** Creates a [ClassId] from a package name and a top-level class name. */
     private fun mkClassId(packageFqName: FqName, topLevelName: String): ClassId =
         ClassId(packageFqName, Name.identifier(topLevelName))
 
@@ -364,16 +373,19 @@ class PsiResolutionStrategy(
      *
      * This is used as a fallback when [fastResolveClassId] cannot determine the class ID.
      */
-    private fun slowResolveClassId(annotationEntry: KtAnnotationEntry): ClassId? = annotationEntry.classId
+    private fun slowResolveClassId(annotationEntry: KtAnnotationEntry): ClassId? =
+        annotationEntry.classId
 
     /**
      * Resolves this [PsiElement] to the set of [KSAnnotated] symbols targeted by [annotation].
      *
-     * The [annotation] is only required for Kotlin sources since annotations may have use site targets.
-     * Java sources never require an [annotation] to be present since annotations directly target the element
-     * being annotated.
+     * The [annotation] is only required for Kotlin sources since annotations may have use site
+     * targets. Java sources never require an [annotation] to be present since annotations directly
+     * target the element being annotated.
      */
-    private fun PsiElement.resolveToKSAnnotated(annotation: KtAnnotationEntry? = null): Collection<KSAnnotated> =
+    private fun PsiElement.resolveToKSAnnotated(
+        annotation: KtAnnotationEntry? = null
+    ): Collection<KSAnnotated> =
         when (val element = this@resolveToKSAnnotated) {
             // Kotlin sources
             is KtDeclaration -> {
@@ -381,44 +393,38 @@ class PsiResolutionStrategy(
                     throw InternalKSPException(
                         "Unexpected null annotation",
                         toLocation(),
-                        javaClass
+                        javaClass,
                     )
                 }
                 element.resolve(annotation)
             }
 
-            is KtFile ->
-                listOf(element.resolve())
+            is KtFile -> listOf(element.resolve())
 
-            is KtTypeReference ->
-                emptyList() // Do nothing
+            is KtTypeReference -> emptyList() // Do nothing
 
             // Java sources
-            is PsiParameter ->
-                listOf(element.resolve())
+            is PsiParameter -> listOf(element.resolve())
 
-            is PsiTypeParameter ->
-                element.resolve()
+            is PsiTypeParameter -> element.resolve()
 
-            is PsiClass ->
-                listOf(element.resolve())
+            is PsiClass -> listOf(element.resolve())
 
-            is PsiField ->
-                listOf(element.resolve())
+            is PsiField -> listOf(element.resolve())
 
-            is PsiMethod ->
-                listOf(element.resolve())
+            is PsiMethod -> listOf(element.resolve())
 
             else ->
                 throw InternalKSPException(
                     "Unreachable branch",
                     element.toLocation(),
-                    element.javaClass
+                    element.javaClass,
                 )
         }
 
     /**
-     * Resolves this [KtDeclaration] to the set of [KSAnnotated] symbols targeted by [annotationEntry].
+     * Resolves this [KtDeclaration] to the set of [KSAnnotated] symbols targeted by
+     * [annotationEntry].
      */
     private fun KtDeclaration.resolve(annotationEntry: KtAnnotationEntry): Collection<KSAnnotated> {
         // TODO: This should perform case distinction instead of getTargetedSymbol
@@ -426,162 +432,167 @@ class PsiResolutionStrategy(
         return ksSym.findTargetedSymbol(annotationEntry.ksUseSiteTarget)
     }
 
-    /**
-     * Resolves the [KSFileImpl] corresponding to this [KtFile].
-     */
-    private fun KtFile.resolve(): KSFileImpl =
-        analyze { symbol }.toKSFile()
+    /** Resolves the [KSFileImpl] corresponding to this [KtFile]. */
+    private fun KtFile.resolve(): KSFileImpl = analyze { symbol }.toKSFile()
 
-    /**
-     * Resolves the [KSValueParameter] corresponding to this [PsiParameter].
-     */
+    /** Resolves the [KSValueParameter] corresponding to this [PsiParameter]. */
     private fun PsiParameter.resolve(): KSValueParameter {
-        val functionDecl = callableSymbol.toKSFunctionDeclaration()
-            ?: throw InternalKSPException(
-                "Failed to convert callable symbol to KSFunctionDeclaration",
-                toLocation(),
-                callableSymbol.javaClass
-            )
+        val functionDecl =
+            callableSymbol.toKSFunctionDeclaration()
+                ?: throw InternalKSPException(
+                    "Failed to convert callable symbol to KSFunctionDeclaration",
+                    toLocation(),
+                    callableSymbol.javaClass,
+                )
         return functionDecl.parameters[parameterIndex()]
     }
 
-    /**
-     * Resolves the [KSTypeParameter]s corresponding to this [PsiTypeParameter].
-     */
-    private fun PsiTypeParameter.resolve(): Collection<KSTypeParameter> = when (val decl = parent.parent) {
-        is PsiMethod ->
-            listOf(resolveTypeParameterOfMethod(decl))
+    /** Resolves the [KSTypeParameter]s corresponding to this [PsiTypeParameter]. */
+    private fun PsiTypeParameter.resolve(): Collection<KSTypeParameter> =
+        when (val decl = parent.parent) {
+            is PsiMethod -> listOf(resolveTypeParameterOfMethod(decl))
 
-        is PsiClass ->
-            resolveTypeParameterOfClass(decl)
+            is PsiClass -> resolveTypeParameterOfClass(decl)
 
-        else ->
-            throw InternalKSPException(
-                "Unexpected Java declaration",
-                decl.toLocation(),
-                decl.javaClass
-            )
-    }
+            else ->
+                throw InternalKSPException(
+                    "Unexpected Java declaration",
+                    decl.toLocation(),
+                    decl.javaClass,
+                )
+        }
 
-    /**
-     * Resolves the [KSClassDeclarationImpl] corresponding to this [PsiClass].
-     */
+    /** Resolves the [KSClassDeclarationImpl] corresponding to this [PsiClass]. */
     private fun PsiClass.resolve(): KSClassDeclarationImpl {
-        val sym = analyze { namedClassSymbol }
-            ?: throw InternalKSPException(
-                "Unexpected null named class symbol",
-                toLocation(),
-                javaClass
-            )
+        val sym =
+            analyze { namedClassSymbol }
+                ?: throw InternalKSPException(
+                    "Unexpected null named class symbol",
+                    toLocation(),
+                    javaClass,
+                )
         return sym.toKSClassDeclaration()
     }
 
-    /**
-     * Resolves the [KSPropertyDeclaration] corresponding to this [PsiField].
-     */
+    /** Resolves the [KSPropertyDeclaration] corresponding to this [PsiField]. */
     private fun PsiField.resolve(): KSPropertyDeclaration {
-        val sym = analyze { this@resolve.callableSymbol }
-            ?: throw InternalKSPException(
-                "Unexpected null callable symbol",
-                toLocation(),
-                javaClass
-            )
+        val sym =
+            analyze { this@resolve.callableSymbol }
+                ?: throw InternalKSPException(
+                    "Unexpected null callable symbol",
+                    toLocation(),
+                    javaClass,
+                )
         return sym.toKSPropertyDeclaration()
             ?: throw InternalKSPException(
                 "Unexpected null KSPropertyDeclaration",
                 toLocation(),
-                javaClass
+                javaClass,
             )
     }
 
-    /**
-     * Resolves the [KSFunctionDeclarationImpl] corresponding to this [PsiMethod].
-     */
+    /** Resolves the [KSFunctionDeclarationImpl] corresponding to this [PsiMethod]. */
     private fun PsiMethod.resolve(): KSFunctionDeclarationImpl {
-        val sym = analyze { this@resolve.callableSymbol }
-            ?: throw InternalKSPException(
-                "Unexpected null callable symbol",
-                toLocation(),
-                javaClass
-            )
+        val sym =
+            analyze { this@resolve.callableSymbol }
+                ?: throw InternalKSPException(
+                    "Unexpected null callable symbol",
+                    toLocation(),
+                    javaClass,
+                )
         return sym.toKSFunctionDeclaration()
             ?: throw InternalKSPException(
                 "Unexpected null KSFunctionDeclaration",
                 toLocation(),
-                javaClass
+                javaClass,
             )
     }
 
     /**
      * Returns the targeted symbols by a given annotated symbol at its use site target.
      *
-     * E.g., `class A(@MyAnno val p: Int)` returns `p, p`, once for the parameter and once for the property.
+     * E.g., `class A(@MyAnno val p: Int)` returns `p, p`, once for the parameter and once for the
+     * property.
      */
-    private fun KSAnnotated.findTargetedSymbol(useSiteTarget: AnnotationUseSiteTarget?): Collection<KSAnnotated> =
+    private fun KSAnnotated.findTargetedSymbol(
+        useSiteTarget: AnnotationUseSiteTarget?
+    ): Collection<KSAnnotated> =
         when (useSiteTarget) {
-            null -> when (this) {
-                is KSValueParameter -> listOfNotNull(this, this.getGeneratedProperty())
+            null ->
+                when (this) {
+                    is KSValueParameter -> listOfNotNull(this, this.getGeneratedProperty())
 
-                is KSFunctionDeclarationImpl -> when {
-                    this.isGetter -> listOf(
-                        this.parentDeclaration?.getter()
-                            ?: throw InternalKSPException(
-                                "Unexpected missing getter",
-                                location,
-                                javaClass
-                            )
-                    )
+                    is KSFunctionDeclarationImpl ->
+                        when {
+                            this.isGetter ->
+                                listOf(
+                                    this.parentDeclaration?.getter()
+                                        ?: throw InternalKSPException(
+                                            "Unexpected missing getter",
+                                            location,
+                                            javaClass,
+                                        )
+                                )
 
-                    this.isSetter -> listOf(
-                        this.parentDeclaration?.setter()
-                            ?: throw InternalKSPException(
-                                "Unexpected missing setter",
-                                location,
-                                javaClass
-                            )
-                    )
+                            this.isSetter ->
+                                listOf(
+                                    this.parentDeclaration?.setter()
+                                        ?: throw InternalKSPException(
+                                            "Unexpected missing setter",
+                                            location,
+                                            javaClass,
+                                        )
+                                )
+
+                            else -> listOf(this)
+                        }
 
                     else -> listOf(this)
                 }
 
-                else -> listOf(this)
-            }
-
-            AnnotationUseSiteTarget.FILE -> when (this) {
-                is KSFile -> listOf(this)
-                else -> listOf(
-                    this.containingFile
-                        ?: throw InternalKSPException(
-                            "Unexpected missing file",
-                            location,
-                            javaClass
+            AnnotationUseSiteTarget.FILE ->
+                when (this) {
+                    is KSFile -> listOf(this)
+                    else ->
+                        listOf(
+                            this.containingFile
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing file",
+                                    location,
+                                    javaClass,
+                                )
                         )
-                )
-            }
+                }
 
-            AnnotationUseSiteTarget.PROPERTY -> when (this) {
-                is KSValueParameter -> listOf(
-                    this.getGeneratedProperty() ?: throw InternalKSPException(
-                        "Unexpected missing property for parameter",
-                        location,
-                        javaClass
-                    )
-                )
+            AnnotationUseSiteTarget.PROPERTY ->
+                when (this) {
+                    is KSValueParameter ->
+                        listOf(
+                            this.getGeneratedProperty()
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing property for parameter",
+                                    location,
+                                    javaClass,
+                                )
+                        )
 
-                else -> listOf(this)
-            }
+                    else -> listOf(this)
+                }
 
-            AnnotationUseSiteTarget.FIELD -> when (this) {
-                is KSValueParameter -> listOf(
-                    this.getGeneratedProperty() ?: throw InternalKSPException(
-                        "Unexpected missing property for parameter",
-                        location,
-                        javaClass
-                    )
-                )
+            AnnotationUseSiteTarget.FIELD ->
+                when (this) {
+                    is KSValueParameter ->
+                        listOf(
+                            this.getGeneratedProperty()
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing property for parameter",
+                                    location,
+                                    javaClass,
+                                )
+                        )
 
-                else -> listOf(this)
-            }
+                    else -> listOf(this)
+                }
 
             AnnotationUseSiteTarget.GET ->
                 listOf(
@@ -589,7 +600,7 @@ class PsiResolutionStrategy(
                         ?: throw InternalKSPException(
                             "Unexpected missing getter",
                             location,
-                            javaClass
+                            javaClass,
                         )
                 )
 
@@ -599,204 +610,218 @@ class PsiResolutionStrategy(
                         ?: throw InternalKSPException(
                             "Unexpected missing setter",
                             location,
-                            javaClass
+                            javaClass,
                         )
                 )
 
-            AnnotationUseSiteTarget.RECEIVER -> when (this) {
-                is KSFunctionDeclarationImpl -> listOf(
-                    extensionReceiver
-                        ?: throw InternalKSPException(
-                            "Unexpected missing extension receiver",
+            AnnotationUseSiteTarget.RECEIVER ->
+                when (this) {
+                    is KSFunctionDeclarationImpl ->
+                        listOf(
+                            extensionReceiver
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing extension receiver",
+                                    location,
+                                    javaClass,
+                                )
+                        )
+
+                    is KSPropertyDeclaration ->
+                        listOf(
+                            extensionReceiver
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing extension receiver",
+                                    location,
+                                    javaClass,
+                                )
+                        )
+
+                    else ->
+                        throw InternalKSPException(
+                            "Unexpected declaration",
                             location,
-                            javaClass
+                            javaClass,
                         )
-                )
-
-                is KSPropertyDeclaration -> listOf(
-                    extensionReceiver
-                        ?: throw InternalKSPException(
-                            "Unexpected missing extension receiver",
-                            location,
-                            javaClass
-                        )
-                )
-
-                else -> throw InternalKSPException(
-                    "Unexpected declaration",
-                    location,
-                    javaClass
-                )
-            }
-
-            AnnotationUseSiteTarget.PARAM -> when (this) {
-                is KSValueParameter -> listOf(this)
-                else -> throw InternalKSPException(
-                    "Unexpected annotated symbol with param use-site target",
-                    location,
-                    javaClass
-                )
-            }
-
-            AnnotationUseSiteTarget.SETPARAM -> when (this) {
-                is KSValueParameter -> {
-                    listOf(
-                        (this.parent as? KSFunctionDeclaration)?.parameters?.singleOrNull()
-                            ?: throw InternalKSPException(
-                                "Unexpected missing setter parameter",
-                                location,
-                                javaClass
-                            )
-                    )
                 }
 
-                is KSPropertyDeclaration -> listOf(
-                    setter?.parameter
-                        ?: throw InternalKSPException(
-                            "Unexpected missing setter parameter",
+            AnnotationUseSiteTarget.PARAM ->
+                when (this) {
+                    is KSValueParameter -> listOf(this)
+                    else ->
+                        throw InternalKSPException(
+                            "Unexpected annotated symbol with param use-site target",
                             location,
-                            javaClass
+                            javaClass,
                         )
-                )
+                }
 
-                else -> throw InternalKSPException(
-                    "Unexpected annotated symbol with 'setparam' use-site target",
-                    location,
-                    javaClass
-                )
-            }
+            AnnotationUseSiteTarget.SETPARAM ->
+                when (this) {
+                    is KSValueParameter -> {
+                        listOf(
+                            (this.parent as? KSFunctionDeclaration)?.parameters?.singleOrNull()
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing setter parameter",
+                                    location,
+                                    javaClass,
+                                )
+                        )
+                    }
+
+                    is KSPropertyDeclaration ->
+                        listOf(
+                            setter?.parameter
+                                ?: throw InternalKSPException(
+                                    "Unexpected missing setter parameter",
+                                    location,
+                                    javaClass,
+                                )
+                        )
+
+                    else ->
+                        throw InternalKSPException(
+                            "Unexpected annotated symbol with 'setparam' use-site target",
+                            location,
+                            javaClass,
+                        )
+                }
 
             AnnotationUseSiteTarget.DELEGATE ->
                 // TODO: Better impl for this
                 listOf(this)
 
-            AnnotationUseSiteTarget.ALL -> when (this) {
-                is KSValueParameter -> {
-                    buildList {
-                        add(this@findTargetedSymbol)
-                        this@findTargetedSymbol.getGeneratedProperty()?.findTargetedSymbol(useSiteTarget)
-                            ?.let { symbols ->
-                                symbols.forEach { addIfNotNull(it) }
-                            }
+            AnnotationUseSiteTarget.ALL ->
+                when (this) {
+                    is KSValueParameter -> {
+                        buildList {
+                            add(this@findTargetedSymbol)
+                            this@findTargetedSymbol.getGeneratedProperty()
+                                ?.findTargetedSymbol(useSiteTarget)
+                                ?.let { symbols ->
+                                    symbols.forEach { addIfNotNull(it) }
+                                }
+                        }
                     }
+
+                    is KSPropertyDeclaration ->
+                        // TODO: Add proper support for backing fields, the ALL use site target also
+                        // targets the field
+                        // TODO: Add support for JvmRecord annotation according to KEEP 402
+                        buildList {
+                            add(this@findTargetedSymbol)
+                            addIfNotNull(this@findTargetedSymbol.getter)
+                            addIfNotNull(this@findTargetedSymbol.setter)
+                            addIfNotNull(this@findTargetedSymbol.setter?.parameter)
+                        }
+
+                    else ->
+                        throw InternalKSPException(
+                            "Unexpected annotated symbol with 'all' use-site target",
+                            location,
+                            javaClass,
+                        )
                 }
-
-                is KSPropertyDeclaration ->
-                    // TODO: Add proper support for backing fields, the ALL use site target also targets the field
-                    // TODO: Add support for JvmRecord annotation according to KEEP 402
-                    buildList {
-                        add(this@findTargetedSymbol)
-                        addIfNotNull(this@findTargetedSymbol.getter)
-                        addIfNotNull(this@findTargetedSymbol.setter)
-                        addIfNotNull(this@findTargetedSymbol.setter?.parameter)
-                    }
-
-                else -> throw InternalKSPException(
-                    "Unexpected annotated symbol with 'all' use-site target",
-                    location,
-                    javaClass
-                )
-            }
         }
 
-    /**
-     * Resolves this [PsiTypeParameter] to its [KSTypeParameter] representation within [method].
-     */
+    /** Resolves this [PsiTypeParameter] to its [KSTypeParameter] representation within [method]. */
     private fun PsiTypeParameter.resolveTypeParameterOfMethod(method: PsiMethod): KSTypeParameter {
-        val callableSym = analyze { method.callableSymbol }
-            ?: throw InternalKSPException(
-                "Unexpected null callable symbol",
-                method.toLocation(),
-                method.javaClass
-            )
-        val functionDecl = callableSym.toKSFunctionDeclaration()
-            ?: throw InternalKSPException(
-                "Failed to convert callable symbol to KSFunctionDeclaration",
-                method.toLocation(),
-                callableSym.javaClass
-            )
+        val callableSym =
+            analyze { method.callableSymbol }
+                ?: throw InternalKSPException(
+                    "Unexpected null callable symbol",
+                    method.toLocation(),
+                    method.javaClass,
+                )
+        val functionDecl =
+            callableSym.toKSFunctionDeclaration()
+                ?: throw InternalKSPException(
+                    "Failed to convert callable symbol to KSFunctionDeclaration",
+                    method.toLocation(),
+                    callableSym.javaClass,
+                )
         return functionDecl.typeParameters[parameterIndex]
     }
 
-    /**
-     * Resolves this [PsiTypeParameter] to its [KSTypeParameter] representations within [clazz].
-     */
-    private fun PsiTypeParameter.resolveTypeParameterOfClass(clazz: PsiClass): List<KSTypeParameter> {
-        val classSym = analyze { clazz.namedClassSymbol }
-            ?: throw InternalKSPException(
-                "Unexpected named class symbol",
-                clazz.toLocation(),
-                clazz.javaClass
-            )
+    /** Resolves this [PsiTypeParameter] to its [KSTypeParameter] representations within [clazz]. */
+    private fun PsiTypeParameter.resolveTypeParameterOfClass(
+        clazz: PsiClass
+    ): List<KSTypeParameter> {
+        val classSym =
+            analyze { clazz.namedClassSymbol }
+                ?: throw InternalKSPException(
+                    "Unexpected named class symbol",
+                    clazz.toLocation(),
+                    clazz.javaClass,
+                )
         val typeParamSym = classSym.toKSClassDeclaration().typeParameters[parameterIndex]
         // Type parameters for classes return two symbols with Analysis API,
         // one as a Psi-based KaFirTypeParameter and one as a "regular" KaFirTypeParameter,
         // so we return a clone here to maintain KSP API parity.
-        val clone = object : KSTypeParameter by typeParamSym {
-            override fun toString(): String = typeParamSym.toString()
-        }
+        val clone =
+            object : KSTypeParameter by typeParamSym {
+                override fun toString(): String = typeParamSym.toString()
+            }
         return listOf(typeParamSym, clone)
     }
 
     /**
-     * Returns the short name used at the annotation site.
-     * Throws an exception if the name is `null`.
+     * Returns the short name used at the annotation site. Throws an exception if the name is
+     * `null`.
      */
     private val PsiAnnotation.shortName: String
-        get() = this.nameReferenceElement?.referenceName
-            ?: throw InternalKSPException(
-                "Unexpected nullable annotation short name",
-                toLocation(),
-                javaClass
-            )
+        get() =
+            this.nameReferenceElement?.referenceName
+                ?: throw InternalKSPException(
+                    "Unexpected nullable annotation short name",
+                    toLocation(),
+                    javaClass,
+                )
 
     /**
-     * Returns the callable symbol, i.e., the method symbol for the Java parameter `this`.
-     * Assumes that `this` is a parameter to a method.
+     * Returns the callable symbol, i.e., the method symbol for the Java parameter `this`. Assumes
+     * that `this` is a parameter to a method.
      */
     private val PsiParameter.callableSymbol: KaCallableSymbol
         get() {
-            val decl = this.parent.parent as? PsiMember
-                ?: throw InternalKSPException(
-                    "Unexpected PsiParameter",
-                    toLocation(),
-                    javaClass
-                )
+            val decl =
+                this.parent.parent as? PsiMember
+                    ?: throw InternalKSPException(
+                        "Unexpected PsiParameter",
+                        toLocation(),
+                        javaClass,
+                    )
             return analyze {
                 decl.callableSymbol
                     ?: throw InternalKSPException(
                         "Unexpected null callable symbol",
                         decl.toLocation(),
-                        decl.javaClass
+                        decl.javaClass,
                     )
             }
         }
 
-    /**
-     * Returns the index of `this` in the list of type parameters.
-     */
+    /** Returns the index of `this` in the list of type parameters. */
     private val PsiTypeParameter.parameterIndex: Int
         get() {
             when (val parent = this.parent) {
-                is PsiTypeParameterList ->
-                    return parent.getTypeParameterIndex(this)
+                is PsiTypeParameterList -> return parent.getTypeParameterIndex(this)
 
                 else ->
                     throw InternalKSPException(
                         "Unexpected parent of PsiTypeParameter",
                         parent.toLocation(),
-                        parent.javaClass
+                        parent.javaClass,
                     )
             }
         }
 
     /**
-     * The fully expanded [ClassId] of the annotation entry.
-     * This member is expensive to compute.
+     * The fully expanded [ClassId] of the annotation entry. This member is expensive to compute.
      */
     private val KtAnnotationEntry.classId: ClassId?
         get() = analyze {
-            // N.B. do not use typeReference.type to get the ClassId because that can fail in certain edge cases, e.g.
+            // N.B. do not use typeReference.type to get the ClassId because that can fail in
+            // certain edge cases, e.g.
             //  https://github.com/google/ksp/issues/2913
             this@classId.resolveToCall()
                 ?.successfulCallOrNull<KaAnnotationCall>()
@@ -804,9 +829,7 @@ class PsiResolutionStrategy(
                 ?.containingClassId
         }
 
-    /**
-     * The use-site target specified for this annotation entry.
-     */
+    /** The use-site target specified for this annotation entry. */
     private val KtAnnotationEntry.ksUseSiteTarget: AnnotationUseSiteTarget?
         get() = useSiteTarget?.getAnnotationUseSiteTarget()?.toKSAnnotationUseSiteTarget()
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectAnnotatedSymbolsPsiVisitor.kt
@@ -46,9 +46,8 @@ import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
 /**
- * A [PsiRecursiveElementWalkingVisitor] that collects [PsiElement]s which
- * are annotated at least once. It does **not** traverse function or method bodies, i.e.,
- * always assumes `inDepth = false`.
+ * A [PsiRecursiveElementWalkingVisitor] that collects [PsiElement]s which are annotated at least
+ * once. It does **not** traverse function or method bodies, i.e., always assumes `inDepth = false`.
  */
 class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
 
@@ -59,96 +58,100 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
             return
         }
         when (element) {
-            is KtAnnotationEntry -> when (val parent = element.parent) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass
-                // @MyAnnotation val myVal = "";
-                // @MyAnnotation fun myFun() {}
-                // fun myMethodWithParameter(@MyAnnotation myParam: Int) {}
-                is KtDeclarationModifierList -> {
-                    result.add(parent.parent)
-                    return
+            is KtAnnotationEntry ->
+                when (val parent = element.parent) {
+                    // Annotations on declarations. Examples:
+                    // @MyAnnotation class MyClass
+                    // @MyAnnotation val myVal = "";
+                    // @MyAnnotation fun myFun() {}
+                    // fun myMethodWithParameter(@MyAnnotation myParam: Int) {}
+                    is KtDeclarationModifierList -> {
+                        result.add(parent.parent)
+                        return
+                    }
+
+                    // Annotations at the file level. Example:
+                    // @file:MyAnnotation
+                    is KtFileAnnotationList -> {
+                        result.add(parent.parent)
+                        return
+                    }
+
+                    // Annotations on expressions. Example:
+                    // val x = @Suppress("UNCHECKED_CAST") list as List<String>
+                    is KtAnnotatedExpression ->
+                        // Do nothing - KSP does not consider expressions / values
+                        return
+
+                    // A group of annotations. Example:
+                    // @[MyAnnotation1, MyAnnotation2] class MyClass
+                    is KtAnnotation -> {
+                        result.add(parent.parent.parent)
+                        return
+                    }
+
+                    else ->
+                        // Explicit crash
+                        throw InternalKSPException(
+                            "Unexpected Kotlin Psi element",
+                            parent.toLocation(),
+                            parent.javaClass,
+                        )
                 }
 
-                // Annotations at the file level. Example:
-                // @file:MyAnnotation
-                is KtFileAnnotationList -> {
-                    result.add(parent.parent)
-                    return
+            is PsiAnnotation ->
+                when (val owner = element.owner) {
+                    // Annotations on declarations. Examples:
+                    // @MyAnnotation class MyClass {}
+                    // @MyAnnotation String myField = "";
+                    // @MyAnnotation void myMethod() {}
+                    // void myMethodWithParameter(@MyAnnotation int myParam) {}
+                    is PsiModifierList -> {
+                        result.add(owner.parent)
+                        return
+                    }
+
+                    // Type parameter annotations. Examples:
+                    // class MyClass<@MyAnnotation A>
+                    // fun <@MyAnnotation A> myFun() {}
+                    is PsiTypeParameter -> {
+                        result.add(owner)
+                        return
+                    }
+
+                    is PsiTypeElement -> {
+                        result.add(owner)
+                        return
+                    }
+
+                    // Type argument annotation / type application. Example:
+                    // interface <A> Foo<A> {}
+                    // abstract class Abs {
+                    //     Foo<String> bar(Foo2<@MyAnnotation Boolean> baz)
+                    //     Foo<@MyAnnotation A> baz(Foo2<A> baz)
+                    // }
+                    is PsiType ->
+                        // Do nothing - Analysis API implementation does not collect these
+                        return
+
+                    // Annotations used as values. Example with other annotation used as default
+                    // value
+                    // @interface MyAnnotation {
+                    //     MyOtherAnnotation value() default @MyOtherAnnotation("default value
+                    // here");
+                    // }
+                    null ->
+                        // Do nothing - Analysis API implementation does not collect these
+                        return
+
+                    else ->
+                        // Explicit crash
+                        throw InternalKSPException(
+                            "Unexpected Java Psi element",
+                            (owner as? PsiElement).toLocation(),
+                            owner.javaClass,
+                        )
                 }
-
-                // Annotations on expressions. Example:
-                // val x = @Suppress("UNCHECKED_CAST") list as List<String>
-                is KtAnnotatedExpression ->
-                    // Do nothing - KSP does not consider expressions / values
-                    return
-
-                // A group of annotations. Example:
-                // @[MyAnnotation1, MyAnnotation2] class MyClass
-                is KtAnnotation -> {
-                    result.add(parent.parent.parent)
-                    return
-                }
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Kotlin Psi element",
-                        parent.toLocation(),
-                        parent.javaClass
-                    )
-            }
-
-            is PsiAnnotation -> when (val owner = element.owner) {
-                // Annotations on declarations. Examples:
-                // @MyAnnotation class MyClass {}
-                // @MyAnnotation String myField = "";
-                // @MyAnnotation void myMethod() {}
-                // void myMethodWithParameter(@MyAnnotation int myParam) {}
-                is PsiModifierList -> {
-                    result.add(owner.parent)
-                    return
-                }
-
-                // Type parameter annotations. Examples:
-                // class MyClass<@MyAnnotation A>
-                // fun <@MyAnnotation A> myFun() {}
-                is PsiTypeParameter -> {
-                    result.add(owner)
-                    return
-                }
-
-                is PsiTypeElement -> {
-                    result.add(owner)
-                    return
-                }
-
-                // Type argument annotation / type application. Example:
-                // interface <A> Foo<A> {}
-                // abstract class Abs {
-                //     Foo<String> bar(Foo2<@MyAnnotation Boolean> baz)
-                //     Foo<@MyAnnotation A> baz(Foo2<A> baz)
-                // }
-                is PsiType ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                // Annotations used as values. Example with other annotation used as default value
-                // @interface MyAnnotation {
-                //     MyOtherAnnotation value() default @MyOtherAnnotation("default value here");
-                // }
-                null ->
-                    // Do nothing - Analysis API implementation does not collect these
-                    return
-
-                else ->
-                    // Explicit crash
-                    throw InternalKSPException(
-                        "Unexpected Java Psi element",
-                        (owner as? PsiElement).toLocation(),
-                        owner.javaClass
-                    )
-            }
         }
         super.visitElement(element)
     }
@@ -173,26 +176,19 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     private fun PsiElement.isPackageDirective(): Boolean =
         isKotlinPackageDirective() || isJavaPackageDirective()
 
-    /**
-     * Returns `true` if the [PsiElement] is either a Kotlin or Java import list.
-     */
-    private fun PsiElement.isImport(): Boolean =
-        isKotlinImportList() || isJavaImportList()
+    /** Returns `true` if the [PsiElement] is either a Kotlin or Java import list. */
+    private fun PsiElement.isImport(): Boolean = isKotlinImportList() || isJavaImportList()
 
-    /**
-     * Return `true` if the [PsiElement] is either a Kotlin or Java doc-comment.
-     */
-    private fun PsiElement.isDocComment(): Boolean =
-        isKotlinDocComment() || isJavaDocComment()
+    /** Return `true` if the [PsiElement] is either a Kotlin or Java doc-comment. */
+    private fun PsiElement.isDocComment(): Boolean = isKotlinDocComment() || isJavaDocComment()
 
-    /**
-     * Return `true` if the [PsiElement] is either a Kotlin function body or a Java method body.
-     */
+    /** Return `true` if the [PsiElement] is either a Kotlin function body or a Java method body. */
     private fun PsiElement.isFunctionOrMethodBody(): Boolean =
         isKotlinFunctionBody() || isJavaMethodBody()
 
     /**
-     * Return `true` if the [PsiElement] is either a Kotlin object expression or a Java anonymous class.
+     * Return `true` if the [PsiElement] is either a Kotlin object expression or a Java anonymous
+     * class.
      */
     private fun PsiElement.isObjectOrAnonymousClass(): Boolean =
         isKotlinObjectExpression() || isJavaAnonymousClass()
@@ -200,72 +196,46 @@ class CollectAnnotatedSymbolsPsiVisitor : PsiRecursiveElementWalkingVisitor() {
     /**
      * Returns `true` is the [PsiElement] is a Kotlin package directive, e.g., `package com.example`
      */
-    private fun PsiElement.isKotlinPackageDirective(): Boolean =
-        this is KtPackageDirective
+    private fun PsiElement.isKotlinPackageDirective(): Boolean = this is KtPackageDirective
 
     /**
      * Returns `true` is the [PsiElement] is a Java package directive, e.g., `package com.example`
      */
-    private fun PsiElement.isJavaPackageDirective(): Boolean =
-        this is PsiPackageStatement
+    private fun PsiElement.isJavaPackageDirective(): Boolean = this is PsiPackageStatement
 
-    /**
-     * Returns `true` if the [PsiElement] is a Kotlin import list.
-     */
-    private fun PsiElement.isKotlinImportList(): Boolean =
-        this is KtImportList
+    /** Returns `true` if the [PsiElement] is a Kotlin import list. */
+    private fun PsiElement.isKotlinImportList(): Boolean = this is KtImportList
 
-    /**
-     * Returns `true` if the [PsiElement] is a Java import list.
-     */
-    private fun PsiElement.isJavaImportList(): Boolean =
-        this is PsiImportList
+    /** Returns `true` if the [PsiElement] is a Java import list. */
+    private fun PsiElement.isJavaImportList(): Boolean = this is PsiImportList
 
-    /**
-     * Returns `true` if the [PsiElement] is a Kotlin doc comment.
-     */
-    private fun PsiElement.isKotlinDocComment(): Boolean =
-        this is KDoc
+    /** Returns `true` if the [PsiElement] is a Kotlin doc comment. */
+    private fun PsiElement.isKotlinDocComment(): Boolean = this is KDoc
 
-    /**
-     * Returns `true` if the [PsiElement] is a Java doc-comment.
-     */
-    private fun PsiElement.isJavaDocComment(): Boolean =
-        this is PsiDocComment
+    /** Returns `true` if the [PsiElement] is a Java doc-comment. */
+    private fun PsiElement.isJavaDocComment(): Boolean = this is PsiDocComment
 
-    /**
-     * Returns `true` if the [PsiElement] is a Kotlin function body.
-     */
-    private fun PsiElement.isKotlinFunctionBody(): Boolean = when (this) {
-        is KtExpression -> when (val parent = this.parent) {
-            is KtFunction ->
-                parent.bodyExpression == this || parent.bodyBlockExpression == this
+    /** Returns `true` if the [PsiElement] is a Kotlin function body. */
+    private fun PsiElement.isKotlinFunctionBody(): Boolean =
+        when (this) {
+            is KtExpression ->
+                when (val parent = this.parent) {
+                    is KtFunction ->
+                        parent.bodyExpression == this || parent.bodyBlockExpression == this
+
+                    else -> false
+                }
 
             else -> false
         }
 
-        else -> false
-    }
-
-    /**
-     * Returns `true` if the [PsiElement] is a Java method body.
-     */
+    /** Returns `true` if the [PsiElement] is a Java method body. */
     private fun PsiElement.isJavaMethodBody(): Boolean =
-        this is PsiExpression ||
-            (
-                this is PsiCodeBlock &&
-                    this.parent is PsiMethod
-                )
+        this is PsiExpression || (this is PsiCodeBlock && this.parent is PsiMethod)
 
-    /**
-     * Returns `true` if the [PsiElement] is a Kotlin object expression.
-     */
-    private fun PsiElement.isKotlinObjectExpression(): Boolean =
-        this is KtObjectLiteralExpression
+    /** Returns `true` if the [PsiElement] is a Kotlin object expression. */
+    private fun PsiElement.isKotlinObjectExpression(): Boolean = this is KtObjectLiteralExpression
 
-    /**
-     * Returns `true` if the [PsiElement] is a Java anonymous class.
-     */
-    private fun PsiElement.isJavaAnonymousClass(): Boolean =
-        this is PsiAnonymousClass
+    /** Returns `true` if the [PsiElement] is a Java anonymous class. */
+    private fun PsiElement.isJavaAnonymousClass(): Boolean = this is PsiAnonymousClass
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectClassifierNameVisitor.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/visitor/CollectClassifierNameVisitor.kt
@@ -30,10 +30,7 @@ import org.jetbrains.kotlin.psi.KtImportList
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtTypeAlias
 
-/**
- * Collects classifier names in the [KtFile] using
- * [CollectClassifierNameVisitor].
- */
+/** Collects classifier names in the [KtFile] using [CollectClassifierNameVisitor]. */
 fun KtFile.collectClassifierNames(): Set<String> {
     val visitor = CollectClassifierNameVisitor()
     accept(visitor)
@@ -41,7 +38,8 @@ fun KtFile.collectClassifierNames(): Set<String> {
 }
 
 /**
- * A [PsiRecursiveElementWalkingVisitor] that collects the names of classes, objects and type aliases.
+ * A [PsiRecursiveElementWalkingVisitor] that collects the names of classes, objects and type
+ * aliases.
  */
 private class CollectClassifierNameVisitor : PsiRecursiveElementWalkingVisitor() {
 
@@ -62,20 +60,21 @@ private class CollectClassifierNameVisitor : PsiRecursiveElementWalkingVisitor()
      * A [PsiElement] may be skippable to avoid deep traversal of the AST.
      *
      * Returns `true` if the [PsiElement] is one of the following:
-     *   - An expression that is not a declaration
-     *   - An import list
-     *   - A package directive
-     *   - A doc comment
-     *   - A comment
+     * - An expression that is not a declaration
+     * - An import list
+     * - A package directive
+     * - A doc comment
+     * - A comment
      */
-    private fun PsiElement.isSkippable(): Boolean = when (this) {
-        is KtExpression -> this !is KtDeclaration
-        is KtImportList,
-        is KtPackageDirective,
-        is KDoc,
-        is PsiComment,
-        is PsiWhiteSpace -> true
+    private fun PsiElement.isSkippable(): Boolean =
+        when (this) {
+            is KtExpression -> this !is KtDeclaration
+            is KtImportList,
+            is KtPackageDirective,
+            is KDoc,
+            is PsiComment,
+            is PsiWhiteSpace -> true
 
-        else -> false
-    }
+            else -> false
+        }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/CommandLineKSPLogger.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/CommandLineKSPLogger.kt
@@ -23,6 +23,7 @@ import com.google.devtools.ksp.symbol.KSNode
 class CommandLineKSPLogger : KSPLogger {
     // TODO: support logging level.
     private val messager = System.err
+
     override fun logging(message: String, symbol: KSNode?) {
         messager.println(message)
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/DualLookupTracker.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/DualLookupTracker.kt
@@ -30,7 +30,13 @@ class DualLookupTracker : LookupTracker {
     override val requiresPosition: Boolean
         get() = symbolTracker.requiresPosition || classTracker.requiresPosition
 
-    override fun record(filePath: String, position: Position, scopeFqName: String, scopeKind: ScopeKind, name: String) {
+    override fun record(
+        filePath: String,
+        position: Position,
+        scopeFqName: String,
+        scopeKind: ScopeKind,
+        name: String,
+    ) {
         symbolTracker.record(filePath, position, scopeFqName, scopeKind, name)
         if (scopeKind == ScopeKind.CLASSIFIER) {
             val (outerScope, className) = separateQualifierAndName(scopeFqName)
@@ -41,6 +47,7 @@ class DualLookupTracker : LookupTracker {
 
     override fun clear() {
         // Do not clear symbolTracker and classTracker.
-        // LookupTracker.clear() is called in repeatAnalysisIfNeeded, but we need records across all rounds.
+        // LookupTracker.clear() is called in repeatAnalysisIfNeeded, but we need records across all
+        // rounds.
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/FileCache.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/FileCache.kt
@@ -23,55 +23,52 @@ import org.jetbrains.kotlin.psi.KtFile
 /**
  * A cache for information extracted from a [KtFile].
  *
- * This class pre-calculates and stores frequently accessed information from a Kotlin PSI file,
- * such as its package name, imports, and local declarations, to avoid redundant PSI traversals.
+ * This class pre-calculates and stores frequently accessed information from a Kotlin PSI file, such
+ * as its package name, imports, and local declarations, to avoid redundant PSI traversals.
  *
  * @param file The [KtFile] from which information is extracted.
  */
 class FileCache(file: KtFile) {
 
-    /**
-     * The fully qualified package name of the file.
-     */
+    /** The fully qualified package name of the file. */
     val packageName = file.packageFqName
 
     /**
      * A map of explicit (non-star) imports in the file.
      *
-     * The keys are the names by which the imported symbols are referred to in the code
-     * (either an alias or the short name), and the values are their fully qualified names.
+     * The keys are the names by which the imported symbols are referred to in the code (either an
+     * alias or the short name), and the values are their fully qualified names.
      */
-    val explicitImports = file.importDirectives
-        .filter { !it.isAllUnder && it.importedFqName != null }
-        .associate { (it.aliasName ?: it.importedFqName!!.shortName().asString()) to it.importedFqName!! }
+    val explicitImports =
+        file.importDirectives
+            .filter { !it.isAllUnder && it.importedFqName != null }
+            .associate {
+                (it.aliasName ?: it.importedFqName!!.shortName().asString()) to it.importedFqName!!
+            }
 
-    /**
-     * A list of fully qualified names of the star imports in the file.
-     */
-    val starImports = file.importDirectives
-        .filter { it.isAllUnder }
-        .mapNotNull { it.importedFqName }
+    /** A list of fully qualified names of the star imports in the file. */
+    val starImports =
+        file.importDirectives.filter { it.isAllUnder }.mapNotNull { it.importedFqName }
 
-    /**
-     * A collection of names for all local declarations within the file.
-     */
+    /** A collection of names for all local declarations within the file. */
     val localDeclarations = file.collectClassifierNames()
 
     companion object {
         // TODO: Figure out if there is a better way to obtain default imports than hard coded list
         // TODO: Move this list somewhere appropriate
         @JvmStatic
-        val DEFAULT_IMPORTS = listOf(
-            "kotlin",
-            "kotlin.annotation",
-            "kotlin.collections",
-            "kotlin.comparisons",
-            "kotlin.io",
-            "kotlin.ranges",
-            "kotlin.sequences",
-            "kotlin.text",
-            "kotlin.jvm",
-            "java.lang"
-        )
+        val DEFAULT_IMPORTS =
+            listOf(
+                "kotlin",
+                "kotlin.annotation",
+                "kotlin.collections",
+                "kotlin.comparisons",
+                "kotlin.io",
+                "kotlin.ranges",
+                "kotlin.sequences",
+                "kotlin.text",
+                "kotlin.jvm",
+                "java.lang",
+            )
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/IncrementalContextAA.kt
@@ -40,6 +40,8 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.Origin
 import com.intellij.psi.PsiJavaFile
 import com.intellij.util.containers.MultiMap
+import java.io.File
+import java.io.Writer
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaJavaFieldSymbol
@@ -66,8 +68,6 @@ import org.jetbrains.kotlin.incremental.components.Position
 import org.jetbrains.kotlin.incremental.components.ScopeKind
 import org.jetbrains.kotlin.incremental.storage.FileToPathConverter
 import org.jetbrains.kotlin.incremental.update
-import java.io.File
-import java.io.Writer
 
 class IncrementalContextAA(
     override val isIncremental: Boolean,
@@ -80,16 +80,17 @@ class IncrementalContextAA(
     knownModified: List<File>,
     knownRemoved: List<File>,
     changedClasses: List<String>,
-) : IncrementalContextBase(
-    anyChangesWildcard,
-    loggingOptions,
-    baseDir,
-    cachesDir,
-    kspOutputDir,
-    knownModified,
-    knownRemoved,
-    changedClasses,
-) {
+) :
+    IncrementalContextBase(
+        anyChangesWildcard,
+        loggingOptions,
+        baseDir,
+        cachesDir,
+        kspOutputDir,
+        knownModified,
+        knownRemoved,
+        changedClasses,
+    ) {
     private val PATH_CONVERTER = RelativeFileToPathConverter(baseDir)
     private val icContext = IncrementalCompilationContext(PATH_CONVERTER, PATH_CONVERTER, true)
 
@@ -97,16 +98,14 @@ class IncrementalContextAA(
 
     private val symbolTrackerLogFile: Writer? =
         if (loggingOptions.incrementalLoggingEnabled) {
-            mkLogFile("symbolTrackerTrace.log").bufferedWriter()
-                .also { logFiles.add(it) }
+            mkLogFile("symbolTrackerTrace.log").bufferedWriter().also { logFiles.add(it) }
         } else {
             null
         }
 
     private val classTrackerLogFile: Writer? =
         if (loggingOptions.incrementalLoggingEnabled) {
-            mkLogFile("enumClassTrackerTrace.log").bufferedWriter()
-                .also { logFiles.add(it) }
+            mkLogFile("enumClassTrackerTrace.log").bufferedWriter().also { logFiles.add(it) }
         } else {
             null
         }
@@ -114,29 +113,32 @@ class IncrementalContextAA(
     override val symbolLookupTracker =
         LookupTrackerWrapperImpl(
             (lookupTracker as? DualLookupTracker)?.symbolTracker ?: LookupTracker.DO_NOTHING,
-            symbolTrackerLogFile
+            symbolTrackerLogFile,
         )
-    override val symbolLookupCache = LookupStorageWrapperImpl(LookupStorage(symbolLookupCacheDir, icContext))
+    override val symbolLookupCache =
+        LookupStorageWrapperImpl(LookupStorage(symbolLookupCacheDir, icContext))
 
     // TODO: rewrite LookupStorage to share file-to-id, etc.
     private val classLookupCacheDir = File(cachesDir, "classLookups")
     override val classLookupTracker =
         LookupTrackerWrapperImpl(
             (lookupTracker as? DualLookupTracker)?.classTracker ?: LookupTracker.DO_NOTHING,
-            classTrackerLogFile
+            classTrackerLogFile,
         )
-    override val classLookupCache = LookupStorageWrapperImpl(LookupStorage(classLookupCacheDir, icContext))
+    override val classLookupCache =
+        LookupStorageWrapperImpl(LookupStorage(classLookupCacheDir, icContext))
 
     // Debugging and testing only.
     fun dumpLookupRecords(): Map<String, List<String>> {
         val map = mutableMapOf<String, List<String>>()
         symbolLookupTracker.lookups.entrySet().forEach { e ->
             val key = "${e.key.scope}.${e.key.name}"
-            map[key] = e.value.map {
-                // Safely try to relativize, since it may fail on Windows
-                // where it and baseDir have different roots.
-                File(it).relativeToOrNull(baseDir)?.path ?: it
-            }
+            map[key] =
+                e.value.map {
+                    // Safely try to relativize, since it may fail on Windows
+                    // where it and baseDir have different roots.
+                    File(it).relativeToOrNull(baseDir)?.path ?: it
+                }
         }
         return map
     }
@@ -172,13 +174,14 @@ class IncrementalContextAA(
                 recordWithArgs(type.original, file)
             }
 
-            is KaErrorType, is KaDynamicType, is KaTypeParameterType -> {}
+            is KaErrorType,
+            is KaDynamicType,
+            is KaTypeParameterType -> {}
         }
     }
 
     fun recordLookup(type: KaType, context: KSNode?) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val file = (context?.containingFile as? KSFileJavaImpl)?.psi ?: return
 
@@ -187,7 +190,7 @@ class IncrementalContextAA(
 
     /**
      * Records a reference to `MyClass::class`.
-     * 
+     *
      * @param type the referenced type, e.g., `MyClass`
      * @param context the parent of [type], i.e., where the reference occurs.
      */
@@ -196,17 +199,16 @@ class IncrementalContextAA(
             return
         }
 
-        val fqn = type.symbol?.classId?.asFqNameString()
-            ?: type.getFqn()
-            ?: return
+        val fqn = type.symbol?.classId?.asFqNameString() ?: type.getFqn() ?: return
 
         recordClassReferenceLookup(fqn, context)
     }
 
     /**
      * Records a reference to `MyClass::class`.
-     * 
-     * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of `MyClass`.
+     *
+     * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of
+     *   `MyClass`.
      * @param context the parent of [fqn], i.e., where the reference occurs.
      */
     fun recordClassReferenceLookup(fqn: String, context: KSNode) {
@@ -222,7 +224,8 @@ class IncrementalContextAA(
     /**
      * Returns a string representing a file path for [context].
      *
-     * If the filepath is already available, it is returned. Otherwise, a synthetic filepath is generated.
+     * If the filepath is already available, it is returned. Otherwise, a synthetic filepath is
+     * generated.
      */
     private fun filePathFor(context: KSNode): String {
         // Try directly getting the filepath
@@ -232,27 +235,29 @@ class IncrementalContextAA(
         }
 
         // Construct synthetic filepath
-        val closestParentDeclaration = context.findFirstParentDeclaration() ?: throw InternalKSPException(
-            "Unexpected missing parent declaration for KSNode '$context'",
-            context.location,
-            context.javaClass
-        )
-
-        val parentDeclarationName = closestParentDeclaration.qualifiedName?.asString()
-            ?: (
-                closestParentDeclaration.packageName.asString()
-                    + "."
-                    + closestParentDeclaration.simpleName.asString()
+        val closestParentDeclaration =
+            context.findFirstParentDeclaration()
+                ?: throw InternalKSPException(
+                    "Unexpected missing parent declaration for KSNode '$context'",
+                    context.location,
+                    context.javaClass,
                 )
+
+        val parentDeclarationName =
+            closestParentDeclaration.qualifiedName?.asString()
+                ?: (closestParentDeclaration.packageName.asString() +
+                    "." +
+                    closestParentDeclaration.simpleName.asString())
 
         return NoSourceFile(baseDir, parentDeclarationName).filePath
     }
 
     /** Returns the nearest parent declaration if it exists */
-    private fun KSNode.findFirstParentDeclaration(): KSDeclaration? = when (this) {
-        is KSDeclaration -> this
-        else -> parent?.findFirstParentDeclaration()
-    }
+    private fun KSNode.findFirstParentDeclaration(): KSDeclaration? =
+        when (this) {
+            is KSDeclaration -> this
+            else -> parent?.findFirstParentDeclaration()
+        }
 
     @OptIn(KaExperimentalApi::class)
     private fun recordLookupForDeclaration(symbol: KaSymbol, file: PsiJavaFile) {
@@ -272,23 +277,22 @@ class IncrementalContextAA(
     }
 
     fun recordLookupForPropertyOrMethod(declaration: KSDeclaration) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val file = (declaration.containingFile as? KSFileJavaImpl)?.psi ?: return
 
-        val symbol = when (declaration) {
-            is KSPropertyDeclarationJavaImpl -> declaration.ktJavaFieldSymbol
-            is KSPropertyDeclarationImpl -> declaration.ktPropertySymbol
-            is KSFunctionDeclarationImpl -> declaration.ktFunctionSymbol
-            else -> return
-        }
+        val symbol =
+            when (declaration) {
+                is KSPropertyDeclarationJavaImpl -> declaration.ktJavaFieldSymbol
+                is KSPropertyDeclarationImpl -> declaration.ktPropertySymbol
+                is KSFunctionDeclarationImpl -> declaration.ktFunctionSymbol
+                else -> return
+            }
         recordLookupForDeclaration(symbol, file)
     }
 
     internal fun recordLookupForGetAll(supers: List<KaType>, predicate: (KaSymbol) -> Boolean) {
-        if (!isIncremental)
-            return
+        if (!isIncremental) return
 
         val visited: MutableSet<KaType> = mutableSetOf()
         analyze {
@@ -296,11 +300,11 @@ class IncrementalContextAA(
                 recordLookupWithSupertypes(it, visited) { type, file ->
                     if (type is KaClassType) {
                         (type.symbol as? KaDeclarationContainerSymbol)?.let {
-                            val declared = it.declaredMemberScope.declarations +
-                                it.staticDeclaredMemberScope.declarations
+                            val declared =
+                                it.declaredMemberScope.declarations +
+                                    it.staticDeclaredMemberScope.declarations
                             declared.forEach {
-                                if (predicate(it))
-                                    recordLookupForDeclaration(it, file)
+                                if (predicate(it)) recordLookupForDeclaration(it, file)
                             }
                         }
                     }
@@ -320,19 +324,23 @@ class IncrementalContextAA(
                 is KaIntersectionType -> conjuncts.flatMap { it.psiJavaFiles }
                 is KaCapturedType -> projection.type?.psiJavaFiles ?: emptyList()
                 is KaDefinitelyNotNullType -> original.psiJavaFiles
-                is KaErrorType, is KaDynamicType, is KaTypeParameterType -> emptyList()
+                is KaErrorType,
+                is KaDynamicType,
+                is KaTypeParameterType -> emptyList()
                 else -> TODO()
             }
         }
 
-    fun recordLookupWithSupertypes(ktType: KaType, visited: MutableSet<KaType>, extra: (KaType, PsiJavaFile) -> Unit) {
-        if (!isIncremental)
-            return
+    fun recordLookupWithSupertypes(
+        ktType: KaType,
+        visited: MutableSet<KaType>,
+        extra: (KaType, PsiJavaFile) -> Unit,
+    ) {
+        if (!isIncremental) return
 
         analyze {
             fun record(type: KaType) {
-                if (type in visited)
-                    return
+                if (type in visited) return
                 visited.add(type)
                 for (superType in type.directSupertypes(false)) {
                     for (file in type.psiJavaFiles) {
@@ -350,14 +358,16 @@ class IncrementalContextAA(
 
     override fun logBeforeCacheFlush(outputs: Set<File>, sourceToOutputs: Map<File, Set<File>>) {
         super.logBeforeCacheFlush(outputs, sourceToOutputs)
-        val lookupRecords = if (loggingOptions.incrementalLoggingEnabled) dumpLookupRecords() else emptyMap()
+        val lookupRecords =
+            if (loggingOptions.incrementalLoggingEnabled) dumpLookupRecords() else emptyMap()
         logLookupGraph(lookupRecords)
         logDependencyGraphFrom(loggingOptions.dependencyGraphOriginName, lookupRecords)
         logFiles.forEach { it.close() }
     }
 
     /**
-     * Computes the dependency graph from [origin] using a normal BFS and logs it as a Graphviz `.dot` file.
+     * Computes the dependency graph from [origin] using a normal BFS and logs it as a Graphviz
+     * `.dot` file.
      */
     private fun logDependencyGraphFrom(origin: String?, lookupRecords: Map<String, List<String>>) {
         if (!loggingOptions.incrementalLoggingEnabled) {
@@ -453,7 +463,7 @@ internal fun recordLookup(ktType: KaType, context: KSNode?) =
 
 /**
  * Records a reference to `MyClass::class`.
- * 
+ *
  * @param ktType the referenced type, e.g., `MyClass`
  * @param context the parent of [ktType], i.e., where the reference occurs.
  */
@@ -462,15 +472,23 @@ internal fun recordClassReferenceLookup(ktType: KaType, context: KSNode) =
 
 /**
  * Records a reference to `MyClass::class`.
- * 
- * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of `MyClass`.
+ *
+ * @param fqn the fully qualified name of the referenced type, e.g., the fully qualified name of
+ *   `MyClass`.
  * @param context the parent of [fqn], i.e., where the reference occurs.
  */
 internal fun recordClassReferenceLookup(fqn: String, context: KSNode) =
     ResolverAAImpl.instance.incrementalContext.recordClassReferenceLookup(fqn, context)
 
-internal fun recordLookupWithSupertypes(ktType: KaType, extra: (KaType, PsiJavaFile) -> Unit = { _, _ -> }) =
-    ResolverAAImpl.instance.incrementalContext.recordLookupWithSupertypes(ktType, mutableSetOf(), extra)
+internal fun recordLookupWithSupertypes(
+    ktType: KaType,
+    extra: (KaType, PsiJavaFile) -> Unit = { _, _ -> },
+) =
+    ResolverAAImpl.instance.incrementalContext.recordLookupWithSupertypes(
+        ktType,
+        mutableSetOf(),
+        extra,
+    )
 
 internal fun recordLookupForPropertyOrMethod(declaration: KSDeclaration) =
     ResolverAAImpl.instance.incrementalContext.recordLookupForPropertyOrMethod(declaration)
@@ -491,13 +509,15 @@ internal fun recordGetSealedSubclasses(classDeclaration: KSClassDeclaration) {
     }
 }
 
-class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker, val trackerLogFile: Writer?) : LookupTrackerWrapper {
+class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker, val trackerLogFile: Writer?) :
+    LookupTrackerWrapper {
     override val lookups: MultiMap<LookupSymbolWrapper, String>
-        get() = MultiMap<LookupSymbolWrapper, String>().also { wrapper ->
-            (lookupTracker as LookupTrackerImpl).lookups.entrySet().forEach { e ->
-                wrapper.putValues(LookupSymbolWrapper(e.key.name, e.key.scope), e.value)
+        get() =
+            MultiMap<LookupSymbolWrapper, String>().also { wrapper ->
+                (lookupTracker as LookupTrackerImpl).lookups.entrySet().forEach { e ->
+                    wrapper.putValues(LookupSymbolWrapper(e.key.name, e.key.scope), e.value)
+                }
             }
-        }
 
     override fun record(filePath: String, scopeFqName: String, name: String) {
         trackerLogFile?.write("$scopeFqName.$name $filePath\n")
@@ -505,18 +525,20 @@ class LookupTrackerWrapperImpl(val lookupTracker: LookupTracker, val trackerLogF
     }
 }
 
-class LookupStorageWrapperImpl(
-    val impl: LookupStorage
-) : LookupStorageWrapper {
+class LookupStorageWrapperImpl(val impl: LookupStorage) : LookupStorageWrapper {
     override fun get(lookupSymbol: LookupSymbolWrapper): Collection<String> =
         impl.get(LookupSymbol(lookupSymbol.name, lookupSymbol.scope))
 
     override fun update(
         lookupTracker: LookupTrackerWrapper,
         filesToCompile: Iterable<File>,
-        removedFiles: Iterable<File>
+        removedFiles: Iterable<File>,
     ) {
-        impl.update((lookupTracker as LookupTrackerWrapperImpl).lookupTracker, filesToCompile, removedFiles)
+        impl.update(
+            (lookupTracker as LookupTrackerWrapperImpl).lookupTracker,
+            filesToCompile,
+            removedFiles,
+        )
     }
 
     override fun removeLookupsFrom(files: Sequence<File>) = impl.removeLookupsFrom(files)
@@ -528,5 +550,6 @@ class LookupStorageWrapperImpl(
 
 internal class RelativeFileToPathConverter(val baseDir: File) : FileToPathConverter {
     override fun toPath(file: File): String = file.path
+
     override fun toFile(path: String): File = File(path).relativeTo(baseDir)
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPCoreEnvironment.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPCoreEnvironment.kt
@@ -34,8 +34,10 @@ class KSPCoreEnvironment(internal val project: MockProject) {
             instance_prop.remove()
         }
     }
+
     init {
         instance = this
     }
+
     val psiDocumentManager = PsiDocumentManager.getInstance(project)
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPLoader.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KSPLoader.kt
@@ -28,12 +28,14 @@ class KSPLoader {
         fun loadAndRunKSP(
             kspConfigStream: ByteArray,
             processorProvider: List<SymbolProcessorProvider>,
-            logLevel: Int
+            logLevel: Int,
         ): Int {
-            val kspConfig = ObjectInputStream(ByteArrayInputStream(kspConfigStream)).use { objectInputStream ->
-                objectInputStream.readObject() as KSPConfig
-            }
-            val ksp = KotlinSymbolProcessing(kspConfig, processorProvider, KspGradleLogger(logLevel))
+            val kspConfig =
+                ObjectInputStream(ByteArrayInputStream(kspConfigStream)).use { objectInputStream ->
+                    objectInputStream.readObject() as KSPConfig
+                }
+            val ksp =
+                KotlinSymbolProcessing(kspConfig, processorProvider, KspGradleLogger(logLevel))
             return ksp.execute().ordinal
         }
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -61,6 +61,8 @@ import com.intellij.psi.PsiTreeChangeAdapter
 import com.intellij.psi.PsiTreeChangeListener
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.util.ui.EDT
+import java.io.File
+import java.nio.file.Path
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaIdeApi
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
@@ -120,29 +122,27 @@ import org.jetbrains.kotlin.platform.konan.NativePlatform
 import org.jetbrains.kotlin.platform.konan.NativePlatforms
 import org.jetbrains.kotlin.platform.wasm.WasmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
-import java.io.File
-import java.nio.file.Path
 
 @OptIn(KaPlatformInterface::class)
 @Suppress("UnstableApiUsage")
 class KotlinSymbolProcessing(
     val kspConfig: KSPConfig,
     val symbolProcessorProviders: List<SymbolProcessorProvider>,
-    val logger: KSPLogger
+    val logger: KSPLogger,
 ) {
-    enum class ExitCode(
-        val code: Int
-    ) {
+    enum class ExitCode(val code: Int) {
         OK(0),
 
         // Whenever there are some error messages.
         PROCESSING_ERROR(1),
 
-        // Let exceptions pop through to the caller. Don't catch and convert them to, e.g., INTERNAL_ERROR.
+        // Let exceptions pop through to the caller. Don't catch and convert them to, e.g.,
+        // INTERNAL_ERROR.
     }
 
     init {
-        // We depend on swing (indirectly through PSI or something), so we want to declare headless mode,
+        // We depend on swing (indirectly through PSI or something), so we want to declare headless
+        // mode,
         // to avoid accidentally starting the UI thread. But, don't set it if it was set externally.
         if (System.getProperty("java.awt.headless") == null) {
             System.setProperty("java.awt.headless", "true")
@@ -152,12 +152,12 @@ class KotlinSymbolProcessing(
 
     @OptIn(KaExperimentalApi::class, KaImplementationDetail::class, KaIdeApi::class)
     private fun createAASession(
-        projectDisposable: Disposable,
+        projectDisposable: Disposable
     ): Triple<StandaloneAnalysisAPISession, KotlinCoreProjectEnvironment, List<KaModule>> {
         val kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment =
             StandaloneProjectFactory.createProjectEnvironment(
                 projectDisposable,
-                KotlinCoreApplicationEnvironmentMode.Production
+                KotlinCoreApplicationEnvironmentMode.Production,
             )
 
         val project: MockProject = kotlinCoreProjectEnvironment.project
@@ -166,87 +166,116 @@ class KotlinSymbolProcessing(
         CoreApplicationEnvironment.registerExtensionPoint(
             project.extensionArea,
             KaResolveExtensionProvider.EP_NAME.name,
-            KaResolveExtensionProvider::class.java
+            KaResolveExtensionProvider::class.java,
         )
 
         // replaces buildKtModuleProviderByCompilerConfiguration(compilerConfiguration)
-        val projectStructureProvider = KtModuleProviderBuilder(
-            kotlinCoreProjectEnvironment.environment, project
-        ).apply {
-            val platform = when (kspConfig) {
-                is KSPJvmConfig -> {
-                    val jvmTarget = JvmTarget.fromString(kspConfig.jvmTarget) ?: JvmTarget.DEFAULT
-                    JvmPlatforms.jvmPlatformByTargetVersion(jvmTarget)
-                }
-
-                is KSPJsConfig -> when (kspConfig.backend) {
-                    "WASM" -> WasmPlatforms.wasmJs
-                    "JS" -> JsPlatforms.defaultJsPlatform
-                    else -> throw IllegalArgumentException("Unknown JS backend: ${kspConfig.backend}")
-                }
-
-                is KSPNativeConfig -> NativePlatforms.nativePlatformByTargetNames(listOf(kspConfig.targetName))
-                is KSPCommonConfig -> CommonPlatforms.defaultCommonPlatform
-                else -> throw IllegalArgumentException("Unknown platform for config: $kspConfig")
-            }
-
-            fun KtModuleBuilder.addModuleDependencies(moduleName: String) {
-                addRegularDependency(
-                    buildKspLibraryModule {
-                        this.platform = platform
-                        addBinaryRoots(kspConfig.libraries.map { it.toPath() })
-                        libraryName = "Libraries for $moduleName"
-                    }
+        val projectStructureProvider =
+            KtModuleProviderBuilder(
+                    kotlinCoreProjectEnvironment.environment,
+                    project,
                 )
+                .apply {
+                    val platform =
+                        when (kspConfig) {
+                            is KSPJvmConfig -> {
+                                val jvmTarget =
+                                    JvmTarget.fromString(kspConfig.jvmTarget) ?: JvmTarget.DEFAULT
+                                JvmPlatforms.jvmPlatformByTargetVersion(jvmTarget)
+                            }
 
-                addFriendDependency(
-                    buildKspLibraryModule {
-                        this.platform = platform
-                        addBinaryRoots(kspConfig.friends.map { it.toPath() })
-                        libraryName = "Friends of $moduleName"
-                    }
-                )
+                            is KSPJsConfig ->
+                                when (kspConfig.backend) {
+                                    "WASM" -> WasmPlatforms.wasmJs
+                                    "JS" -> JsPlatforms.defaultJsPlatform
+                                    else ->
+                                        throw IllegalArgumentException(
+                                            "Unknown JS backend: ${kspConfig.backend}"
+                                        )
+                                }
 
-                if (kspConfig is KSPJvmConfig && kspConfig.jdkHome != null) {
-                    addRegularDependency(
-                        buildKspSdkModule {
-                            this.platform = platform
-                            addBinaryRootsFromJdkHome(kspConfig.jdkHome!!.toPath(), isJre = false)
-                            libraryName = "JDK for $moduleName"
+                            is KSPNativeConfig ->
+                                NativePlatforms.nativePlatformByTargetNames(
+                                    listOf(kspConfig.targetName)
+                                )
+                            is KSPCommonConfig -> CommonPlatforms.defaultCommonPlatform
+                            else ->
+                                throw IllegalArgumentException(
+                                    "Unknown platform for config: $kspConfig"
+                                )
                         }
-                    )
+
+                    fun KtModuleBuilder.addModuleDependencies(moduleName: String) {
+                        addRegularDependency(
+                            buildKspLibraryModule {
+                                this.platform = platform
+                                addBinaryRoots(kspConfig.libraries.map { it.toPath() })
+                                libraryName = "Libraries for $moduleName"
+                            }
+                        )
+
+                        addFriendDependency(
+                            buildKspLibraryModule {
+                                this.platform = platform
+                                addBinaryRoots(kspConfig.friends.map { it.toPath() })
+                                libraryName = "Friends of $moduleName"
+                            }
+                        )
+
+                        if (kspConfig is KSPJvmConfig && kspConfig.jdkHome != null) {
+                            addRegularDependency(
+                                buildKspSdkModule {
+                                    this.platform = platform
+                                    addBinaryRootsFromJdkHome(
+                                        kspConfig.jdkHome!!.toPath(),
+                                        isJre = false,
+                                    )
+                                    libraryName = "JDK for $moduleName"
+                                }
+                            )
+                        }
+                    }
+
+                    buildKspSourceModule {
+                            val languageVersion =
+                                LanguageVersion.fromFullVersionString(kspConfig.languageVersion)!!
+                            val apiVersion =
+                                LanguageVersion.fromFullVersionString(kspConfig.apiVersion)!!
+                            languageVersionSettings =
+                                LanguageVersionSettingsImpl(
+                                    languageVersion,
+                                    ApiVersion.createByLanguageVersion(apiVersion),
+                                    specificFeatures =
+                                        mapOf(
+                                            LanguageFeature
+                                                .AnnotationDefaultTargetMigrationWarning to
+                                                LanguageFeature.State.ENABLED,
+                                            LanguageFeature
+                                                .PropertyParamAnnotationDefaultTargetMode to
+                                                LanguageFeature.State.ENABLED,
+                                        ),
+                                )
+
+                            this.platform = platform
+                            this.moduleName = kspConfig.moduleName
+
+                            addModuleDependencies(moduleName)
+
+                            // Single file java source roots are added in reinitJavaFileManager()
+                            // later.
+                            val roots = mutableListOf<File>()
+                            roots.addAll(kspConfig.sourceRoots)
+                            roots.addAll(kspConfig.commonSourceRoots)
+                            if (kspConfig is KSPJvmConfig) {
+                                roots.addAll(kspConfig.javaSourceRoots)
+                            }
+                            addSourceRoots(roots.map { it.toPath() })
+                        }
+                        .apply(::addModule)
+
+                    this.platform = platform
                 }
-            }
-
-            buildKspSourceModule {
-                val languageVersion = LanguageVersion.fromFullVersionString(kspConfig.languageVersion)!!
-                val apiVersion = LanguageVersion.fromFullVersionString(kspConfig.apiVersion)!!
-                languageVersionSettings = LanguageVersionSettingsImpl(
-                    languageVersion,
-                    ApiVersion.createByLanguageVersion(apiVersion),
-                    specificFeatures = mapOf(
-                        LanguageFeature.AnnotationDefaultTargetMigrationWarning to LanguageFeature.State.ENABLED,
-                        LanguageFeature.PropertyParamAnnotationDefaultTargetMode to LanguageFeature.State.ENABLED
-                    )
-                )
-
-                this.platform = platform
-                this.moduleName = kspConfig.moduleName
-
-                addModuleDependencies(moduleName)
-
-                // Single file java source roots are added in reinitJavaFileManager() later.
-                val roots = mutableListOf<File>()
-                roots.addAll(kspConfig.sourceRoots)
-                roots.addAll(kspConfig.commonSourceRoots)
-                if (kspConfig is KSPJvmConfig) {
-                    roots.addAll(kspConfig.javaSourceRoots)
-                }
-                addSourceRoots(roots.map { it.toPath() })
-            }.apply(::addModule)
-
-            this.platform = platform
-        }.build()
+                .build()
 
         // register services and build session
         val ktModuleProviderImpl = projectStructureProvider
@@ -257,23 +286,27 @@ class KotlinSymbolProcessing(
             projectStructureProvider,
         )
         val ktFiles = allSourceFiles.filterIsInstance<KtFile>()
-        val libraryRoots = StandaloneProjectFactory.getAllBinaryRoots(modules, kotlinCoreProjectEnvironment.environment)
-        val createPackagePartProvider =
-            StandaloneProjectFactory.createPackagePartsProvider(
-                libraryRoots,
+        val libraryRoots =
+            StandaloneProjectFactory.getAllBinaryRoots(
+                modules,
+                kotlinCoreProjectEnvironment.environment,
             )
+        val createPackagePartProvider =
+            StandaloneProjectFactory.createPackagePartsProvider(libraryRoots)
 
         kotlinCoreProjectEnvironment.registerApplicationServices(
             org.jetbrains.kotlin.analysis.api.permissions.KaAnalysisPermissionRegistry::class.java,
-            org.jetbrains.kotlin.analysis.api.impl.base.permissions.KaBaseAnalysisPermissionRegistry::class.java
+            org.jetbrains.kotlin.analysis.api.impl.base.permissions
+                    .KaBaseAnalysisPermissionRegistry::class
+                .java,
         )
         kotlinCoreProjectEnvironment.registerApplicationServices(
             KotlinAnalysisPermissionOptions::class.java,
-            KotlinStandaloneAnalysisPermissionOptions::class.java
+            KotlinStandaloneAnalysisPermissionOptions::class.java,
         )
         kotlinCoreProjectEnvironment.registerApplicationServices(
             KaResolutionActivityTracker::class.java,
-            LLFirResolutionActivityTracker::class.java
+            LLFirResolutionActivityTracker::class.java,
         )
 
         registerProjectServices(
@@ -283,23 +316,27 @@ class KotlinSymbolProcessing(
         )
 
         CoreApplicationEnvironment.registerExtensionPoint(
-            project.extensionArea, PsiTreeChangeListener.EP.name, PsiTreeChangeAdapter::class.java
+            project.extensionArea,
+            PsiTreeChangeListener.EP.name,
+            PsiTreeChangeAdapter::class.java,
         )
         return Triple(
             StandaloneAnalysisAPISession(kotlinCoreProjectEnvironment) {
-                // This is only used by kapt4, which should query a provider, instead of have it passed here IMHO.
-                // kapt4's implementation is static, which may or may not work for us depending on future use cases.
+                // This is only used by kapt4, which should query a provider, instead of have it
+                // passed here IMHO.
+                // kapt4's implementation is static, which may or may not work for us depending on
+                // future use cases.
                 // Let's implement it later if necessary.
                 TODO("Not implemented yet.")
             },
             kotlinCoreProjectEnvironment,
-            modules
+            modules,
         )
     }
 
     private fun <T> KotlinCoreProjectEnvironment.registerApplicationServices(
         serviceInterface: Class<T>,
-        serviceImplementation: Class<out T>
+        serviceImplementation: Class<out T>,
     ) {
         val application = environment.application
         if (application.getServiceIfCreated(serviceInterface) == null) {
@@ -321,42 +358,48 @@ class KotlinSymbolProcessing(
         project.apply {
             registerService(
                 KotlinMessageBusProvider::class.java,
-                KotlinProjectMessageBusProvider::class.java
+                KotlinProjectMessageBusProvider::class.java,
             )
             FirStandaloneServiceRegistrar.registerProjectServices(project)
             FirStandaloneServiceRegistrar.registerProjectExtensionPoints(project)
             FirStandaloneServiceRegistrar.registerProjectModelServices(
                 project,
-                kotlinCoreProjectEnvironment.parentDisposable
+                kotlinCoreProjectEnvironment.parentDisposable,
             )
 
             registerService(
                 KotlinModificationTrackerFactory::class.java,
-                KotlinStandaloneModificationTrackerFactory::class.java
+                KotlinStandaloneModificationTrackerFactory::class.java,
             )
             registerService(
                 KotlinLifetimeTokenFactory::class.java,
-                KotlinAlwaysAccessibleLifetimeTokenFactory::class.java
+                KotlinAlwaysAccessibleLifetimeTokenFactory::class.java,
             )
 
             // Despite being a static implementation, this is only used by IDE tests
             registerService(
                 KotlinAnnotationsResolverFactory::class.java,
-                KotlinStandaloneAnnotationsResolverFactory(project, ktFiles)
+                KotlinStandaloneAnnotationsResolverFactory(project, ktFiles),
             )
             registerService(
                 KotlinDeclarationProviderFactory::class.java,
-                IncrementalKotlinDeclarationProviderFactory(this, kotlinCoreProjectEnvironment.environment)
+                IncrementalKotlinDeclarationProviderFactory(
+                    this,
+                    kotlinCoreProjectEnvironment.environment,
+                ),
             )
             registerService(
                 KotlinDirectInheritorsProvider::class.java,
-                KspStandaloneDirectInheritorsProvider::class.java
+                KspStandaloneDirectInheritorsProvider::class.java,
             )
             registerService(
                 KotlinDeclarationProviderMerger::class.java,
-                KotlinStandaloneDeclarationProviderMerger(this)
+                KotlinStandaloneDeclarationProviderMerger(this),
             )
-            registerService(KotlinPackageProviderFactory::class.java, IncrementalKotlinPackageProviderFactory(project))
+            registerService(
+                KotlinPackageProviderFactory::class.java,
+                IncrementalKotlinPackageProviderFactory(project),
+            )
 
             registerService(
                 SealedClassInheritorsProvider::class.java,
@@ -365,12 +408,12 @@ class KotlinSymbolProcessing(
 
             registerService(
                 KotlinPackagePartProviderFactory::class.java,
-                KotlinStaticPackagePartProviderFactory(packagePartProvider)
+                KotlinStaticPackagePartProviderFactory(packagePartProvider),
             )
 
             registerService(
                 KotlinPlatformSettings::class.java,
-                KotlinStandalonePlatformSettings()
+                KotlinStandalonePlatformSettings(),
             )
             // replace KaFirStopWorldCacheCleaner with no op implementation
             @OptIn(KaImplementationDetail::class)
@@ -397,16 +440,12 @@ class KotlinSymbolProcessing(
         }
 
         // Update Kotlin providers for newly generated source files.
-        (
-            project.getService(
-                KotlinDeclarationProviderFactory::class.java
-            ) as IncrementalKotlinDeclarationProviderFactory
-            ).update(ktFiles)
-        (
-            project.getService(
-                KotlinPackageProviderFactory::class.java
-            ) as IncrementalKotlinPackageProviderFactory
-            ).update(ktFiles)
+        (project.getService(KotlinDeclarationProviderFactory::class.java)
+                as IncrementalKotlinDeclarationProviderFactory)
+            .update(ktFiles)
+        (project.getService(KotlinPackageProviderFactory::class.java)
+                as IncrementalKotlinPackageProviderFactory)
+            .update(ktFiles)
 
         javaFileManager?.initialize(modules, javaFiles)
 
@@ -421,16 +460,20 @@ class KotlinSymbolProcessing(
         newJavaFiles: List<File>,
     ): List<KSFile> {
         val project = kotlinCoreProjectEnvironment.project
-        val ktFiles = getPsiFilesFromPaths<KtFile>(
-            project,
-            newKotlinFiles.map { it.toPath() }.toSet()
-        ).toSet()
-        val javaFiles = if (javaFileManager != null) {
-            getPsiFilesFromPaths<PsiJavaFile>(
-                project,
-                newJavaFiles.map { it.toPath() }.toSet()
-            ).toSet()
-        } else emptySet()
+        val ktFiles =
+            getPsiFilesFromPaths<KtFile>(
+                    project,
+                    newKotlinFiles.map { it.toPath() }.toSet(),
+                )
+                .toSet()
+        val javaFiles =
+            if (javaFileManager != null) {
+                getPsiFilesFromPaths<PsiJavaFile>(
+                        project,
+                        newJavaFiles.map { it.toPath() }.toSet(),
+                    )
+                    .toSet()
+            } else emptySet()
 
         // Add new files to content scope.
         val contentScope = ResolverAAImpl.ktModule.contentScope as IncrementalGlobalSearchScope
@@ -438,16 +481,12 @@ class KotlinSymbolProcessing(
         contentScope.addAll(javaFiles.map { it.virtualFile })
 
         // Update Kotlin providers for newly generated source files.
-        (
-            project.getService(
-                KotlinDeclarationProviderFactory::class.java
-            ) as IncrementalKotlinDeclarationProviderFactory
-            ).update(ktFiles)
-        (
-            project.getService(
-                KotlinPackageProviderFactory::class.java
-            ) as IncrementalKotlinPackageProviderFactory
-            ).update(ktFiles)
+        (project.getService(KotlinDeclarationProviderFactory::class.java)
+                as IncrementalKotlinDeclarationProviderFactory)
+            .update(ktFiles)
+        (project.getService(KotlinPackageProviderFactory::class.java)
+                as IncrementalKotlinPackageProviderFactory)
+            .update(ktFiles)
 
         // Update Java providers for newly generated source files.
         javaFileManager?.add(javaFiles)
@@ -459,26 +498,26 @@ class KotlinSymbolProcessing(
     // TODO: performance
     @OptIn(KaImplementationDetail::class)
     fun execute(): ExitCode {
-        val logger = object : KSPLogger by logger {
-            var hasError: Boolean = false
+        val logger =
+            object : KSPLogger by logger {
+                var hasError: Boolean = false
 
-            override fun error(message: String, symbol: KSNode?) {
-                hasError = true
-                logger.error(message, symbol)
-            }
-
-            override fun warn(message: String, symbol: KSNode?) {
-                if (kspConfig.allWarningsAsErrors)
+                override fun error(message: String, symbol: KSNode?) {
                     hasError = true
-                logger.warn(message, symbol)
-            }
-        }
+                    logger.error(message, symbol)
+                }
 
-        val projectDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.project")
+                override fun warn(message: String, symbol: KSNode?) {
+                    if (kspConfig.allWarningsAsErrors) hasError = true
+                    logger.warn(message, symbol)
+                }
+            }
+
+        val projectDisposable: Disposable =
+            Disposer.newDisposable("StandaloneAnalysisAPISession.project")
         var kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment? = null
         try {
-            val (analysisAPISession, env, modules) =
-                createAASession(projectDisposable)
+            val (analysisAPISession, env, modules) = createAASession(projectDisposable)
             kotlinCoreProjectEnvironment = env
             val project = analysisAPISession.project
             // Initializes it
@@ -491,56 +530,64 @@ class KotlinSymbolProcessing(
             ResolverAAImpl.kspConfig = kspConfig
 
             // Initializing environments
-            val javaFileManager = if (kspConfig is KSPJvmConfig) {
-                IncrementalJavaFileManager(env)
-            } else null
+            val javaFileManager =
+                if (kspConfig is KSPJvmConfig) {
+                    IncrementalJavaFileManager(env)
+                } else null
 
-            val allKSFiles =
-                prepareAllKSFiles(env, modules, javaFileManager)
+            val allKSFiles = prepareAllKSFiles(env, modules, javaFileManager)
             val anyChangesWildcard = AnyChanges(kspConfig.projectBaseDir)
-            val codeGenerator = CodeGeneratorImpl(
-                kspConfig.classOutputDir,
-                { if (kspConfig is KSPJvmConfig) kspConfig.javaOutputDir else kspConfig.kotlinOutputDir },
-                kspConfig.kotlinOutputDir,
-                kspConfig.resourceOutputDir,
-                kspConfig.projectBaseDir,
-                anyChangesWildcard,
-                allKSFiles,
-                kspConfig.incremental
-            )
+            val codeGenerator =
+                CodeGeneratorImpl(
+                    kspConfig.classOutputDir,
+                    {
+                        if (kspConfig is KSPJvmConfig) kspConfig.javaOutputDir
+                        else kspConfig.kotlinOutputDir
+                    },
+                    kspConfig.kotlinOutputDir,
+                    kspConfig.resourceOutputDir,
+                    kspConfig.projectBaseDir,
+                    anyChangesWildcard,
+                    allKSFiles,
+                    kspConfig.incremental,
+                )
 
             val dualLookupTracker = DualLookupTracker()
-            val incrementalContext = IncrementalContextAA(
-                kspConfig.incremental,
-                dualLookupTracker,
-                File(anyChangesWildcard.filePath).relativeTo(kspConfig.projectBaseDir),
-                kspConfig.incrementalContextLoggingOptions,
-                kspConfig.projectBaseDir,
-                kspConfig.cachesDir,
-                kspConfig.outputBaseDir,
-                kspConfig.modifiedSources,
-                kspConfig.removedSources,
-                kspConfig.changedClasses,
-            )
+            val incrementalContext =
+                IncrementalContextAA(
+                    kspConfig.incremental,
+                    dualLookupTracker,
+                    File(anyChangesWildcard.filePath).relativeTo(kspConfig.projectBaseDir),
+                    kspConfig.incrementalContextLoggingOptions,
+                    kspConfig.projectBaseDir,
+                    kspConfig.cachesDir,
+                    kspConfig.outputBaseDir,
+                    kspConfig.modifiedSources,
+                    kspConfig.removedSources,
+                    kspConfig.changedClasses,
+                )
             var allDirtyKSFiles = incrementalContext.calcDirtyFiles(allKSFiles).toList()
             var newKSFiles = allDirtyKSFiles
 
             val targetPlatform = ResolverAAImpl.ktModule.targetPlatform
-            val symbolProcessorEnvironment = SymbolProcessorEnvironment(
-                kspConfig.processorOptions,
-                kspConfig.languageVersion.toKotlinVersion(),
-                codeGenerator,
-                logger,
-                kspConfig.apiVersion.toKotlinVersion(),
-                KotlinCompilerVersion.getVersion().toKotlinVersion(),
-                targetPlatform.getPlatformInfo(kspConfig),
-                KotlinVersion(2, 0)
-            )
+            val symbolProcessorEnvironment =
+                SymbolProcessorEnvironment(
+                    kspConfig.processorOptions,
+                    kspConfig.languageVersion.toKotlinVersion(),
+                    codeGenerator,
+                    logger,
+                    kspConfig.apiVersion.toKotlinVersion(),
+                    KotlinCompilerVersion.getVersion().toKotlinVersion(),
+                    targetPlatform.getPlatformInfo(kspConfig),
+                    KotlinVersion(2, 0),
+                )
 
             // Load and instantiate processsors
             val deferredSymbols = mutableMapOf<SymbolProcessor, List<Restorable>>()
             val processors = providers.map { provider ->
-                provider.create(symbolProcessorEnvironment).also { deferredSymbols[it] = mutableListOf() }
+                provider.create(symbolProcessorEnvironment).also {
+                    deferredSymbols[it] = mutableListOf()
+                }
             }
 
             fun dropCaches() {
@@ -558,27 +605,29 @@ class KotlinSymbolProcessing(
             // 1) there is an error
             // 2) there is no more new files.
             while (!logger.hasError) {
-                // FirSession in AA is created lazily. Getting it instantiates module providers, which requires source roots
-                // to be resolved. Therefore, due to the implementation, it has to be registered repeatedly after the files
+                // FirSession in AA is created lazily. Getting it instantiates module providers,
+                // which requires source roots
+                // to be resolved. Therefore, due to the implementation, it has to be registered
+                // repeatedly after the files
                 // are created.
                 val firSession = ResolverAAImpl.ktModule.getResolutionFacade(project)
                 firSession.useSiteFirSession.registerResolveComponents(
                     KtRegisteredDiagnosticFactoriesStorage(),
-                    dualLookupTracker
+                    dualLookupTracker,
                 )
 
                 val resolutionStrategy =
                     if (kspConfig.experimentalPsiResolution)
                         PsiResolutionStrategy(newKSFiles, deferredSymbols)
-                    else
-                        AAResolutionStrategy(newKSFiles, deferredSymbols)
+                    else AAResolutionStrategy(newKSFiles, deferredSymbols)
 
-                val resolver = ResolverAAImpl(
-                    allDirtyKSFiles,
-                    project,
-                    incrementalContext,
-                    resolutionStrategy
-                )
+                val resolver =
+                    ResolverAAImpl(
+                        allDirtyKSFiles,
+                        project,
+                        incrementalContext,
+                        resolutionStrategy,
+                    )
                 ResolverAAImpl.instance = resolver
                 ResolverAAImpl.instance.functionAsMemberOfCache = mutableMapOf()
                 ResolverAAImpl.instance.propertyAsMemberOfCache = mutableMapOf()
@@ -586,17 +635,22 @@ class KotlinSymbolProcessing(
                 processors.forEach { processor ->
                     incrementalContext.closeFilesOnException {
                         deferredSymbols[processor] =
-                            processor.process(resolver)
+                            processor
+                                .process(resolver)
                                 .filter { it.origin == Origin.KOTLIN || it.origin == Origin.JAVA }
                                 .filterIsInstance<Deferrable>()
                                 .mapNotNull(Deferrable::defer)
                     }
-                    if (!deferredSymbols.containsKey(processor) || deferredSymbols[processor]!!.isEmpty()) {
+                    if (
+                        !deferredSymbols.containsKey(processor) ||
+                            deferredSymbols[processor]!!.isEmpty()
+                    ) {
                         deferredSymbols.remove(processor)
                     }
                 }
 
-                val allKSFilesPointers = allDirtyKSFiles.filterIsInstance<Deferrable>().map { it.defer() }
+                val allKSFilesPointers =
+                    allDirtyKSFiles.filterIsInstance<Deferrable>().map { it.defer() }
 
                 if (logger.hasError || codeGenerator.generatedFile.isEmpty()) {
                     break
@@ -604,14 +658,17 @@ class KotlinSymbolProcessing(
 
                 dropCaches()
 
-                newKSFiles = prepareNewKSFiles(
-                    env,
-                    javaFileManager,
-                    codeGenerator.generatedFile.filter { it.extension.lowercase() == "kt" },
-                    codeGenerator.generatedFile.filter { it.extension.lowercase() == "java" },
-                )
-                // Now that caches are dropped, KtSymbols and KS* are invalid. They need to be restored from deferred.
-                // Do not replace `!!` with `?.`. Implementations of KSFile in KSP2 must implement Deferrable and
+                newKSFiles =
+                    prepareNewKSFiles(
+                        env,
+                        javaFileManager,
+                        codeGenerator.generatedFile.filter { it.extension.lowercase() == "kt" },
+                        codeGenerator.generatedFile.filter { it.extension.lowercase() == "java" },
+                    )
+                // Now that caches are dropped, KtSymbols and KS* are invalid. They need to be
+                // restored from deferred.
+                // Do not replace `!!` with `?.`. Implementations of KSFile in KSP2 must implement
+                // Deferrable and
                 // return non-null.
                 allDirtyKSFiles = allKSFilesPointers.map { it!!.restore() as KSFile } + newKSFiles
                 incrementalContext.registerGeneratedFiles(newKSFiles)
@@ -629,7 +686,7 @@ class KotlinSymbolProcessing(
                 incrementalContext.updateCachesAndOutputs(
                     allDirtyKSFiles,
                     codeGenerator.outputs,
-                    codeGenerator.sourceToOutputs
+                    codeGenerator.sourceToOutputs,
                 )
             } else {
                 incrementalContext.closeFiles()
@@ -639,7 +696,8 @@ class KotlinSymbolProcessing(
             codeGenerator.closeFiles()
         } finally {
             maybeRunInWriteAction {
-                (kotlinCoreProjectEnvironment?.environment?.jarFileSystem as? CoreJarFileSystem)?.clearHandlersCache()
+                (kotlinCoreProjectEnvironment?.environment?.jarFileSystem as? CoreJarFileSystem)
+                    ?.clearHandlersCache()
                 Disposer.dispose(projectDisposable)
                 ResolverAAImpl.tearDown()
                 KSPCoreEnvironment.tearDown()
@@ -660,46 +718,47 @@ private inline fun <reified T : PsiFileSystemItem> getPsiFilesFromPaths(
         for (path in paths) {
             val vFile = fs.findFileByPath(path.toString()) ?: continue
             val psiFileSystemItem =
-                if (vFile.isDirectory)
-                    psiManager.findDirectory(vFile) as? T
-                else
-                    psiManager.findFile(vFile) as? T
+                if (vFile.isDirectory) psiManager.findDirectory(vFile) as? T
+                else psiManager.findFile(vFile) as? T
             psiFileSystemItem?.let { add(it) }
         }
     }
 }
 
 fun String?.toKotlinVersion(): KotlinVersion {
-    if (this == null)
-        return KotlinVersion.CURRENT
+    if (this == null) return KotlinVersion.CURRENT
 
-    return split('-').first().split('.').map { it.toInt() }.let {
-        when (it.size) {
-            1 -> KotlinVersion(it[0], 0, 0)
-            2 -> KotlinVersion(it[0], it[1], 0)
-            3 -> KotlinVersion(it[0], it[1], it[2])
-            else -> KotlinVersion.CURRENT
+    return split('-')
+        .first()
+        .split('.')
+        .map { it.toInt() }
+        .let {
+            when (it.size) {
+                1 -> KotlinVersion(it[0], 0, 0)
+                2 -> KotlinVersion(it[0], it[1], 0)
+                3 -> KotlinVersion(it[0], it[1], it[2])
+                else -> KotlinVersion.CURRENT
+            }
         }
-    }
 }
 
 fun TargetPlatform.getPlatformInfo(kspConfig: KSPConfig): List<PlatformInfo> =
     componentPlatforms.map { platform ->
         when (platform) {
-            is JdkPlatform -> JvmPlatformInfoImpl(
-                platformName = platform.platformName,
-                jvmTarget = platform.targetVersion.toString(),
-                jvmDefaultMode = (kspConfig as? KSPJvmConfig)?.jvmDefaultMode ?: "disable"
-            )
+            is JdkPlatform ->
+                JvmPlatformInfoImpl(
+                    platformName = platform.platformName,
+                    jvmTarget = platform.targetVersion.toString(),
+                    jvmDefaultMode = (kspConfig as? KSPJvmConfig)?.jvmDefaultMode ?: "disable",
+                )
 
-            is JsPlatform -> JsPlatformInfoImpl(
-                platformName = platform.platformName
-            )
+            is JsPlatform -> JsPlatformInfoImpl(platformName = platform.platformName)
 
-            is NativePlatform -> NativePlatformInfoImpl(
-                platformName = platform.platformName,
-                targetName = platform.targetName
-            )
+            is NativePlatform ->
+                NativePlatformInfoImpl(
+                    platformName = platform.platformName,
+                    targetName = platform.targetName,
+                )
             // Unknown platform; toString() may be more informative than platformName
             else -> UnknownPlatformInfoImpl(platform.toString())
         }
@@ -707,8 +766,7 @@ fun TargetPlatform.getPlatformInfo(kspConfig: KSPConfig): List<PlatformInfo> =
 
 private fun <R> maybeRunInWriteAction(f: () -> R) {
     synchronized(EDT::class.java) {
-        if (!EDT.isCurrentThreadEdt())
-            EDT.updateEdt()
+        if (!EDT.isCurrentThreadEdt()) EDT.updateEdt()
         if (ApplicationManager.getApplication() != null) {
             runWriteAction {
                 f()
@@ -720,14 +778,16 @@ private fun <R> maybeRunInWriteAction(f: () -> R) {
 }
 
 /*
-* NoOp implementation of the KaFirCacheCleaner
-*
-* The stop world cache cleaner that is registered by default [KaFirStopWorldCacheCleaner] can
-* get analysis session into an invalid state which leads to build failures.
-*/
+ * NoOp implementation of the KaFirCacheCleaner
+ *
+ * The stop world cache cleaner that is registered by default [KaFirStopWorldCacheCleaner] can
+ * get analysis session into an invalid state which leads to build failures.
+ */
 @OptIn(KaImplementationDetail::class)
 class NoOpCacheCleaner : KaFirCacheCleaner {
     override fun enterAnalysis() {}
+
     override fun exitAnalysis() {}
+
     override fun scheduleCleanup() {}
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -190,8 +190,10 @@ class ResolverAAImpl(
     }
 
     lateinit var propertyAsMemberOfCache: MutableMap<Pair<KSPropertyDeclaration, KSType>, KSType>
-    lateinit var functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>
-    val javaFileManager = project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
+    lateinit var functionAsMemberOfCache:
+        MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>
+    val javaFileManager =
+        project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
     private val classBinaryCache = ClsKotlinBinaryClassCache()
     private val packageInfoFiles by lazyMemoizedSequence {
         allKSFiles.filter { it.fileName == "package-info.java" }.asSequence()
@@ -248,19 +250,22 @@ class ResolverAAImpl(
         when (declaration.origin) {
             Origin.JAVA -> {
                 addVisibilityModifiers()
-                if (declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE)
+                if (
+                    declaration is KSClassDeclaration &&
+                        declaration.classKind == ClassKind.INTERFACE
+                )
                     modifiers.add(Modifier.ABSTRACT)
             }
 
             Origin.KOTLIN -> {
                 addVisibilityModifiers()
-                if (!declaration.isOpen())
-                    modifiers.add(Modifier.FINAL)
+                if (!declaration.isOpen()) modifiers.add(Modifier.FINAL)
                 (declaration as? KSClassDeclarationImpl)?.let {
                     analyze {
                         if (
-                            it.ktClassOrObjectSymbol.staticMemberScope
-                                .declarations.contains(declaration.ktDeclarationSymbol)
+                            it.ktClassOrObjectSymbol.staticMemberScope.declarations.contains(
+                                declaration.ktDeclarationSymbol
+                            )
                         )
                             modifiers.add(Modifier.JAVA_STATIC)
                     }
@@ -280,25 +285,23 @@ class ResolverAAImpl(
                     modifiers.add(Modifier.JAVA_VOLATILE)
                 when (declaration) {
                     is KSClassDeclaration -> {
-                        if (declaration.isCompanionObject)
-                            modifiers.add(Modifier.JAVA_STATIC)
+                        if (declaration.isCompanionObject) modifiers.add(Modifier.JAVA_STATIC)
                         if (declaration.classKind == ClassKind.INTERFACE)
                             modifiers.add(Modifier.ABSTRACT)
                     }
 
                     is KSPropertyDeclaration -> {
-                        if (declaration.isAbstract())
-                            modifiers.add(Modifier.ABSTRACT)
+                        if (declaration.isAbstract()) modifiers.add(Modifier.ABSTRACT)
                     }
 
                     is KSFunctionDeclaration -> {
-                        if (declaration.isAbstract)
-                            modifiers.add(Modifier.ABSTRACT)
+                        if (declaration.isAbstract) modifiers.add(Modifier.ABSTRACT)
                     }
                 }
             }
 
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
+            Origin.KOTLIN_LIB,
+            Origin.JAVA_LIB -> {
                 if (declaration.hasAnnotation(JVM_STATIC_ANNOTATION_FQN)) {
                     modifiers.add(Modifier.JAVA_STATIC)
                 }
@@ -326,39 +329,49 @@ class ResolverAAImpl(
     }
 
     internal val KSPropertyDeclaration.jvmAccessFlag: Int
-        get() = when (origin) {
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
-                val fileManager = instance.javaFileManager
-                val parentClass = this.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId!!
-                BinaryClassInfoCache.getCached(classId, fileManager)
-                    ?.fieldAccFlags?.get(this.simpleName.asString()) ?: 0
-            }
+        get() =
+            when (origin) {
+                Origin.KOTLIN_LIB,
+                Origin.JAVA_LIB -> {
+                    val fileManager = instance.javaFileManager
+                    val parentClass = this.findParentOfType<KSClassDeclaration>()
+                    val classId =
+                        (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId!!
+                    BinaryClassInfoCache.getCached(classId, fileManager)
+                        ?.fieldAccFlags
+                        ?.get(this.simpleName.asString()) ?: 0
+                }
 
-            else -> throw InternalKSPException(
-                "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
-                this.location,
-                this.javaClass
-            )
-        }
+                else ->
+                    throw InternalKSPException(
+                        "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
+                        this.location,
+                        this.javaClass,
+                    )
+            }
 
     internal val KSFunctionDeclaration.jvmAccessFlag: Int
-        get() = when (origin) {
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
-                val jvmDesc = mapToJvmSignatureInternal(this)
-                val fileManager = instance.javaFileManager
-                val parentClass = this.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId!!
-                BinaryClassInfoCache.getCached(classId, fileManager)
-                    ?.methodAccFlags?.get(this.simpleName.asString() + jvmDesc) ?: 0
-            }
+        get() =
+            when (origin) {
+                Origin.KOTLIN_LIB,
+                Origin.JAVA_LIB -> {
+                    val jvmDesc = mapToJvmSignatureInternal(this)
+                    val fileManager = instance.javaFileManager
+                    val parentClass = this.findParentOfType<KSClassDeclaration>()
+                    val classId =
+                        (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId!!
+                    BinaryClassInfoCache.getCached(classId, fileManager)
+                        ?.methodAccFlags
+                        ?.get(this.simpleName.asString() + jvmDesc) ?: 0
+                }
 
-            else -> throw InternalKSPException(
-                "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
-                this.location,
-                this.javaClass,
-            )
-        }
+                else ->
+                    throw InternalKSPException(
+                        "Unexpected origin: '$origin', expected 'KOTLIN_LIB' or 'JAVA_LIB'",
+                        this.location,
+                        this.javaClass,
+                    )
+            }
 
     override fun getAllFiles(): Sequence<KSFile> {
         return allKSFiles.asSequence()
@@ -373,28 +386,37 @@ class ResolverAAImpl(
             val simpleName = name.getShortName()
             val classId = ClassId(FqName(parent), Name.identifier(simpleName))
             analyze {
-                classId.toKtClassSymbol()
-            }?.let { return it }
-            return (findClass(KSNameImpl.getCached(name.getQualifier())) as? KaNamedClassSymbol)?.let {
-                analyze {
-                    (
-                        it.staticMemberScope.classifiers { it.asString() == simpleName }.singleOrNull()
-                            ?: it.memberScope.classifiers { it.asString() == simpleName }.singleOrNull()
-                        ) as? KaNamedClassSymbol
-                        ?: it.staticMemberScope.callables { it.asString() == simpleName }.singleOrNull()
-                            as? KaEnumEntrySymbol
+                    classId.toKtClassSymbol()
                 }
-            }
+                ?.let {
+                    return it
+                }
+            return (findClass(KSNameImpl.getCached(name.getQualifier())) as? KaNamedClassSymbol)
+                ?.let {
+                    analyze {
+                        (it.staticMemberScope
+                            .classifiers { it.asString() == simpleName }
+                            .singleOrNull()
+                            ?: it.memberScope
+                                .classifiers { it.asString() == simpleName }
+                                .singleOrNull())
+                            as? KaNamedClassSymbol
+                            ?: it.staticMemberScope
+                                .callables { it.asString() == simpleName }
+                                .singleOrNull() as? KaEnumEntrySymbol
+                    }
+                }
         }
         return findClass(name)?.let {
             when (it) {
                 is KaNamedClassSymbol -> KSClassDeclarationImpl.getCached(it)
                 is KaEnumEntrySymbol -> KSClassDeclarationEnumEntryImpl.getCached(it)
-                else -> throw InternalKSPException(
-                    "Unexpected class declaration symbol: '$it'",
-                    it.psi.toLocation(),
-                    it.javaClass,
-                )
+                else ->
+                    throw InternalKSPException(
+                        "Unexpected class declaration symbol: '$it'",
+                        it.psi.toLocation(),
+                        it.javaClass,
+                    )
             }
         }
     }
@@ -403,7 +425,8 @@ class ResolverAAImpl(
     @KspExperimental
     override fun getDeclarationsFromPackage(packageName: String): Sequence<KSDeclaration> {
         return analyze {
-            findPackage(FqName(packageName))?.packageScope?.declarations?.distinct()?.mapNotNull { symbol ->
+            findPackage(FqName(packageName))?.packageScope?.declarations?.distinct()?.mapNotNull {
+                symbol ->
                 when (symbol) {
                     is KaNamedClassSymbol -> KSClassDeclarationImpl.getCached(symbol)
                     is KaFunctionSymbol -> KSFunctionDeclarationImpl.getCached(symbol)
@@ -416,7 +439,9 @@ class ResolverAAImpl(
         }
     }
 
-    override fun getDeclarationsInSourceOrder(container: KSDeclarationContainer): Sequence<KSDeclaration> {
+    override fun getDeclarationsInSourceOrder(
+        container: KSDeclarationContainer
+    ): Sequence<KSDeclaration> {
         if (container.origin != Origin.KOTLIN_LIB) {
             return container.declarations
         }
@@ -429,8 +454,10 @@ class ResolverAAImpl(
         require(container is AbstractKSDeclarationImpl)
         val fileManager = instance.javaFileManager
         var parentClass: KSNode = container
-        while (parentClass.parent != null &&
-            (parentClass !is KSClassDeclarationImpl || parentClass.ktClassOrObjectSymbol.classId == null)
+        while (
+            parentClass.parent != null &&
+                (parentClass !is KSClassDeclarationImpl ||
+                    parentClass.ktClassOrObjectSymbol.classId == null)
         ) {
             parentClass = parentClass.parent!!
         }
@@ -439,7 +466,8 @@ class ResolverAAImpl(
             return container.declarations
         }
 
-        // Members of Foo's companion object are compiled into Foo and Foo$Companion. Total ordering is not recoverable
+        // Members of Foo's companion object are compiled into Foo and Foo$Companion. Total ordering
+        // is not recoverable
         // from class files. Let's give up and rely on AA for now.
         if (parentClass.isCompanionObject) {
             return container.declarations
@@ -447,23 +475,28 @@ class ResolverAAImpl(
 
         val classId = parentClass.ktClassOrObjectSymbol.classId ?: return container.declarations
         val virtualFile = classId.getVirtualFile(fileManager) ?: return container.declarations
-        val kotlinClass = classBinaryCache.getKotlinBinaryClass(virtualFile) ?: return container.declarations
+        val kotlinClass =
+            classBinaryCache.getKotlinBinaryClass(virtualFile) ?: return container.declarations
         val declarationOrdering = DeclarationOrdering(kotlinClass)
 
         @Suppress("UNCHECKED_CAST")
-        return (container.declarations as? Sequence<AbstractKSDeclarationImpl>)
-            ?.sortedWith(declarationOrdering.comparator) ?: container.declarations
+        return (container.declarations as? Sequence<AbstractKSDeclarationImpl>)?.sortedWith(
+            declarationOrdering.comparator
+        ) ?: container.declarations
     }
 
     override fun getFunctionDeclarationsByName(
         name: KSName,
-        includeTopLevel: Boolean
+        includeTopLevel: Boolean,
     ): Sequence<KSFunctionDeclaration> {
         val qualifier = name.getQualifier()
         val functionName = name.getShortName()
-        val nonTopLevelResult = this.getClassDeclarationByName(qualifier)?.getDeclaredFunctions()
-            ?.filter { it.simpleName.asString() == functionName } ?: emptySequence()
-        return if (!includeTopLevel) nonTopLevelResult else {
+        val nonTopLevelResult =
+            this.getClassDeclarationByName(qualifier)?.getDeclaredFunctions()?.filter {
+                it.simpleName.asString() == functionName
+            } ?: emptySequence()
+        return if (!includeTopLevel) nonTopLevelResult
+        else {
             nonTopLevelResult.plus(
                 analyze {
                     findTopLevelCallables(FqName(qualifier), Name.identifier(functionName))
@@ -480,8 +513,7 @@ class ResolverAAImpl(
     override fun getJavaWildcard(reference: KSTypeReference): KSTypeReference {
         val (ref, indexes) = reference.findOuterMostRef()
         val type = ref.resolve()
-        if (type.isError)
-            return reference
+        if (type.isError) return reference
         val position = findRefPosition(ref)
         val ktType = (type as KSTypeImpl).type.fullyExpand()
         // TODO: Upstream this:
@@ -489,12 +521,15 @@ class ResolverAAImpl(
         // and corresponding type mapping APIs.
         val coneType = (ktType as KaFirType).coneType
         val mode = analyze {
-            val typeContext = analyze { useSiteModule.getResolutionFacade(project).useSiteFirSession.typeContext }
+            val typeContext = analyze {
+                useSiteModule.getResolutionFacade(project).useSiteFirSession.typeContext
+            }
             when (position) {
-                RefPosition.RETURN_TYPE -> typeContext.getOptimalModeForReturnType(
-                    coneType,
-                    reference.isReturnTypeOfAnnotationMethod()
-                )
+                RefPosition.RETURN_TYPE ->
+                    typeContext.getOptimalModeForReturnType(
+                        coneType,
+                        reference.isReturnTypeOfAnnotationMethod(),
+                    )
 
                 RefPosition.SUPER_TYPE -> TypeMappingMode.SUPER_TYPE
                 RefPosition.PARAMETER_TYPE -> typeContext.getOptimalModeForValueParameter(coneType)
@@ -513,22 +548,28 @@ class ResolverAAImpl(
 
     override fun getJvmCheckedException(accessor: KSPropertyAccessor): Sequence<KSType> {
         return when (accessor.origin) {
-            Origin.KOTLIN, Origin.SYNTHETIC -> {
+            Origin.KOTLIN,
+            Origin.SYNTHETIC -> {
                 extractThrowsAnnotation(accessor)
             }
 
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
+            Origin.KOTLIN_LIB,
+            Origin.JAVA_LIB -> {
                 val fileManager = javaFileManager
                 val parentClass = accessor.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
-                    ?: return emptySequence()
-                val virtualFileContent = classId.getFileContent(fileManager) ?: return emptySequence()
+                val classId =
+                    (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
+                        ?: return emptySequence()
+                val virtualFileContent =
+                    classId.getFileContent(fileManager) ?: return emptySequence()
                 val jvmDesc = this.mapToJvmSignatureInternal(accessor)
                 extractThrowsFromClassFile(
                     virtualFileContent,
                     jvmDesc,
                     (if (accessor is KSPropertyGetter) "get" else "set") +
-                        accessor.receiver.simpleName.asString().replaceFirstChar(Char::uppercaseChar)
+                        accessor.receiver.simpleName
+                            .asString()
+                            .replaceFirstChar(Char::uppercaseChar),
                 )
             }
 
@@ -540,8 +581,9 @@ class ResolverAAImpl(
     override fun getJvmCheckedException(function: KSFunctionDeclaration): Sequence<KSType> {
         return when (function.origin) {
             Origin.JAVA -> {
-                val psi = ((function as KSFunctionDeclarationImpl).ktFunctionSymbol.psi as? PsiMethod)
-                    ?: return emptySequence()
+                val psi =
+                    ((function as KSFunctionDeclarationImpl).ktFunctionSymbol.psi as? PsiMethod)
+                        ?: return emptySequence()
                 psi.throwsList.referencedTypes.asSequence().mapNotNull {
                     analyze {
                         it.asKaType(psi)?.let { KSTypeImpl.getCached(it) }
@@ -553,14 +595,21 @@ class ResolverAAImpl(
                 extractThrowsAnnotation(function)
             }
 
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
+            Origin.KOTLIN_LIB,
+            Origin.JAVA_LIB -> {
                 val fileManager = javaFileManager
                 val parentClass = function.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
-                    ?: return emptySequence()
-                val virtualFileContent = classId.getFileContent(fileManager) ?: return emptySequence()
+                val classId =
+                    (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
+                        ?: return emptySequence()
+                val virtualFileContent =
+                    classId.getFileContent(fileManager) ?: return emptySequence()
                 val jvmDesc = this.mapToJvmSignature(function)
-                extractThrowsFromClassFile(virtualFileContent, jvmDesc, function.simpleName.asString())
+                extractThrowsFromClassFile(
+                    virtualFileContent,
+                    jvmDesc,
+                    function.simpleName.asString(),
+                )
             }
 
             else -> emptySequence()
@@ -569,10 +618,11 @@ class ResolverAAImpl(
 
     // TODO: handle library symbols
     override fun getJvmName(accessor: KSPropertyAccessor): String {
-        val symbol: KaPropertyAccessorSymbol? = when (accessor) {
-            is KSPropertyAccessorImpl -> accessor.ktPropertyAccessorSymbol
-            else -> null
-        }
+        val symbol: KaPropertyAccessorSymbol? =
+            when (accessor) {
+                is KSPropertyAccessorImpl -> accessor.ktPropertyAccessorSymbol
+                else -> null
+            }
 
         symbol?.explictJvmName()?.let {
             return it
@@ -582,8 +632,9 @@ class ResolverAAImpl(
         val containingClass = accessor.receiver.closestClassDeclaration()
 
         val isAnnotationClass = containingClass?.classKind == ClassKind.ANNOTATION_CLASS
-        val isJvmRecord = containingClass is KSClassDeclarationImpl &&
-            containingClass.ktClassOrObjectSymbol.isJvmRecord()
+        val isJvmRecord =
+            containingClass is KSClassDeclarationImpl &&
+                containingClass.ktClassOrObjectSymbol.isJvmRecord()
 
         // Annotation classes and @JvmRecord data classes both use bare property names
         // as accessor names (no get/set prefix).
@@ -591,11 +642,12 @@ class ResolverAAImpl(
             return propertyName
         }
         // https://kotlinlang.org/docs/java-to-kotlin-interop.html#properties
-        val prefixedName = when (accessor) {
-            is KSPropertyGetter -> JvmAbi.getterName(propertyName)
-            is KSPropertySetter -> JvmAbi.setterName(propertyName)
-            else -> ""
-        }
+        val prefixedName =
+            when (accessor) {
+                is KSPropertyGetter -> JvmAbi.getterName(propertyName)
+                is KSPropertySetter -> JvmAbi.setterName(propertyName)
+                else -> ""
+            }
 
         val inlineSuffix = symbol?.inlineSuffix ?: ""
         val mangledName = symbol?.internalSuffix ?: ""
@@ -610,10 +662,11 @@ class ResolverAAImpl(
             return declaration.simpleName.asString()
         }
 
-        val symbol: KaFunctionSymbol? = when (declaration) {
-            is KSFunctionDeclarationImpl -> declaration.ktFunctionSymbol
-            else -> null
-        }
+        val symbol: KaFunctionSymbol? =
+            when (declaration) {
+                is KSFunctionDeclarationImpl -> declaration.ktFunctionSymbol
+                else -> null
+            }
 
         symbol?.explictJvmName()?.let {
             return it
@@ -637,19 +690,29 @@ class ResolverAAImpl(
         @Suppress("UNCHECKED_CAST")
         return declaration.closestClassDeclaration()?.let {
             // Find classId for JvmClassName for member callables.
-            (it as? KSClassDeclarationImpl)?.ktClassOrObjectSymbol?.classId
-                ?.asString()?.replace(".", "$")?.replace("/", ".")
-        } ?: declaration.containingFile?.let {
-            // Find containing file facade class name from file symbol
-            (it as? KSFileImpl)?.let {
-                ((it.ktFileSymbol.psi as? KtFile)?.findFacadeClass() as? KtLightClassForFacade)
-                    ?.facadeClassFqName?.asString()
+            (it as? KSClassDeclarationImpl)
+                ?.ktClassOrObjectSymbol
+                ?.classId
+                ?.asString()
+                ?.replace(".", "$")
+                ?.replace("/", ".")
+        }
+            ?: declaration.containingFile?.let {
+                // Find containing file facade class name from file symbol
+                (it as? KSFileImpl)?.let {
+                    ((it.ktFileSymbol.psi as? KtFile)?.findFacadeClass() as? KtLightClassForFacade)
+                        ?.facadeClassFqName
+                        ?.asString()
+                }
+                // Down cast to fir symbol for library symbols as light facade class for libraries
+                // not available in AA.
             }
-            // Down cast to fir symbol for library symbols as light facade class for libraries not available in AA.
-        } ?: (
-            ((declaration as? AbstractKSDeclarationImpl)?.ktDeclarationSymbol as? KaFirSymbol<FirCallableSymbol<*>>)
-                ?.firSymbol?.containerSource as? JvmPackagePartSource
-            )?.classId?.asFqNameString()
+            ?: (((declaration as? AbstractKSDeclarationImpl)?.ktDeclarationSymbol
+                        as? KaFirSymbol<FirCallableSymbol<*>>)
+                    ?.firSymbol
+                    ?.containerSource as? JvmPackagePartSource)
+                ?.classId
+                ?.asFqNameString()
     }
 
     override fun getOwnerJvmClassName(declaration: KSFunctionDeclaration): String? {
@@ -660,39 +723,50 @@ class ResolverAAImpl(
         return getOwnerJvmClassNameHelper(declaration)
     }
 
-    override fun getPropertyDeclarationByName(name: KSName, includeTopLevel: Boolean): KSPropertyDeclaration? {
+    override fun getPropertyDeclarationByName(
+        name: KSName,
+        includeTopLevel: Boolean,
+    ): KSPropertyDeclaration? {
         val qualifier = name.getQualifier()
         val propertyName = name.getShortName()
-        val nonTopLevelResult = this.getClassDeclarationByName(qualifier)?.getDeclaredProperties()
-            ?.singleOrNull { it.simpleName.asString() == propertyName }
+        val nonTopLevelResult =
+            this.getClassDeclarationByName(qualifier)?.getDeclaredProperties()?.singleOrNull {
+                it.simpleName.asString() == propertyName
+            }
         return if (!includeTopLevel) {
             nonTopLevelResult
         } else {
-            val topLevelResult = (
-                analyze {
-                    findTopLevelCallables(FqName(qualifier), Name.identifier(propertyName)).singleOrNull {
-                        it is KaPropertySymbol
-                    }?.toKSDeclaration() as? KSPropertyDeclaration
-                }
-                )
+            val topLevelResult =
+                (analyze {
+                    findTopLevelCallables(FqName(qualifier), Name.identifier(propertyName))
+                        .singleOrNull {
+                            it is KaPropertySymbol
+                        }
+                        ?.toKSDeclaration() as? KSPropertyDeclaration
+                })
             if (topLevelResult != null && nonTopLevelResult != null) {
                 throw InternalKSPException(
                     buildString {
                         appendLine("Found multiple properties with same qualified name.")
-                        appendLine("Top-level: '$topLevelResult' at ${topLevelResult.location.render()}")
+                        appendLine(
+                            "Top-level: '$topLevelResult' at ${topLevelResult.location.render()}"
+                        )
                         appendLine(
                             "Non-top-level: '$nonTopLevelResult' at ${nonTopLevelResult.location.render()}"
                         )
                     },
                     topLevelResult.location,
-                    topLevelResult.javaClass
+                    topLevelResult.javaClass,
                 )
             }
             nonTopLevelResult ?: topLevelResult
         }
     }
 
-    override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> {
+    override fun getSymbolsWithAnnotation(
+        annotationName: String,
+        inDepth: Boolean,
+    ): Sequence<KSAnnotated> {
         val expandedIfAlias = analyze {
             val classId = ClassId.fromString(annotationName)
             findTypeAlias(classId)?.expandedType?.symbol?.classId?.asFqNameString()
@@ -710,30 +784,40 @@ class ResolverAAImpl(
         return type is KSTypeImpl && (type.type as KaFirType).coneType.isRaw()
     }
 
-    internal fun KSFile.getPackageAnnotations() = (this as? KSFileJavaImpl)?.psi?.packageStatement?.annotationList
-        ?.annotations?.map { KSAnnotationJavaImpl.getCached(it, this) } ?: emptyList<KSAnnotation>()
+    internal fun KSFile.getPackageAnnotations() =
+        (this as? KSFileJavaImpl)?.psi?.packageStatement?.annotationList?.annotations?.map {
+            KSAnnotationJavaImpl.getCached(it, this)
+        } ?: emptyList<KSAnnotation>()
 
     @KspExperimental
     override fun getPackageAnnotations(packageName: String): Sequence<KSAnnotation> {
-        return packageInfoFiles.singleOrNull { it.packageName.asString() == packageName }
-            ?.getPackageAnnotations()?.asSequence() ?: emptySequence()
+        return packageInfoFiles
+            .singleOrNull { it.packageName.asString() == packageName }
+            ?.getPackageAnnotations()
+            ?.asSequence() ?: emptySequence()
     }
 
     @KspExperimental
     override fun getPackagesWithAnnotation(annotationName: String): Sequence<String> {
-        return packageInfoFiles.filter {
-            it.getPackageAnnotations().any {
-                (it.annotationType.element as? KSClassifierReference)?.referencedName()
-                    ?.substringAfterLast(".") == annotationName.substringAfterLast(".") &&
-                    it.annotationType.resolve().declaration.qualifiedName?.asString() == annotationName
+        return packageInfoFiles
+            .filter {
+                it.getPackageAnnotations().any {
+                    (it.annotationType.element as? KSClassifierReference)
+                        ?.referencedName()
+                        ?.substringAfterLast(".") == annotationName.substringAfterLast(".") &&
+                        it.annotationType.resolve().declaration.qualifiedName?.asString() ==
+                            annotationName
+                }
             }
-        }.map { it.packageName.asString() }
+            .map { it.packageName.asString() }
     }
 
     @OptIn(KaExperimentalApi::class)
     @KspExperimental
     override fun getModuleName(): KSName {
-        return KSNameImpl.getCached((ktModule.stableModuleName ?: ktModule.name).removeSurrounding("<", ">"))
+        return KSNameImpl.getCached(
+            (ktModule.stableModuleName ?: ktModule.name).removeSurrounding("<", ">")
+        )
     }
 
     @KspExperimental
@@ -756,28 +840,30 @@ class ResolverAAImpl(
     }
 
     override fun overrides(overrider: KSDeclaration, overridee: KSDeclaration): Boolean {
-        val overriderSymbol = when (overrider) {
-            is KSFunctionDeclarationImpl -> if (overrider.ktFunctionSymbol is KaPropertyAccessorSymbol) {
-                (overrider.parent as KSPropertyDeclarationImpl).ktPropertySymbol
-            } else {
-                overrider.ktFunctionSymbol
-            }
+        val overriderSymbol =
+            when (overrider) {
+                is KSFunctionDeclarationImpl ->
+                    if (overrider.ktFunctionSymbol is KaPropertyAccessorSymbol) {
+                        (overrider.parent as KSPropertyDeclarationImpl).ktPropertySymbol
+                    } else {
+                        overrider.ktFunctionSymbol
+                    }
 
-            is KSPropertyDeclarationImpl -> overrider.ktPropertySymbol
-            else -> return false
-        }
-        val overrideeSymbol = when (overridee) {
-            is KSFunctionDeclarationImpl -> overridee.ktFunctionSymbol
-            is KSPropertyDeclarationImpl -> overridee.ktPropertySymbol
-            else -> return false
-        }
+                is KSPropertyDeclarationImpl -> overrider.ktPropertySymbol
+                else -> return false
+            }
+        val overrideeSymbol =
+            when (overridee) {
+                is KSFunctionDeclarationImpl -> overridee.ktFunctionSymbol
+                is KSPropertyDeclarationImpl -> overridee.ktPropertySymbol
+                else -> return false
+            }
         overrider.closestClassDeclaration()?.asStarProjectedType()?.let {
             recordLookupWithSupertypes((it as KSTypeImpl).type)
         }
         recordLookupForPropertyOrMethod(overrider)
         recordLookupForPropertyOrMethod(overridee)
-        if (!overridee.isVisibleFrom(overrider))
-            return false
+        if (!overridee.isVisibleFrom(overrider)) return false
         return analyze {
             overriderSymbol.allOverriddenSymbols.contains(overrideeSymbol) ||
                 overriderSymbol.intersectionOverriddenSymbols.contains(overrideeSymbol)
@@ -787,31 +873,42 @@ class ResolverAAImpl(
     override fun overrides(
         overrider: KSDeclaration,
         overridee: KSDeclaration,
-        containingClass: KSClassDeclaration
+        containingClass: KSClassDeclaration,
     ): Boolean {
         recordLookupForPropertyOrMethod(overrider)
         recordLookupForPropertyOrMethod(overridee)
         return when (overrider) {
-            is KSPropertyDeclaration -> containingClass.getAllProperties().singleOrNull {
-                recordLookupForPropertyOrMethod(it)
-                it.simpleName.asString() == overrider.simpleName.asString()
-            }?.let { overrides(it, overridee) } ?: false
+            is KSPropertyDeclaration ->
+                containingClass
+                    .getAllProperties()
+                    .singleOrNull {
+                        recordLookupForPropertyOrMethod(it)
+                        it.simpleName.asString() == overrider.simpleName.asString()
+                    }
+                    ?.let { overrides(it, overridee) } ?: false
 
             is KSFunctionDeclaration -> {
-                val candidates = containingClass.getAllFunctions().filter {
-                    it.simpleName.asString() == overridee.simpleName.asString()
-                }
-                if (overrider.simpleName.asString().startsWith("get") ||
-                    overrider.simpleName.asString().startsWith("set")
+                val candidates =
+                    containingClass.getAllFunctions().filter {
+                        it.simpleName.asString() == overridee.simpleName.asString()
+                    }
+                if (
+                    overrider.simpleName.asString().startsWith("get") ||
+                        overrider.simpleName.asString().startsWith("set")
                 ) {
-                    candidates.plus(
-                        containingClass.getAllProperties().filter {
-                            val overriderName = overrider.simpleName.asString().substring(3)
-                                .replaceFirstChar { it.lowercase() }
-                            it.simpleName.asString() == overriderName ||
-                                it.simpleName.asString().replaceFirstChar { it.lowercase() } == overriderName
-                        }
-                    ).any { overrides(it, overridee) }
+                    candidates
+                        .plus(
+                            containingClass.getAllProperties().filter {
+                                val overriderName =
+                                    overrider.simpleName.asString().substring(3).replaceFirstChar {
+                                        it.lowercase()
+                                    }
+                                it.simpleName.asString() == overriderName ||
+                                    it.simpleName.asString().replaceFirstChar { it.lowercase() } ==
+                                        overriderName
+                            }
+                        )
+                        .any { overrides(it, overridee) }
                 } else {
                     candidates.any {
                         recordLookupForPropertyOrMethod(it)
@@ -849,9 +946,10 @@ class ResolverAAImpl(
         }
 
         return when (ksAnnotated) {
-            is KSClassDeclaration -> analyze {
-                (ksAnnotated.asStarProjectedType() as KSTypeImpl).toSignature()
-            }
+            is KSClassDeclaration ->
+                analyze {
+                    (ksAnnotated.asStarProjectedType() as KSTypeImpl).toSignature()
+                }
 
             is KSFunctionDeclarationImpl -> {
                 analyze {
@@ -893,10 +991,11 @@ class ResolverAAImpl(
 
     @OptIn(KaExperimentalApi::class)
     internal fun computeAsMemberOf(property: KSPropertyDeclaration, containing: KSType): KSType {
-        val declaredIn = property.closestClassDeclaration()
-            ?: throw IllegalArgumentException(
-                "Cannot call asMemberOf with a property that is not declared in a class or an interface"
-            )
+        val declaredIn =
+            property.closestClassDeclaration()
+                ?: throw IllegalArgumentException(
+                    "Cannot call asMemberOf with a property that is not declared in a class or an interface"
+                )
         val key = property to containing
         return propertyAsMemberOfCache.getOrPut(key) {
             val resolved = property.type.resolve()
@@ -915,25 +1014,27 @@ class ResolverAAImpl(
                 }
                 analyze {
                     buildSubstitutor {
-                        fillInDeepSubstitutor(containing.type, this@buildSubstitutor)
-                    }.let {
-                        // recursively substitute to ensure transitive substitution works.
-                        // should fix in upstream as well.
-                        var result = resolved.type
-                        var cnt = 0
-                        while (it.substitute(result) != result) {
-                            if (cnt > 100) {
-                                throw InternalKSPException(
-                                    message = "Potential infinite loop in type substitution for computeAsMemberOf",
-                                    property.location,
-                                    property.javaClass
-                                )
-                            }
-                            result = it.substitute(result)
-                            cnt += 1
+                            fillInDeepSubstitutor(containing.type, this@buildSubstitutor)
                         }
-                        KSTypeImpl.getCached(result)
-                    }
+                        .let {
+                            // recursively substitute to ensure transitive substitution works.
+                            // should fix in upstream as well.
+                            var result = resolved.type
+                            var cnt = 0
+                            while (it.substitute(result) != result) {
+                                if (cnt > 100) {
+                                    throw InternalKSPException(
+                                        message =
+                                            "Potential infinite loop in type substitution for computeAsMemberOf",
+                                        property.location,
+                                        property.javaClass,
+                                    )
+                                }
+                                result = it.substitute(result)
+                                cnt += 1
+                            }
+                            KSTypeImpl.getCached(result)
+                        }
                 }
             } else {
                 return if (resolved.isError) resolved else KSErrorType(resolved.toString())
@@ -942,11 +1043,15 @@ class ResolverAAImpl(
     }
 
     @OptIn(KaExperimentalApi::class)
-    internal fun computeAsMemberOf(function: KSFunctionDeclaration, containing: KSType): KSFunction {
-        val propertyDeclaredIn = function.closestClassDeclaration()
-            ?: throw IllegalArgumentException(
-                "Cannot call asMemberOf with a function that is not declared in a class or an interface"
-            )
+    internal fun computeAsMemberOf(
+        function: KSFunctionDeclaration,
+        containing: KSType,
+    ): KSFunction {
+        val propertyDeclaredIn =
+            function.closestClassDeclaration()
+                ?: throw IllegalArgumentException(
+                    "Cannot call asMemberOf with a function that is not declared in a class or an interface"
+                )
         val key = function to containing
         return functionAsMemberOfCache.getOrPut(key) {
             if (containing is KSTypeImpl) {
@@ -965,33 +1070,40 @@ class ResolverAAImpl(
                 }
                 analyze {
                     buildSubstitutor {
-                        fillInDeepSubstitutor(containing.type, this@buildSubstitutor)
-                    }.let {
-                        // recursively substitute to ensure transitive substitution works.
-                        // should fix in upstream as well.
-                        // for functions we need to test both returnType and value parameters converges.
-                        var funcToSub = (function as KSFunctionDeclarationImpl).ktFunctionSymbol.substitute(it)
-                        var next = funcToSub.substitute(it)
-                        var cnt = 0
-                        while (
-                            funcToSub.returnType != next.returnType ||
-                            funcToSub.valueParameters.zip(next.valueParameters)
-                                .any { it.first.returnType != it.second.returnType } ||
-                            funcToSub.receiverType != next.receiverType
-                        ) {
-                            if (cnt > 100) {
-                                throw InternalKSPException(
-                                    message = "Potential infinite loop in type substitution for computeAsMemberOf",
-                                    function.location,
-                                    function.javaClass
-                                )
-                            }
-                            funcToSub = next
-                            next = funcToSub.substitute(it)
-                            cnt += 1
+                            fillInDeepSubstitutor(containing.type, this@buildSubstitutor)
                         }
-                        KSFunctionImpl(funcToSub, it)
-                    }
+                        .let {
+                            // recursively substitute to ensure transitive substitution works.
+                            // should fix in upstream as well.
+                            // for functions we need to test both returnType and value parameters
+                            // converges.
+                            var funcToSub =
+                                (function as KSFunctionDeclarationImpl)
+                                    .ktFunctionSymbol
+                                    .substitute(it)
+                            var next = funcToSub.substitute(it)
+                            var cnt = 0
+                            while (
+                                funcToSub.returnType != next.returnType ||
+                                    funcToSub.valueParameters.zip(next.valueParameters).any {
+                                        it.first.returnType != it.second.returnType
+                                    } ||
+                                    funcToSub.receiverType != next.receiverType
+                            ) {
+                                if (cnt > 100) {
+                                    throw InternalKSPException(
+                                        message =
+                                            "Potential infinite loop in type substitution for computeAsMemberOf",
+                                        function.location,
+                                        function.javaClass,
+                                    )
+                                }
+                                funcToSub = next
+                                next = funcToSub.substitute(it)
+                                cnt += 1
+                            }
+                            KSFunctionImpl(funcToSub, it)
+                        }
                 }
             } else KSFunctionErrorImpl(function)
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSAnnotationJavaImpl.kt
@@ -48,8 +48,8 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.name.ClassId
 
-class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, override val parent: KSNode?) :
-    KSAnnotation {
+class KSAnnotationJavaImpl
+private constructor(private val psi: PsiAnnotation, override val parent: KSNode?) : KSAnnotation {
     companion object : KSObjectCache<PsiAnnotation, KSAnnotationJavaImpl>() {
         fun getCached(psi: PsiAnnotation, parent: KSNode?) =
             KSAnnotationJavaImpl.cache.getOrPut(psi) { KSAnnotationJavaImpl(psi, parent) }
@@ -57,10 +57,8 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
 
     private val type: KaType by lazy {
         fun PsiClass.fqn(): String? {
-            val parent = containingClass?.fqn()
-                ?: return qualifiedName?.replace('.', '/')
-            if (name == null)
-                return null
+            val parent = containingClass?.fqn() ?: return qualifiedName?.replace('.', '/')
+            if (name == null) return null
             return "$parent.$name"
         }
         analyze {
@@ -79,81 +77,110 @@ class KSAnnotationJavaImpl private constructor(private val psi: PsiAnnotation, o
     override val arguments: List<KSValueArgument> by lazy {
         analyze {
             val annotationConstructor =
-                (type.classifierSymbol() as? KaClassSymbol)?.memberScope?.constructors?.singleOrNull()
-            val presentArgs = psi.parameterList.attributes.mapIndexed { index, it ->
-                val name = it.name ?: annotationConstructor?.valueParameters?.getOrNull(index)?.name?.asString()
-                val value = it.value
-                val calculatedValue: Any? = if (value is PsiArrayInitializerMemberValue) {
-                    value.initializers.map {
-                        calcValue(it, this@KSAnnotationJavaImpl)
-                    }
-                } else {
-                    calcValue(it.value, this@KSAnnotationJavaImpl)
+                (type.classifierSymbol() as? KaClassSymbol)
+                    ?.memberScope
+                    ?.constructors
+                    ?.singleOrNull()
+            val presentArgs =
+                psi.parameterList.attributes.mapIndexed { index, it ->
+                    val name =
+                        it.name
+                            ?: annotationConstructor
+                                ?.valueParameters
+                                ?.getOrNull(index)
+                                ?.name
+                                ?.asString()
+                    val value = it.value
+                    val calculatedValue: Any? =
+                        if (value is PsiArrayInitializerMemberValue) {
+                            value.initializers.map {
+                                calcValue(it, this@KSAnnotationJavaImpl)
+                            }
+                        } else {
+                            calcValue(it.value, this@KSAnnotationJavaImpl)
+                        }
+                    KSValueArgumentLiteImpl(
+                        name?.let { KSNameImpl.getCached(it) },
+                        calculatedValue,
+                        this@KSAnnotationJavaImpl,
+                        Origin.JAVA,
+                        it.toLocation(),
+                    )
                 }
-                KSValueArgumentLiteImpl(
-                    name?.let { KSNameImpl.getCached(it) },
-                    calculatedValue,
-                    this@KSAnnotationJavaImpl,
-                    Origin.JAVA,
-                    it.toLocation()
-                )
-            }
             val presentValueArgumentNames = presentArgs.map { it.name?.asString() ?: "" }
-            presentArgs + defaultArguments.filter { ksValueArgument ->
-                val name = ksValueArgument.name?.asString() ?: return@filter false
-                if (name in presentValueArgumentNames)
-                    return@filter false
-                annotationConstructor?.valueParameters?.any { it.name.asString() == name && it.hasDefaultValue } == true
-            }
+            presentArgs +
+                defaultArguments.filter { ksValueArgument ->
+                    val name = ksValueArgument.name?.asString() ?: return@filter false
+                    if (name in presentValueArgumentNames) return@filter false
+                    annotationConstructor?.valueParameters?.any {
+                        it.name.asString() == name && it.hasDefaultValue
+                    } == true
+                }
         }
     }
 
     @OptIn(KaImplementationDetail::class)
     override val defaultArguments: List<KSValueArgument> by lazy {
         analyze {
-            (type.classifierSymbol() as? KaClassSymbol)?.memberScope?.constructors?.singleOrNull()
+            (type.classifierSymbol() as? KaClassSymbol)
+                ?.memberScope
+                ?.constructors
+                ?.singleOrNull()
                 ?.let { symbol ->
                     // ClsClassImpl means psi is decompiled psi.
                     if (
-                        symbol.origin == KaSymbolOrigin.JAVA_SOURCE && symbol.psi != null &&
-                        symbol.psi !is ClsClassImpl && symbol.psi is PsiClass
+                        symbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
+                            symbol.psi != null &&
+                            symbol.psi !is ClsClassImpl &&
+                            symbol.psi is PsiClass
                     ) {
-                        (symbol.psi as PsiClass).allMethods.filterIsInstance<PsiAnnotationMethod>()
+                        (symbol.psi as PsiClass)
+                            .allMethods
+                            .filterIsInstance<PsiAnnotationMethod>()
                             .mapNotNull { annoMethod ->
                                 annoMethod.defaultValue?.let { value ->
-                                    val calculatedValue: Any? = if (value is PsiArrayInitializerMemberValue) {
-                                        value.initializers.map {
-                                            calcValue(it, this@KSAnnotationJavaImpl)
+                                    val calculatedValue: Any? =
+                                        if (value is PsiArrayInitializerMemberValue) {
+                                            value.initializers.map {
+                                                calcValue(it, this@KSAnnotationJavaImpl)
+                                            }
+                                        } else {
+                                            calcValue(value, this@KSAnnotationJavaImpl)
                                         }
-                                    } else {
-                                        calcValue(value, this@KSAnnotationJavaImpl)
-                                    }
                                     KSValueArgumentLiteImpl(
                                         KSNameImpl.getCached(annoMethod.name),
                                         calculatedValue,
                                         this@KSAnnotationJavaImpl,
                                         Origin.SYNTHETIC,
-                                        value.toLocation()
+                                        value.toLocation(),
                                     )
                                 }
                             }
                     } else {
                         symbol.valueParameters.mapNotNull { valueParameterSymbol ->
-                            val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
+                            val constantValue =
+                                valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
                             if (constantValue is KaAnnotationValue.ClassLiteralValue) {
-                                recordClassReferenceLookup(constantValue.type, this@KSAnnotationJavaImpl)
+                                recordClassReferenceLookup(
+                                    constantValue.type,
+                                    this@KSAnnotationJavaImpl,
+                                )
                             }
                             KSValueArgumentImpl.getCached(
                                 KaBaseNamedAnnotationValue(
                                     valueParameterSymbol.name,
-                                    // null will be returned as the `constantValue` for non array annotation values.
-                                    // fallback to unsupported annotation value to indicate such use cases.
-                                    // when seeing unsupported annotation value we return `null` for the value.
-                                    // which might still be incorrect but there might not be a perfect way.
-                                    constantValue
+                                    // null will be returned as the `constantValue` for non array
+                                    // annotation values.
+                                    // fallback to unsupported annotation value to indicate such use
+                                    // cases.
+                                    // when seeing unsupported annotation value we return `null` for
+                                    // the value.
+                                    // which might still be incorrect but there might not be a
+                                    // perfect way.
+                                    constantValue,
                                 ),
                                 this@KSAnnotationJavaImpl,
-                                Origin.SYNTHETIC
+                                Origin.SYNTHETIC,
                             )
                         }
                     }
@@ -188,57 +215,68 @@ fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode): Any? {
         }
         return KSAnnotationJavaImpl.getCached(value, null)
     }
-    val result = when (value) {
-        is PsiReference -> value.resolve()?.let { resolved ->
-            JavaPsiFacade.getInstance(value.project).constantEvaluationHelper.computeConstantExpression(value)
-                ?: resolved
-        }
+    val result =
+        when (value) {
+            is PsiReference ->
+                value.resolve()?.let { resolved ->
+                    JavaPsiFacade.getInstance(value.project)
+                        .constantEvaluationHelper
+                        .computeConstantExpression(value) ?: resolved
+                }
 
-        else -> value?.let {
-            JavaPsiFacade.getInstance(value.project).constantEvaluationHelper.computeConstantExpression(value)
+            else ->
+                value?.let {
+                    JavaPsiFacade.getInstance(value.project)
+                        .constantEvaluationHelper
+                        .computeConstantExpression(value)
+                }
         }
-    }
     return when (result) {
         is PsiPrimitiveType -> {
             result.boxedTypeName?.let {
-                ResolverAAImpl.instance
-                    .getClassDeclarationByName(it)?.asStarProjectedType()
+                ResolverAAImpl.instance.getClassDeclarationByName(it)?.asStarProjectedType()
             } ?: KSErrorType(result.boxedTypeName)
         }
 
         is PsiArrayType -> {
-            val componentType = when (val component = result.componentType) {
-                is PsiPrimitiveType -> component.boxedTypeName?.let { boxedTypeName ->
-                    ResolverAAImpl.instance
-                        .getClassDeclarationByName(boxedTypeName)?.asStarProjectedType()
-                } ?: KSErrorType(component.boxedTypeName)
+            val componentType =
+                when (val component = result.componentType) {
+                    is PsiPrimitiveType ->
+                        component.boxedTypeName?.let { boxedTypeName ->
+                            ResolverAAImpl.instance
+                                .getClassDeclarationByName(boxedTypeName)
+                                ?.asStarProjectedType()
+                        } ?: KSErrorType(component.boxedTypeName)
 
-                else -> {
-                    ResolverAAImpl.instance
-                        .getClassDeclarationByName(component.canonicalText)?.asStarProjectedType()
-                        ?.also { ksType ->
-                            ksType.toKaType()?.let { kaType ->
-                                recordClassReferenceLookup(kaType, parent)
-                            }
-                        }
-                        ?: KSErrorType(component.canonicalText)
+                    else -> {
+                        ResolverAAImpl.instance
+                            .getClassDeclarationByName(component.canonicalText)
+                            ?.asStarProjectedType()
+                            ?.also { ksType ->
+                                ksType.toKaType()?.let { kaType ->
+                                    recordClassReferenceLookup(kaType, parent)
+                                }
+                            } ?: KSErrorType(component.canonicalText)
+                    }
                 }
-            }
-            val componentTypeRef = ResolverAAImpl.instance.createKSTypeReferenceFromKSType(componentType)
-            val typeArgs = listOf(ResolverAAImpl.instance.getTypeArgument(componentTypeRef, Variance.INVARIANT))
-            ResolverAAImpl.instance
-                .getClassDeclarationByName("kotlin.Array")!!.asType(typeArgs)
+            val componentTypeRef =
+                ResolverAAImpl.instance.createKSTypeReferenceFromKSType(componentType)
+            val typeArgs =
+                listOf(
+                    ResolverAAImpl.instance.getTypeArgument(componentTypeRef, Variance.INVARIANT)
+                )
+            ResolverAAImpl.instance.getClassDeclarationByName("kotlin.Array")!!.asType(typeArgs)
         }
 
         is PsiType -> {
             ResolverAAImpl.instance
-                .getClassDeclarationByName(result.canonicalText)?.asStarProjectedType()
+                .getClassDeclarationByName(result.canonicalText)
+                ?.asStarProjectedType()
                 ?.also { ksType ->
                     ksType.toKaType()?.let { kaType ->
                         recordClassReferenceLookup(kaType, parent)
                     }
-                }
-                ?: KSErrorType(result.canonicalText)
+                } ?: KSErrorType(result.canonicalText)
         }
 
         is PsiLiteralValue -> {
@@ -246,17 +284,22 @@ fun calcValue(value: PsiAnnotationMemberValue?, parent: KSNode): Any? {
         }
 
         is PsiField -> {
-            // manually handle enums as constant expression evaluator does not seem to be resolving them.
+            // manually handle enums as constant expression evaluator does not seem to be resolving
+            // them.
             val containingClass = result.containingClass
             @Suppress("UnstableApiUsage")
             if (containingClass?.classKind == JvmClassKind.ENUM) {
                 // this is an enum entry
-                containingClass.qualifiedName?.let {
-                    ResolverAAImpl.instance.getClassDeclarationByName(it)
-                }?.declarations?.find {
-                    it is KSClassDeclaration && it.classKind == ClassKind.ENUM_ENTRY &&
-                        it.simpleName.asString() == result.name
-                } as? KSClassDeclarationEnumEntryImpl
+                containingClass.qualifiedName
+                    ?.let {
+                        ResolverAAImpl.instance.getClassDeclarationByName(it)
+                    }
+                    ?.declarations
+                    ?.find {
+                        it is KSClassDeclaration &&
+                            it.classKind == ClassKind.ENUM_ENTRY &&
+                            it.simpleName.asString() == result.name
+                    } as? KSClassDeclarationEnumEntryImpl
             } else {
                 null
             }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSValueArgumentLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/java/KSValueArgumentLiteImpl.kt
@@ -8,7 +8,7 @@ class KSValueArgumentLiteImpl(
     override val value: Any?,
     override val parent: KSNode,
     override val origin: Origin,
-    override val location: Location
+    override val location: Location,
 ) : AbstractKSValueArgumentImpl() {
     override val isSpread: Boolean = false
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/AbstractKSDeclarationImpl.kt
@@ -69,28 +69,32 @@ abstract class AbstractKSDeclarationImpl : KSDeclaration, Deferrable {
         get() = originalAnnotations
 
     override val modifiers: Set<Modifier> by lazy {
-        if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC) {
+        if (
+            origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC
+        ) {
             when (val ktDeclarationSymbol = this.ktDeclarationSymbol) {
                 is KaPropertySymbol -> ktDeclarationSymbol.toModifiers()
                 is KaClassSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaFunctionSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaJavaFieldSymbol -> ktDeclarationSymbol.toModifiers()
                 is KaTypeAliasSymbol -> ktDeclarationSymbol.toModifiers()
-                else -> throw InternalKSPException(
-                    "Unexpected symbol type: $ktDeclarationSymbol",
-                    this.location,
-                    ktDeclarationSymbol.javaClass
-                )
+                else ->
+                    throw InternalKSPException(
+                        "Unexpected symbol type: $ktDeclarationSymbol",
+                        this.location,
+                        ktDeclarationSymbol.javaClass,
+                    )
             }
         } else {
             when (val psi = ktDeclarationSymbol.psi) {
                 is KtModifierListOwner -> psi.toKSModifiers()
                 is PsiModifierListOwner -> psi.toKSModifiers()
-                else -> throw InternalKSPException(
-                    "Unexpected symbol type ${ktDeclarationSymbol.psi?.javaClass}",
-                    this.location,
-                    psi?.javaClass ?: this.javaClass
-                )
+                else ->
+                    throw InternalKSPException(
+                        "Unexpected symbol type ${ktDeclarationSymbol.psi?.javaClass}",
+                        this.location,
+                        psi?.javaClass ?: this.javaClass,
+                    )
             }
         }
     }
@@ -112,7 +116,7 @@ abstract class AbstractKSDeclarationImpl : KSDeclaration, Deferrable {
             }?.let {
                 KSNameImpl.getCached(it)
             } //  null -> non top level declaration, find in parent
-                ?: ktDeclarationSymbol.getContainingKSSymbol()?.packageName
+            ?: ktDeclarationSymbol.getContainingKSSymbol()?.packageName
                 ?: throw InternalKSPException(
                     "failed to find package name for $this",
                     this.location,
@@ -134,9 +138,13 @@ abstract class AbstractKSDeclarationImpl : KSDeclaration, Deferrable {
         analyze {
             ktDeclarationSymbol.containingSymbol?.let {
                 ktDeclarationSymbol.getContainingKSSymbol()
-            } ?: (ktDeclarationSymbol.psi?.parentOfType<PsiClass>(withSelf = false))?.namedClassSymbol?.let {
-                KSClassDeclarationImpl.getCached(it)
-            } ?: ktDeclarationSymbol.toContainingFile()
+            }
+                ?: (ktDeclarationSymbol.psi?.parentOfType<PsiClass>(withSelf = false))
+                    ?.namedClassSymbol
+                    ?.let {
+                        KSClassDeclarationImpl.getCached(it)
+                    }
+                ?: ktDeclarationSymbol.toContainingFile()
         }
     }
 
@@ -152,10 +160,12 @@ abstract class AbstractKSDeclarationImpl : KSDeclaration, Deferrable {
             (ktDeclarationSymbol.psi as KtAnnotated).annotations(ktDeclarationSymbol, this)
         } else if (
             ktDeclarationSymbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
-            ktDeclarationSymbol.psi is PsiJvmModifiersOwner
+                ktDeclarationSymbol.psi is PsiJvmModifiersOwner
         ) {
             (ktDeclarationSymbol.psi as PsiJvmModifiersOwner)
-                .annotations.map { KSAnnotationJavaImpl.getCached(it, this) }.asSequence()
+                .annotations
+                .map { KSAnnotationJavaImpl.getCached(it, this) }
+                .asSequence()
         } else {
             ktDeclarationSymbol.annotations(this)
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSAnnotationImpl.kt
@@ -35,16 +35,17 @@ import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 
 // TODO: implement a psi based version of annotation application.
-class KSAnnotationImpl private constructor(
+class KSAnnotationImpl
+private constructor(
     private val ktAnnotationEntry: KtAnnotationEntry,
     override val parent: KSNode?,
-    private val resolveToAnnotationApplication: () -> KaAnnotation
+    private val resolveToAnnotationApplication: () -> KaAnnotation,
 ) : KSAnnotation {
     companion object : KSObjectCache<IdKeyPair<KtAnnotationEntry, KSNode?>, KSAnnotationImpl>() {
         fun getCached(
             ktAnnotationEntry: KtAnnotationEntry,
             parent: KSNode? = null,
-            resolveToAnnotationApplication: () -> KaAnnotation
+            resolveToAnnotationApplication: () -> KaAnnotation,
         ) =
             cache.getOrPut(IdKeyPair(ktAnnotationEntry, parent)) {
                 KSAnnotationImpl(ktAnnotationEntry, parent, resolveToAnnotationApplication)
@@ -60,16 +61,17 @@ class KSAnnotationImpl private constructor(
             ktAnnotationEntry.typeReference!!.let {
                 KSTypeReferenceImpl.getCached(
                     it,
-                    this@KSAnnotationImpl
+                    this@KSAnnotationImpl,
                 )
             }
         }
     }
 
     override val arguments: List<KSValueArgument> by lazy {
-        val presentArgs = annotationApplication.arguments.map {
-            KSValueArgumentImpl.getCached(it, this, origin)
-        }
+        val presentArgs =
+            annotationApplication.arguments.map {
+                KSValueArgumentImpl.getCached(it, this, origin)
+            }
         val presentNames = presentArgs.mapNotNull { it.name?.asString() }
         val absentArgs = defaultArguments.filter {
             it.name?.asString() !in presentNames
@@ -82,39 +84,45 @@ class KSAnnotationImpl private constructor(
         analyze {
             annotationApplication.classId?.toKtClassSymbol()?.let { symbol ->
                 if (
-                    symbol.origin == KaSymbolOrigin.JAVA_SOURCE && symbol.psi != null &&
-                    symbol.psi !is ClsClassImpl && symbol.psi is PsiClass
+                    symbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
+                        symbol.psi != null &&
+                        symbol.psi !is ClsClassImpl &&
+                        symbol.psi is PsiClass
                 ) {
-                    (symbol.psi as PsiClass).allMethods.filterIsInstance<PsiAnnotationMethod>()
+                    (symbol.psi as PsiClass)
+                        .allMethods
+                        .filterIsInstance<PsiAnnotationMethod>()
                         .mapNotNull { annoMethod ->
                             annoMethod.defaultValue?.let { value ->
-                                val calculatedValue: Any? = if (value is PsiArrayInitializerMemberValue) {
-                                    value.initializers.map {
-                                        calcValue(it, this@KSAnnotationImpl)
+                                val calculatedValue: Any? =
+                                    if (value is PsiArrayInitializerMemberValue) {
+                                        value.initializers.map {
+                                            calcValue(it, this@KSAnnotationImpl)
+                                        }
+                                    } else {
+                                        calcValue(value, this@KSAnnotationImpl)
                                     }
-                                } else {
-                                    calcValue(value, this@KSAnnotationImpl)
-                                }
                                 KSValueArgumentLiteImpl(
                                     KSNameImpl.getCached(annoMethod.name),
                                     calculatedValue,
                                     this@KSAnnotationImpl,
                                     Origin.SYNTHETIC,
-                                    value.toLocation()
+                                    value.toLocation(),
                                 )
                             }
                         }
                 } else {
                     symbol.memberScope.constructors.singleOrNull()?.let {
                         it.valueParameters.mapNotNull { valueParameterSymbol ->
-                            val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
+                            val constantValue =
+                                valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
                             KSValueArgumentImpl.getCached(
                                 KaBaseNamedAnnotationValue(
                                     valueParameterSymbol.name,
-                                    constantValue
+                                    constantValue,
                                 ),
                                 this@KSAnnotationImpl,
-                                Origin.SYNTHETIC
+                                Origin.SYNTHETIC,
                             )
                         }
                     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSCallableReferenceImpl.kt
@@ -10,27 +10,37 @@ import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 
 // TODO: implement a psi based version, rename this class to resolved Impl.
-class KSCallableReferenceImpl private constructor(
+class KSCallableReferenceImpl
+private constructor(
     private val ktFunctionalType: KaFunctionType,
-    override val parent: KSNode?
+    override val parent: KSNode?,
 ) : KSCallableReference {
     companion object : KSObjectCache<IdKeyPair<KaType, KSNode?>, KSCallableReference>() {
         fun getCached(ktFunctionalType: KaFunctionType, parent: KSNode?): KSCallableReference =
-            cache.getOrPut(IdKeyPair(ktFunctionalType, parent)) { KSCallableReferenceImpl(ktFunctionalType, parent) }
+            cache.getOrPut(IdKeyPair(ktFunctionalType, parent)) {
+                KSCallableReferenceImpl(ktFunctionalType, parent)
+            }
     }
+
     override val receiverType: KSTypeReference?
-        get() = ktFunctionalType.receiverType?.abbreviationOrSelf?.let { KSTypeReferenceResolvedImpl.getCached(it) }
+        get() =
+            ktFunctionalType.receiverType?.abbreviationOrSelf?.let {
+                KSTypeReferenceResolvedImpl.getCached(it)
+            }
 
     override val functionParameters: List<KSValueParameter>
-        get() = ktFunctionalType.parameterTypes.map {
-            KSValueParameterLiteImpl.getCached(it, this@KSCallableReferenceImpl)
-        }
+        get() =
+            ktFunctionalType.parameterTypes.map {
+                KSValueParameterLiteImpl.getCached(it, this@KSCallableReferenceImpl)
+            }
 
     override val returnType: KSTypeReference
-        get() = KSTypeReferenceResolvedImpl.getCached(ktFunctionalType.returnType.abbreviationOrSelf)
+        get() =
+            KSTypeReferenceResolvedImpl.getCached(ktFunctionalType.returnType.abbreviationOrSelf)
 
     override val typeArguments: List<KSTypeArgument>
-        get() = ktFunctionalType.typeArguments().map { KSTypeArgumentResolvedImpl.getCached(it, this) }
+        get() =
+            ktFunctionalType.typeArguments().map { KSTypeArgumentResolvedImpl.getCached(it, this) }
 
     override val origin: Origin
         get() = parent?.origin ?: Origin.SYNTHETIC

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationEnumEntryImpl.kt
@@ -23,18 +23,23 @@ import com.google.devtools.ksp.symbol.Location
 import org.jetbrains.kotlin.analysis.api.symbols.KaEnumEntrySymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaNamedClassSymbol
 
-class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntrySymbol: KaEnumEntrySymbol) :
+class KSClassDeclarationEnumEntryImpl
+private constructor(private val ktEnumEntrySymbol: KaEnumEntrySymbol) :
     KSClassDeclaration,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktEnumEntrySymbol) {
-    override val ktDeclarationSymbol get() = ktEnumEntrySymbol
+    override val ktDeclarationSymbol
+        get() = ktEnumEntrySymbol
+
     companion object : KSObjectCache<KaEnumEntrySymbol, KSClassDeclarationEnumEntryImpl>() {
         fun getCached(ktEnumEntrySymbol: KaEnumEntrySymbol) =
             cache.getOrPut(ktEnumEntrySymbol) { KSClassDeclarationEnumEntryImpl(ktEnumEntrySymbol) }
     }
 
     override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached("${this.parentDeclaration!!.qualifiedName!!.asString()}.${simpleName.asString()}")
+        KSNameImpl.getCached(
+            "${this.parentDeclaration!!.qualifiedName!!.asString()}.${simpleName.asString()}"
+        )
     }
 
     override val classKind: ClassKind = ClassKind.ENUM_ENTRY
@@ -56,8 +61,9 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
             }
             recordLookupForGetAllFunctions(ktEnumEntrySymbol.returnType.directSupertypes.toList())
         }
-        return ktEnumEntrySymbol.enumEntryInitializer?.declarations()?.filterIsInstance<KSFunctionDeclaration>()
-            ?: emptySequence()
+        return ktEnumEntrySymbol.enumEntryInitializer
+            ?.declarations()
+            ?.filterIsInstance<KSFunctionDeclaration>() ?: emptySequence()
     }
 
     override fun getAllProperties(): Sequence<KSPropertyDeclaration> {
@@ -67,8 +73,9 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
             }
             recordLookupForGetAllProperties(ktEnumEntrySymbol.returnType.directSupertypes.toList())
         }
-        return ktEnumEntrySymbol.enumEntryInitializer?.declarations()?.filterIsInstance<KSPropertyDeclaration>()
-            ?: emptySequence()
+        return ktEnumEntrySymbol.enumEntryInitializer
+            ?.declarations()
+            ?.filterIsInstance<KSPropertyDeclaration>() ?: emptySequence()
     }
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
@@ -87,10 +94,9 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
 
     override val parentDeclaration: KSDeclaration? by lazy {
         analyze {
-            (
-                ktEnumEntrySymbol.containingSymbol
-                    as? KaNamedClassSymbol
-                )?.let { KSClassDeclarationImpl.getCached(it) }
+            (ktEnumEntrySymbol.containingSymbol as? KaNamedClassSymbol)?.let {
+                KSClassDeclarationImpl.getCached(it)
+            }
         }
     }
 
@@ -104,8 +110,9 @@ class KSClassDeclarationEnumEntryImpl private constructor(private val ktEnumEntr
 
     override val parent: KSNode by lazy {
         analyze {
-            (ktEnumEntrySymbol.containingSymbol as KaNamedClassSymbol)
-                .let { KSClassDeclarationImpl.getCached(it) }
+            (ktEnumEntrySymbol.containingSymbol as KaNamedClassSymbol).let {
+                KSClassDeclarationImpl.getCached(it)
+            }
         }
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassDeclarationImpl.kt
@@ -39,7 +39,8 @@ import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
-class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSymbol: KaClassSymbol) :
+class KSClassDeclarationImpl
+private constructor(internal val ktClassOrObjectSymbol: KaClassSymbol) :
     KSClassDeclaration,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktClassOrObjectSymbol) {
@@ -64,7 +65,9 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
             KaClassKind.ENUM_CLASS -> ClassKind.ENUM_CLASS
             KaClassKind.ANNOTATION_CLASS -> ClassKind.ANNOTATION_CLASS
             KaClassKind.INTERFACE -> ClassKind.INTERFACE
-            KaClassKind.COMPANION_OBJECT, KaClassKind.ANONYMOUS_OBJECT, KaClassKind.OBJECT -> ClassKind.OBJECT
+            KaClassKind.COMPANION_OBJECT,
+            KaClassKind.ANONYMOUS_OBJECT,
+            KaClassKind.OBJECT -> ClassKind.OBJECT
         }
     }
 
@@ -73,9 +76,11 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
             null
         } else {
             analyze {
-                ktClassOrObjectSymbol.memberScope.constructors.singleOrNull { it.isPrimary }?.let {
-                    KSFunctionDeclarationImpl.getCached(it)
-                }
+                ktClassOrObjectSymbol.memberScope.constructors
+                    .singleOrNull { it.isPrimary }
+                    ?.let {
+                        KSFunctionDeclarationImpl.getCached(it)
+                    }
             }
         }
     }
@@ -85,27 +90,43 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
             if (classKind == ClassKind.ANNOTATION_CLASS || classKind == ClassKind.ENUM_CLASS) {
                 null
             } else {
-                classOrObject.superTypeListEntries.map {
-                    KSTypeReferenceImpl.getCached(it.typeReference!!, this)
-                }.asSequence().ifEmpty {
-                    sequenceOf(
-                        KSTypeReferenceSyntheticImpl.getCached(ResolverAAImpl.instance.builtIns.anyType, this)
-                    )
-                }
+                classOrObject.superTypeListEntries
+                    .map {
+                        KSTypeReferenceImpl.getCached(it.typeReference!!, this)
+                    }
+                    .asSequence()
+                    .ifEmpty {
+                        sequenceOf(
+                            KSTypeReferenceSyntheticImpl.getCached(
+                                ResolverAAImpl.instance.builtIns.anyType,
+                                this,
+                            )
+                        )
+                    }
             }
-        } ?: analyze {
-            val supers = ktClassOrObjectSymbol.superTypes.mapIndexed { index, type ->
-                KSTypeReferenceResolvedImpl.getCached(type.abbreviationOrSelf, this@KSClassDeclarationImpl, index)
-            }
-            // AA is returning additional kotlin.Any for java classes, explicitly extending kotlin.Any will result in
-            // compile error, therefore filtering by name should work.
-            // TODO: reconsider how to model super types for interface.
-            if (supers.size > 1) {
-                supers.filterNot { it.resolve().declaration.qualifiedName?.asString() == "kotlin.Any" }
-            } else {
-                supers
-            }.asSequence()
         }
+            ?: analyze {
+                val supers =
+                    ktClassOrObjectSymbol.superTypes.mapIndexed { index, type ->
+                        KSTypeReferenceResolvedImpl.getCached(
+                            type.abbreviationOrSelf,
+                            this@KSClassDeclarationImpl,
+                            index,
+                        )
+                    }
+                // AA is returning additional kotlin.Any for java classes, explicitly extending
+                // kotlin.Any will result in
+                // compile error, therefore filtering by name should work.
+                // TODO: reconsider how to model super types for interface.
+                if (supers.size > 1) {
+                        supers.filterNot {
+                            it.resolve().declaration.qualifiedName?.asString() == "kotlin.Any"
+                        }
+                    } else {
+                        supers
+                    }
+                    .asSequence()
+            }
     }
 
     override val isCompanionObject: Boolean by lazy {
@@ -136,26 +157,35 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
 
     override fun asType(typeArguments: List<KSTypeArgument>): KSType {
         errorTypeOnInconsistentArguments(
-            arguments = typeArguments,
-            placeholdersProvider = { asStarProjectedType().arguments },
-            withCorrectedArguments = ::asType,
-            errorType = ::KSErrorType,
-        )?.let { error -> return error }
+                arguments = typeArguments,
+                placeholdersProvider = { asStarProjectedType().arguments },
+                withCorrectedArguments = ::asType,
+                errorType = ::KSErrorType,
+            )
+            ?.let { error ->
+                return error
+            }
         return analyze {
             ktClassOrObjectSymbol.tryResolveToTypePhase()
             if (typeArguments.isEmpty()) {
-                // Resolving a class symbol also resolves its type parameters.
-                typeParameters.map { buildTypeParameterType((it as KSTypeParameterImpl).ktTypeParameterSymbol) }
-                    .let { typeParameterTypes ->
-                        buildClassType(ktClassOrObjectSymbol) {
-                            typeParameterTypes.forEach { argument(it) }
+                    // Resolving a class symbol also resolves its type parameters.
+                    typeParameters
+                        .map {
+                            buildTypeParameterType(
+                                (it as KSTypeParameterImpl).ktTypeParameterSymbol
+                            )
                         }
+                        .let { typeParameterTypes ->
+                            buildClassType(ktClassOrObjectSymbol) {
+                                typeParameterTypes.forEach { argument(it) }
+                            }
+                        }
+                } else {
+                    buildClassType(ktClassOrObjectSymbol) {
+                        typeArguments.forEach { argument(it.toKtTypeProjection()) }
                     }
-            } else {
-                buildClassType(ktClassOrObjectSymbol) {
-                    typeArguments.forEach { argument(it.toKtTypeProjection()) }
                 }
-            }.let { KSTypeImpl.getCached(it) }
+                .let { KSTypeImpl.getCached(it) }
         }
     }
 
@@ -167,17 +197,14 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
                     var current: KSNode? = this@KSClassDeclarationImpl
                     while (current is KSClassDeclarationImpl) {
                         current.ktClassOrObjectSymbol.typeParameters.forEach { _ ->
-                            argument(
-                                KaBaseStarTypeProjection(
-                                    current.ktClassOrObjectSymbol.token
-                                )
-                            )
+                            argument(KaBaseStarTypeProjection(current.ktClassOrObjectSymbol.token))
                         }
-                        current = if (Modifier.INNER in current.modifiers) {
-                            current.parent
-                        } else {
-                            null
-                        }
+                        current =
+                            if (Modifier.INNER in current.modifiers) {
+                                current.parent
+                            } else {
+                                null
+                            }
                     }
                 }
             )
@@ -204,8 +231,10 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
 
     private fun canUsePsiResolution(): Boolean {
         return (origin == Origin.JAVA || origin == Origin.JAVA_LIB) &&
-            // Java annotations, enums, and types that map to Kotlin types (e.g. java.lang.String -> kotlin.String) have
-            // additional properties added by the Analysis API that don't actually exist in the Java type so just skip
+            // Java annotations, enums, and types that map to Kotlin types (e.g. java.lang.String ->
+            // kotlin.String) have
+            // additional properties added by the Analysis API that don't actually exist in the Java
+            // type so just skip
             // them to avoid this complexity.
             classKind != ClassKind.ANNOTATION_CLASS &&
             classKind != ClassKind.ENUM_CLASS &&
@@ -214,65 +243,101 @@ class KSClassDeclarationImpl private constructor(internal val ktClassOrObjectSym
 
     private fun PsiClass.getDeclarationsFromPsi(): Sequence<KSDeclaration> {
         // 1. Fields
-        val psiFields = fields.asSequence()
-            .map { KSPropertyDeclarationJavaImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
+        val psiFields =
+            fields.asSequence().map {
+                KSPropertyDeclarationJavaImpl.getCached(
+                    psi = it,
+                    parent = this@KSClassDeclarationImpl,
+                )
+            }
 
         // 2. Methods (Non-constructors)
-        val psiMethods = methods.asSequence()
-            // Mimic FIR dropping malformed constructors that don't match class name, e.g. `class Foo { Bar() {} }`
-            .filter { !it.isConstructor }
-            // Mimic FIR dropping Object overrides in Java interfaces (e.g. `@Override boolean equals(Object)`).
-            .filter { !(isInterface && it.isObjectOverride()) }
-            .map { KSFunctionDeclarationImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
+        val psiMethods =
+            methods
+                .asSequence()
+                // Mimic FIR dropping malformed constructors that don't match class name, e.g.
+                // `class Foo { Bar() {} }`
+                .filter { !it.isConstructor }
+                // Mimic FIR dropping Object overrides in Java interfaces (e.g. `@Override boolean
+                // equals(Object)`).
+                .filter { !(isInterface && it.isObjectOverride()) }
+                .map {
+                    KSFunctionDeclarationImpl.getCached(
+                        psi = it,
+                        parent = this@KSClassDeclarationImpl,
+                    )
+                }
 
         // 3. Constructors
         // IntelliJ's PSI lacks implicit constructors. If none are explicitly declared,
         // we must fetch the synthesized constructor from the Analysis API.
-        val psiConstructors = if (constructors.isEmpty() && !isInterface) {
-            analyze {
-                ktClassOrObjectSymbol.declaredMemberScope.constructors.map {
-                    KSFunctionDeclarationImpl.getCached(it)
+        val psiConstructors =
+            if (constructors.isEmpty() && !isInterface) {
+                analyze {
+                    ktClassOrObjectSymbol.declaredMemberScope.constructors.map {
+                        KSFunctionDeclarationImpl.getCached(it)
+                    }
+                }
+            } else {
+                constructors.asSequence().map {
+                    KSFunctionDeclarationImpl.getCached(
+                        psi = it,
+                        parent = this@KSClassDeclarationImpl,
+                    )
                 }
             }
-        } else {
-            constructors.asSequence()
-                .map { KSFunctionDeclarationImpl.getCached(psi = it, parent = this@KSClassDeclarationImpl) }
-        }
 
         // 4. Inner Classes
-        val psiInnerClasses = innerClasses.asSequence()
-            .mapNotNull { psiInnerClass ->
+        val psiInnerClasses =
+            innerClasses.asSequence().mapNotNull { psiInnerClass ->
                 analyze {
-                    val name = psiInnerClass.name?.let { Name.identifier(it) } ?: return@analyze null
-                    val instanceSymbols = ktClassOrObjectSymbol.declaredMemberScope.classifiers(name)
-                    val staticSymbols = ktClassOrObjectSymbol.staticDeclaredMemberScope.classifiers(name)
+                    val name =
+                        psiInnerClass.name?.let { Name.identifier(it) } ?: return@analyze null
+                    val instanceSymbols =
+                        ktClassOrObjectSymbol.declaredMemberScope.classifiers(name)
+                    val staticSymbols =
+                        ktClassOrObjectSymbol.staticDeclaredMemberScope.classifiers(name)
                     (instanceSymbols + staticSymbols)
                         .filterIsInstance<KaNamedClassSymbol>()
-                        .find { it.psi == psiInnerClass || it.psi?.isEquivalentTo(psiInnerClass) == true }
+                        .find {
+                            it.psi == psiInnerClass || it.psi?.isEquivalentTo(psiInnerClass) == true
+                        }
                         ?.let { KSClassDeclarationImpl.getCached(it) }
                 }
             }
 
         // 5. Partition members into static and instance members to emulate FIR's ordering.
-        val (psiStaticMembers, psiInstanceMembers) = (psiFields + psiMethods + psiInnerClasses).partition {
-            Modifier.JAVA_STATIC in it.modifiers ||
-                // Nested classes in KSP don't get the static modifier.
-                (it is KSClassDeclaration && Modifier.INNER !in it.modifiers)
-        }
+        val (psiStaticMembers, psiInstanceMembers) =
+            (psiFields + psiMethods + psiInnerClasses).partition {
+                Modifier.JAVA_STATIC in it.modifiers ||
+                    // Nested classes in KSP don't get the static modifier.
+                    (it is KSClassDeclaration && Modifier.INNER !in it.modifiers)
+            }
 
-        // Note: We could return declarations in source order by iterating over PsiClass.declarations directly.
-        // However, this ordering matches how things are done using the Analysis API to keep things consistent.
+        // Note: We could return declarations in source order by iterating over
+        // PsiClass.declarations directly.
+        // However, this ordering matches how things are done using the Analysis API to keep things
+        // consistent.
         return psiInstanceMembers.asSequence() + psiConstructors + psiStaticMembers.asSequence()
     }
 
     private fun getDeclarationsFromAnalysisApi(): Sequence<KSDeclaration> {
-        val decls = ktClassOrObjectSymbol.declarations()
-            // The Analysis API is known to leak certain inherited members, so we filter those cases out here.
-            .filter { !it.isLeakedInheritedMember(this) }
+        val decls =
+            ktClassOrObjectSymbol
+                .declarations()
+                // The Analysis API is known to leak certain inherited members, so we filter those
+                // cases out here.
+                .filter { !it.isLeakedInheritedMember(this) }
 
-        return if ((origin == Origin.JAVA || origin == Origin.JAVA_LIB) && classKind != ClassKind.ANNOTATION_CLASS) {
+        return if (
+            (origin == Origin.JAVA || origin == Origin.JAVA_LIB) &&
+                classKind != ClassKind.ANNOTATION_CLASS
+        ) {
             decls.flatMap { decl ->
-                if (decl is KSPropertyDeclarationImpl && decl.ktPropertySymbol is KaSyntheticJavaPropertySymbol) {
+                if (
+                    decl is KSPropertyDeclarationImpl &&
+                        decl.ktPropertySymbol is KaSyntheticJavaPropertySymbol
+                ) {
                     sequenceOf(decl.getter, decl.setter).mapNotNull { accessor ->
                         KSFunctionDeclarationImpl.getCached(
                             (accessor as? KSPropertyAccessorImpl)?.ktPropertyAccessorSymbol

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSClassifierReferenceImpl.kt
@@ -24,13 +24,16 @@ import com.google.devtools.ksp.symbol.KSTypeArgument
 import com.google.devtools.ksp.symbol.Location
 import org.jetbrains.kotlin.psi.KtUserType
 
-class KSClassifierReferenceImpl private constructor(
+class KSClassifierReferenceImpl
+private constructor(
     val ktUserType: KtUserType,
-    override val parent: KSNode
+    override val parent: KSNode,
 ) : KSClassifierReference {
     companion object : KSObjectCache<IdKeyPair<KtUserType, KSNode?>, KSClassifierReferenceImpl>() {
         fun getCached(ktUserType: KtUserType, parent: KSNode) =
-            cache.getOrPut(IdKeyPair(ktUserType, parent)) { KSClassifierReferenceImpl(ktUserType, parent) }
+            cache.getOrPut(IdKeyPair(ktUserType, parent)) {
+                KSClassifierReferenceImpl(ktUserType, parent)
+            }
     }
 
     override val origin = parent.origin
@@ -57,8 +60,11 @@ class KSClassifierReferenceImpl private constructor(
     }
 
     override fun toString(): String {
-        return ktUserType.referencedName + if (typeArguments.isNotEmpty()) "<${
+        return ktUserType.referencedName +
+            if (typeArguments.isNotEmpty())
+                "<${
         typeArguments.map { it.toString() }.joinToString(", ")
-        }>" else ""
+        }>"
+            else ""
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDefNonNullReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDefNonNullReferenceImpl.kt
@@ -5,15 +5,22 @@ import com.google.devtools.ksp.common.KSObjectCache
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.types.KaDefinitelyNotNullType
 
-class KSDefNonNullReferenceImpl private constructor(
+class KSDefNonNullReferenceImpl
+private constructor(
     private val ktDefinitelyNotNullType: KaDefinitelyNotNullType,
-    override val parent: KSTypeReference?
+    override val parent: KSTypeReference?,
 ) : KSDefNonNullReference {
-    companion object : KSObjectCache<IdKeyPair<KaDefinitelyNotNullType, KSTypeReference?>, KSDefNonNullReference>() {
+    companion object :
+        KSObjectCache<
+            IdKeyPair<KaDefinitelyNotNullType, KSTypeReference?>,
+            KSDefNonNullReference,
+        >() {
         fun getCached(ktType: KaDefinitelyNotNullType, parent: KSTypeReference?) =
-            KSDefNonNullReferenceImpl.cache
-                .getOrPut(IdKeyPair(ktType, parent)) { KSDefNonNullReferenceImpl(ktType, parent) }
+            KSDefNonNullReferenceImpl.cache.getOrPut(IdKeyPair(ktType, parent)) {
+                KSDefNonNullReferenceImpl(ktType, parent)
+            }
     }
+
     override val enclosedType: KSClassifierReference by lazy {
         ktDefinitelyNotNullType.original.toClassifierReference(parent) as KSClassifierReference
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSDynamicReferenceImpl.kt
@@ -5,7 +5,8 @@ import com.google.devtools.ksp.symbol.*
 
 class KSDynamicReferenceImpl private constructor(override val parent: KSNode) : KSDynamicReference {
     companion object : KSObjectCache<KSTypeReference, KSDynamicReferenceImpl>() {
-        fun getCached(parent: KSTypeReference) = cache.getOrPut(parent) { KSDynamicReferenceImpl(parent) }
+        fun getCached(parent: KSTypeReference) =
+            cache.getOrPut(parent) { KSDynamicReferenceImpl(parent) }
     }
 
     override val origin = Origin.KOTLIN

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorType.kt
@@ -18,12 +18,11 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 
 import com.google.devtools.ksp.symbol.*
 
-class KSErrorType(
-    private val hint: String?,
-) : KSType {
-    constructor(name: String, message: String?) : this(
-        hint = listOfNotNull(name, message).takeIf { it.isNotEmpty() }?.joinToString(" % ")
-    )
+class KSErrorType(private val hint: String?) : KSType {
+    constructor(
+        name: String,
+        message: String?,
+    ) : this(hint = listOfNotNull(name, message).takeIf { it.isNotEmpty() }?.joinToString(" % "))
 
     override val declaration: KSDeclaration
         get() = KSErrorTypeClassDeclaration(this)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSErrorTypeClassDeclaration.kt
@@ -20,9 +20,7 @@ package com.google.devtools.ksp.impl.symbol.kotlin
 import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 
-class KSErrorTypeClassDeclaration(
-    private val type: KSType,
-) : KSClassDeclaration {
+class KSErrorTypeClassDeclaration(private val type: KSType) : KSClassDeclaration {
     override val annotations: Sequence<KSAnnotation>
         get() = emptySequence()
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSExpectActualImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSExpectActualImpl.kt
@@ -39,8 +39,9 @@ class KSExpectActualImpl(private val declarationSymbol: KaDeclarationSymbol) : K
             emptySequence()
         } else {
             analyze {
-                declarationSymbol.getExpectsForActual().mapNotNull { it.toKSDeclaration() }
-            }.asSequence()
+                    declarationSymbol.getExpectsForActual().mapNotNull { it.toKSDeclaration() }
+                }
+                .asSequence()
         }
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileImpl.kt
@@ -39,7 +39,8 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : KSFile, Deferrable {
     companion object : KSObjectCache<KaFileSymbol, KSFileImpl>() {
-        fun getCached(ktFileSymbol: KaFileSymbol) = cache.getOrPut(ktFileSymbol) { KSFileImpl(ktFileSymbol) }
+        fun getCached(ktFileSymbol: KaFileSymbol) =
+            cache.getOrPut(ktFileSymbol) { KSFileImpl(ktFileSymbol) }
     }
 
     private val psi: PsiFile
@@ -48,11 +49,12 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
     override val packageName: KSName by lazy {
         when (psi) {
             is KtFile -> KSNameImpl.getCached((psi as KtFile).packageFqName.asString())
-            else -> throw InternalKSPException(
-                "Unhandled psi file type",
-                psi.toLocation(),
-                psi.javaClass
-            )
+            else ->
+                throw InternalKSPException(
+                    "Unhandled psi file type",
+                    psi.toLocation(),
+                    psi.javaClass,
+                )
         }
     }
 
@@ -72,11 +74,12 @@ class KSFileImpl private constructor(internal val ktFileSymbol: KaFileSymbol) : 
                     is KaNamedFunctionSymbol -> KSFunctionDeclarationImpl.getCached(it)
                     is KaPropertySymbol -> KSPropertyDeclarationImpl.getCached(it)
                     is KaTypeAliasSymbol -> KSTypeAliasImpl.getCached(it)
-                    else -> throw InternalKSPException(
-                        "Unhandled case in 'declarations'",
-                        it.psi.toLocation(),
-                        it.javaClass,
-                    )
+                    else ->
+                        throw InternalKSPException(
+                            "Unhandled case in 'declarations'",
+                            it.psi.toLocation(),
+                            it.javaClass,
+                        )
                 }
             }
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFileJavaImpl.kt
@@ -69,7 +69,8 @@ class KSFileJavaImpl private constructor(val psi: PsiJavaFile) : KSFile, Deferra
         return "File: ${this.fileName}"
     }
 
-    // Although Resolver.getSymbolsWithAnnotation never returns a java file because the latter cannot have file
+    // Although Resolver.getSymbolsWithAnnotation never returns a java file because the latter
+    // cannot have file
     // annotations, this is used internally to restore files across rounds.
     override fun defer(): Restorable {
         return Restorable {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionDeclarationImpl.kt
@@ -83,13 +83,19 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
 
     abstract val ktFunctionSymbol: KaFunctionSymbol
 
-    override val ktDeclarationSymbol: KaFunctionSymbol get() = ktFunctionSymbol
+    override val ktDeclarationSymbol: KaFunctionSymbol
+        get() = ktFunctionSymbol
 
     // Manual delegation for KSExpectActual to avoid eager evaluation in the class header
     private val expectActualImpl by lazy { KSExpectActualImpl(ktFunctionSymbol) }
-    override val isActual: Boolean get() = expectActualImpl.isActual
-    override val isExpect: Boolean get() = expectActualImpl.isExpect
+    override val isActual: Boolean
+        get() = expectActualImpl.isActual
+
+    override val isExpect: Boolean
+        get() = expectActualImpl.isExpect
+
     override fun findActuals(): Sequence<KSDeclaration> = expectActualImpl.findActuals()
+
     override fun findExpects(): Sequence<KSDeclaration> = expectActualImpl.findExpects()
 
     override val functionKind: FunctionKind by lazy {
@@ -103,11 +109,12 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
             }
 
             KaSymbolLocation.TOP_LEVEL -> FunctionKind.TOP_LEVEL
-            else -> throw InternalKSPException(
-                "Unexpected location ${ktFunctionSymbol.location}",
-                this.location,
-                ktFunctionSymbol.javaClass
-            )
+            else ->
+                throw InternalKSPException(
+                    "Unexpected location ${ktFunctionSymbol.location}",
+                    this.location,
+                    ktFunctionSymbol.javaClass,
+                )
         }
     }
 
@@ -135,22 +142,22 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
             if (!ktFunctionSymbol.isExtension) {
                 null
             } else {
-                (ktFunctionSymbol.psiIfSource() as? KtFunction)?.receiverTypeReference
-                    ?.let {
-                        // receivers are modeled as parameter in AA therefore annotations are stored in
-                        // the corresponding receiver parameter, need to pass it to the `KSTypeReferenceImpl`
-                        KSTypeReferenceImpl.getCached(
-                            it,
-                            this@KSFunctionDeclarationImpl,
-                            ktFunctionSymbol.receiverParameter?.annotations ?: emptyList()
-                        )
-                    }
+                (ktFunctionSymbol.psiIfSource() as? KtFunction)?.receiverTypeReference?.let {
+                    // receivers are modeled as parameter in AA therefore annotations are stored in
+                    // the corresponding receiver parameter, need to pass it to the
+                    // `KSTypeReferenceImpl`
+                    KSTypeReferenceImpl.getCached(
+                        it,
+                        this@KSFunctionDeclarationImpl,
+                        ktFunctionSymbol.receiverParameter?.annotations ?: emptyList(),
+                    )
+                }
                     ?: ktFunctionSymbol.receiverType?.abbreviationOrSelf?.let {
                         KSTypeReferenceResolvedImpl.getCached(
                             it,
                             this@KSFunctionDeclarationImpl,
                             -1,
-                            ktFunctionSymbol.receiverParameter?.annotations ?: emptyList()
+                            ktFunctionSymbol.receiverParameter?.annotations ?: emptyList(),
                         )
                     }
             }
@@ -158,14 +165,21 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
     }
 
     override val returnType: KSTypeReference? by lazy {
-        (ktFunctionSymbol.psiIfSource() as? KtFunction)?.typeReference?.let { KSTypeReferenceImpl.getCached(it, this) }
+        (ktFunctionSymbol.psiIfSource() as? KtFunction)?.typeReference?.let {
+            KSTypeReferenceImpl.getCached(it, this)
+        }
             ?: analyze {
                 // Constructors
                 if (ktFunctionSymbol is KaConstructorSymbol) {
-                    ((parentDeclaration as KSClassDeclaration).asStarProjectedType() as KSTypeImpl).type
-                } else {
-                    ktFunctionSymbol.returnType.abbreviationOrSelf
-                }.let { KSTypeReferenceResolvedImpl.getCached(it, this@KSFunctionDeclarationImpl) }
+                        ((parentDeclaration as KSClassDeclaration).asStarProjectedType()
+                                as KSTypeImpl)
+                            .type
+                    } else {
+                        ktFunctionSymbol.returnType.abbreviationOrSelf
+                    }
+                    .let {
+                        KSTypeReferenceResolvedImpl.getCached(it, this@KSFunctionDeclarationImpl)
+                    }
             }
     }
 
@@ -179,12 +193,17 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
         }
         recordLookupForPropertyOrMethod(this)
         return analyze {
-            if (ktFunctionSymbol is KaPropertyAccessorSymbol) {
-                (parentDeclaration as? KSPropertyDeclarationImpl)?.ktPropertySymbol
-            } else {
-                ktFunctionSymbol
-            }?.directlyOverriddenSymbols?.firstOrNull()?.fakeOverrideOriginal?.toKSDeclaration()
-        }?.also { recordLookupForPropertyOrMethod(it) }
+                if (ktFunctionSymbol is KaPropertyAccessorSymbol) {
+                        (parentDeclaration as? KSPropertyDeclarationImpl)?.ktPropertySymbol
+                    } else {
+                        ktFunctionSymbol
+                    }
+                    ?.directlyOverriddenSymbols
+                    ?.firstOrNull()
+                    ?.fakeOverrideOriginal
+                    ?.toKSDeclaration()
+            }
+            ?.also { recordLookupForPropertyOrMethod(it) }
     }
 
     override fun asMemberOf(containing: KSType): KSFunction {
@@ -194,34 +213,40 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
     override val simpleName: KSName by lazy {
         when (val ktFunctionSymbol = this.ktFunctionSymbol) {
             is KaNamedFunctionSymbol -> KSNameImpl.getCached(ktFunctionSymbol.name.asString())
-            is KaPropertyAccessorSymbol -> when (val psi = ktFunctionSymbol.psi) {
-                is PsiMethod -> KSNameImpl.getCached(psi.name)
-                else -> {
-                    // 1. Try to get the callable id
-                    // 2. Try to synthetically construct the getter or setter as e.g., "propertyName.getter()"
-                    // 3. Fall back to <no name>
-                    val name = ktFunctionSymbol.callableId?.callableName?.asString()
-                        ?: analyze { ktFunctionSymbol.containingSymbol?.name?.asString() }?.let { propertyName ->
-                            buildString {
-                                append(propertyName)
-                                append(".")
-                                when (ktFunctionSymbol) {
-                                    is KaPropertyGetterSymbol -> append("getter")
-                                    is KaPropertySetterSymbol -> append("setter")
-                                }
-                                append("()")
-                            }
-                        } ?: "<no name>"
-                    KSNameImpl.getCached(name)
+            is KaPropertyAccessorSymbol ->
+                when (val psi = ktFunctionSymbol.psi) {
+                    is PsiMethod -> KSNameImpl.getCached(psi.name)
+                    else -> {
+                        // 1. Try to get the callable id
+                        // 2. Try to synthetically construct the getter or setter as e.g.,
+                        // "propertyName.getter()"
+                        // 3. Fall back to <no name>
+                        val name =
+                            ktFunctionSymbol.callableId?.callableName?.asString()
+                                ?: analyze { ktFunctionSymbol.containingSymbol?.name?.asString() }
+                                    ?.let { propertyName ->
+                                        buildString {
+                                            append(propertyName)
+                                            append(".")
+                                            when (ktFunctionSymbol) {
+                                                is KaPropertyGetterSymbol -> append("getter")
+                                                is KaPropertySetterSymbol -> append("setter")
+                                            }
+                                            append("()")
+                                        }
+                                    }
+                                ?: "<no name>"
+                        KSNameImpl.getCached(name)
+                    }
                 }
-            }
 
             is KaConstructorSymbol -> KSNameImpl.getCached("<init>")
-            else -> throw InternalKSPException(
-                "Unexpected function symbol type ${ktFunctionSymbol.javaClass}",
-                this.location,
-                ktFunctionSymbol.javaClass
-            )
+            else ->
+                throw InternalKSPException(
+                    "Unexpected function symbol type ${ktFunctionSymbol.javaClass}",
+                    this.location,
+                    ktFunctionSymbol.javaClass,
+                )
         }
     }
 
@@ -238,17 +263,21 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
         if (!psi.hasBlockBody()) {
             emptySequence()
         } else {
-            psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.flatMap {
-                analyze {
-                    when (val symbol = it.symbol) {
-                        is KaDestructuringDeclarationSymbol -> {
-                            symbol.entries.mapNotNull { it.toKSDeclaration() }
-                        }
+            psi.bodyBlockExpression
+                ?.statements
+                ?.asSequence()
+                ?.filterIsInstance<KtDeclaration>()
+                ?.flatMap {
+                    analyze {
+                        when (val symbol = it.symbol) {
+                            is KaDestructuringDeclarationSymbol -> {
+                                symbol.entries.mapNotNull { it.toKSDeclaration() }
+                            }
 
-                        else -> listOfNotNull(symbol.toKSDeclaration())
+                            else -> listOfNotNull(symbol.toKSDeclaration())
+                        }
                     }
-                }
-            } ?: emptySequence()
+                } ?: emptySequence()
         }
     }
 
@@ -256,7 +285,7 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
         // Override origin for java synthetic constructors.
         if (
             ktFunctionSymbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
-            (ktFunctionSymbol.psi == null || ktFunctionSymbol.psi is PsiClass)
+                (ktFunctionSymbol.psi == null || ktFunctionSymbol.psi is PsiClass)
         ) {
             Origin.SYNTHETIC
         } else {
@@ -265,18 +294,19 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
     }
 
     private fun isSyntheticConstructor(): Boolean {
-        return isConstructor() && (
-            origin == Origin.SYNTHETIC ||
-                (origin == Origin.JAVA && ktFunctionSymbol.psi == null || ktFunctionSymbol.psi is PsiClass)
-            )
+        return isConstructor() &&
+            (origin == Origin.SYNTHETIC ||
+                (origin == Origin.JAVA && ktFunctionSymbol.psi == null ||
+                    ktFunctionSymbol.psi is PsiClass))
     }
 
     override val annotations: Sequence<KSAnnotation>
-        get() = if (isSyntheticConstructor()) {
-            emptySequence()
-        } else {
-            super.annotations
-        }
+        get() =
+            if (isSyntheticConstructor()) {
+                emptySequence()
+            } else {
+                super.annotations
+            }
 
     override fun toString(): String {
         // TODO: fix origin for implicit Java constructor in AA
@@ -309,24 +339,25 @@ sealed class KSFunctionDeclarationImpl : KSFunctionDeclaration, AbstractKSDeclar
     }
 }
 
-private class KSFunctionDeclarationAAImpl(
-    override val ktFunctionSymbol: KaFunctionSymbol
-) : KSFunctionDeclaration, KSFunctionDeclarationImpl() {
+private class KSFunctionDeclarationAAImpl(override val ktFunctionSymbol: KaFunctionSymbol) :
+    KSFunctionDeclaration, KSFunctionDeclarationImpl() {
     companion object : KSObjectCache<KaFunctionSymbol, KSFunctionDeclarationAAImpl>() {
-        fun getCached(symbol: KaFunctionSymbol) = cache.getOrPut(symbol) {
-            KSFunctionDeclarationAAImpl(symbol)
-        }
+        fun getCached(symbol: KaFunctionSymbol) =
+            cache.getOrPut(symbol) {
+                KSFunctionDeclarationAAImpl(symbol)
+            }
     }
 }
 
 private class KSFunctionDeclarationPsiImpl(
     val psiMethod: PsiMethod,
-    val parentClass: KSClassDeclarationImpl
+    val parentClass: KSClassDeclarationImpl,
 ) : KSFunctionDeclaration, KSFunctionDeclarationImpl() {
     companion object : KSObjectCache<PsiMethod, KSFunctionDeclarationPsiImpl>() {
-        fun getCached(psiMethod: PsiMethod, parentClass: KSClassDeclarationImpl) = cache.getOrPut(psiMethod) {
-            KSFunctionDeclarationPsiImpl(psiMethod, parentClass)
-        }
+        fun getCached(psiMethod: PsiMethod, parentClass: KSClassDeclarationImpl) =
+            cache.getOrPut(psiMethod) {
+                KSFunctionDeclarationPsiImpl(psiMethod, parentClass)
+            }
     }
 
     override val ktFunctionSymbol: KaFunctionSymbol by lazy {
@@ -339,26 +370,31 @@ private class KSFunctionDeclarationPsiImpl(
     }
 
     override val simpleName: KSName by lazy {
-        if (psiMethod.isConstructor) KSNameImpl.getCached("<init>") else KSNameImpl.getCached(psiMethod.name)
+        if (psiMethod.isConstructor) KSNameImpl.getCached("<init>")
+        else KSNameImpl.getCached(psiMethod.name)
     }
 
     override val origin: Origin by lazy {
         when (parent) {
-            // If our lazy parent resolution determined that this method belongs to a Kotlin property,
+            // If our lazy parent resolution determined that this method belongs to a Kotlin
+            // property,
             // it means FIR considers it a synthetic property accessor.
             is KSPropertyDeclaration -> Origin.SYNTHETIC
             else -> parentClass.origin
         }
     }
 
-    override val containingFile: KSFile? get() = parentClass.containingFile
+    override val containingFile: KSFile?
+        get() = parentClass.containingFile
 
-    override val packageName: KSName get() = parentClass.packageName
+    override val packageName: KSName
+        get() = parentClass.packageName
 
     override val isAbstract: Boolean by lazy { psiMethod.hasModifierProperty(PsiModifier.ABSTRACT) }
 
     override val functionKind: FunctionKind by lazy {
-        if (psiMethod.hasModifierProperty(PsiModifier.STATIC)) FunctionKind.STATIC else FunctionKind.MEMBER
+        if (psiMethod.hasModifierProperty(PsiModifier.STATIC)) FunctionKind.STATIC
+        else FunctionKind.MEMBER
     }
 
     override val modifiers: Set<Modifier> by lazy {
@@ -382,7 +418,8 @@ private class KSFunctionDeclarationPsiImpl(
                 psiModifiers.add(Modifier.FINAL)
             }
             psiMethod.hasModifierProperty(PsiModifier.STATIC) -> {
-                // Emulate AA: Static methods in compiled Java libraries are treated as final in Kotlin
+                // Emulate AA: Static methods in compiled Java libraries are treated as final in
+                // Kotlin
                 psiModifiers.add(Modifier.FINAL)
             }
             !psiMethod.hasModifierProperty(PsiModifier.FINAL) &&
@@ -404,7 +441,8 @@ private class KSFunctionDeclarationPsiImpl(
 }
 
 /**
- * Resolves the [KaFunctionSymbol] that corresponds to the given [PsiMethod] within the [parent] class.
+ * Resolves the [KaFunctionSymbol] that corresponds to the given [PsiMethod] within the [parent]
+ * class.
  *
  * This method searches for a symbol whose underlying PSI matches the provided [psiMethod] using
  * exact identity or equivalence. It handles several Kotlin Analysis API (FIR) interop edge cases:
@@ -414,63 +452,81 @@ private class KSFunctionDeclarationPsiImpl(
  *    on Java classes triggers a severe performance bottleneck in the Analysis API, as it lacks a
  *    dedicated declared enhancement scope for Java classes and falls back to resolving the entire
  *    inherited use-site scope recursively.
- * 2. **Property Accessor Fallback:** If a Java method follows getter/setter conventions (e.g., `getFoo()`)
- *    and overrides a Kotlin property (`val foo`), FIR hides the method from the standard function scope
- *    and exposes it as a property symbol instead. If the initial function match fails, this method
- *    falls back to searching for property accessors via `findKaPropertyAccessorSymbols`.
+ * 2. **Property Accessor Fallback:** If a Java method follows getter/setter conventions (e.g.,
+ *    `getFoo()`) and overrides a Kotlin property (`val foo`), FIR hides the method from the
+ *    standard function scope and exposes it as a property symbol instead. If the initial function
+ *    match fails, this method falls back to searching for property accessors via
+ *    `findKaPropertyAccessorSymbols`.
  *
  * @param psiMethod The Java PSI method to resolve.
  * @param parent The enclosing class declaration proxy.
  * @return The resolved [KaFunctionSymbol], or null if the symbol could not be found.
  */
-fun KaSession.findKaFunctionSymbol(psiMethod: PsiMethod, parentClass: KSClassDeclarationImpl): KaFunctionSymbol? {
+fun KaSession.findKaFunctionSymbol(
+    psiMethod: PsiMethod,
+    parentClass: KSClassDeclarationImpl,
+): KaFunctionSymbol? {
     fun Sequence<KaSymbol>.firstMatchingPsiMethod(psi: PsiMethod): KaFunctionSymbol? {
-        return filterIsInstance<KaFunctionSymbol>().find { it.psi == psi || it.psi?.isEquivalentTo(psi) == true }
+        return filterIsInstance<KaFunctionSymbol>().find {
+            it.psi == psi || it.psi?.isEquivalentTo(psi) == true
+        }
     }
     val parentSymbol = parentClass.ktClassOrObjectSymbol
     return if (psiMethod.isConstructor) {
         parentSymbol.declaredMemberScope.constructors.firstMatchingPsiMethod(psiMethod)
     } else {
         val methodName = Name.identifier(psiMethod.name)
-        // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here since the psi method
-        // is declared in the parent. However, those methods trigger the performance issue mentioned in
-        // https://youtrack.jetbrains.com/issue/KT-85692, so stick with memberScope/staticMemberScope instead.
+        // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here
+        // since the psi method
+        // is declared in the parent. However, those methods trigger the performance issue mentioned
+        // in
+        // https://youtrack.jetbrains.com/issue/KT-85692, so stick with
+        // memberScope/staticMemberScope instead.
         parentSymbol.memberScope.callables(methodName).firstMatchingPsiMethod(psiMethod)
-            ?: parentSymbol.staticMemberScope.callables(methodName).firstMatchingPsiMethod(psiMethod)
-            // If the above match failed, it means that FIR hid the method because it overrides a Kotlin property (e.g.
-            // `getX` -> `x`), so we need to find the property and get the KaFunctionSymbol from it instead.
-            ?: findKaPropertyAccessorSymbols(psiMethod, parentClass).firstMatchingPsiMethod(psiMethod)
+            ?: parentSymbol.staticMemberScope
+                .callables(methodName)
+                .firstMatchingPsiMethod(psiMethod)
+            // If the above match failed, it means that FIR hid the method because it overrides a
+            // Kotlin property (e.g.
+            // `getX` -> `x`), so we need to find the property and get the KaFunctionSymbol from it
+            // instead.
+            ?: findKaPropertyAccessorSymbols(psiMethod, parentClass)
+                .firstMatchingPsiMethod(psiMethod)
     }
 }
 
 private fun KaSession.findKaPropertyAccessorSymbols(
     psiMethod: PsiMethod,
-    parentClass: KSClassDeclarationImpl
+    parentClass: KSClassDeclarationImpl,
 ): Sequence<KaPropertyAccessorSymbol> {
     val methodName = psiMethod.name
-    val namesToSearch = when {
-        // A standard Java getter like `getFoo()` overrides a Kotlin property named `foo` or `Foo`.
-        methodName.startsWith("get") && methodName.length > 3 -> {
-            val accessorBase = methodName.substring(3)
-            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
-            sequenceOf(propertyName, accessorBase)
+    val namesToSearch =
+        when {
+            // A standard Java getter like `getFoo()` overrides a Kotlin property named `foo` or
+            // `Foo`.
+            methodName.startsWith("get") && methodName.length > 3 -> {
+                val accessorBase = methodName.substring(3)
+                val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+                sequenceOf(propertyName, accessorBase)
+            }
+            // A Java boolean getter like `isFoo()` can override a Kotlin property named `foo` or
+            // `Foo`,
+            // OR a property explicitly named `isFoo`. All are valid in Kotlin interoperability.
+            methodName.startsWith("is") && methodName.length > 2 -> {
+                val accessorBase = methodName.substring(2)
+                val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+                sequenceOf(propertyName, accessorBase, methodName)
+            }
+            // A Java setter like `setFoo()` can override a standard Kotlin property named `foo` or
+            // `Foo`,
+            // OR it can override a boolean property explicitly named `isFoo`.
+            methodName.startsWith("set") && methodName.length > 3 -> {
+                val accessorBase = methodName.substring(3)
+                val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
+                sequenceOf(propertyName, accessorBase, "is$accessorBase")
+            }
+            else -> return emptySequence()
         }
-        // A Java boolean getter like `isFoo()` can override a Kotlin property named `foo` or `Foo`,
-        // OR a property explicitly named `isFoo`. All are valid in Kotlin interoperability.
-        methodName.startsWith("is") && methodName.length > 2 -> {
-            val accessorBase = methodName.substring(2)
-            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
-            sequenceOf(propertyName, accessorBase, methodName)
-        }
-        // A Java setter like `setFoo()` can override a standard Kotlin property named `foo` or `Foo`,
-        // OR it can override a boolean property explicitly named `isFoo`.
-        methodName.startsWith("set") && methodName.length > 3 -> {
-            val accessorBase = methodName.substring(3)
-            val propertyName = accessorBase.replaceFirstChar { it.lowercaseChar() }
-            sequenceOf(propertyName, accessorBase, "is$accessorBase")
-        }
-        else -> return emptySequence()
-    }
     return namesToSearch
         .flatMap { parentClass.ktClassOrObjectSymbol.memberScope.callables(Name.identifier(it)) }
         .filterIsInstance<KaPropertySymbol>()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionErrorImpl.kt
@@ -5,25 +5,26 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
 
-class KSFunctionErrorImpl(
-    private val declaration: KSFunctionDeclaration
-) : KSFunction {
+class KSFunctionErrorImpl(private val declaration: KSFunctionDeclaration) : KSFunction {
     override val isError: Boolean = true
 
     override val returnType: KSType
         get() = KSErrorType.fromReferenceBestEffort(declaration.returnType)
 
     override val parameterTypes: List<KSType?>
-        get() = declaration.parameters.map {
-            KSErrorType.fromReferenceBestEffort(it.type)
-        }
+        get() =
+            declaration.parameters.map {
+                KSErrorType.fromReferenceBestEffort(it.type)
+            }
+
     override val typeParameters: List<KSTypeParameter>
         get() = emptyList()
 
     override val extensionReceiverType: KSType?
-        get() = declaration.extensionReceiver?.let {
-            KSErrorType.fromReferenceBestEffort(it)
-        }
+        get() =
+            declaration.extensionReceiver?.let {
+                KSErrorType.fromReferenceBestEffort(it)
+            }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSFunctionImpl.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.InternalKSPException
 import com.google.devtools.ksp.symbol.KSFunction
 import com.google.devtools.ksp.symbol.KSType
 import com.google.devtools.ksp.symbol.KSTypeParameter
+import java.util.*
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.signatures.KaFunctionSignature
 import org.jetbrains.kotlin.analysis.api.symbols.KaFunctionSymbol
@@ -29,9 +30,10 @@ import org.jetbrains.kotlin.analysis.api.types.KaSubstitutor
 import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
-import java.util.*
 
-class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
+class KSFunctionImpl
+@OptIn(KaExperimentalApi::class)
+constructor(
     val functionSignature: KaFunctionSignature<KaFunctionSymbol>,
     private val substitutor: KaSubstitutor,
 ) : KSFunction {
@@ -41,34 +43,37 @@ class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
     }
 
     override val parameterTypes: List<KSType?> by lazy {
-        functionSignature.valueParameters.map { it.returnType.abbreviationOrSelf.let { KSTypeImpl.getCached(it) } }
+        functionSignature.valueParameters.map {
+            it.returnType.abbreviationOrSelf.let { KSTypeImpl.getCached(it) }
+        }
     }
 
     @OptIn(KaExperimentalApi::class)
     override val typeParameters: List<KSTypeParameter> by lazy {
         functionSignature.symbol.typeParameters.map { typeParam ->
-            val bounds = typeParam.upperBounds.ifNotEmpty {
-                map { bound ->
-                    // Substitude to a fixed point.
-                    var prev = bound
-                    var curr = substitutor.substitute(bound)
-                    val seen = mutableSetOf<Pair<KaType, KaType>>()
-                    while (prev != curr) {
-                        val pair = Pair(prev, curr)
-                        if (pair in seen) {
-                            throw InternalKSPException(
-                                "Recurrent substitution of bounds of $typeParam: $bound by $substitutor",
-                                typeParam.psi.toLocation(),
-                                typeParam.javaClass
-                            )
+            val bounds =
+                typeParam.upperBounds.ifNotEmpty {
+                    map { bound ->
+                        // Substitude to a fixed point.
+                        var prev = bound
+                        var curr = substitutor.substitute(bound)
+                        val seen = mutableSetOf<Pair<KaType, KaType>>()
+                        while (prev != curr) {
+                            val pair = Pair(prev, curr)
+                            if (pair in seen) {
+                                throw InternalKSPException(
+                                    "Recurrent substitution of bounds of $typeParam: $bound by $substitutor",
+                                    typeParam.psi.toLocation(),
+                                    typeParam.javaClass,
+                                )
+                            }
+                            seen.add(pair)
+                            prev = curr
+                            curr = substitutor.substitute(curr)
                         }
-                        seen.add(pair)
-                        prev = curr
-                        curr = substitutor.substitute(curr)
+                        curr
                     }
-                    curr
                 }
-            }
             KSTypeParameterImpl.getCached(typeParam, bounds)
         }
     }
@@ -79,14 +84,15 @@ class KSFunctionImpl @OptIn(KaExperimentalApi::class) constructor(
 
     override val isError: Boolean = false
 
-    private val cachedHashCode by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        Objects.hash(
-            returnType ?: 0,
-            parameterTypes,
-            typeParameters,
-            extensionReceiverType ?: 0
-        )
-    }
+    private val cachedHashCode by
+        lazy(LazyThreadSafetyMode.PUBLICATION) {
+            Objects.hash(
+                returnType ?: 0,
+                parameterTypes,
+                typeParameters,
+                extensionReceiverType ?: 0,
+            )
+        }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyAccessorImpl.kt
@@ -35,18 +35,21 @@ import org.jetbrains.kotlin.psi.KtPropertyAccessor
 
 abstract class KSPropertyAccessorImpl(
     internal val ktPropertyAccessorSymbol: KaPropertyAccessorSymbol,
-    override val receiver: KSPropertyDeclaration
+    override val receiver: KSPropertyDeclaration,
 ) : KSPropertyAccessor, Deferrable {
 
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
-        // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
-        ktPropertyAccessorSymbol.annotations.asSequence()
+        // (ktPropertyAccessorSymbol.psi as?
+        // KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
+        ktPropertyAccessorSymbol.annotations
+            .asSequence()
             .filter { it.useSiteTarget != AnnotationUseSiteTarget.SETTER_PARAMETER }
             .map { KSAnnotationResolvedImpl.getCached(it, this, definitionOrigin) }
     }
 
     internal val originalAnnotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
-        // (ktPropertyAccessorSymbol.psi as? KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
+        // (ktPropertyAccessorSymbol.psi as?
+        // KtPropertyAccessor)?.annotations(ktPropertyAccessorSymbol, this) ?:
         ktPropertyAccessorSymbol.annotations(this)
     }
 
@@ -55,21 +58,27 @@ abstract class KSPropertyAccessorImpl(
     }
 
     override val modifiers: Set<Modifier> by lazy {
-        (
-            if (origin == Origin.JAVA_LIB || origin == Origin.KOTLIN_LIB || origin == Origin.SYNTHETIC) {
+        (if (
+                origin == Origin.JAVA_LIB ||
+                    origin == Origin.KOTLIN_LIB ||
+                    origin == Origin.SYNTHETIC
+            ) {
                 (ktPropertyAccessorSymbol.toModifiers())
             } else {
-                (ktPropertyAccessorSymbol.psi as? KtModifierListOwner)?.toKSModifiers() ?: emptySet()
+                (ktPropertyAccessorSymbol.psi as? KtModifierListOwner)?.toKSModifiers()
+                    ?: emptySet()
+            })
+            .let {
+                if (
+                    origin == Origin.SYNTHETIC &&
+                        (receiver.parentDeclaration as? KSClassDeclaration)?.classKind ==
+                            ClassKind.INTERFACE
+                ) {
+                    it + Modifier.ABSTRACT
+                } else {
+                    it
+                }
             }
-            ).let {
-            if (origin == Origin.SYNTHETIC &&
-                (receiver.parentDeclaration as? KSClassDeclaration)?.classKind == ClassKind.INTERFACE
-            ) {
-                it + Modifier.ABSTRACT
-            } else {
-                it
-            }
-        }
     }
 
     override val origin: Origin by lazy {
@@ -85,24 +94,32 @@ abstract class KSPropertyAccessorImpl(
         get() = ktPropertyAccessorSymbol.getContainingKSSymbol()
 
     override val declarations: Sequence<KSDeclaration> by lazyMemoizedSequence {
-        val psi = ktPropertyAccessorSymbol.psi as? KtPropertyAccessor ?: return@lazyMemoizedSequence emptySequence()
+        val psi =
+            ktPropertyAccessorSymbol.psi as? KtPropertyAccessor
+                ?: return@lazyMemoizedSequence emptySequence()
         if (!psi.hasBlockBody()) {
             emptySequence()
         } else {
-            psi.bodyBlockExpression?.statements?.asSequence()?.filterIsInstance<KtDeclaration>()?.mapNotNull {
-                analyze {
-                    it.symbol.toKSDeclaration()
-                }
-            } ?: emptySequence()
+            psi.bodyBlockExpression
+                ?.statements
+                ?.asSequence()
+                ?.filterIsInstance<KtDeclaration>()
+                ?.mapNotNull {
+                    analyze {
+                        it.symbol.toKSDeclaration()
+                    }
+                } ?: emptySequence()
         }
     }
 }
 
-class KSPropertySetterImpl private constructor(
+class KSPropertySetterImpl
+private constructor(
     owner: KSPropertyDeclaration,
-    setter: KaPropertySetterSymbol
+    setter: KaPropertySetterSymbol,
 ) : KSPropertyAccessorImpl(setter, owner), KSPropertySetter {
-    companion object : KSObjectCache<Pair<KSPropertyDeclaration, KaPropertySetterSymbol>, KSPropertySetterImpl>() {
+    companion object :
+        KSObjectCache<Pair<KSPropertyDeclaration, KaPropertySetterSymbol>, KSPropertySetterImpl>() {
         fun getCached(owner: KSPropertyDeclaration, setter: KaPropertySetterSymbol) =
             cache.getOrPut(Pair(owner, setter)) { KSPropertySetterImpl(owner, setter) }
     }
@@ -128,19 +145,25 @@ class KSPropertySetterImpl private constructor(
     }
 }
 
-class KSPropertyGetterImpl private constructor(
+class KSPropertyGetterImpl
+private constructor(
     owner: KSPropertyDeclaration,
-    getter: KaPropertyGetterSymbol
+    getter: KaPropertyGetterSymbol,
 ) : KSPropertyAccessorImpl(getter, owner), KSPropertyGetter {
-    companion object : KSObjectCache<Pair<KSPropertyDeclaration, KaPropertyGetterSymbol>, KSPropertyGetterImpl>() {
+    companion object :
+        KSObjectCache<Pair<KSPropertyDeclaration, KaPropertyGetterSymbol>, KSPropertyGetterImpl>() {
         fun getCached(owner: KSPropertyDeclaration, getter: KaPropertyGetterSymbol) =
             cache.getOrPut(Pair(owner, getter)) { KSPropertyGetterImpl(owner, getter) }
     }
 
     override val returnType: KSTypeReference? by lazy {
-        ((owner as? KSPropertyDeclarationImpl)?.ktPropertySymbol?.psiIfSource() as? KtProperty)?.typeReference
+        ((owner as? KSPropertyDeclarationImpl)?.ktPropertySymbol?.psiIfSource() as? KtProperty)
+            ?.typeReference
             ?.let { KSTypeReferenceImpl.getCached(it, this) }
-            ?: KSTypeReferenceResolvedImpl.getCached(getter.returnType.abbreviationOrSelf, this@KSPropertyGetterImpl)
+            ?: KSTypeReferenceResolvedImpl.getCached(
+                getter.returnType.abbreviationOrSelf,
+                this@KSPropertyGetterImpl,
+            )
     }
 
     override fun <D, R> accept(visitor: KSVisitor<D, R>, data: D): R {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -47,11 +47,14 @@ import org.jetbrains.kotlin.load.kotlin.KotlinJvmBinarySourceElement
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtProperty
 
-class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbol: KaPropertySymbol) :
+class KSPropertyDeclarationImpl
+private constructor(internal val ktPropertySymbol: KaPropertySymbol) :
     KSPropertyDeclaration,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktPropertySymbol) {
-    override val ktDeclarationSymbol get() = ktPropertySymbol
+    override val ktDeclarationSymbol
+        get() = ktPropertySymbol
+
     companion object : KSObjectCache<KaPropertySymbol, KSPropertyDeclarationImpl>() {
         fun getCached(ktPropertySymbol: KaPropertySymbol) =
             cache.getOrPut(ktPropertySymbol) { KSPropertyDeclarationImpl(ktPropertySymbol) }
@@ -61,13 +64,18 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
         get() = annotations
 
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
-        ktPropertySymbol.annotations.asSequence()
+        ktPropertySymbol.annotations
+            .asSequence()
             .filter { !it.isUseSiteTargetAnnotation() }
             .map { KSAnnotationResolvedImpl.getCached(it, this, definitionOrigin) }
             .plus(
                 // TODO: optimize for psi
                 ktPropertySymbol.backingFieldSymbol?.annotations?.map {
-                    KSAnnotationResolvedImpl.getCached(it, this@KSPropertyDeclarationImpl, definitionOrigin)
+                    KSAnnotationResolvedImpl.getCached(
+                        it,
+                        this@KSPropertyDeclarationImpl,
+                        definitionOrigin,
+                    )
                 } ?: emptyList()
             )
     }
@@ -89,31 +97,32 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
     }
 
     override val extensionReceiver: KSTypeReference? by lazy {
-        (ktPropertySymbol.psiIfSource() as? KtProperty)?.receiverTypeReference
-            ?.let {
-                // receivers are modeled as parameter in AA therefore annotations are stored in
-                // the corresponding receiver parameter, need to pass it to the `KSTypeReferenceImpl`
-                KSTypeReferenceImpl.getCached(
-                    it,
-                    this,
-                    ktPropertySymbol.receiverParameter?.annotations ?: emptyList()
-                )
-            }
+        (ktPropertySymbol.psiIfSource() as? KtProperty)?.receiverTypeReference?.let {
+            // receivers are modeled as parameter in AA therefore annotations are stored in
+            // the corresponding receiver parameter, need to pass it to the `KSTypeReferenceImpl`
+            KSTypeReferenceImpl.getCached(
+                it,
+                this,
+                ktPropertySymbol.receiverParameter?.annotations ?: emptyList(),
+            )
+        }
             ?: ktPropertySymbol.receiverType?.abbreviationOrSelf?.let {
                 KSTypeReferenceResolvedImpl.getCached(
                     it,
                     this@KSPropertyDeclarationImpl,
                     -1,
-                    ktPropertySymbol.receiverParameter?.annotations ?: emptyList()
+                    ktPropertySymbol.receiverParameter?.annotations ?: emptyList(),
                 )
             }
     }
 
     override val type: KSTypeReference by lazy {
-        (ktPropertySymbol.psiIfSource() as? KtProperty)?.typeReference?.let { KSTypeReferenceImpl.getCached(it, this) }
+        (ktPropertySymbol.psiIfSource() as? KtProperty)?.typeReference?.let {
+            KSTypeReferenceImpl.getCached(it, this)
+        }
             ?: KSTypeReferenceResolvedImpl.getCached(
                 ktPropertySymbol.returnType.abbreviationOrSelf,
-                this@KSPropertyDeclarationImpl
+                this@KSPropertyDeclarationImpl,
             )
     }
 
@@ -130,19 +139,22 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
                 (ktPropertySymbol as? KaKotlinPropertySymbol)?.isLateInit == true -> true
                 ktPropertySymbol.modality == KaSymbolModality.ABSTRACT -> false
                 else -> {
-                    if (!ResolverAAImpl.instance.isJvm)
-                        return@lazy ktPropertySymbol.hasBackingField
-                    val classId = when (
-                        val containerSource =
-                            (ktPropertySymbol as? KaFirKotlinPropertySymbol<*>)?.firSymbol?.containerSource
-                    ) {
-                        is JvmPackagePartSource -> containerSource.classId
-                        is KotlinJvmBinarySourceElement -> containerSource.binaryClass.classId
-                        else -> null
-                    } ?: return@lazy ktPropertySymbol.hasBackingField
+                    if (!ResolverAAImpl.instance.isJvm) return@lazy ktPropertySymbol.hasBackingField
+                    val classId =
+                        when (
+                            val containerSource =
+                                (ktPropertySymbol as? KaFirKotlinPropertySymbol<*>)
+                                    ?.firSymbol
+                                    ?.containerSource
+                        ) {
+                            is JvmPackagePartSource -> containerSource.classId
+                            is KotlinJvmBinarySourceElement -> containerSource.binaryClass.classId
+                            else -> null
+                        } ?: return@lazy ktPropertySymbol.hasBackingField
                     val fileManager = ResolverAAImpl.instance.javaFileManager
                     BinaryClassInfoCache.getCached(classId, fileManager)
-                        ?.fieldAccFlags?.containsKey(simpleName.asString()) ?: ktPropertySymbol.hasBackingField
+                        ?.fieldAccFlags
+                        ?.containsKey(simpleName.asString()) ?: ktPropertySymbol.hasBackingField
                 }
             }
         } else {
@@ -160,9 +172,12 @@ class KSPropertyDeclarationImpl private constructor(internal val ktPropertySymbo
         }
         recordLookupForPropertyOrMethod(this)
         return analyze {
-            ktPropertySymbol.directlyOverriddenSymbols.firstOrNull()
-                ?.fakeOverrideOriginal?.toKSDeclaration() as? KSPropertyDeclaration
-        }?.also { recordLookupForPropertyOrMethod(it) }
+                ktPropertySymbol.directlyOverriddenSymbols
+                    .firstOrNull()
+                    ?.fakeOverrideOriginal
+                    ?.toKSDeclaration() as? KSPropertyDeclaration
+            }
+            ?.also { recordLookupForPropertyOrMethod(it) }
     }
 
     override fun asMemberOf(containing: KSType): KSType {
@@ -231,8 +246,10 @@ internal fun KaPropertySymbol.toModifiers(): Set<Modifier> {
 
 internal fun KSAnnotation.isValidOnProperty(): Boolean =
     annotationType.resolve().declaration.annotations.none { metaAnnotation ->
-        metaAnnotation.annotationType.resolve().declaration.qualifiedName?.asString() == "kotlin.annotation.Target" &&
+        metaAnnotation.annotationType.resolve().declaration.qualifiedName?.asString() ==
+            "kotlin.annotation.Target" &&
             (metaAnnotation.arguments.singleOrNull()?.value as? ArrayList<*>)?.none {
-            (it as? KSClassDeclaration)?.qualifiedName?.asString() == "kotlin.annotation.AnnotationTarget.PROPERTY"
-        } ?: false
+                (it as? KSClassDeclaration)?.qualifiedName?.asString() ==
+                    "kotlin.annotation.AnnotationTarget.PROPERTY"
+            } ?: false
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationJavaImpl.kt
@@ -37,8 +37,10 @@ import org.jetbrains.kotlin.name.Name
 sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDeclarationImpl() {
     companion object {
         // Factory for PSI Fast Path
-        fun getCached(psi: PsiField, parent: KSClassDeclarationImpl): KSPropertyDeclarationJavaImpl =
-            KSPropertyDeclarationJavaPsiImpl.getCached(psi, parent)
+        fun getCached(
+            psi: PsiField,
+            parent: KSClassDeclarationImpl,
+        ): KSPropertyDeclarationJavaImpl = KSPropertyDeclarationJavaPsiImpl.getCached(psi, parent)
 
         // Factory for AA Slow Path
         fun getCached(symbol: KaJavaFieldSymbol): KSPropertyDeclarationJavaImpl =
@@ -52,9 +54,14 @@ sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDe
 
     // Manual delegation for KSExpectActual to avoid eager evaluation in the class header
     private val expectActualImpl by lazy { KSExpectActualImpl(ktJavaFieldSymbol) }
-    override val isActual: Boolean get() = expectActualImpl.isActual
-    override val isExpect: Boolean get() = expectActualImpl.isExpect
+    override val isActual: Boolean
+        get() = expectActualImpl.isActual
+
+    override val isExpect: Boolean
+        get() = expectActualImpl.isExpect
+
     override fun findActuals(): Sequence<KSDeclaration> = expectActualImpl.findActuals()
+
     override fun findExpects(): Sequence<KSDeclaration> = expectActualImpl.findExpects()
 
     override val getter: KSPropertyGetter?
@@ -67,7 +74,10 @@ sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDe
         get() = null
 
     override val type: KSTypeReference by lazy {
-        KSTypeReferenceResolvedImpl.getCached(ktJavaFieldSymbol.returnType, this@KSPropertyDeclarationJavaImpl)
+        KSTypeReferenceResolvedImpl.getCached(
+            ktJavaFieldSymbol.returnType,
+            this@KSPropertyDeclarationJavaImpl,
+        )
     }
 
     override val isMutable: Boolean
@@ -92,7 +102,9 @@ sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDe
         get() = emptyList()
 
     override val qualifiedName: KSName? by lazy {
-        KSNameImpl.getCached("${this.parentDeclaration!!.qualifiedName!!.asString()}.${simpleName.asString()}")
+        KSNameImpl.getCached(
+            "${this.parentDeclaration!!.qualifiedName!!.asString()}.${simpleName.asString()}"
+        )
     }
 
     override val packageName: KSName
@@ -110,13 +122,13 @@ sealed class KSPropertyDeclarationJavaImpl : KSPropertyDeclaration, AbstractKSDe
     }
 }
 
-private class KSPropertyDeclarationJavaAAImpl(
-    override val ktJavaFieldSymbol: KaJavaFieldSymbol
-) : KSPropertyDeclarationJavaImpl() {
+private class KSPropertyDeclarationJavaAAImpl(override val ktJavaFieldSymbol: KaJavaFieldSymbol) :
+    KSPropertyDeclarationJavaImpl() {
     companion object : KSObjectCache<KaJavaFieldSymbol, KSPropertyDeclarationJavaAAImpl>() {
-        fun getCached(symbol: KaJavaFieldSymbol) = cache.getOrPut(symbol) {
-            KSPropertyDeclarationJavaAAImpl(symbol)
-        }
+        fun getCached(symbol: KaJavaFieldSymbol) =
+            cache.getOrPut(symbol) {
+                KSPropertyDeclarationJavaAAImpl(symbol)
+            }
     }
 }
 
@@ -125,26 +137,32 @@ private class KSPropertyDeclarationJavaPsiImpl(
     override val parent: KSClassDeclarationImpl,
 ) : KSPropertyDeclarationJavaImpl() {
     companion object : KSObjectCache<PsiField, KSPropertyDeclarationJavaPsiImpl>() {
-        fun getCached(psiField: PsiField, parent: KSClassDeclarationImpl) = cache.getOrPut(psiField) {
-            KSPropertyDeclarationJavaPsiImpl(psiField, parent)
-        }
+        fun getCached(psiField: PsiField, parent: KSClassDeclarationImpl) =
+            cache.getOrPut(psiField) {
+                KSPropertyDeclarationJavaPsiImpl(psiField, parent)
+            }
     }
 
     override val ktJavaFieldSymbol: KaJavaFieldSymbol by lazy {
         analyze {
             val targetName = Name.identifier(psiField.name)
-            // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used here since the psi
-            // field is declared in the parent. However, those scopes trigger the performance issue mentioned in
-            // https://youtrack.jetbrains.com/issue/KT-85692, so stick with memberScope/staticMemberScope instead.
+            // Note: Technically, declaredMemberScope and staticDeclaredMemberScope could be used
+            // here since the psi
+            // field is declared in the parent. However, those scopes trigger the performance issue
+            // mentioned in
+            // https://youtrack.jetbrains.com/issue/KT-85692, so stick with
+            // memberScope/staticMemberScope instead.
             val instanceSymbols = parent.ktClassOrObjectSymbol.memberScope.callables(targetName)
             val staticSymbols = parent.ktClassOrObjectSymbol.staticMemberScope.callables(targetName)
-            (instanceSymbols + staticSymbols)
-                .find { it.psi == psiField || it.psi?.isEquivalentTo(psiField) == true } as? KaJavaFieldSymbol
-        } ?: throw InternalKSPException(
-            "Failed to resolve KaJavaFieldSymbol for field ${psiField.name}",
-            psiField.toLocation(),
-            psiField.javaClass,
-        )
+            (instanceSymbols + staticSymbols).find {
+                it.psi == psiField || it.psi?.isEquivalentTo(psiField) == true
+            } as? KaJavaFieldSymbol
+        }
+            ?: throw InternalKSPException(
+                "Failed to resolve KaJavaFieldSymbol for field ${psiField.name}",
+                psiField.toLocation(),
+                psiField.javaClass,
+            )
     }
 
     override val simpleName: KSName by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationLocalVariableImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationLocalVariableImpl.kt
@@ -14,15 +14,20 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaLocalVariableSymbol
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.psi.KtProperty
 
-class KSPropertyDeclarationLocalVariableImpl private constructor(
-    private val ktLocalVariableSymbol: KaLocalVariableSymbol
-) : KSPropertyDeclaration,
+class KSPropertyDeclarationLocalVariableImpl
+private constructor(private val ktLocalVariableSymbol: KaLocalVariableSymbol) :
+    KSPropertyDeclaration,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktLocalVariableSymbol) {
-    override val ktDeclarationSymbol get() = ktLocalVariableSymbol
-    companion object : KSObjectCache<KaLocalVariableSymbol, KSPropertyDeclarationLocalVariableImpl>() {
+    override val ktDeclarationSymbol
+        get() = ktLocalVariableSymbol
+
+    companion object :
+        KSObjectCache<KaLocalVariableSymbol, KSPropertyDeclarationLocalVariableImpl>() {
         fun getCached(ktLocalVariableSymbol: KaLocalVariableSymbol) =
-            cache.getOrPut(ktLocalVariableSymbol) { KSPropertyDeclarationLocalVariableImpl(ktLocalVariableSymbol) }
+            cache.getOrPut(ktLocalVariableSymbol) {
+                KSPropertyDeclarationLocalVariableImpl(ktLocalVariableSymbol)
+            }
     }
 
     override val getter: KSPropertyGetter? = null
@@ -32,9 +37,13 @@ class KSPropertyDeclarationLocalVariableImpl private constructor(
     override val extensionReceiver: KSTypeReference? = null
 
     override val type: KSTypeReference by lazy {
-        (ktLocalVariableSymbol.psiIfSource() as? KtProperty)?.typeReference
-            ?.let { KSTypeReferenceImpl.getCached(it, this) }
-            ?: KSTypeReferenceResolvedImpl.getCached(ktLocalVariableSymbol.returnType.abbreviationOrSelf, this)
+        (ktLocalVariableSymbol.psiIfSource() as? KtProperty)?.typeReference?.let {
+            KSTypeReferenceImpl.getCached(it, this)
+        }
+            ?: KSTypeReferenceResolvedImpl.getCached(
+                ktLocalVariableSymbol.returnType.abbreviationOrSelf,
+                this,
+            )
     }
 
     override val isMutable: Boolean = !ktLocalVariableSymbol.isVal

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeAliasImpl.kt
@@ -26,7 +26,9 @@ class KSTypeAliasImpl private constructor(private val ktTypeAliasSymbol: KaTypeA
     KSTypeAlias,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktTypeAliasSymbol) {
-    override val ktDeclarationSymbol get() = ktTypeAliasSymbol
+    override val ktDeclarationSymbol
+        get() = ktTypeAliasSymbol
+
     companion object : KSObjectCache<KaTypeAliasSymbol, KSTypeAliasImpl>() {
         fun getCached(ktTypeAliasSymbol: KaTypeAliasSymbol) =
             cache.getOrPut(ktTypeAliasSymbol) { KSTypeAliasImpl(ktTypeAliasSymbol) }
@@ -39,7 +41,7 @@ class KSTypeAliasImpl private constructor(private val ktTypeAliasSymbol: KaTypeA
     override val type: KSTypeReference by lazy {
         KSTypeReferenceResolvedImpl.getCached(
             ktTypeAliasSymbol.expandedType.let { it.abbreviation ?: it },
-            this
+            this,
         )
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentImpl.kt
@@ -28,11 +28,15 @@ import com.google.devtools.ksp.symbol.Variance
 import org.jetbrains.kotlin.psi.KtProjectionKind
 import org.jetbrains.kotlin.psi.KtTypeProjection
 
-class KSTypeArgumentImpl(private val ktTypeArgument: KtTypeProjection, override val parent: KSNode) : KSTypeArgument {
+class KSTypeArgumentImpl(
+    private val ktTypeArgument: KtTypeProjection,
+    override val parent: KSNode,
+) : KSTypeArgument {
     companion object : KSObjectCache<KtTypeProjection, KSTypeArgument>() {
-        fun getCached(ktTypeArgument: KtTypeProjection, parent: KSNode) = cache.getOrPut(ktTypeArgument) {
-            KSTypeArgumentImpl(ktTypeArgument, parent)
-        }
+        fun getCached(ktTypeArgument: KtTypeProjection, parent: KSNode) =
+            cache.getOrPut(ktTypeArgument) {
+                KSTypeArgumentImpl(ktTypeArgument, parent)
+            }
     }
 
     override val origin = Origin.KOTLIN

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeArgumentLiteImpl.kt
@@ -11,12 +11,14 @@ import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
 
-class KSTypeArgumentLiteImpl private constructor(override val type: KSTypeReference, override val variance: Variance) :
+class KSTypeArgumentLiteImpl
+private constructor(override val type: KSTypeReference, override val variance: Variance) :
     KSTypeArgument, Deferrable {
     companion object : KSObjectCache<Pair<KSTypeReference, Variance>, KSTypeArgument>() {
-        fun getCached(type: KSTypeReference, variance: Variance) = cache.getOrPut(Pair(type, variance)) {
-            KSTypeArgumentLiteImpl(type, variance)
-        }
+        fun getCached(type: KSTypeReference, variance: Variance) =
+            cache.getOrPut(Pair(type, variance)) {
+                KSTypeArgumentLiteImpl(type, variance)
+            }
     }
 
     override val annotations: Sequence<KSAnnotation> = emptySequence()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeImpl.kt
@@ -37,9 +37,10 @@ import org.jetbrains.kotlin.analysis.api.types.*
 
 class KSTypeImpl private constructor(internal val type: KaType) : KSType {
     companion object : KSObjectCache<IdKey<KaType>, KSTypeImpl>() {
-        fun getCached(type: KaType): KSTypeImpl = cache.getOrPut(IdKey(type)) {
-            KSTypeImpl(type)
-        }
+        fun getCached(type: KaType): KSTypeImpl =
+            cache.getOrPut(IdKey(type)) {
+                KSTypeImpl(type)
+            }
     }
 
     private fun KaType.toDeclaration(): KSDeclaration {
@@ -54,8 +55,7 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
 
                 is KaTypeParameterType -> KSTypeParameterImpl.getCached(symbol)
                 is KaClassErrorType -> KSErrorTypeClassDeclaration(this@KSTypeImpl)
-                is KaFlexibleType ->
-                    type.lowerBoundIfFlexible().toDeclaration()
+                is KaFlexibleType -> type.lowerBoundIfFlexible().toDeclaration()
 
                 is KaDefinitelyNotNullType -> this@toDeclaration.original.toDeclaration()
                 else -> KSErrorTypeClassDeclaration(this@KSTypeImpl)
@@ -65,14 +65,16 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
 
     override val declaration: KSDeclaration by lazy {
         (type as? KaFunctionType)?.abbreviatedSymbol()?.toKSDeclaration()
-            ?: type.abbreviation?.toDeclaration() ?: type.toDeclaration()
+            ?: type.abbreviation?.toDeclaration()
+            ?: type.toDeclaration()
     }
 
     override val nullability: Nullability by lazy {
         when {
-            type is KaFlexibleType && analyze {
-                !type.lowerBound.isMarkedNullable && type.upperBound.isMarkedNullable
-            } -> Nullability.PLATFORM
+            type is KaFlexibleType &&
+                analyze {
+                    !type.lowerBound.isMarkedNullable && type.upperBound.isMarkedNullable
+                } -> Nullability.PLATFORM
             analyze { type.isNullable } -> Nullability.NULLABLE
             else -> Nullability.NOT_NULL
         }
@@ -85,22 +87,24 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
             if (type is KaFlexibleType) {
                 type.upperBound.typeArguments().map { KSTypeArgumentResolvedImpl.getCached(it) }
             } else {
-                (type as? KaClassType)?.typeArguments()?.map { KSTypeArgumentResolvedImpl.getCached(it) }
-                    ?: emptyList()
+                (type as? KaClassType)?.typeArguments()?.map {
+                    KSTypeArgumentResolvedImpl.getCached(it)
+                } ?: emptyList()
             }
         }
     }
 
     @OptIn(KaImplementationDetail::class)
     override val annotations: Sequence<KSAnnotation>
-        get() = type.annotations() +
-            if (type is KaFunctionType && type.receiverType != null) {
-                sequenceOf(
-                    KSAnnotationResolvedImpl.getCached(getExtensionFunctionTypeAnnotation())
-                )
-            } else {
-                emptySequence()
-            }
+        get() =
+            type.annotations() +
+                if (type is KaFunctionType && type.receiverType != null) {
+                    sequenceOf(
+                        KSAnnotationResolvedImpl.getCached(getExtensionFunctionTypeAnnotation())
+                    )
+                } else {
+                    emptySequence()
+                }
 
     override fun isAssignableFrom(that: KSType): Boolean {
         if (that.isError || this.isError) {
@@ -124,17 +128,24 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
             return this
         }
         errorTypeOnInconsistentArguments(
-            arguments = arguments,
-            placeholdersProvider = { type.typeArguments().map { KSTypeArgumentResolvedImpl.getCached(it) } },
-            withCorrectedArguments = ::replace,
-            errorType = ::KSErrorType,
-        )?.let { error -> return error }
+                arguments = arguments,
+                placeholdersProvider = {
+                    type.typeArguments().map { KSTypeArgumentResolvedImpl.getCached(it) }
+                },
+                withCorrectedArguments = ::replace,
+                errorType = ::KSErrorType,
+            )
+            ?.let { error ->
+                return error
+            }
         return getCached(type.replace(arguments.map { it.toKtTypeProjection() }))
     }
 
     @OptIn(KaImplementationDetail::class)
     override fun starProjection(): KSType {
-        return getCached(type.replace(List(type.typeArguments().size) { KaBaseStarTypeProjection(type.token) }))
+        return getCached(
+            type.replace(List(type.typeArguments().size) { KaBaseStarTypeProjection(type.token) })
+        )
     }
 
     override fun makeNullable(): KSType {
@@ -152,7 +163,8 @@ class KSTypeImpl private constructor(internal val type: KaType) : KSType {
     override val isMarkedNullable: Boolean = analyze { type.isMarkedNullable }
 
     override val isError: Boolean
-        // TODO: non exist type returns KtNonErrorClassType, check upstream for KtClassErrorType usage.
+        // TODO: non exist type returns KtNonErrorClassType, check upstream for KtClassErrorType
+        // usage.
         get() = type is KaErrorType || type.classifierSymbol() == null
 
     override val isFunctionType: Boolean

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeParameterImpl.kt
@@ -26,15 +26,19 @@ import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.symbols.KaTypeParameterSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaType
 
-class KSTypeParameterImpl private constructor(
+class KSTypeParameterImpl
+private constructor(
     internal val ktTypeParameterSymbol: KaTypeParameterSymbol,
-    private val boundsSubstitued: List<KaType>?
+    private val boundsSubstitued: List<KaType>?,
 ) :
     KSTypeParameter,
     AbstractKSDeclarationImpl(),
     KSExpectActual by KSExpectActualImpl(ktTypeParameterSymbol) {
-    override val ktDeclarationSymbol get() = ktTypeParameterSymbol
-    companion object : KSObjectCache<Pair<KaTypeParameterSymbol, List<KaType>?>, KSTypeParameterImpl>() {
+    override val ktDeclarationSymbol
+        get() = ktTypeParameterSymbol
+
+    companion object :
+        KSObjectCache<Pair<KaTypeParameterSymbol, List<KaType>?>, KSTypeParameterImpl>() {
         fun getCached(ktTypeParameterSymbol: KaTypeParameterSymbol, bounds: List<KaType>? = null) =
             cache.getOrPut(Pair(ktTypeParameterSymbol, bounds)) {
                 KSTypeParameterImpl(ktTypeParameterSymbol, bounds)
@@ -56,15 +60,24 @@ class KSTypeParameterImpl private constructor(
     override val isReified: Boolean = ktTypeParameterSymbol.isReified
 
     override val bounds: Sequence<KSTypeReference> by lazy {
-        boundsSubstitued?.mapIndexed { index, type ->
-            KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
-        }?.asSequence() ?: ktTypeParameterSymbol.upperBounds.asSequence().mapIndexed { index, type ->
-            KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
-        }.ifEmpty {
-            sequenceOf(
-                KSTypeReferenceSyntheticImpl.getCached(ResolverAAImpl.instance.builtIns.anyType.makeNullable(), this)
-            )
-        }
+        boundsSubstitued
+            ?.mapIndexed { index, type ->
+                KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
+            }
+            ?.asSequence()
+            ?: ktTypeParameterSymbol.upperBounds
+                .asSequence()
+                .mapIndexed { index, type ->
+                    KSTypeReferenceResolvedImpl.getCached(type, this@KSTypeParameterImpl, index)
+                }
+                .ifEmpty {
+                    sequenceOf(
+                        KSTypeReferenceSyntheticImpl.getCached(
+                            ResolverAAImpl.instance.builtIns.anyType.makeNullable(),
+                            this,
+                        )
+                    )
+                }
     }
 
     override val typeParameters: List<KSTypeParameter> = emptyList()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSTypeReferenceImpl.kt
@@ -41,13 +41,13 @@ import org.jetbrains.kotlin.psi.KtUserType
 class KSTypeReferenceImpl(
     private val ktTypeReference: KtTypeReference,
     override val parent: KSNode?,
-    private val additionalAnnotations: List<KaAnnotation>
+    private val additionalAnnotations: List<KaAnnotation>,
 ) : KSTypeReference {
     companion object : KSObjectCache<IdKeyPair<KtTypeReference, KSNode?>, KSTypeReference>() {
         fun getCached(
             ktTypeReference: KtTypeReference,
             parent: KSNode? = null,
-            additionalAnnotations: List<KaAnnotation> = emptyList()
+            additionalAnnotations: List<KaAnnotation> = emptyList(),
         ): KSTypeReference {
             return cache.getOrPut(IdKeyPair(ktTypeReference, parent)) {
                 KSTypeReferenceImpl(ktTypeReference, parent, additionalAnnotations)
@@ -63,8 +63,7 @@ class KSTypeReferenceImpl(
     }
     override val element: KSReferenceElement? by lazy {
         var typeElement = ktTypeReference.typeElement
-        while (typeElement is KtNullableType)
-            typeElement = typeElement.innerType
+        while (typeElement is KtNullableType) typeElement = typeElement.innerType
         when (typeElement) {
             is KtUserType -> KSClassifierReferenceImpl.getCached(typeElement, this)
             is KtDynamicType -> KSDynamicReferenceImpl.getCached(this)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueArgumentImpl.kt
@@ -22,13 +22,18 @@ import com.google.devtools.ksp.common.impl.KSNameImpl
 import com.google.devtools.ksp.symbol.*
 import org.jetbrains.kotlin.analysis.api.annotations.KaNamedAnnotationValue
 
-class KSValueArgumentImpl private constructor(
+class KSValueArgumentImpl
+private constructor(
     private val namedAnnotationValue: KaNamedAnnotationValue,
     override val parent: KSNode?,
-    override val origin: Origin
+    override val origin: Origin,
 ) : AbstractKSValueArgumentImpl(), Deferrable {
     companion object : KSObjectCache<KaNamedAnnotationValue, KSValueArgumentImpl>() {
-        fun getCached(namedAnnotationValue: KaNamedAnnotationValue, parent: KSNode?, origin: Origin) =
+        fun getCached(
+            namedAnnotationValue: KaNamedAnnotationValue,
+            parent: KSNode?,
+            origin: Origin,
+        ) =
             cache.getOrPut(namedAnnotationValue) {
                 KSValueArgumentImpl(namedAnnotationValue, parent, origin)
             }
@@ -62,8 +67,7 @@ abstract class AbstractKSValueArgumentImpl : KSValueArgument {
     }
 
     override fun equals(other: Any?): Boolean {
-        if (other !is KSValueArgument)
-            return false
+        if (other !is KSValueArgument) return false
 
         return other.name == this.name && other.value == this.value
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterImpl.kt
@@ -32,13 +32,16 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 
-class KSValueParameterImpl private constructor(
+class KSValueParameterImpl
+private constructor(
     private val ktValueParameterSymbol: KaValueParameterSymbol,
-    override val parent: KSAnnotated
+    override val parent: KSAnnotated,
 ) : KSValueParameter, Deferrable {
     companion object : KSObjectCache<KaValueParameterSymbol, KSValueParameterImpl>() {
         fun getCached(ktValueParameterSymbol: KaValueParameterSymbol, parent: KSAnnotated) =
-            cache.getOrPut(ktValueParameterSymbol) { KSValueParameterImpl(ktValueParameterSymbol, parent) }
+            cache.getOrPut(ktValueParameterSymbol) {
+                KSValueParameterImpl(ktValueParameterSymbol, parent)
+            }
     }
 
     override val name: KSName? by lazy {
@@ -57,7 +60,7 @@ class KSValueParameterImpl private constructor(
         // analyze { KtTypeReference.type }.
         KSTypeReferenceResolvedImpl.getCached(
             ktValueParameterSymbol.returnType.abbreviationOrSelf,
-            this@KSValueParameterImpl
+            this@KSValueParameterImpl,
         )
     }
 
@@ -73,14 +76,19 @@ class KSValueParameterImpl private constructor(
 
     private val KaValueParameterSymbol.primaryConstructorProperty: KaPropertySymbol? by lazy {
         when (ktValueParameterSymbol.origin) {
-            // ktValueParameterSymbol.generatedPrimaryConstructorProperty is always null in libraries.
+            // ktValueParameterSymbol.generatedPrimaryConstructorProperty is always null in
+            // libraries.
             // TODO: fix in AA
-            KaSymbolOrigin.LIBRARY, KaSymbolOrigin.JAVA_LIBRARY -> analyze {
-                val cstr = ktValueParameterSymbol.containingDeclaration as? KaConstructorSymbol
-                val cls = cstr?.containingDeclaration as? KaClassSymbol
-                cls?.declaredMemberScope?.declarations?.filterIsInstance<KaPropertySymbol>()
-                    ?.firstOrNull { it.name == ktValueParameterSymbol.name }
-            }
+            KaSymbolOrigin.LIBRARY,
+            KaSymbolOrigin.JAVA_LIBRARY ->
+                analyze {
+                    val cstr = ktValueParameterSymbol.containingDeclaration as? KaConstructorSymbol
+                    val cls = cstr?.containingDeclaration as? KaClassSymbol
+                    cls?.declaredMemberScope
+                        ?.declarations
+                        ?.filterIsInstance<KaPropertySymbol>()
+                        ?.firstOrNull { it.name == ktValueParameterSymbol.name }
+                }
 
             else -> ktValueParameterSymbol.generatedPrimaryConstructorProperty
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterLiteImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSValueParameterLiteImpl.kt
@@ -10,12 +10,14 @@ import org.jetbrains.kotlin.analysis.api.types.KaType
 class KSValueParameterLiteImpl private constructor(ktType: KaType, override val parent: KSNode) :
     KSValueParameter {
     companion object : KSObjectCache<IdKeyPair<KaType, KSNode>, KSValueParameter>() {
-        fun getCached(ktType: KaType, parent: KSNode): KSValueParameter = cache.getOrPut(IdKeyPair(ktType, parent)) {
-            KSValueParameterLiteImpl(ktType, parent)
-        }
+        fun getCached(ktType: KaType, parent: KSNode): KSValueParameter =
+            cache.getOrPut(IdKeyPair(ktType, parent)) {
+                KSValueParameterLiteImpl(ktType, parent)
+            }
     }
 
-    // preferably maybe use empty name to match compiler, but use underscore to match FE1.0 implementation.
+    // preferably maybe use empty name to match compiler, but use underscore to match FE1.0
+    // implementation.
     override val name: KSName = KSNameImpl.getCached("_")
 
     override val type: KSTypeReference = KSTypeReferenceResolvedImpl.getCached(ktType)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSAnnotationResolvedImpl.kt
@@ -32,14 +32,18 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget.*
 import org.jetbrains.kotlin.psi.KtFile
 
-class KSAnnotationResolvedImpl private constructor(
+class KSAnnotationResolvedImpl
+private constructor(
     private val annotationApplication: KaAnnotation,
     override val parent: KSNode?,
     override val origin: Origin,
 ) : KSAnnotation {
-    companion object :
-        KSObjectCache<IdKeyPair<KaAnnotation, KSNode?>, KSAnnotationResolvedImpl>() {
-        fun getCached(annotationApplication: KaAnnotation, parent: KSNode? = null, origin: Origin? = parent?.origin) =
+    companion object : KSObjectCache<IdKeyPair<KaAnnotation, KSNode?>, KSAnnotationResolvedImpl>() {
+        fun getCached(
+            annotationApplication: KaAnnotation,
+            parent: KSNode? = null,
+            origin: Origin? = parent?.origin,
+        ) =
             cache.getOrPut(IdKeyPair(annotationApplication, parent)) {
                 KSAnnotationResolvedImpl(annotationApplication, parent, origin ?: Origin.SYNTHETIC)
             }
@@ -49,19 +53,21 @@ class KSAnnotationResolvedImpl private constructor(
         analyze {
             KSTypeReferenceResolvedImpl.getCached(
                 buildClassType(annotationApplication.classId!!),
-                parent = this@KSAnnotationResolvedImpl
+                parent = this@KSAnnotationResolvedImpl,
             )
         }
     }
     override val arguments: List<KSValueArgument> by lazy {
-        val presentArgs = annotationApplication.arguments.map { arg ->
-            val argOrigin = if (origin == Origin.SYNTHETIC) {
-                arg.expression.sourcePsi?.containingFile?.let { containingFile ->
-                    if (containingFile is KtFile) Origin.KOTLIN else Origin.JAVA
-                } ?: Origin.JAVA_LIB // FIXME: how to tell from KOTLIN_LIB?
-            } else origin
-            KSValueArgumentImpl.getCached(arg, this, argOrigin)
-        }
+        val presentArgs =
+            annotationApplication.arguments.map { arg ->
+                val argOrigin =
+                    if (origin == Origin.SYNTHETIC) {
+                        arg.expression.sourcePsi?.containingFile?.let { containingFile ->
+                            if (containingFile is KtFile) Origin.KOTLIN else Origin.JAVA
+                        } ?: Origin.JAVA_LIB // FIXME: how to tell from KOTLIN_LIB?
+                    } else origin
+                KSValueArgumentImpl.getCached(arg, this, argOrigin)
+            }
         val presentNames = presentArgs.mapNotNull { it.name?.asString() }
         val absentArgs = analyze {
             val annotationClass = annotationApplication.classId?.toKtClassSymbol()
@@ -69,8 +75,7 @@ class KSAnnotationResolvedImpl private constructor(
             val params = annotationConstructor?.valueParameters
             defaultArguments.filter { arg ->
                 val name = arg.name?.asString() ?: return@filter false
-                if (name in presentNames)
-                    return@filter false
+                if (name in presentNames) return@filter false
                 params?.any { it.name.asString() == name && it.hasDefaultValue } == true
             }
         }
@@ -82,42 +87,51 @@ class KSAnnotationResolvedImpl private constructor(
         analyze {
             annotationApplication.classId?.toKtClassSymbol()?.let { symbol ->
                 if (
-                    symbol.origin == KaSymbolOrigin.JAVA_SOURCE && symbol.psi != null &&
-                    symbol.psi !is ClsClassImpl && symbol.psi is PsiClass
+                    symbol.origin == KaSymbolOrigin.JAVA_SOURCE &&
+                        symbol.psi != null &&
+                        symbol.psi !is ClsClassImpl &&
+                        symbol.psi is PsiClass
                 ) {
-                    (symbol.psi as PsiClass).allMethods.filterIsInstance<PsiAnnotationMethod>()
+                    (symbol.psi as PsiClass)
+                        .allMethods
+                        .filterIsInstance<PsiAnnotationMethod>()
                         .mapNotNull { annoMethod ->
                             annoMethod.defaultValue?.let { value ->
-                                val calculatedValue: Any? = if (value is PsiArrayInitializerMemberValue) {
-                                    value.initializers.map {
-                                        calcValue(it, this@KSAnnotationResolvedImpl)
+                                val calculatedValue: Any? =
+                                    if (value is PsiArrayInitializerMemberValue) {
+                                        value.initializers.map {
+                                            calcValue(it, this@KSAnnotationResolvedImpl)
+                                        }
+                                    } else {
+                                        calcValue(value, this@KSAnnotationResolvedImpl)
                                     }
-                                } else {
-                                    calcValue(value, this@KSAnnotationResolvedImpl)
-                                }
                                 KSValueArgumentLiteImpl(
                                     KSNameImpl.getCached(annoMethod.name),
                                     calculatedValue,
                                     this@KSAnnotationResolvedImpl,
                                     Origin.SYNTHETIC,
-                                    value.toLocation()
+                                    value.toLocation(),
                                 )
                             }
                         }
                 } else {
                     symbol.memberScope.constructors.singleOrNull()?.let {
                         it.valueParameters.mapNotNull { valueParameterSymbol ->
-                            val constantValue = valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
+                            val constantValue =
+                                valueParameterSymbol.getDefaultValue() ?: return@mapNotNull null
                             if (constantValue is KaAnnotationValue.ClassLiteralValue) {
-                                recordClassReferenceLookup(constantValue.type, this@KSAnnotationResolvedImpl)
+                                recordClassReferenceLookup(
+                                    constantValue.type,
+                                    this@KSAnnotationResolvedImpl,
+                                )
                             }
                             KSValueArgumentImpl.getCached(
                                 KaBaseNamedAnnotationValue(
                                     valueParameterSymbol.name,
-                                    constantValue
+                                    constantValue,
                                 ),
                                 this@KSAnnotationResolvedImpl,
-                                Origin.SYNTHETIC
+                                Origin.SYNTHETIC,
                             )
                         }
                     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSClassifierReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSClassifierReferenceResolvedImpl.kt
@@ -8,13 +8,17 @@ import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaClassTypeQualifier
 import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
 
-class KSClassifierReferenceResolvedImpl private constructor(
+class KSClassifierReferenceResolvedImpl
+private constructor(
     private val ktType: KaClassType,
     private val index: Int,
-    override val parent: KSTypeReference?
+    override val parent: KSTypeReference?,
 ) : KSClassifierReference {
     companion object :
-        KSObjectCache<IdKeyTriple<KaClassType, Int, KSTypeReference?>, KSClassifierReferenceResolvedImpl>() {
+        KSObjectCache<
+            IdKeyTriple<KaClassType, Int, KSTypeReference?>,
+            KSClassifierReferenceResolvedImpl,
+        >() {
         fun getCached(ktType: KaClassType, index: Int, parent: KSTypeReference?) =
             cache.getOrPut(IdKeyTriple(ktType, index, parent)) {
                 KSClassifierReferenceResolvedImpl(ktType, index, parent)
@@ -46,17 +50,25 @@ class KSClassifierReferenceResolvedImpl private constructor(
         get() = parent?.location ?: NonExistLocation
 
     override fun toString(): String {
-        return referencedName() + if (typeArguments.isNotEmpty()) "<${
+        return referencedName() +
+            if (typeArguments.isNotEmpty())
+                "<${
         typeArguments.joinToString(", ") { it.toString() }
-        }>" else ""
+        }>"
+            else ""
     }
 }
 
-class KSClassifierParameterImpl private constructor(
+class KSClassifierParameterImpl
+private constructor(
     private val ktType: KaTypeParameterType,
-    override val parent: KSTypeReference?
+    override val parent: KSTypeReference?,
 ) : KSClassifierReference {
-    companion object : KSObjectCache<IdKeyPair<KaTypeParameterType, KSTypeReference?>, KSClassifierParameterImpl>() {
+    companion object :
+        KSObjectCache<
+            IdKeyPair<KaTypeParameterType, KSTypeReference?>,
+            KSClassifierParameterImpl,
+        >() {
         fun getCached(ktType: KaTypeParameterType, parent: KSTypeReference?) =
             KSClassifierParameterImpl.cache.getOrPut(IdKeyPair(ktType, parent)) {
                 KSClassifierParameterImpl(ktType, parent)
@@ -71,8 +83,10 @@ class KSClassifierParameterImpl private constructor(
 
     override val typeArguments: List<KSTypeArgument>
         get() = emptyList()
+
     override val origin: Origin
         get() = parent?.origin ?: Origin.SYNTHETIC
+
     override val location: Location
         get() = parent?.location ?: NonExistLocation
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeArgumentResolvedImpl.kt
@@ -29,13 +29,17 @@ import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.KaTypeArgumentWithVariance
 import org.jetbrains.kotlin.analysis.api.types.KaTypeProjection
 
-class KSTypeArgumentResolvedImpl private constructor(
+class KSTypeArgumentResolvedImpl
+private constructor(
     private val ktTypeProjection: KaTypeProjection,
-    override val parent: KSNode?
+    override val parent: KSNode?,
 ) : KSTypeArgument, Deferrable {
-    companion object : KSObjectCache<IdKeyPair<KaTypeProjection, KSNode?>, KSTypeArgumentResolvedImpl>() {
+    companion object :
+        KSObjectCache<IdKeyPair<KaTypeProjection, KSNode?>, KSTypeArgumentResolvedImpl>() {
         fun getCached(ktTypeProjection: KaTypeProjection, parent: KSNode? = null) =
-            cache.getOrPut(IdKeyPair(ktTypeProjection, parent)) { KSTypeArgumentResolvedImpl(ktTypeProjection, parent) }
+            cache.getOrPut(IdKeyPair(ktTypeProjection, parent)) {
+                KSTypeArgumentResolvedImpl(ktTypeProjection, parent)
+            }
     }
 
     override val variance: Variance by lazy {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/resolved/KSTypeReferenceResolvedImpl.kt
@@ -40,18 +40,19 @@ import org.jetbrains.kotlin.analysis.api.types.*
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtTypeParameter
 
-class KSTypeReferenceResolvedImpl private constructor(
+class KSTypeReferenceResolvedImpl
+private constructor(
     private val ktType: KaType,
     override val parent: KSNode?,
     private val index: Int,
-    private val additionalAnnotations: List<KaAnnotation>
+    private val additionalAnnotations: List<KaAnnotation>,
 ) : KSTypeReference, Deferrable {
     companion object : KSObjectCache<IdKeyTriple<KaType, KSNode?, Int>, KSTypeReference>() {
         fun getCached(
             type: KaType,
             parent: KSNode? = null,
             index: Int = -1,
-            additionalAnnotations: List<KaAnnotation> = emptyList()
+            additionalAnnotations: List<KaAnnotation> = emptyList(),
         ): KSTypeReference =
             cache.getOrPut(IdKeyTriple(type, parent, index)) {
                 KSTypeReferenceResolvedImpl(type, parent, index, additionalAnnotations)
@@ -74,7 +75,9 @@ class KSTypeReferenceResolvedImpl private constructor(
 
     override val annotations: Sequence<KSAnnotation> by lazyMemoizedSequence {
         ktType.annotations(this) +
-            additionalAnnotations.asSequence().map { KSAnnotationResolvedImpl.getCached(it, this, origin) }
+            additionalAnnotations.asSequence().map {
+                KSAnnotationResolvedImpl.getCached(it, this, origin)
+            }
     }
 
     override val origin: Origin = parent?.origin ?: Origin.SYNTHETIC
@@ -87,15 +90,19 @@ class KSTypeReferenceResolvedImpl private constructor(
                 is KSClassDeclarationImpl -> {
                     when (val psi = parent.ktClassOrObjectSymbol.psi) {
                         is KtClassOrObject -> psi.superTypeListEntries[index].toLocation()
-                        is PsiClass -> (psi as? PsiClassReferenceType)?.reference?.toLocation() ?: NonExistLocation
+                        is PsiClass ->
+                            (psi as? PsiClassReferenceType)?.reference?.toLocation()
+                                ?: NonExistLocation
                         else -> NonExistLocation
                     }
                 }
                 is KSTypeParameterImpl -> {
                     when (val psi = parent.ktTypeParameterSymbol.psi) {
                         is KtTypeParameter -> parent.location
-                        is PsiTypeParameter -> (psi.extendsListTypes[index] as? PsiClassReferenceType)
-                            ?.reference?.toLocation() ?: NonExistLocation
+                        is PsiTypeParameter ->
+                            (psi.extendsListTypes[index] as? PsiClassReferenceType)
+                                ?.reference
+                                ?.toLocation() ?: NonExistLocation
                         else -> NonExistLocation
                     }
                 }
@@ -109,11 +116,12 @@ class KSTypeReferenceResolvedImpl private constructor(
     }
 
     override val modifiers: Set<Modifier>
-        get() = if (ktType is KaFunctionType && ktType.isSuspend) {
-            setOf(Modifier.SUSPEND)
-        } else {
-            emptySet()
-        }
+        get() =
+            if (ktType is KaFunctionType && ktType.isSuspend) {
+                setOf(Modifier.SUSPEND)
+            } else {
+                emptySet()
+            }
 
     override fun toString(): String {
         return ktType.abbreviationOrSelf.render()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/synthetic/KSSyntheticAnnotations.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/synthetic/KSSyntheticAnnotations.kt
@@ -8,11 +8,12 @@ import org.jetbrains.kotlin.analysis.api.platform.lifetime.KotlinAlwaysAccessibl
 import org.jetbrains.kotlin.name.ClassId
 
 @OptIn(KaImplementationDetail::class, KaPlatformInterface::class)
-fun getExtensionFunctionTypeAnnotation() = KaAnnotationImpl(
-    ClassId.fromString(ExtensionFunctionType::class.qualifiedName!!),
-    null,
-    null,
-    lazyOf(emptyList()),
-    null,
-    KotlinAlwaysAccessibleLifetimeToken(ResolverAAImpl.ktModule.project)
-)
+fun getExtensionFunctionTypeAnnotation() =
+    KaAnnotationImpl(
+        ClassId.fromString(ExtensionFunctionType::class.qualifiedName!!),
+        null,
+        null,
+        lazyOf(emptyList()),
+        null,
+        KotlinAlwaysAccessibleLifetimeToken(ResolverAAImpl.ktModule.project),
+    )

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -123,6 +123,7 @@ import org.jetbrains.kotlin.builtins.jvm.JavaToKotlinClassMap.mapKotlinToJava
 import org.jetbrains.kotlin.codegen.state.InfoForMangling
 import org.jetbrains.kotlin.codegen.state.collectFunctionSignatureForManglingSuffix
 import org.jetbrains.kotlin.codegen.state.md5base64
+import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget as AnnotationUseSiteTargetAA
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.utils.moduleName
@@ -150,31 +151,34 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.types.Variance
 import org.jetbrains.kotlin.types.typeUtil.getEffectiveVariance
 import org.jetbrains.kotlin.utils.KotlinExceptionWithAttachments
-import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget as AnnotationUseSiteTargetAA
 
-internal val ktSymbolOriginToOrigin = mapOf(
-    KaSymbolOrigin.JAVA_SOURCE to Origin.JAVA,
-    KaSymbolOrigin.JAVA_LIBRARY to Origin.JAVA_LIB,
-    KaSymbolOrigin.SOURCE to Origin.KOTLIN,
-    KaSymbolOrigin.SAM_CONSTRUCTOR to Origin.SYNTHETIC,
-    KaSymbolOrigin.SOURCE_MEMBER_GENERATED to Origin.SYNTHETIC,
-    KaSymbolOrigin.DELEGATED to Origin.SYNTHETIC,
-    KaSymbolOrigin.PROPERTY_BACKING_FIELD to Origin.KOTLIN,
-    KaSymbolOrigin.JAVA_SYNTHETIC_PROPERTY to Origin.SYNTHETIC,
-    KaSymbolOrigin.INTERSECTION_OVERRIDE to Origin.SYNTHETIC,
-    // TODO: distinguish between kotlin library and java library.
-    KaSymbolOrigin.LIBRARY to Origin.KOTLIN_LIB,
-    KaSymbolOrigin.SUBSTITUTION_OVERRIDE to Origin.JAVA_LIB
-)
+internal val ktSymbolOriginToOrigin =
+    mapOf(
+        KaSymbolOrigin.JAVA_SOURCE to Origin.JAVA,
+        KaSymbolOrigin.JAVA_LIBRARY to Origin.JAVA_LIB,
+        KaSymbolOrigin.SOURCE to Origin.KOTLIN,
+        KaSymbolOrigin.SAM_CONSTRUCTOR to Origin.SYNTHETIC,
+        KaSymbolOrigin.SOURCE_MEMBER_GENERATED to Origin.SYNTHETIC,
+        KaSymbolOrigin.DELEGATED to Origin.SYNTHETIC,
+        KaSymbolOrigin.PROPERTY_BACKING_FIELD to Origin.KOTLIN,
+        KaSymbolOrigin.JAVA_SYNTHETIC_PROPERTY to Origin.SYNTHETIC,
+        KaSymbolOrigin.INTERSECTION_OVERRIDE to Origin.SYNTHETIC,
+        // TODO: distinguish between kotlin library and java library.
+        KaSymbolOrigin.LIBRARY to Origin.KOTLIN_LIB,
+        KaSymbolOrigin.SUBSTITUTION_OVERRIDE to Origin.JAVA_LIB,
+    )
 
 internal fun mapAAOrigin(ktSymbol: KaSymbol): Origin {
-    val symbolOrigin = ktSymbolOriginToOrigin[ktSymbol.origin]
-        ?: throw InternalKSPException(
-            "Unhandled origin ${ktSymbol.origin.name}",
-            ktSymbol.psi.toLocation(),
-            ktSymbol.javaClass,
-        )
-    return if (symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true) {
+    val symbolOrigin =
+        ktSymbolOriginToOrigin[ktSymbol.origin]
+            ?: throw InternalKSPException(
+                "Unhandled origin ${ktSymbol.origin.name}",
+                ktSymbol.psi.toLocation(),
+                ktSymbol.javaClass,
+            )
+    return if (
+        symbolOrigin == Origin.JAVA && ktSymbol.psi?.containingFile?.fileType?.isBinary == true
+    ) {
         Origin.JAVA_LIB
     } else {
         symbolOrigin
@@ -208,11 +212,12 @@ internal fun KaAnnotationValue.render(): String {
             if (type.isError) type.toString() else "$type::class"
         }
 
-        is KaAnnotationValue.UnsupportedValue -> throw InternalKSPException(
-            "Unsupported annotation value: $this",
-            NonExistLocation,
-            this.javaClass
-        )
+        is KaAnnotationValue.UnsupportedValue ->
+            throw InternalKSPException(
+                "Unsupported annotation value: $this",
+                NonExistLocation,
+                this.javaClass,
+            )
     }
 }
 
@@ -226,46 +231,58 @@ internal fun KaType.render(inFunctionType: Boolean = false): String {
         }
         append(
             when (this@render) {
-                is KaClassType -> buildString {
-                    val symbol = this@render.classifierSymbol()
-                    if (symbol is KaTypeAliasSymbol) {
-                        if (!inFunctionType) {
-                            append("[typealias ${symbol.name.asString()}]")
+                is KaClassType ->
+                    buildString {
+                        val symbol = this@render.classifierSymbol()
+                        if (symbol is KaTypeAliasSymbol) {
+                            if (!inFunctionType) {
+                                append("[typealias ${symbol.name.asString()}]")
+                            } else {
+                                append(this@render.fullyExpand().render(inFunctionType = true))
+                            }
                         } else {
-                            append(this@render.fullyExpand().render(inFunctionType = true))
-                        }
-                    } else {
-                        append(this@render.symbol.name?.asString())
-                        if (typeArguments().isNotEmpty()) {
-                            typeArguments().joinToString(separator = ", ", prefix = "<", postfix = ">") {
-                                when (it) {
-                                    is KaStarTypeProjection -> "*"
-                                    is KaTypeArgumentWithVariance ->
-                                        "${it.variance}" +
-                                            (if (it.variance != Variance.INVARIANT) " " else "") +
-                                            it.type.render(this@render is KaFunctionType)
-                                }
-                            }.also { append(it) }
+                            append(this@render.symbol.name?.asString())
+                            if (typeArguments().isNotEmpty()) {
+                                typeArguments()
+                                    .joinToString(separator = ", ", prefix = "<", postfix = ">") {
+                                        when (it) {
+                                            is KaStarTypeProjection -> "*"
+                                            is KaTypeArgumentWithVariance ->
+                                                "${it.variance}" +
+                                                    (if (it.variance != Variance.INVARIANT) " "
+                                                    else "") +
+                                                    it.type.render(this@render is KaFunctionType)
+                                        }
+                                    }
+                                    .also { append(it) }
+                            }
                         }
                     }
-                }
 
-                is KaClassErrorType -> KSErrorType(qualifiers.joinToString(".") { it.name.asString() }).toString()
+                is KaClassErrorType ->
+                    KSErrorType(qualifiers.joinToString(".") { it.name.asString() }).toString()
                 is KaErrorType -> KSErrorType(presentableText).toString()
                 is KaCapturedType -> this@render.toString()
                 is KaDefinitelyNotNullType -> original.render(inFunctionType) + " & Any"
                 is KaDynamicType -> "<dynamic type>"
-                is KaFlexibleType -> "(${lowerBound.render(inFunctionType)}..${upperBound.render(inFunctionType)})"
+                is KaFlexibleType ->
+                    "(${lowerBound.render(inFunctionType)}..${upperBound.render(inFunctionType)})"
                 is KaIntersectionType ->
-                    this@render.conjuncts
-                        .joinToString(separator = " & ", prefix = "(", postfix = ")") { it.render(inFunctionType) }
+                    this@render.conjuncts.joinToString(
+                        separator = " & ",
+                        prefix = "(",
+                        postfix = ")",
+                    ) {
+                        it.render(inFunctionType)
+                    }
 
                 is KaTypeParameterType -> name.asString()
-                else -> throw InternalKSPException(
-                    "Unhandled type",
-                    NonExistLocation,
-                    this@render.javaClass
-                )
+                else ->
+                    throw InternalKSPException(
+                        "Unhandled type",
+                        NonExistLocation,
+                        this@render.javaClass,
+                    )
             }
         )
         if (analyze { isMarkedNullable }) {
@@ -278,30 +295,34 @@ internal fun KaType.toClassifierReference(parent: KSTypeReference?): KSReference
     return when (val ktType = this) {
         is KaFunctionType -> KSCallableReferenceImpl.getCached(ktType, parent)
         is KaDynamicType -> KSDynamicReferenceImpl.getCached(parent!!)
-        is KaUsualClassType -> KSClassifierReferenceResolvedImpl.getCached(ktType, ktType.qualifiers.size - 1, parent)
+        is KaUsualClassType ->
+            KSClassifierReferenceResolvedImpl.getCached(ktType, ktType.qualifiers.size - 1, parent)
         is KaFlexibleType -> ktType.lowerBound.toClassifierReference(parent)
         is KaErrorType -> null
         is KaTypeParameterType -> KSClassifierParameterImpl.getCached(ktType, parent)
         is KaDefinitelyNotNullType -> KSDefNonNullReferenceImpl.getCached(ktType, parent)
-        else -> throw InternalKSPException(
-            "Unexpected type element",
-            NonExistLocation,
-            ktType.javaClass,
-        )
+        else ->
+            throw InternalKSPException(
+                "Unexpected type element",
+                NonExistLocation,
+                ktType.javaClass,
+            )
     }
 }
 
 @OptIn(KaImplementationDetail::class, KaPlatformInterface::class)
 internal fun KSTypeArgument.toKtTypeProjection(): KaTypeProjection {
-    val variance = when (this.variance) {
-        com.google.devtools.ksp.symbol.Variance.INVARIANT -> Variance.INVARIANT
-        com.google.devtools.ksp.symbol.Variance.COVARIANT -> Variance.OUT_VARIANCE
-        com.google.devtools.ksp.symbol.Variance.CONTRAVARIANT -> Variance.IN_VARIANCE
-        else -> null
-    }
+    val variance =
+        when (this.variance) {
+            com.google.devtools.ksp.symbol.Variance.INVARIANT -> Variance.INVARIANT
+            com.google.devtools.ksp.symbol.Variance.COVARIANT -> Variance.OUT_VARIANCE
+            com.google.devtools.ksp.symbol.Variance.CONTRAVARIANT -> Variance.IN_VARIANCE
+            else -> null
+        }
     val argType = (this.type?.resolve() as? KSTypeImpl)?.type
     // TODO: maybe make a singleton of alwaysAccessibleLifetimeToken?
-    val alwaysAccessibleLifetimeToken = KotlinAlwaysAccessibleLifetimeToken(ResolverAAImpl.ktModule.project)
+    val alwaysAccessibleLifetimeToken =
+        KotlinAlwaysAccessibleLifetimeToken(ResolverAAImpl.ktModule.project)
     return if (argType == null || variance == null) {
         KaBaseStarTypeProjection(alwaysAccessibleLifetimeToken)
     } else {
@@ -314,15 +335,17 @@ internal fun PsiElement?.toLocation(): Location {
         return NonExistLocation
     }
     val file = this.containingFile
-    val document = KSPCoreEnvironment.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
+    val document =
+        KSPCoreEnvironment.instance.psiDocumentManager.getDocument(file) ?: return NonExistLocation
     return FileLocation(file.virtualFile.path, document.getLineNumber(this.textOffset) + 1)
 }
 
 internal fun KaSymbol.toContainingFile(): KSFile? {
     return when (val psi = this.psi) {
-        is KtElement -> analyze {
-            KSFileImpl.getCached(psi.containingKtFile.symbol)
-        }
+        is KtElement ->
+            analyze {
+                KSFileImpl.getCached(psi.containingKtFile.symbol)
+            }
 
         is PsiElement -> KSFileJavaImpl.getCached(psi.containingFile as PsiJavaFile)
         else -> null
@@ -339,29 +362,33 @@ internal inline fun <R> analyze(crossinline action: KaSession.() -> R): R {
 internal fun KaDeclarationContainerSymbol.declarations(): Sequence<KSDeclaration> {
     return analyze {
         this@declarations.let {
-            it.declaredMemberScope.declarations + it.staticDeclaredMemberScope.declarations
-        }.distinct().map { symbol ->
-            when (symbol) {
-                is KaNamedClassSymbol -> KSClassDeclarationImpl.getCached(symbol)
-                is KaFunctionSymbol -> KSFunctionDeclarationImpl.getCached(symbol)
-                is KaPropertySymbol -> KSPropertyDeclarationImpl.getCached(symbol)
-                is KaEnumEntrySymbol -> KSClassDeclarationEnumEntryImpl.getCached(symbol)
-                is KaJavaFieldSymbol -> KSPropertyDeclarationJavaImpl.getCached(symbol)
-                is KaTypeAliasSymbol -> KSTypeAliasImpl.getCached(symbol)
-                else -> throw InternalKSPException(
-                    "Unexpected declaration symbol",
-                    symbol.psi.toLocation(),
-                    symbol.javaClass
-                )
+                it.declaredMemberScope.declarations + it.staticDeclaredMemberScope.declarations
             }
-        }
+            .distinct()
+            .map { symbol ->
+                when (symbol) {
+                    is KaNamedClassSymbol -> KSClassDeclarationImpl.getCached(symbol)
+                    is KaFunctionSymbol -> KSFunctionDeclarationImpl.getCached(symbol)
+                    is KaPropertySymbol -> KSPropertyDeclarationImpl.getCached(symbol)
+                    is KaEnumEntrySymbol -> KSClassDeclarationEnumEntryImpl.getCached(symbol)
+                    is KaJavaFieldSymbol -> KSPropertyDeclarationJavaImpl.getCached(symbol)
+                    is KaTypeAliasSymbol -> KSTypeAliasImpl.getCached(symbol)
+                    else ->
+                        throw InternalKSPException(
+                            "Unexpected declaration symbol",
+                            symbol.psi.toLocation(),
+                            symbol.javaClass,
+                        )
+                }
+            }
     }
 }
 
 @OptIn(KaExperimentalApi::class)
 internal fun KaDeclarationContainerSymbol.getAllProperties(): Sequence<KSPropertyDeclaration> {
     return analyze {
-        this@getAllProperties.memberScope.callables { true }
+        this@getAllProperties.memberScope
+            .callables { true }
             .filter {
                 it.isVisibleInClass(this@getAllProperties as KaClassSymbol) ||
                     it.containingSymbol == this@getAllProperties ||
@@ -380,14 +407,16 @@ internal fun KaDeclarationContainerSymbol.getAllProperties(): Sequence<KSPropert
 @OptIn(KaExperimentalApi::class)
 internal fun KaDeclarationContainerSymbol.getAllFunctions(): Sequence<KSFunctionDeclaration> {
     return analyze {
-        this@getAllFunctions.memberScope.let { it.callables { true } + it.constructors }
+        this@getAllFunctions.memberScope
+            .let { it.callables { true } + it.constructors }
             .filter {
                 it.isVisibleInClass(this@getAllFunctions as KaClassSymbol) ||
                     it.containingSymbol == this@getAllFunctions ||
                     it.containingSymbol?.psi == this@getAllFunctions.psi
             }
             .mapNotNull { callableSymbol ->
-                // TODO: replace with single safe cast if no more implementations of KSFunctionDeclaration is added.
+                // TODO: replace with single safe cast if no more implementations of
+                // KSFunctionDeclaration is added.
                 when (callableSymbol) {
                     is KaFunctionSymbol -> KSFunctionDeclarationImpl.getCached(callableSymbol)
                     else -> null
@@ -400,38 +429,47 @@ private val jvmRepeatableClassId = ClassId.fromString("java/lang/annotation/Repe
 private val repeatableClassId = ClassId.fromString("kotlin/annotation/Repeatable")
 
 private fun KaClassSymbol.isRepeatableAnnotation(container: KaAnnotation): Boolean {
-    return this.classKind == KaClassKind.ANNOTATION_CLASS && annotations.any {
-        when (it.classId) {
-            jvmRepeatableClassId -> {
-                it.arguments.singleOrNull()?.let { arg ->
-                    val expression = arg.expression as? KaAnnotationValue.ClassLiteralValue ?: return@let null
-                    arg.name.asString() == "value" && expression.classId == container.classId
-                } ?: false
-            }
+    return this.classKind == KaClassKind.ANNOTATION_CLASS &&
+        annotations.any {
+            when (it.classId) {
+                jvmRepeatableClassId -> {
+                    it.arguments.singleOrNull()?.let { arg ->
+                        val expression =
+                            arg.expression as? KaAnnotationValue.ClassLiteralValue
+                                ?: return@let null
+                        arg.name.asString() == "value" && expression.classId == container.classId
+                    } ?: false
+                }
 
-            repeatableClassId -> {
-                container.classId?.asFqNameString() == "${this.classId?.asFqNameString()}.Container"
-            }
+                repeatableClassId -> {
+                    container.classId?.asFqNameString() ==
+                        "${this.classId?.asFqNameString()}.Container"
+                }
 
-            else -> false
+                else -> false
+            }
         }
-    }
 }
 
 private fun KaAnnotated.annotationsWithRepeatableUnfolded(): List<KaAnnotation> {
     return if (
-        this is KaSymbol && (this.origin == KaSymbolOrigin.LIBRARY || this.origin == KaSymbolOrigin.JAVA_LIBRARY)
+        this is KaSymbol &&
+            (this.origin == KaSymbolOrigin.LIBRARY || this.origin == KaSymbolOrigin.JAVA_LIBRARY)
     ) {
         annotations.flatMap { container ->
             // Try to unwrap repeatable containers
             // https://github.com/Kotlin/KEEP/blob/master/proposals/repeatable-annotations.md
             val containedAnnotations: List<KaAnnotation>? =
-                (container.arguments.singleOrNull()?.expression as? KaAnnotationValue.ArrayValue)?.values?.map {
-                    (it as? KaAnnotationValue.NestedAnnotationValue)?.annotation ?: return@flatMap listOf(container)
-                }
+                (container.arguments.singleOrNull()?.expression as? KaAnnotationValue.ArrayValue)
+                    ?.values
+                    ?.map {
+                        (it as? KaAnnotationValue.NestedAnnotationValue)?.annotation
+                            ?: return@flatMap listOf(container)
+                    }
             val containedAnnotationClassId: ClassId =
                 containedAnnotations?.firstOrNull()?.classId ?: return@flatMap listOf(container)
-            val containedClass = containedAnnotationClassId.toKtClassSymbol() ?: return@flatMap listOf(container)
+            val containedClass =
+                containedAnnotationClassId.toKtClassSymbol() ?: return@flatMap listOf(container)
             if (containedClass.isRepeatableAnnotation(container)) {
                 containedAnnotations
             } else {
@@ -442,21 +480,25 @@ private fun KaAnnotated.annotationsWithRepeatableUnfolded(): List<KaAnnotation> 
 }
 
 internal fun KaAnnotated.annotations(parent: KSNode? = null): Sequence<KSAnnotation> {
-    return annotationsWithRepeatableUnfolded().asSequence().map { KSAnnotationResolvedImpl.getCached(it, parent) }
+    return annotationsWithRepeatableUnfolded().asSequence().map {
+        KSAnnotationResolvedImpl.getCached(it, parent)
+    }
 }
 
 internal fun KtAnnotated.annotations(
     kaAnnotated: KaAnnotated,
     parent: KSNode? = null,
-    candidates: List<KaAnnotation> = kaAnnotated.annotationsWithRepeatableUnfolded()
+    candidates: List<KaAnnotation> = kaAnnotated.annotationsWithRepeatableUnfolded(),
 ): Sequence<KSAnnotation> {
-    if (candidates.isEmpty())
-        return emptySequence()
-    return annotationEntries.filter { !it.isUseSiteTargetAnnotation() }.asSequence().map { annotationEntry ->
-        KSAnnotationImpl.getCached(annotationEntry, parent) {
-            candidates.single { it.psi == annotationEntry }
+    if (candidates.isEmpty()) return emptySequence()
+    return annotationEntries
+        .filter { !it.isUseSiteTargetAnnotation() }
+        .asSequence()
+        .map { annotationEntry ->
+            KSAnnotationImpl.getCached(annotationEntry, parent) {
+                candidates.single { it.psi == annotationEntry }
+            }
         }
-    }
 }
 
 internal fun KaSymbol.getContainingKSSymbol(): KSDeclaration? {
@@ -473,23 +515,25 @@ internal fun KaSymbol.getContainingKSSymbol(): KSDeclaration? {
 internal fun KaSymbol.toKSDeclaration(): KSDeclaration? = toKSAnnotated() as? KSDeclaration
 
 // For efficiency & simplicity, KaDestructuringDeclarationSymbol is handled by caller.
-internal fun KaSymbol.toKSAnnotated(): KSAnnotated = when (this) {
-    is KaPropertySymbol -> toKSPropertyDeclaration()
-    is KaNamedClassSymbol -> toKSClassDeclaration()
-    is KaFunctionSymbol -> toKSFunctionDeclaration()
-    is KaTypeAliasSymbol -> toKSTypeAlias()
-    is KaJavaFieldSymbol -> this@toKSAnnotated.toKSPropertyDeclaration()
-    is KaFileSymbol -> toKSFile()
-    is KaEnumEntrySymbol -> toKSClassDeclarationEnumEntry()
-    is KaTypeParameterSymbol -> toKSTypeParameter()
-    is KaLocalVariableSymbol -> toKSPropertyDeclarationLocalVariable()
-    is KaValueParameterSymbol -> toKSValueParameter()
-    else -> throw InternalKSPException(
-        "Unexpected class for KtSymbol",
-        this.psi.toLocation(),
-        this.javaClass
-    )
-}
+internal fun KaSymbol.toKSAnnotated(): KSAnnotated =
+    when (this) {
+        is KaPropertySymbol -> toKSPropertyDeclaration()
+        is KaNamedClassSymbol -> toKSClassDeclaration()
+        is KaFunctionSymbol -> toKSFunctionDeclaration()
+        is KaTypeAliasSymbol -> toKSTypeAlias()
+        is KaJavaFieldSymbol -> this@toKSAnnotated.toKSPropertyDeclaration()
+        is KaFileSymbol -> toKSFile()
+        is KaEnumEntrySymbol -> toKSClassDeclarationEnumEntry()
+        is KaTypeParameterSymbol -> toKSTypeParameter()
+        is KaLocalVariableSymbol -> toKSPropertyDeclarationLocalVariable()
+        is KaValueParameterSymbol -> toKSValueParameter()
+        else ->
+            throw InternalKSPException(
+                "Unexpected class for KtSymbol",
+                this.psi.toLocation(),
+                this.javaClass,
+            )
+    }
 
 internal fun KaPropertySymbol.toKSPropertyDeclaration(): KSPropertyDeclarationImpl =
     KSPropertyDeclarationImpl.getCached(this)
@@ -500,24 +544,24 @@ internal fun KaNamedClassSymbol.toKSClassDeclaration(): KSClassDeclarationImpl =
 internal fun KaFunctionSymbol.toKSFunctionDeclaration(): KSFunctionDeclarationImpl =
     KSFunctionDeclarationImpl.getCached(this)
 
-internal fun KaCallableSymbol.toKSFunctionDeclaration(): KSFunctionDeclarationImpl? = when (this) {
-    is KaFunctionSymbol -> this.toKSFunctionDeclaration()
-    else -> null
-}
+internal fun KaCallableSymbol.toKSFunctionDeclaration(): KSFunctionDeclarationImpl? =
+    when (this) {
+        is KaFunctionSymbol -> this.toKSFunctionDeclaration()
+        else -> null
+    }
 
-internal fun KaCallableSymbol.toKSPropertyDeclaration(): KSPropertyDeclaration? = when (this) {
-    is KaJavaFieldSymbol -> this.toKSPropertyDeclaration()
-    else -> null
-}
+internal fun KaCallableSymbol.toKSPropertyDeclaration(): KSPropertyDeclaration? =
+    when (this) {
+        is KaJavaFieldSymbol -> this.toKSPropertyDeclaration()
+        else -> null
+    }
 
-internal fun KaTypeAliasSymbol.toKSTypeAlias(): KSTypeAliasImpl =
-    KSTypeAliasImpl.getCached(this)
+internal fun KaTypeAliasSymbol.toKSTypeAlias(): KSTypeAliasImpl = KSTypeAliasImpl.getCached(this)
 
 internal fun KaJavaFieldSymbol.toKSPropertyDeclaration(): KSPropertyDeclaration =
     KSPropertyDeclarationJavaImpl.getCached(this)
 
-internal fun KaFileSymbol.toKSFile(): KSFileImpl =
-    KSFileImpl.getCached(this)
+internal fun KaFileSymbol.toKSFile(): KSFileImpl = KSFileImpl.getCached(this)
 
 internal fun KaEnumEntrySymbol.toKSClassDeclarationEnumEntry(): KSClassDeclarationEnumEntryImpl =
     KSClassDeclarationEnumEntryImpl.getCached(this)
@@ -525,102 +569,110 @@ internal fun KaEnumEntrySymbol.toKSClassDeclarationEnumEntry(): KSClassDeclarati
 internal fun KaTypeParameterSymbol.toKSTypeParameter(): KSTypeParameterImpl =
     KSTypeParameterImpl.getCached(this)
 
-internal fun KaLocalVariableSymbol.toKSPropertyDeclarationLocalVariable(): KSPropertyDeclarationLocalVariableImpl =
-    KSPropertyDeclarationLocalVariableImpl.getCached(this)
+internal fun KaLocalVariableSymbol.toKSPropertyDeclarationLocalVariable():
+    KSPropertyDeclarationLocalVariableImpl = KSPropertyDeclarationLocalVariableImpl.getCached(this)
 
 internal fun KaValueParameterSymbol.toKSValueParameter(): KSValueParameterImpl =
     KSValueParameterImpl.getCached(this, this.getContainingKSSymbol()!!)
 
-internal fun AnnotationUseSiteTargetAA.toKSAnnotationUseSiteTarget(): AnnotationUseSiteTarget = when (this) {
-    AnnotationUseSiteTargetAA.ALL -> AnnotationUseSiteTarget.ALL
-    AnnotationUseSiteTargetAA.FIELD -> AnnotationUseSiteTarget.FIELD
-    AnnotationUseSiteTargetAA.FILE -> AnnotationUseSiteTarget.FILE
-    AnnotationUseSiteTargetAA.PROPERTY -> AnnotationUseSiteTarget.PROPERTY
-    AnnotationUseSiteTargetAA.PROPERTY_GETTER -> AnnotationUseSiteTarget.GET
-    AnnotationUseSiteTargetAA.PROPERTY_SETTER -> AnnotationUseSiteTarget.SET
-    AnnotationUseSiteTargetAA.RECEIVER -> AnnotationUseSiteTarget.RECEIVER
-    AnnotationUseSiteTargetAA.CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
-    AnnotationUseSiteTargetAA.SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
-    AnnotationUseSiteTargetAA.PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
-}
+internal fun AnnotationUseSiteTargetAA.toKSAnnotationUseSiteTarget(): AnnotationUseSiteTarget =
+    when (this) {
+        AnnotationUseSiteTargetAA.ALL -> AnnotationUseSiteTarget.ALL
+        AnnotationUseSiteTargetAA.FIELD -> AnnotationUseSiteTarget.FIELD
+        AnnotationUseSiteTargetAA.FILE -> AnnotationUseSiteTarget.FILE
+        AnnotationUseSiteTargetAA.PROPERTY -> AnnotationUseSiteTarget.PROPERTY
+        AnnotationUseSiteTargetAA.PROPERTY_GETTER -> AnnotationUseSiteTarget.GET
+        AnnotationUseSiteTargetAA.PROPERTY_SETTER -> AnnotationUseSiteTarget.SET
+        AnnotationUseSiteTargetAA.RECEIVER -> AnnotationUseSiteTarget.RECEIVER
+        AnnotationUseSiteTargetAA.CONSTRUCTOR_PARAMETER -> AnnotationUseSiteTarget.PARAM
+        AnnotationUseSiteTargetAA.SETTER_PARAMETER -> AnnotationUseSiteTarget.SETPARAM
+        AnnotationUseSiteTargetAA.PROPERTY_DELEGATE_FIELD -> AnnotationUseSiteTarget.DELEGATE
+    }
 
 /**
- * Optionally returns the [KaType] for the [KSType].
- * In other words, it unpacks the underlying analysis API type from the KSP type.
+ * Optionally returns the [KaType] for the [KSType]. In other words, it unpacks the underlying
+ * analysis API type from the KSP type.
  */
-internal fun KSType.toKaType(): KaType? =
-    (this as? KSTypeImpl)?.type
+internal fun KSType.toKaType(): KaType? = (this as? KSTypeImpl)?.type
 
-internal fun KSPropertyAccessor.getter(): KSPropertyGetter? = when (this) {
-    is KSPropertyGetter -> this
-    is KSPropertySetter -> null
-    else -> null
-}
+internal fun KSPropertyAccessor.getter(): KSPropertyGetter? =
+    when (this) {
+        is KSPropertyGetter -> this
+        is KSPropertySetter -> null
+        else -> null
+    }
 
-internal fun KSPropertyAccessor.setter(): KSPropertySetter? = when (this) {
-    is KSPropertyGetter -> null
-    is KSPropertySetter -> this
-    else -> null
-}
+internal fun KSPropertyAccessor.setter(): KSPropertySetter? =
+    when (this) {
+        is KSPropertyGetter -> null
+        is KSPropertySetter -> this
+        else -> null
+    }
 
-internal fun KSAnnotated.getter(): KSPropertyGetter? = when (this) {
-    is KSDeclaration -> this.getter()
-    is KSFile -> null
-    is KSPropertyAccessor -> this.getter()
-    is KSTypeArgument -> null
-    is KSTypeReference -> null
-    is KSValueArgument -> null
-    is KSValueParameter -> this.getter()
-    else -> null
-}
+internal fun KSAnnotated.getter(): KSPropertyGetter? =
+    when (this) {
+        is KSDeclaration -> this.getter()
+        is KSFile -> null
+        is KSPropertyAccessor -> this.getter()
+        is KSTypeArgument -> null
+        is KSTypeReference -> null
+        is KSValueArgument -> null
+        is KSValueParameter -> this.getter()
+        else -> null
+    }
 
-internal fun KSAnnotated.setter(): KSPropertySetter? = when (this) {
-    is KSDeclaration -> this.setter()
-    is KSFile -> null
-    is KSPropertyAccessor -> this.setter()
-    is KSTypeArgument -> null
-    is KSTypeReference -> null
-    is KSValueArgument -> null
-    is KSValueParameter -> this.setter()
-    else -> null
-}
+internal fun KSAnnotated.setter(): KSPropertySetter? =
+    when (this) {
+        is KSDeclaration -> this.setter()
+        is KSFile -> null
+        is KSPropertyAccessor -> this.setter()
+        is KSTypeArgument -> null
+        is KSTypeReference -> null
+        is KSValueArgument -> null
+        is KSValueParameter -> this.setter()
+        else -> null
+    }
 
-internal fun KSValueParameter.getter(): KSPropertyGetter? =
-    getGeneratedProperty()?.getter
+internal fun KSValueParameter.getter(): KSPropertyGetter? = getGeneratedProperty()?.getter
 
-internal fun KSValueParameter.setter(): KSPropertySetter? =
-    getGeneratedProperty()?.setter
+internal fun KSValueParameter.setter(): KSPropertySetter? = getGeneratedProperty()?.setter
 
-internal fun KSDeclaration.getter(): KSPropertyGetter? = when (this) {
-    is KSPropertyDeclaration -> this.getter
-    else -> null
-}
+internal fun KSDeclaration.getter(): KSPropertyGetter? =
+    when (this) {
+        is KSPropertyDeclaration -> this.getter
+        else -> null
+    }
 
-internal fun KSDeclaration.setter(): KSPropertySetter? = when (this) {
-    is KSPropertyDeclaration -> this.setter
-    else -> null
-}
+internal fun KSDeclaration.setter(): KSPropertySetter? =
+    when (this) {
+        is KSPropertyDeclaration -> this.setter
+        else -> null
+    }
 
-/**
- * Returns the generated property if the value parameter is declared as `val` or `var`.
- */
-internal fun KSValueParameter.getGeneratedProperty(): KSPropertyDeclaration? = when (this) {
-    is KSValueParameterImpl -> if (isVal || isVar) generatedProperty else null
-    is KSValueParameterLiteImpl -> null
-    else -> throw InternalKSPException(
-        "Unexpected KSValueParameter type",
-        this.location,
-        this.javaClass
-    )
-}
+/** Returns the generated property if the value parameter is declared as `val` or `var`. */
+internal fun KSValueParameter.getGeneratedProperty(): KSPropertyDeclaration? =
+    when (this) {
+        is KSValueParameterImpl -> if (isVal || isVar) generatedProperty else null
+        is KSValueParameterLiteImpl -> null
+        else ->
+            throw InternalKSPException(
+                "Unexpected KSValueParameter type",
+                this.location,
+                this.javaClass,
+            )
+    }
 
 @OptIn(ClassIdBasedLocality::class)
 internal fun ClassId.toKtClassSymbol(): KaClassSymbol? {
     return analyze {
         if (this@toKtClassSymbol.isLocal) {
-            this@toKtClassSymbol.outerClassId?.toKtClassSymbol()?.declaredMemberScope?.classifiers {
-                it.asString() == this@toKtClassSymbol.shortClassName.asString()
-            }?.singleOrNull() as? KaClassSymbol
+            this@toKtClassSymbol.outerClassId
+                ?.toKtClassSymbol()
+                ?.declaredMemberScope
+                ?.classifiers {
+                    it.asString() == this@toKtClassSymbol.shortClassName.asString()
+                }
+                ?.singleOrNull() as? KaClassSymbol
         } else {
             // Try to find KaFirPsiJavaClassSymbol. See KT-74598 for details.
             val candidate = findClass(this@toKtClassSymbol)
@@ -628,8 +680,7 @@ internal fun ClassId.toKtClassSymbol(): KaClassSymbol? {
             // Checking of JAVA_SOURCE is needed because psi can come from libraries.
             if (candidate?.origin == KaSymbolOrigin.JAVA_SOURCE && psi is PsiClass)
                 psi.namedClassSymbol
-            else
-                candidate
+            else candidate
         }
     }
 }
@@ -646,7 +697,8 @@ internal fun KaType.classifierSymbol(): KaClassifierSymbol? {
             is KaTypeParameterType -> this.symbol
             // TODO: upstream is not exposing enough information for captured types.
             is KaCapturedType -> TODO("fix in upstream")
-            is KaClassErrorType, is KaErrorType -> null
+            is KaClassErrorType,
+            is KaErrorType -> null
             is KaFunctionType -> (this as? KaFirFunctionType)?.abbreviatedSymbol() ?: symbol
             is KaUsualClassType -> symbol
             is KaDefinitelyNotNullType -> original.classifierSymbol()
@@ -656,11 +708,12 @@ internal fun KaType.classifierSymbol(): KaClassifierSymbol? {
             is KaFlexibleType -> lowerBound.classifierSymbol()
             // TODO: KSP does not support intersection type.
             is KaIntersectionType -> null
-            else -> throw InternalKSPException(
-                "Unexpected type",
-                NonExistLocation,
-                this.javaClass
-            )
+            else ->
+                throw InternalKSPException(
+                    "Unexpected type",
+                    NonExistLocation,
+                    this.javaClass,
+                )
         }
     } catch (e: KotlinExceptionWithAttachments) {
         // The implementation for getting symbols from a type throws an exception
@@ -671,45 +724,43 @@ internal fun KaType.classifierSymbol(): KaClassifierSymbol? {
 
 internal fun KaType.typeArguments(): List<KaTypeProjection> {
     return if (this is KaFlexibleType) {
-        this.lowerBound
-    } else {
-        this
-    }.let {
-        (it as? KaClassType)?.qualifiers?.reversed()?.flatMap(KaResolvedClassTypeQualifier::typeArguments)
-            ?: emptyList()
-    }
+            this.lowerBound
+        } else {
+            this
+        }
+        .let {
+            (it as? KaClassType)
+                ?.qualifiers
+                ?.reversed()
+                ?.flatMap(KaResolvedClassTypeQualifier::typeArguments) ?: emptyList()
+        }
 }
 
 /**
- * Optionally returns the fully qualified name for the [KSAnnotated].
- * This function may be expensive to compute since it must resolve the type of the annotation.
+ * Optionally returns the fully qualified name for the [KSAnnotated]. This function may be expensive
+ * to compute since it must resolve the type of the annotation.
  */
-internal fun KSAnnotation.getFqn(): String? =
-    annotationType.resolve().toKaType()?.getFqn()
+internal fun KSAnnotation.getFqn(): String? = annotationType.resolve().toKaType()?.getFqn()
 
-/**
- * Optionally returns the fully qualified name for a [KaType].
- */
-internal fun KaType.getFqn(): String? =
-    fullyExpand().symbol?.classId?.asFqNameString()
+/** Optionally returns the fully qualified name for a [KaType]. */
+internal fun KaType.getFqn(): String? = fullyExpand().symbol?.classId?.asFqNameString()
 
-/**
- * Returns the Psi element for [KSFile], if it exists.
- */
+/** Returns the Psi element for [KSFile], if it exists. */
 internal val KSFile.psi: PsiElement?
-    get() = when (this) {
-        is KSFileImpl -> ktFileSymbol.psi
-        is KSFileJavaImpl -> psi
-        else -> null
-    }
+    get() =
+        when (this) {
+            is KSFileImpl -> ktFileSymbol.psi
+            is KSFileJavaImpl -> psi
+            else -> null
+        }
 
 internal fun KaSymbolVisibility.toModifier(): Modifier {
     return when (this) {
         KaSymbolVisibility.PUBLIC -> Modifier.PUBLIC
         KaSymbolVisibility.PRIVATE -> Modifier.PRIVATE
         KaSymbolVisibility.INTERNAL -> Modifier.INTERNAL
-        KaSymbolVisibility.PROTECTED, KaSymbolVisibility.PACKAGE_PROTECTED ->
-            Modifier.PROTECTED
+        KaSymbolVisibility.PROTECTED,
+        KaSymbolVisibility.PACKAGE_PROTECTED -> Modifier.PROTECTED
 
         else -> Modifier.PUBLIC
     }
@@ -732,47 +783,57 @@ internal inline fun <reified T : KSNode> KSNode.findParentOfType(): KSNode? {
     return result
 }
 
-internal fun KaAnnotationValue.toValue(parent: KSNode? = null, origin: Origin? = null): Any? = when (this) {
-    is KaAnnotationValue.ArrayValue -> this.values.map { it.toValue(parent, origin) }
-    is KaAnnotationValue.NestedAnnotationValue -> KSAnnotationResolvedImpl.getCached(this.annotation, parent, origin)
-    // TODO: Enum entry should return a type, use declaration as a placeholder.
-    is KaAnnotationValue.EnumEntryValue -> this.callableId?.classId?.let { classId ->
-        analyze {
-            classId.toKtClassSymbol()?.let { classSymbol ->
-                classSymbol.declarations().filterIsInstance<KSClassDeclarationEnumEntryImpl>().singleOrNull {
-                    it.simpleName.asString() == this@toValue.callableId?.callableName?.asString()
+internal fun KaAnnotationValue.toValue(parent: KSNode? = null, origin: Origin? = null): Any? =
+    when (this) {
+        is KaAnnotationValue.ArrayValue -> this.values.map { it.toValue(parent, origin) }
+        is KaAnnotationValue.NestedAnnotationValue ->
+            KSAnnotationResolvedImpl.getCached(this.annotation, parent, origin)
+        // TODO: Enum entry should return a type, use declaration as a placeholder.
+        is KaAnnotationValue.EnumEntryValue ->
+            this.callableId?.classId?.let { classId ->
+                analyze {
+                    classId.toKtClassSymbol()?.let { classSymbol ->
+                        classSymbol
+                            .declarations()
+                            .filterIsInstance<KSClassDeclarationEnumEntryImpl>()
+                            .singleOrNull {
+                                it.simpleName.asString() ==
+                                    this@toValue.callableId?.callableName?.asString()
+                            }
+                    }
                 }
+            } ?: KSErrorType
+
+        is KaAnnotationValue.ClassLiteralValue -> {
+            parent?.let { ctx ->
+                recordClassReferenceLookup(type, ctx)
             }
+            KSTypeImpl.getCached(type)
         }
-    } ?: KSErrorType
 
-    is KaAnnotationValue.ClassLiteralValue -> {
-        parent?.let { ctx ->
-            recordClassReferenceLookup(type, ctx)
-        }
-        KSTypeImpl.getCached(type)
+        is KaAnnotationValue.ConstantValue -> this.value.value
+        is KaAnnotationValue.UnsupportedValue -> null
     }
-
-    is KaAnnotationValue.ConstantValue -> this.value.value
-    is KaAnnotationValue.UnsupportedValue -> null
-}
 
 @OptIn(SymbolInternals::class, KaImplementationDetail::class, KaExperimentalApi::class)
 internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
     return this.psi.let { psiElement ->
         when (psiElement) {
-            is KtParameter -> analyze {
-                psiElement.defaultValue?.evaluateAsAnnotationValue()
-            }
+            is KtParameter ->
+                analyze {
+                    psiElement.defaultValue?.evaluateAsAnnotationValue()
+                }
             // ClsMethodImpl means the psi is decompiled psi.
-            null, is ClsMemberImpl<*> -> {
+            null,
+            is ClsMemberImpl<*> -> {
                 // TODO: multiplatform
-                if (!ResolverAAImpl.instance.isJvm)
-                    return@let null
+                if (!ResolverAAImpl.instance.isJvm) return@let null
                 val fileManager = ResolverAAImpl.instance.javaFileManager
-                val parentClass = this.getContainingKSSymbol()!!.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
-                    ?: return@let null
+                val parentClass =
+                    this.getContainingKSSymbol()!!.findParentOfType<KSClassDeclaration>()
+                val classId =
+                    (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
+                        ?: return@let null
 
                 val defaultValue: JavaAnnotationArgument? = analyze {
                     val jc = fileManager.findClass(classId, analysisScope) ?: return@analyze null
@@ -784,49 +845,61 @@ internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
                     val symbolBuilder = it.builder
                     val expectedTypeRef = it.firSymbol.fir.returnTypeRef
                     // when no default value is declared in the class file, ideally users should
-                    // apply a value for such property at use site, therefore value obtained here should not be
+                    // apply a value for such property at use site, therefore value obtained here
+                    // should not be
                     // returned. In case of a user failed to do so, we try our best to return values
                     // to ensure no annotation argument is missing from KSP side.
                     // Supplying `JavaUnknownAnnotationArgumentImpl` as the expression base
-                    // will produce empty array for array type values and `null` for the rest of value types.
-                    val expression = (defaultValue ?: JavaUnknownAnnotationArgumentImpl(null))
-                        .toFirExpression(firSession, JavaTypeParameterStack.EMPTY, expectedTypeRef, null)
+                    // will produce empty array for array type values and `null` for the rest of
+                    // value types.
+                    val expression =
+                        (defaultValue ?: JavaUnknownAnnotationArgumentImpl(null)).toFirExpression(
+                            firSession,
+                            JavaTypeParameterStack.EMPTY,
+                            expectedTypeRef,
+                            null,
+                        )
                     FirAnnotationValueConverter.toConstantValue(expression, symbolBuilder)
                 }
             }
 
-            else -> throw InternalKSPException(
-                "Unhandled default value type",
-                psiElement.toLocation(),
-                psiElement.javaClass,
-            )
+            else ->
+                throw InternalKSPException(
+                    "Unhandled default value type",
+                    psiElement.toLocation(),
+                    psiElement.javaClass,
+                )
         }
     }
 }
 
 @OptIn(KaExperimentalApi::class)
 internal fun fillInDeepSubstitutor(context: KaType, substitutorBuilder: KaSubstitutorBuilder) {
-    val unwrappedType = when (context) {
-        is KaClassType -> context
-        is KaFlexibleType -> {
-            fillInDeepSubstitutor(context.upperBound, substitutorBuilder)
-            fillInDeepSubstitutor(context.lowerBound, substitutorBuilder)
-            return
-        }
+    val unwrappedType =
+        when (context) {
+            is KaClassType -> context
+            is KaFlexibleType -> {
+                fillInDeepSubstitutor(context.upperBound, substitutorBuilder)
+                fillInDeepSubstitutor(context.lowerBound, substitutorBuilder)
+                return
+            }
 
-        else -> return
-    }
+            else -> return
+        }
     val parameters = unwrappedType.symbol.typeParameters
     val arguments = unwrappedType.typeArguments
     if (parameters.size != arguments.size) {
         throw InternalKSPException(
             "Unexpected invalid substitution for $context",
             NonExistLocation,
-            context.javaClass
+            context.javaClass,
         )
     }
     parameters.zip(arguments).forEach { (param, projection) ->
-        val arg = projection.type ?: param.upperBounds.firstOrNull() ?: analyze { useSiteSession.builtinTypes.any }
+        val arg =
+            projection.type
+                ?: param.upperBounds.firstOrNull()
+                ?: analyze { useSiteSession.builtinTypes.any }
         substitutorBuilder.substitution(param, arg)
     }
     (context.symbol as? KaClassSymbol)?.superTypes?.forEach {
@@ -835,7 +908,10 @@ internal fun fillInDeepSubstitutor(context: KaType, substitutorBuilder: KaSubsti
 }
 
 internal fun KaSymbol.psiIfSource(): PsiElement? {
-    return if (origin == KaSymbolOrigin.SOURCE || origin == KaSymbolOrigin.JAVA_SOURCE && toContainingFile() != null) {
+    return if (
+        origin == KaSymbolOrigin.SOURCE ||
+            origin == KaSymbolOrigin.JAVA_SOURCE && toContainingFile() != null
+    ) {
         psi
     } else {
         null
@@ -855,8 +931,7 @@ fun <T : KaSymbol> T.defer(restore: (T) -> KSAnnotated?): Restorable {
     return Restorable {
         analyze {
             val restored = ptr.restoreSymbol() ?: return@analyze null
-            @Suppress("UNCHECKED_CAST")
-            restore(restored as T)
+            @Suppress("UNCHECKED_CAST") restore(restored as T)
         }
     }
 }
@@ -880,10 +955,11 @@ internal fun KaType.convertToKotlinType(): KaType {
     if (declaration.classId == null) {
         return this
     }
-    val base = if (declaration.classId != null && declaration.shouldMapToKotlinForAssignabilityCheck()) {
-        JavaToKotlinClassMap.mapJavaToKotlin(declaration.classId!!.asSingleFqName())?.toKtClassSymbol()
-            ?: declaration
-    } else declaration
+    val base =
+        if (declaration.classId != null && declaration.shouldMapToKotlinForAssignabilityCheck()) {
+            JavaToKotlinClassMap.mapJavaToKotlin(declaration.classId!!.asSingleFqName())
+                ?.toKtClassSymbol() ?: declaration
+        } else declaration
     return analyze {
         buildClassType(base.tryResolveToTypePhase()) {
             this@convertToKotlinType.typeArguments().forEach { typeProjection ->
@@ -914,10 +990,11 @@ internal fun KaType.replace(newArgs: List<KaTypeProjection>): KaType {
     require(newArgs.isEmpty() || newArgs.size == this.typeArguments().size)
     return analyze {
         when (val symbol = classifierSymbol().tryResolveToTypePhase()) {
-            is KaClassLikeSymbol -> useSiteSession.buildClassType(symbol) {
-                newArgs.forEach { arg -> argument(arg) }
-                isMarkedNullable = this@replace.isMarkedNullable
-            }
+            is KaClassLikeSymbol ->
+                useSiteSession.buildClassType(symbol) {
+                    newArgs.forEach { arg -> argument(arg) }
+                    isMarkedNullable = this@replace.isMarkedNullable
+                }
             // No need to copy nullability for type parameters
             // because it is overridden to be always nullable in compiler.
             is KaTypeParameterSymbol -> useSiteSession.buildTypeParameterType(symbol)
@@ -929,13 +1006,14 @@ internal fun KaType.replace(newArgs: List<KaTypeProjection>): KaType {
 internal fun getVarianceForWildcard(
     parameter: KaTypeParameterSymbol,
     projection: KaTypeProjection,
-    mode: TypeMappingMode
+    mode: TypeMappingMode,
 ): Variance {
-    val projectionKind = if (projection is KaTypeArgumentWithVariance) {
-        projection.variance
-    } else {
-        Variance.OUT_VARIANCE
-    }
+    val projectionKind =
+        if (projection is KaTypeArgumentWithVariance) {
+            projection.variance
+        } else {
+            Variance.OUT_VARIANCE
+        }
     val parameterVariance = parameter.variance
     if (parameterVariance == Variance.INVARIANT) {
         return projectionKind
@@ -946,10 +1024,15 @@ internal fun getVarianceForWildcard(
     if (projectionKind == Variance.INVARIANT || projectionKind == parameterVariance) {
         if (mode.skipDeclarationSiteWildcardsIfPossible && projection !is KaStarTypeProjection) {
             val type = projection.type ?: return parameterVariance
-            if (parameterVariance == Variance.OUT_VARIANCE && type.isMostPreciseCovariantArgument()) {
+            if (
+                parameterVariance == Variance.OUT_VARIANCE && type.isMostPreciseCovariantArgument()
+            ) {
                 return Variance.INVARIANT
             }
-            if (parameterVariance == Variance.IN_VARIANCE && type.isMostPreciseContravariantArgument()) {
+            if (
+                parameterVariance == Variance.IN_VARIANCE &&
+                    type.isMostPreciseContravariantArgument()
+            ) {
                 return Variance.INVARIANT
             }
         }
@@ -963,35 +1046,40 @@ internal fun KaType.isMostPreciseContravariantArgument(): Boolean = analyze { is
 internal fun KaType.isMostPreciseCovariantArgument() = !canHaveSubtypesIgnoreNullability()
 
 @OptIn(KaExperimentalApi::class)
-private fun KaType.canHaveSubtypesIgnoreNullability(): Boolean =
-    analyze {
-        val type = fullyExpandedType
-        val symbol = expandedSymbol ?: return@analyze true
-        if (symbol.classKind == KaClassKind.ENUM_CLASS || symbol.isExpect) {
-            return@analyze true
-        }
-        if (symbol.modality != KaSymbolModality.FINAL) {
-            return@analyze true
-        }
-
-        symbol.typeParameters.forEachIndexed { idx, param ->
-            val projection = type.typeArguments().get(idx)
-
-            if (projection !is KaTypeArgumentWithVariance) {
-                return@analyze true
-            }
-
-            val projectionType = projection.type
-            val effectiveVariance = getEffectiveVariance(param.variance, projection.variance)
-            if (effectiveVariance == Variance.OUT_VARIANCE && !projectionType.isMostPreciseCovariantArgument()) {
-                return@analyze true
-            }
-            if (effectiveVariance == Variance.IN_VARIANCE && !projectionType.isMostPreciseContravariantArgument()) {
-                return@analyze true
-            }
-        }
-        false
+private fun KaType.canHaveSubtypesIgnoreNullability(): Boolean = analyze {
+    val type = fullyExpandedType
+    val symbol = expandedSymbol ?: return@analyze true
+    if (symbol.classKind == KaClassKind.ENUM_CLASS || symbol.isExpect) {
+        return@analyze true
     }
+    if (symbol.modality != KaSymbolModality.FINAL) {
+        return@analyze true
+    }
+
+    symbol.typeParameters.forEachIndexed { idx, param ->
+        val projection = type.typeArguments().get(idx)
+
+        if (projection !is KaTypeArgumentWithVariance) {
+            return@analyze true
+        }
+
+        val projectionType = projection.type
+        val effectiveVariance = getEffectiveVariance(param.variance, projection.variance)
+        if (
+            effectiveVariance == Variance.OUT_VARIANCE &&
+                !projectionType.isMostPreciseCovariantArgument()
+        ) {
+            return@analyze true
+        }
+        if (
+            effectiveVariance == Variance.IN_VARIANCE &&
+                !projectionType.isMostPreciseContravariantArgument()
+        ) {
+            return@analyze true
+        }
+    }
+    false
+}
 
 @OptIn(KaExperimentalApi::class)
 internal fun KaType.toWildcard(mode: TypeMappingMode): KaType {
@@ -1005,14 +1093,19 @@ internal fun KaType.toWildcard(mode: TypeMappingMode): KaType {
                     parameters.zip(args).map { (param, arg) ->
                         val argMode = mode.updateFromAnnotations(arg.type)
                         val variance = getVarianceForWildcard(param, arg, argMode)
-                        val genericMode = argMode.toGenericArgumentMode(
-                            getEffectiveVariance(
-                                param.variance,
-                                (arg as? KaTypeArgumentWithVariance)?.variance ?: Variance.INVARIANT
+                        val genericMode =
+                            argMode.toGenericArgumentMode(
+                                getEffectiveVariance(
+                                    param.variance,
+                                    (arg as? KaTypeArgumentWithVariance)?.variance
+                                        ?: Variance.INVARIANT,
+                                )
                             )
-                        )
                         val argType =
-                            arg.type ?: useSiteSession.builtinTypes.any.withNullability(isMarkedNullable = true)
+                            arg.type
+                                ?: useSiteSession.builtinTypes.any.withNullability(
+                                    isMarkedNullable = true
+                                )
                         argument(argType.toWildcard(genericMode), variance)
                     }
                     isMarkedNullable = this@toWildcard.isMarkedNullable
@@ -1028,20 +1121,16 @@ internal fun KaType.toWildcard(mode: TypeMappingMode): KaType {
     }
 }
 
-internal fun TypeMappingMode.suppressJvmWildcards(
-    suppress: Boolean
-): TypeMappingMode {
+internal fun TypeMappingMode.suppressJvmWildcards(suppress: Boolean): TypeMappingMode {
     return TypeMappingMode.createWithConstantDeclarationSiteWildcardsMode(
         skipDeclarationSiteWildcards = suppress,
         isForAnnotationParameter = isForAnnotationParameter,
         needInlineClassWrapping = needInlineClassWrapping,
-        mapTypeAliases = mapTypeAliases
+        mapTypeAliases = mapTypeAliases,
     )
 }
 
-internal fun TypeMappingMode.updateFromParents(
-    ref: KSTypeReference
-): TypeMappingMode {
+internal fun TypeMappingMode.updateFromParents(ref: KSTypeReference): TypeMappingMode {
     return ref.findJvmSuppressWildcards()?.let {
         this.suppressJvmWildcards(it)
     } ?: this
@@ -1051,44 +1140,63 @@ internal fun KSTypeReference.findJvmSuppressWildcards(): Boolean? {
     var candidate: KSNode? = this
     while (candidate != null) {
         if ((candidate is KSTypeReference || candidate is KSDeclaration)) {
-            (candidate as KSAnnotated).annotations.singleOrNull {
-                it.annotationType.resolve().declaration.qualifiedName?.asString()?.equals(
-                    JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME.asString()
-                ) == true
-            }?.let { a -> a.arguments.singleOrNull { it.name?.asString() == "suppress" } }?.let {
-                return it.value as? Boolean
-            }
+            (candidate as KSAnnotated)
+                .annotations
+                .singleOrNull {
+                    it.annotationType
+                        .resolve()
+                        .declaration
+                        .qualifiedName
+                        ?.asString()
+                        ?.equals(JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME.asString()) == true
+                }
+                ?.let { a -> a.arguments.singleOrNull { it.name?.asString() == "suppress" } }
+                ?.let {
+                    return it.value as? Boolean
+                }
         }
         candidate = candidate.parent
     }
     return null
 }
 
-internal fun TypeMappingMode.updateFromAnnotations(
-    type: KaType?
-): TypeMappingMode {
+internal fun TypeMappingMode.updateFromAnnotations(type: KaType?): TypeMappingMode {
     if (type == null) {
         return this
     }
-    type.annotations().firstOrNull {
-        it.annotationType.resolve().declaration.qualifiedName?.asString()
-            ?.equals(JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME.asString()) == true
-    }?.let { annotation ->
-        annotation.arguments.firstOrNull { it.name?.asString() == "suppress" }?.let {
-            return (it.value as? Boolean)?.let(::suppressJvmWildcards) ?: this
+    type
+        .annotations()
+        .firstOrNull {
+            it.annotationType
+                .resolve()
+                .declaration
+                .qualifiedName
+                ?.asString()
+                ?.equals(JVM_SUPPRESS_WILDCARDS_ANNOTATION_FQ_NAME.asString()) == true
         }
-    }
-    val hasJavaWildCardAnnotation = type.annotations().any {
-        it.annotationType.resolve().declaration.qualifiedName?.asString()
-            ?.equals(JVM_WILDCARD_ANNOTATION_FQ_NAME.asString()) == true
-    }
+        ?.let { annotation ->
+            annotation.arguments
+                .firstOrNull { it.name?.asString() == "suppress" }
+                ?.let {
+                    return (it.value as? Boolean)?.let(::suppressJvmWildcards) ?: this
+                }
+        }
+    val hasJavaWildCardAnnotation =
+        type.annotations().any {
+            it.annotationType
+                .resolve()
+                .declaration
+                .qualifiedName
+                ?.asString()
+                ?.equals(JVM_WILDCARD_ANNOTATION_FQ_NAME.asString()) == true
+        }
     return if (hasJavaWildCardAnnotation) {
         TypeMappingMode.createWithConstantDeclarationSiteWildcardsMode(
             skipDeclarationSiteWildcards = false,
             isForAnnotationParameter = isForAnnotationParameter,
             fallbackMode = this,
             needInlineClassWrapping = needInlineClassWrapping,
-            mapTypeAliases = mapTypeAliases
+            mapTypeAliases = mapTypeAliases,
         )
     } else {
         this
@@ -1121,51 +1229,65 @@ private fun KaType.asInfoForMangling(): InfoForMangling? {
 private fun mangleInlineSuffix(
     parameters: List<KaType>,
     returnType: KaType?,
-    shouldMangleReturnType: Boolean
+    shouldMangleReturnType: Boolean,
 ): String {
-    val signature = collectFunctionSignatureForManglingSuffix(
-        false,
-        parameters.any { it.requiresMangling() },
-        parameters.map { it.asInfoForMangling() },
-        if (shouldMangleReturnType) returnType?.asInfoForMangling() else null
-    ) ?: return ""
+    val signature =
+        collectFunctionSignatureForManglingSuffix(
+            false,
+            parameters.any { it.requiresMangling() },
+            parameters.map { it.asInfoForMangling() },
+            if (shouldMangleReturnType) returnType?.asInfoForMangling() else null,
+        ) ?: return ""
     return "-${md5base64(signature)}"
 }
 
 private val KaSymbol.isKotlin: Boolean
-    get() = when (origin) {
-        KaSymbolOrigin.SOURCE, KaSymbolOrigin.LIBRARY -> true
-        else -> false
-    }
+    get() =
+        when (origin) {
+            KaSymbolOrigin.SOURCE,
+            KaSymbolOrigin.LIBRARY -> true
+            else -> false
+        }
 
 internal val KaFunctionSymbol.inlineSuffix: String
-    get() = mangleInlineSuffix(
-        valueParameters.map { it.returnType },
-        returnType,
-        analyze {
-            returnType.requiresMangling() && isKotlin && containingDeclaration != null
-        }
-    )
+    get() =
+        mangleInlineSuffix(
+            valueParameters.map { it.returnType },
+            returnType,
+            analyze {
+                returnType.requiresMangling() && isKotlin && containingDeclaration != null
+            },
+        )
 
 internal val KaPropertyAccessorSymbol.inlineSuffix: String
-    get() = when (this) {
-        is KaPropertyGetterSymbol ->
-            mangleInlineSuffix(
-                emptyList(),
-                returnType,
-                analyze {
-                    returnType.requiresMangling() && isKotlin && containingDeclaration?.containingDeclaration != null
-                }
-            )
+    get() =
+        when (this) {
+            is KaPropertyGetterSymbol ->
+                mangleInlineSuffix(
+                    emptyList(),
+                    returnType,
+                    analyze {
+                        returnType.requiresMangling() &&
+                            isKotlin &&
+                            containingDeclaration?.containingDeclaration != null
+                    },
+                )
 
-        is KaPropertySetterSymbol -> mangleInlineSuffix(listOf(parameter.returnType), null, false)
-    }
+            is KaPropertySetterSymbol ->
+                mangleInlineSuffix(listOf(parameter.returnType), null, false)
+        }
 
 private val jvmNameClassId = ClassId.fromString("kotlin/jvm/JvmName")
+
 internal fun KaCallableSymbol.explictJvmName(): String? {
-    return annotations.singleOrNull() {
-        it.classId == jvmNameClassId
-    }?.arguments?.single()?.expression?.toValue() as? String
+    return annotations
+        .singleOrNull() {
+            it.classId == jvmNameClassId
+        }
+        ?.arguments
+        ?.single()
+        ?.expression
+        ?.toValue() as? String
 }
 
 private val javaLangRecordClassId = ClassId.fromString("java/lang/Record")
@@ -1176,27 +1298,25 @@ internal fun KaClassSymbol.isJvmRecord(): Boolean {
     }
     // The @JvmRecord annotation is not retained in class files, so compiled record
     // classes are recognized by their java.lang.Record supertype instead.
-    return origin == KaSymbolOrigin.LIBRARY && analyze {
-        superTypes.any { (it as? KaClassType)?.classId == javaLangRecordClassId }
-    }
+    return origin == KaSymbolOrigin.LIBRARY &&
+        analyze {
+            superTypes.any { (it as? KaClassType)?.classId == javaLangRecordClassId }
+        }
 }
 
 @OptIn(SymbolInternals::class)
 internal val KaDeclarationSymbol.internalSuffix: String
     get() = analyze {
-        if (visibility != KaSymbolVisibility.INTERNAL)
-            return@analyze ""
+        if (visibility != KaSymbolVisibility.INTERNAL) return@analyze ""
 
         // Skip top level functions and properties
         when (this@internalSuffix) {
             is KaPropertyAccessorSymbol -> {
-                if (containingDeclaration?.containingDeclaration == null)
-                    return@analyze ""
+                if (containingDeclaration?.containingDeclaration == null) return@analyze ""
             }
 
             is KaFunctionSymbol -> {
-                if (containingDeclaration == null)
-                    return@analyze ""
+                if (containingDeclaration == null) return@analyze ""
             }
 
             else -> {}
@@ -1222,16 +1342,16 @@ internal val KaDeclarationSymbol.internalSuffix: String
  * Checks if this symbol is an artifact of inheritance that the Kotlin Analysis API (FIR)
  * incorrectly leaked into the current class's declarations list.
  *
- * KSP's contract dictates that `KSClassDeclaration.declarations` should only return
- * explicitly declared members. This method identifies leaked or synthesized members
- * so they can be filtered out.
+ * KSP's contract dictates that `KSClassDeclaration.declarations` should only return explicitly
+ * declared members. This method identifies leaked or synthesized members so they can be filtered
+ * out.
  *
  * It specifically identifies the following Analysis API leaks:
  *
- * **1. Compiler-Generated Intersection Overrides**
- * An intersection override occurs when a class inherits from multiple supertypes that
- * declare the same member with the same signature. The compiler synthesizes a new member
- * in the subclass.
+ * **1. Compiler-Generated Intersection Overrides** An intersection override occurs when a class
+ * inherits from multiple supertypes that declare the same member with the same signature. The
+ * compiler synthesizes a new member in the subclass.
+ *
  * ```kotlin
  * interface A { fun execute() }
  * interface B { fun execute() }
@@ -1239,19 +1359,19 @@ internal val KaDeclarationSymbol.internalSuffix: String
  * interface C : A, B
  * ```
  *
- * **2. Compiler-Generated Substitution Overrides**
- * A substitution override is created when a generic type parameter from a supertype
- * is substituted with a concrete type in the subclass.
+ * **2. Compiler-Generated Substitution Overrides** A substitution override is created when a
+ * generic type parameter from a supertype is substituted with a concrete type in the subclass.
+ *
  * ```kotlin
  * interface Base<T> { fun process(item: T) }
  * // FIR synthesizes a substitution override `fun process(item: String)` inside Derived.
  * interface Derived : Base<String>
  * ```
  *
- * **3. Inherited Synthetic Java Properties**
- * The Analysis API exposes Java getter/setter methods that override a Kotlin property
- * as synthetic property symbols. Due to a quirk in the FIR provider, these can leak
- * into a subclass's declarations even if only inherited.
+ * **3. Inherited Synthetic Java Properties** The Analysis API exposes Java getter/setter methods
+ * that override a Kotlin property as synthetic property symbols. Due to a quirk in the FIR
+ * provider, these can leak into a subclass's declarations even if only inherited.
+ *
  * ```kotlin
  * interface FooProvider1 { val foo: Foo }
  * ```
@@ -1262,9 +1382,13 @@ internal val KaDeclarationSymbol.internalSuffix: String
  * ```
  */
 internal fun KSDeclaration.isLeakedInheritedMember(currentClass: KSClassDeclarationImpl): Boolean {
-    val declarationSymbol = (this as? AbstractKSDeclarationImpl)?.ktDeclarationSymbol ?: return false
+    val declarationSymbol =
+        (this as? AbstractKSDeclarationImpl)?.ktDeclarationSymbol ?: return false
     val origin = declarationSymbol.origin
-    if (origin == KaSymbolOrigin.INTERSECTION_OVERRIDE || origin == KaSymbolOrigin.SUBSTITUTION_OVERRIDE) {
+    if (
+        origin == KaSymbolOrigin.INTERSECTION_OVERRIDE ||
+            origin == KaSymbolOrigin.SUBSTITUTION_OVERRIDE
+    ) {
         return true
     }
 
@@ -1278,16 +1402,16 @@ internal fun KSDeclaration.isLeakedInheritedMember(currentClass: KSClassDeclarat
 }
 
 /**
- * Performs a Breadth-First Search (BFS) over the FIR supertype hierarchy to determine if this
- * class inherits from a Kotlin built-in type that structurally alters its Java members.
+ * Performs a Breadth-First Search (BFS) over the FIR supertype hierarchy to determine if this class
+ * inherits from a Kotlin built-in type that structurally alters its Java members.
  *
  * This FIR-based traversal is required because PSI-based hierarchy checks (e.g.,
  * `InheritanceUtil.isInheritor`) are unreliable for compiled library dependencies
  * (`Origin.JAVA_LIB`) in KSP's isolated environments due to incomplete ASTs.
  *
- * If this returns true, KSP must bypass the PSI fast path to avoid exposing Java methods
- * that FIR intentionally hides or renames (such as `remove(int)` or `entrySet()`), which
- * would otherwise cause symbol resolution crashes during validation.
+ * If this returns true, KSP must bypass the PSI fast path to avoid exposing Java methods that FIR
+ * intentionally hides or renames (such as `remove(int)` or `entrySet()`), which would otherwise
+ * cause symbol resolution crashes during validation.
  *
  * @return `true` if this class or any of its supertypes requires specialized compiler mapping.
  */
@@ -1317,10 +1441,10 @@ fun KaClassSymbol.isOrInheritsFromKotlinAlteredType(): Boolean {
  * Checks if the given fully qualified name belongs to a Kotlin built-in type that applies
  * specialized mapping to its Java members.
  *
- * The Kotlin Analysis API (FIR) intentionally hides Java collection mutator methods and
- * maps methods from specific types to properties or renamed identifiers (e.g., mapping
- * `length()` to a property for `CharSequence`, or `remove` to `removeAt`). KSP must
- * fall back to the Analysis API slow path for these types to maintain behavioral consistency.
+ * The Kotlin Analysis API (FIR) intentionally hides Java collection mutator methods and maps
+ * methods from specific types to properties or renamed identifiers (e.g., mapping `length()` to a
+ * property for `CharSequence`, or `remove` to `removeAt`). KSP must fall back to the Analysis API
+ * slow path for these types to maintain behavioral consistency.
  */
 private fun isKotlinAlteredType(fqName: String): Boolean {
     // Exclude benign mapped types that do not structurally alter Java members.
@@ -1337,7 +1461,8 @@ private fun isKotlinAlteredType(fqName: String): Boolean {
     return mapKotlinToJava(FqNameUnsafe(fqName)) != null
 }
 
-// Annotations on deeply synthesized members like getter of Java annotation arguments can be defined in src.
+// Annotations on deeply synthesized members like getter of Java annotation arguments can be defined
+// in src.
 internal val KSNode.definitionOrigin: Origin
     get() = containingFile?.origin ?: origin
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/BinaryUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/BinaryUtils.kt
@@ -30,6 +30,9 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSType
 import com.intellij.openapi.vfs.VirtualFile
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.IdentityHashMap
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCliJavaFileManagerImpl
 import org.jetbrains.kotlin.load.java.structure.impl.JavaClassImpl
 import org.jetbrains.kotlin.load.kotlin.KotlinJvmBinaryClass
@@ -40,71 +43,68 @@ import org.jetbrains.org.objectweb.asm.ClassVisitor
 import org.jetbrains.org.objectweb.asm.FieldVisitor
 import org.jetbrains.org.objectweb.asm.MethodVisitor
 import org.jetbrains.org.objectweb.asm.Opcodes
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import java.util.IdentityHashMap
 
 data class BinaryClassInfo(
     val fieldAccFlags: Map<String, Int>,
-    val methodAccFlags: Map<String, Int>
+    val methodAccFlags: Map<String, Int>,
 )
 
 /**
- * Lookup cache for field names for deserialized classes.
- * To check if a field has backing field, we need to look for binary field names, hence they are cached here.
+ * Lookup cache for field names for deserialized classes. To check if a field has backing field, we
+ * need to look for binary field names, hence they are cached here.
  */
 object BinaryClassInfoCache : KSObjectCache<ClassId, BinaryClassInfo?>() {
-    fun getCached(classId: ClassId, fileManager: KotlinCliJavaFileManagerImpl) = cache.getOrPut(classId) {
-        val fieldAccFlags = mutableMapOf<String, Int>()
-        val methodAccFlags = mutableMapOf<String, Int>()
-        val virtualFileContent = classId.getFileContent(fileManager) ?: return@getOrPut null
-        ClassReader(virtualFileContent).accept(
-            object : ClassVisitor(Opcodes.API_VERSION) {
-                override fun visitField(
-                    access: Int,
-                    name: String?,
-                    descriptor: String?,
-                    signature: String?,
-                    value: Any?
-                ): FieldVisitor? {
-                    if (name != null) {
-                        fieldAccFlags[name] = access
-                    }
-                    return null
-                }
+    fun getCached(classId: ClassId, fileManager: KotlinCliJavaFileManagerImpl) =
+        cache.getOrPut(classId) {
+            val fieldAccFlags = mutableMapOf<String, Int>()
+            val methodAccFlags = mutableMapOf<String, Int>()
+            val virtualFileContent = classId.getFileContent(fileManager) ?: return@getOrPut null
+            ClassReader(virtualFileContent)
+                .accept(
+                    object : ClassVisitor(Opcodes.API_VERSION) {
+                        override fun visitField(
+                            access: Int,
+                            name: String?,
+                            descriptor: String?,
+                            signature: String?,
+                            value: Any?,
+                        ): FieldVisitor? {
+                            if (name != null) {
+                                fieldAccFlags[name] = access
+                            }
+                            return null
+                        }
 
-                override fun visitMethod(
-                    access: Int,
-                    name: String?,
-                    descriptor: String?,
-                    signature: String?,
-                    exceptions: Array<out String>?
-                ): MethodVisitor? {
-                    if (name != null) {
-                        methodAccFlags[name + descriptor] = access
-                    }
-                    return null
-                }
-            },
-            ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES
-        )
-        BinaryClassInfo(fieldAccFlags, methodAccFlags)
-    }
+                        override fun visitMethod(
+                            access: Int,
+                            name: String?,
+                            descriptor: String?,
+                            signature: String?,
+                            exceptions: Array<out String>?,
+                        ): MethodVisitor? {
+                            if (name != null) {
+                                methodAccFlags[name + descriptor] = access
+                            }
+                            return null
+                        }
+                    },
+                    ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+                )
+            BinaryClassInfo(fieldAccFlags, methodAccFlags)
+        }
 }
 
-fun KSAnnotated.hasAnnotation(fqn: String): Boolean =
-    annotations.any {
-        fqn.endsWith(it.shortName.asString()) &&
-            it.annotationType.resolve().declaration.qualifiedName?.asString() == fqn
-    }
+fun KSAnnotated.hasAnnotation(fqn: String): Boolean = annotations.any {
+    fqn.endsWith(it.shortName.asString()) &&
+        it.annotationType.resolve().declaration.qualifiedName?.asString() == fqn
+}
 
 // Validate classfile formate. May throw.
 private fun validateClassfileFormat(content: ByteArray) {
     if (content.size < 4) {
         throw IllegalArgumentException("Invalid bytecode format")
     }
-    val magic = ByteBuffer.wrap(content, 0, 4)
-        .order(ByteOrder.BIG_ENDIAN).int
+    val magic = ByteBuffer.wrap(content, 0, 4).order(ByteOrder.BIG_ENDIAN).int
     if (magic != 0xCAFEBABE.toInt()) {
         throw IllegalArgumentException("Invalid bytecode format: $magic")
     }
@@ -113,40 +113,40 @@ private fun validateClassfileFormat(content: ByteArray) {
 fun Resolver.extractThrowsFromClassFile(
     virtualFileContent: ByteArray,
     jvmDesc: String?,
-    simpleName: String?
+    simpleName: String?,
 ): Sequence<KSType> {
     validateClassfileFormat(virtualFileContent)
 
     val exceptionNames = mutableListOf<String>()
-    ClassReader(virtualFileContent).accept(
-        object : ClassVisitor(Opcodes.API_VERSION) {
-            override fun visitMethod(
-                access: Int,
-                name: String?,
-                descriptor: String?,
-                signature: String?,
-                exceptions: Array<out String>?,
-            ): MethodVisitor {
-                if (name == simpleName && jvmDesc == descriptor) {
-                    exceptions?.toList()?.let { exceptionNames.addAll(it) }
+    ClassReader(virtualFileContent)
+        .accept(
+            object : ClassVisitor(Opcodes.API_VERSION) {
+                override fun visitMethod(
+                    access: Int,
+                    name: String?,
+                    descriptor: String?,
+                    signature: String?,
+                    exceptions: Array<out String>?,
+                ): MethodVisitor {
+                    if (name == simpleName && jvmDesc == descriptor) {
+                        exceptions?.toList()?.let { exceptionNames.addAll(it) }
+                    }
+                    return object : MethodVisitor(Opcodes.API_VERSION) {}
                 }
-                return object : MethodVisitor(Opcodes.API_VERSION) {
-                }
-            }
-        },
-        ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES
-    )
-    return exceptionNames.mapNotNull {
-        this.getClassDeclarationByName(
-            it.replace("/", ".").replace("$", ".")
-        )?.asStarProjectedType()
-    }.asSequence()
+            },
+            ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG or ClassReader.SKIP_FRAMES,
+        )
+    return exceptionNames
+        .mapNotNull {
+            this.getClassDeclarationByName(it.replace("/", ".").replace("$", "."))
+                ?.asStarProjectedType()
+        }
+        .asSequence()
 }
 
 @KspExperimental
-internal class DeclarationOrdering(
-    binaryClass: KotlinJvmBinaryClass
-) : KotlinJvmBinaryClass.MemberVisitor {
+internal class DeclarationOrdering(binaryClass: KotlinJvmBinaryClass) :
+    KotlinJvmBinaryClass.MemberVisitor {
     // Map of fieldName -> Order
     private val fieldOrdering = mutableMapOf<String, Int>()
     // Map of method name to (jvm desc -> Order) map
@@ -165,9 +165,10 @@ internal class DeclarationOrdering(
         orderProvider.seal()
     }
 
-    val comparator = Comparator<AbstractKSDeclarationImpl> { first, second ->
-        getOrder(first).compareTo(getOrder(second))
-    }
+    val comparator =
+        Comparator<AbstractKSDeclarationImpl> { first, second ->
+            getOrder(first).compareTo(getOrder(second))
+        }
 
     private fun getOrder(decl: AbstractKSDeclarationImpl): Int {
         return declOrdering.getOrPut(decl) {
@@ -194,9 +195,7 @@ internal class DeclarationOrdering(
                     orderProvider.next(decl)
                 }
                 is KSFunctionDeclarationImpl -> {
-                    findMethodOrder(
-                        ResolverAAImpl.instance.getJvmName(decl)
-                    ) {
+                    findMethodOrder(ResolverAAImpl.instance.getJvmName(decl)) {
                         ResolverAAImpl.instance.mapToJvmSignature(decl).toString()
                     }
                 }
@@ -207,7 +206,7 @@ internal class DeclarationOrdering(
 
     private inline fun findMethodOrder(
         jvmName: String,
-        crossinline getJvmDesc: () -> String
+        crossinline getJvmDesc: () -> String,
     ): Int {
         val methods = methodOrdering[jvmName]
         // if there is 1 method w/ that name, just return.
@@ -234,7 +233,7 @@ internal class DeclarationOrdering(
     override fun visitField(
         name: Name,
         desc: String,
-        initializer: Any?
+        initializer: Any?,
     ): KotlinJvmBinaryClass.AnnotationVisitor? {
         fieldOrdering.getOrPut(name.asString()) {
             orderProvider.next(name)
@@ -244,17 +243,18 @@ internal class DeclarationOrdering(
 
     override fun visitMethod(
         name: Name,
-        desc: String
+        desc: String,
     ): KotlinJvmBinaryClass.MethodAnnotationVisitor? {
-        methodOrdering.getOrPut(name.asString()) {
-            mutableMapOf()
-        }[desc] = orderProvider.next(name)
+        methodOrdering
+            .getOrPut(name.asString()) {
+                mutableMapOf()
+            }[desc] = orderProvider.next(name)
         return null
     }
 
     /**
-     * Helper class to generate order values for items.
-     * Each time we see a new declaration, we give it an increasing order.
+     * Helper class to generate order values for items. Each time we see a new declaration, we give
+     * it an increasing order.
      *
      * This provider can also run in STRICT MODE to ensure that if we don't find an expected value
      * during sorting, we can crash instead of picking the next ID. For now, it is only used for
@@ -280,7 +280,7 @@ internal class DeclarationOrdering(
             check(!sealed || !STRICT_MODE) {
                 "couldn't find item $ref"
             }
-            return nextId ++
+            return nextId++
         }
 
         /**
@@ -288,9 +288,10 @@ internal class DeclarationOrdering(
          * for declarations where we don't care about the order (e.g. inner class declarations).
          */
         fun nextIgnoreSealed(): Int {
-            return nextId ++
+            return nextId++
         }
     }
+
     companion object {
         /**
          * Used in tests to prevent fallback behavior of creating a new ID when we cannot find the

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/PsiUtils.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/util/PsiUtils.kt
@@ -34,8 +34,7 @@ import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 private fun parseDocString(raw: String): String? {
     val t1 = raw.trim()
-    if (!t1.startsWith("/**") || !t1.endsWith("*/"))
-        return null
+    if (!t1.startsWith("/**") || !t1.endsWith("*/")) return null
     val lineSep = t1.findAnyOf(listOf("\r\n", "\n", "\r"))?.second ?: ""
     return t1.trim('/').trim('*').lines().joinToString(lineSep) {
         it.trimStart().trimStart('*')
@@ -43,9 +42,12 @@ private fun parseDocString(raw: String): String? {
 }
 
 fun PsiElement.getDocString(): String? =
-    this.firstChild.siblings().firstOrNull { it is PsiComment }?.let {
-        parseDocString(it.text)
-    }
+    this.firstChild
+        .siblings()
+        .firstOrNull { it is PsiComment }
+        ?.let {
+            parseDocString(it.text)
+        }
 
 fun KtModifierListOwner.toKSModifiers(): Set<Modifier> {
     val modifierList = this.modifierList
@@ -53,66 +55,64 @@ fun KtModifierListOwner.toKSModifiers(): Set<Modifier> {
 }
 
 fun KtModifierList?.toKSModifiers(): Set<Modifier> {
-    if (this == null)
-        return emptySet()
+    if (this == null) return emptySet()
     val modifiers = mutableSetOf<Modifier>()
-    modifiers.addAll(
-        modifierMap.entries
-            .filter { hasModifier(it.key) }
-            .map { it.value }
-    )
+    modifiers.addAll(modifierMap.entries.filter { hasModifier(it.key) }.map { it.value })
     return modifiers
 }
 
-val modifierMap = mapOf(
-    KtTokens.PUBLIC_KEYWORD to Modifier.PUBLIC,
-    KtTokens.PRIVATE_KEYWORD to Modifier.PRIVATE,
-    KtTokens.INTERNAL_KEYWORD to Modifier.INTERNAL,
-    KtTokens.PROTECTED_KEYWORD to Modifier.PROTECTED,
-    KtTokens.IN_KEYWORD to Modifier.IN,
-    KtTokens.OUT_KEYWORD to Modifier.OUT,
-    KtTokens.OVERRIDE_KEYWORD to Modifier.OVERRIDE,
-    KtTokens.LATEINIT_KEYWORD to Modifier.LATEINIT,
-    KtTokens.ENUM_KEYWORD to Modifier.ENUM,
-    KtTokens.SEALED_KEYWORD to Modifier.SEALED,
-    KtTokens.ANNOTATION_KEYWORD to Modifier.ANNOTATION,
-    KtTokens.DATA_KEYWORD to Modifier.DATA,
-    KtTokens.INNER_KEYWORD to Modifier.INNER,
-    KtTokens.FUN_KEYWORD to Modifier.FUN,
-    KtTokens.VALUE_KEYWORD to Modifier.VALUE,
-    KtTokens.SUSPEND_KEYWORD to Modifier.SUSPEND,
-    KtTokens.TAILREC_KEYWORD to Modifier.TAILREC,
-    KtTokens.OPERATOR_KEYWORD to Modifier.OPERATOR,
-    KtTokens.INFIX_KEYWORD to Modifier.INFIX,
-    KtTokens.INLINE_KEYWORD to Modifier.INLINE,
-    KtTokens.EXTERNAL_KEYWORD to Modifier.EXTERNAL,
-    KtTokens.ABSTRACT_KEYWORD to Modifier.ABSTRACT,
-    KtTokens.FINAL_KEYWORD to Modifier.FINAL,
-    KtTokens.OPEN_KEYWORD to Modifier.OPEN,
-    KtTokens.VARARG_KEYWORD to Modifier.VARARG,
-    KtTokens.NOINLINE_KEYWORD to Modifier.NOINLINE,
-    KtTokens.CROSSINLINE_KEYWORD to Modifier.CROSSINLINE,
-    KtTokens.REIFIED_KEYWORD to Modifier.REIFIED,
-    KtTokens.EXPECT_KEYWORD to Modifier.EXPECT,
-    KtTokens.ACTUAL_KEYWORD to Modifier.ACTUAL,
-    KtTokens.CONST_KEYWORD to Modifier.CONST
-)
+val modifierMap =
+    mapOf(
+        KtTokens.PUBLIC_KEYWORD to Modifier.PUBLIC,
+        KtTokens.PRIVATE_KEYWORD to Modifier.PRIVATE,
+        KtTokens.INTERNAL_KEYWORD to Modifier.INTERNAL,
+        KtTokens.PROTECTED_KEYWORD to Modifier.PROTECTED,
+        KtTokens.IN_KEYWORD to Modifier.IN,
+        KtTokens.OUT_KEYWORD to Modifier.OUT,
+        KtTokens.OVERRIDE_KEYWORD to Modifier.OVERRIDE,
+        KtTokens.LATEINIT_KEYWORD to Modifier.LATEINIT,
+        KtTokens.ENUM_KEYWORD to Modifier.ENUM,
+        KtTokens.SEALED_KEYWORD to Modifier.SEALED,
+        KtTokens.ANNOTATION_KEYWORD to Modifier.ANNOTATION,
+        KtTokens.DATA_KEYWORD to Modifier.DATA,
+        KtTokens.INNER_KEYWORD to Modifier.INNER,
+        KtTokens.FUN_KEYWORD to Modifier.FUN,
+        KtTokens.VALUE_KEYWORD to Modifier.VALUE,
+        KtTokens.SUSPEND_KEYWORD to Modifier.SUSPEND,
+        KtTokens.TAILREC_KEYWORD to Modifier.TAILREC,
+        KtTokens.OPERATOR_KEYWORD to Modifier.OPERATOR,
+        KtTokens.INFIX_KEYWORD to Modifier.INFIX,
+        KtTokens.INLINE_KEYWORD to Modifier.INLINE,
+        KtTokens.EXTERNAL_KEYWORD to Modifier.EXTERNAL,
+        KtTokens.ABSTRACT_KEYWORD to Modifier.ABSTRACT,
+        KtTokens.FINAL_KEYWORD to Modifier.FINAL,
+        KtTokens.OPEN_KEYWORD to Modifier.OPEN,
+        KtTokens.VARARG_KEYWORD to Modifier.VARARG,
+        KtTokens.NOINLINE_KEYWORD to Modifier.NOINLINE,
+        KtTokens.CROSSINLINE_KEYWORD to Modifier.CROSSINLINE,
+        KtTokens.REIFIED_KEYWORD to Modifier.REIFIED,
+        KtTokens.EXPECT_KEYWORD to Modifier.EXPECT,
+        KtTokens.ACTUAL_KEYWORD to Modifier.ACTUAL,
+        KtTokens.CONST_KEYWORD to Modifier.CONST,
+    )
 
 fun KtClassOrObject.getClassType(): ClassKind {
     return when (this) {
         is KtObjectDeclaration -> ClassKind.OBJECT
         is KtEnumEntry -> ClassKind.ENUM_ENTRY
-        is KtClass -> when {
-            this.isEnum() -> ClassKind.ENUM_CLASS
-            this.isInterface() -> ClassKind.INTERFACE
-            this.isAnnotation() -> ClassKind.ANNOTATION_CLASS
-            else -> ClassKind.CLASS
-        }
+        is KtClass ->
+            when {
+                this.isEnum() -> ClassKind.ENUM_CLASS
+                this.isInterface() -> ClassKind.INTERFACE
+                this.isAnnotation() -> ClassKind.ANNOTATION_CLASS
+                else -> ClassKind.CLASS
+            }
 
-        else -> throw InternalKSPException(
-            "Unexpected psi type",
-            this.toLocation(),
-            this.javaClass,
-        )
+        else ->
+            throw InternalKSPException(
+                "Unexpected psi type",
+                this.toLocation(),
+                this.javaClass,
+            )
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalJavaFileManager.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalJavaFileManager.kt
@@ -35,13 +35,18 @@ class IncrementalJavaFileManager(val environment: KotlinCoreProjectEnvironment) 
         sourceFiles: Set<PsiJavaFile>,
     ) {
         val project = environment.project
-        val javaFileManager = project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
+        val javaFileManager =
+            project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
         val compilerConfiguration = CompilerConfiguration.create()
-        val javaModuleFinder = CliJavaModuleFinder(null, compilerConfiguration, javaFileManager, project, null)
+        val javaModuleFinder =
+            CliJavaModuleFinder(null, compilerConfiguration, javaFileManager, project, null)
         val javaModuleGraph = JavaModuleGraph(javaModuleFinder)
-        val allSourceFileRoots = sourceFiles.map { JavaRoot(it.virtualFile, JavaRoot.RootType.SOURCE) }
+        val allSourceFileRoots = sourceFiles.map {
+            JavaRoot(it.virtualFile, JavaRoot.RootType.SOURCE)
+        }
         val jdkRoots = getDefaultJdkModuleRoots(javaModuleFinder, javaModuleGraph)
-        val libraryRoots = StandaloneProjectFactory.getAllBinaryRoots(modules, environment.environment)
+        val libraryRoots =
+            StandaloneProjectFactory.getAllBinaryRoots(modules, environment.environment)
 
         val rootsWithSingleJavaFileRoots = buildList {
             addAll(libraryRoots)
@@ -49,28 +54,33 @@ class IncrementalJavaFileManager(val environment: KotlinCoreProjectEnvironment) 
             addAll(jdkRoots)
         }
 
-        val (roots, newSingleJavaFileRoots) = rootsWithSingleJavaFileRoots.partition { (file) ->
-            file.isDirectory || file.extension != JavaFileType.DEFAULT_EXTENSION
-        }
+        val (roots, newSingleJavaFileRoots) =
+            rootsWithSingleJavaFileRoots.partition { (file) ->
+                file.isDirectory || file.extension != JavaFileType.DEFAULT_EXTENSION
+            }
 
         singleJavaFileRoots.addAll(newSingleJavaFileRoots)
 
-        rootsIndex = JvmDependenciesDynamicCompoundIndex(true).apply {
-            addIndex(JvmDependenciesIndexImpl(roots))
-        }
+        rootsIndex =
+            JvmDependenciesDynamicCompoundIndex(true).apply {
+                addIndex(JvmDependenciesIndexImpl(roots))
+            }
 
         val corePackageIndex = project.getService(PackageIndex::class.java) as CorePackageIndex
         roots.forEach { javaRoot ->
             if (javaRoot.file.isDirectory) {
                 if (javaRoot.type == JavaRoot.RootType.SOURCE) {
                     // NB: [JavaCoreProjectEnvironment#addSourcesToClasspath] calls:
-                    //   1) [CoreJavaFileManager#addToClasspath], which is used to look up Java roots;
+                    //   1) [CoreJavaFileManager#addToClasspath], which is used to look up Java
+                    // roots;
                     //   2) [CorePackageIndex#addToClasspath], which populates [PackageIndex]; and
-                    //   3) [FileIndexFacade#addLibraryRoot], which conflicts with this SOURCE root when generating a library scope.
+                    //   3) [FileIndexFacade#addLibraryRoot], which conflicts with this SOURCE root
+                    // when generating a library scope.
                     // Thus, here we manually call first two, which are used to:
                     //   1) create [PsiPackage] as a package resolution result; and
                     //   2) find directories by package name.
-                    // With both supports, annotations defined in package-info.java can be properly propagated.
+                    // With both supports, annotations defined in package-info.java can be properly
+                    // propagated.
                     javaFileManager.addToClasspath(javaRoot.file)
                     corePackageIndex.addToClasspath(javaRoot.file)
                 } else {
@@ -79,29 +89,39 @@ class IncrementalJavaFileManager(val environment: KotlinCoreProjectEnvironment) 
             }
         }
 
-        packagePartProviders = listOf(
-            StandaloneProjectFactory.createPackagePartsProvider(
-                libraryRoots + jdkRoots,
-                LanguageVersionSettingsImpl(LanguageVersion.LATEST_STABLE, ApiVersion.LATEST)
-            ).invoke(ProjectScope.getLibrariesScope(project))
-        )
+        packagePartProviders =
+            listOf(
+                StandaloneProjectFactory.createPackagePartsProvider(
+                        libraryRoots + jdkRoots,
+                        LanguageVersionSettingsImpl(
+                            LanguageVersion.LATEST_STABLE,
+                            ApiVersion.LATEST,
+                        ),
+                    )
+                    .invoke(ProjectScope.getLibrariesScope(project))
+            )
 
         javaFileManager.initialize(
             rootsIndex,
             packagePartProviders,
             SingleJavaFileRootsIndex(singleJavaFileRoots),
-            true, null
+            true,
+            null,
         )
     }
 
     fun add(sourceFiles: Set<PsiJavaFile>) {
         val project = environment.project
-        val javaFileManager = project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
-        val allSourceFileRoots = sourceFiles.map { JavaRoot(it.virtualFile, JavaRoot.RootType.SOURCE) }
-
-        val (roots, newSingleJavaFileRoots) = allSourceFileRoots.partition { (file) ->
-            file.isDirectory || file.extension != JavaFileType.DEFAULT_EXTENSION
+        val javaFileManager =
+            project.getService(JavaFileManager::class.java) as KotlinCliJavaFileManagerImpl
+        val allSourceFileRoots = sourceFiles.map {
+            JavaRoot(it.virtualFile, JavaRoot.RootType.SOURCE)
         }
+
+        val (roots, newSingleJavaFileRoots) =
+            allSourceFileRoots.partition { (file) ->
+                file.isDirectory || file.extension != JavaFileType.DEFAULT_EXTENSION
+            }
 
         singleJavaFileRoots.addAll(newSingleJavaFileRoots)
 
@@ -114,13 +134,16 @@ class IncrementalJavaFileManager(val environment: KotlinCoreProjectEnvironment) 
             if (javaRoot.file.isDirectory) {
                 if (javaRoot.type == JavaRoot.RootType.SOURCE) {
                     // NB: [JavaCoreProjectEnvironment#addSourcesToClasspath] calls:
-                    //   1) [CoreJavaFileManager#addToClasspath], which is used to look up Java roots;
+                    //   1) [CoreJavaFileManager#addToClasspath], which is used to look up Java
+                    // roots;
                     //   2) [CorePackageIndex#addToClasspath], which populates [PackageIndex]; and
-                    //   3) [FileIndexFacade#addLibraryRoot], which conflicts with this SOURCE root when generating a library scope.
+                    //   3) [FileIndexFacade#addLibraryRoot], which conflicts with this SOURCE root
+                    // when generating a library scope.
                     // Thus, here we manually call first two, which are used to:
                     //   1) create [PsiPackage] as a package resolution result; and
                     //   2) find directories by package name.
-                    // With both supports, annotations defined in package-info.java can be properly propagated.
+                    // With both supports, annotations defined in package-info.java can be properly
+                    // propagated.
                     javaFileManager.addToClasspath(javaRoot.file)
                     corePackageIndex.addToClasspath(javaRoot.file)
                 } else {
@@ -133,20 +156,25 @@ class IncrementalJavaFileManager(val environment: KotlinCoreProjectEnvironment) 
             rootsIndex,
             packagePartProviders,
             SingleJavaFileRootsIndex(singleJavaFileRoots),
-            true, null
+            true,
+            null,
         )
     }
 }
 
 private fun getDefaultJdkModuleRoots(
     javaModuleFinder: CliJavaModuleFinder,
-    javaModuleGraph: JavaModuleGraph
+    javaModuleGraph: JavaModuleGraph,
 ): List<JavaRoot> {
-    // In contrast to `ClasspathRootsResolver.addModularRoots`, we do not need to handle automatic Java modules because JDK modules
+    // In contrast to `ClasspathRootsResolver.addModularRoots`, we do not need to handle automatic
+    // Java modules because JDK modules
     // aren't automatic.
-    return javaModuleGraph.getAllDependencies(javaModuleFinder.computeDefaultRootModules()).flatMap { moduleName ->
-        val module = javaModuleFinder.findModule(moduleName) ?: return@flatMap emptyList<JavaRoot>()
-        val result = module.getJavaModuleRoots()
-        result
-    }
+    return javaModuleGraph
+        .getAllDependencies(javaModuleFinder.computeDefaultRootModules())
+        .flatMap { moduleName ->
+            val module =
+                javaModuleFinder.findModule(moduleName) ?: return@flatMap emptyList<JavaRoot>()
+            val result = module.getJavaModuleRoots()
+            result
+        }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProviderFactory.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinDeclarationProviderFactory.kt
@@ -20,24 +20,28 @@ class IncrementalKotlinDeclarationProviderFactory(
     private val project: Project,
     private val environment: CoreApplicationEnvironment,
 ) : KotlinDeclarationProviderFactory {
-    private val staticFactories: MutableList<KotlinStandaloneDeclarationProviderFactory> = mutableListOf()
+    private val staticFactories: MutableList<KotlinStandaloneDeclarationProviderFactory> =
+        mutableListOf()
 
     override fun createDeclarationProvider(
         scope: GlobalSearchScope,
-        contextualModule: KaModule?
+        contextualModule: KaModule?,
     ): KotlinDeclarationProvider {
-        val providers = staticFactories.map { it.createDeclarationProvider(scope, contextualModule) }
+        val providers = staticFactories.map {
+            it.createDeclarationProvider(scope, contextualModule)
+        }
         return KotlinCompositeDeclarationProvider.create(providers)
     }
 
     fun update(files: Collection<KtFile>) {
         val skipBuiltIns = staticFactories.isNotEmpty()
-        val staticFactory = KotlinStandaloneDeclarationProviderFactory(
-            project,
-            environment,
-            files,
-            skipBuiltins = skipBuiltIns
-        )
+        val staticFactory =
+            KotlinStandaloneDeclarationProviderFactory(
+                project,
+                environment,
+                files,
+                skipBuiltins = skipBuiltIns,
+            )
         staticFactories.add(staticFactory)
     }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/IncrementalKotlinPackageProviderFactory.kt
@@ -12,10 +12,10 @@ import org.jetbrains.kotlin.analysis.api.standalone.base.packages.KotlinStandalo
 import org.jetbrains.kotlin.psi.KtFile
 
 @OptIn(KaPlatformInterface::class)
-class IncrementalKotlinPackageProviderFactory(
-    private val project: Project,
-) : KotlinPackageProviderFactory, Disposable {
-    private val staticFactories: MutableList<KotlinStandalonePackageProviderFactory> = mutableListOf()
+class IncrementalKotlinPackageProviderFactory(private val project: Project) :
+    KotlinPackageProviderFactory, Disposable {
+    private val staticFactories: MutableList<KotlinStandalonePackageProviderFactory> =
+        mutableListOf()
 
     override fun createPackageProvider(searchScope: GlobalSearchScope): KotlinPackageProvider {
         val providers = staticFactories.map { it.createPackageProvider(searchScope) }
@@ -23,15 +23,15 @@ class IncrementalKotlinPackageProviderFactory(
     }
 
     fun update(files: Collection<KtFile>) {
-        val staticFactory = KotlinStandalonePackageProviderFactory(
-            project = project,
-            indexedFiles = files,
-            libraryRoots = emptyList()
-        )
+        val staticFactory =
+            KotlinStandalonePackageProviderFactory(
+                project = project,
+                indexedFiles = files,
+                libraryRoots = emptyList(),
+            )
         Disposer.register(this, staticFactory)
         staticFactories.add(staticFactory)
     }
 
-    override fun dispose() {
-    }
+    override fun dispose() {}
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
@@ -16,6 +16,7 @@
  */
 
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package com.google.devtools.ksp.standalone
 
 import com.intellij.core.CoreApplicationEnvironment
@@ -23,6 +24,10 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.search.GlobalSearchScope
+import java.nio.file.Path
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
 import org.jetbrains.kotlin.analysis.api.impl.base.util.LibraryUtils
@@ -33,10 +38,6 @@ import org.jetbrains.kotlin.analysis.project.structure.builder.KtBinaryModuleBui
 import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleBuilderDsl
 import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleProviderBuilder
 import org.jetbrains.kotlin.analysis.project.structure.impl.KaLibraryModuleImpl
-import java.nio.file.Path
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 @KtModuleBuilderDsl
 open class KspLibraryModuleBuilder(
@@ -52,12 +53,13 @@ open class KspLibraryModuleBuilder(
     fun build(isSdk: Boolean): KaLibraryModule {
         val binaryRoots = getBinaryRoots()
         val binaryVirtualFiles = getBinaryVirtualFiles()
-        val contentScope = LibraryRootsSearchScope(
-            StandaloneProjectFactory.getVirtualFilesForLibraryRoots(
-                binaryRoots,
-                coreApplicationEnvironment,
-            ) + binaryVirtualFiles
-        )
+        val contentScope =
+            LibraryRootsSearchScope(
+                StandaloneProjectFactory.getVirtualFilesForLibraryRoots(
+                    binaryRoots,
+                    coreApplicationEnvironment,
+                ) + binaryVirtualFiles
+            )
         return KaLibraryModuleImpl(
             directRegularDependencies,
             directDependsOnDependencies,
@@ -69,13 +71,15 @@ open class KspLibraryModuleBuilder(
             binaryVirtualFiles,
             libraryName,
             librarySources,
-            isSdk
+            isSdk,
         )
     }
 }
 
 @OptIn(ExperimentalContracts::class)
-inline fun KtModuleProviderBuilder.buildKspLibraryModule(init: KspLibraryModuleBuilder.() -> Unit): KaLibraryModule {
+inline fun KtModuleProviderBuilder.buildKspLibraryModule(
+    init: KspLibraryModuleBuilder.() -> Unit
+): KaLibraryModule {
     contract {
         callsInPlace(init, InvocationKind.EXACTLY_ONCE)
     }
@@ -89,23 +93,24 @@ internal class SimpleTrie(paths: List<String>) {
 
     val root = TrieNode()
 
-    private val m = mutableMapOf<Pair<TrieNode, String>, TrieNode>().apply {
-        paths.forEach { path ->
-            var p = root
-            for (d in path.trim('/').split('/')) {
-                p = getOrPut(Pair(p, d)) { TrieNode() }
+    private val m =
+        mutableMapOf<Pair<TrieNode, String>, TrieNode>().apply {
+            paths.forEach { path ->
+                var p = root
+                for (d in path.trim('/').split('/')) {
+                    p = getOrPut(Pair(p, d)) { TrieNode() }
+                }
+                p.isTerminal = true
             }
-            p.isTerminal = true
         }
-    }
 
     fun contains(s: String): Boolean {
         var p = root
         for (d in s.trim('/').split('/')) {
-            p = m.get(Pair(p, d))?.also {
-                if (it.isTerminal)
-                    return true
-            } ?: return false
+            p =
+                m.get(Pair(p, d))?.also {
+                    if (it.isTerminal) return true
+                } ?: return false
         }
         return false
     }
@@ -138,7 +143,9 @@ public class KspSdkModuleBuilder(
 }
 
 @OptIn(ExperimentalContracts::class)
-public inline fun KtModuleProviderBuilder.buildKspSdkModule(init: KspSdkModuleBuilder.() -> Unit): KaLibraryModule {
+public inline fun KtModuleProviderBuilder.buildKspSdkModule(
+    init: KspSdkModuleBuilder.() -> Unit
+): KaLibraryModule {
     contract {
         callsInPlace(init, InvocationKind.EXACTLY_ONCE)
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspSourceModuleBuilder.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspSourceModuleBuilder.kt
@@ -16,6 +16,7 @@
  */
 
 @file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
 package com.google.devtools.ksp.standalone
 
 import com.intellij.core.CoreApplicationEnvironment
@@ -24,6 +25,10 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiManager
 import com.intellij.psi.search.GlobalSearchScope
+import java.nio.file.Path
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleBuilder
 import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleBuilderDsl
@@ -33,15 +38,11 @@ import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.LanguageVersion
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
-import java.nio.file.Path
-import kotlin.contracts.ExperimentalContracts
-import kotlin.contracts.InvocationKind
-import kotlin.contracts.contract
 
 @KtModuleBuilderDsl
 class KspModuleBuilder(
     private val coreApplicationEnvironment: CoreApplicationEnvironment,
-    private val project: Project
+    private val project: Project,
 ) : KtModuleBuilder() {
     public lateinit var moduleName: String
     public var languageVersionSettings: LanguageVersionSettings =
@@ -81,9 +82,10 @@ class KspModuleBuilder(
         val localFileSystem = coreApplicationEnvironment.localFileSystem
         return buildSet {
             for (root in sourceRoots) {
-                val files = root.toFile().walk().filter {
-                    it.isDirectory || it.extension.lowercase() in analyzableExtensions
-                }
+                val files =
+                    root.toFile().walk().filter {
+                        it.isDirectory || it.extension.lowercase() in analyzableExtensions
+                    }
                 for (file in files) {
                     val virtualFile = localFileSystem.findFileByIoFile(file) ?: continue
                     add(virtualFile)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspStandaloneDirectInheritorsProvider.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspStandaloneDirectInheritorsProvider.kt
@@ -23,11 +23,14 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.contains
 
-// TODO: copied from upstream as a workaround, remove after upstream fixes standalone session builder for KSP.
+// TODO: copied from upstream as a workaround, remove after upstream fixes standalone session
+// builder for KSP.
 @OptIn(KaPlatformInterface::class, LLFirInternals::class, SymbolInternals::class)
-class KspStandaloneDirectInheritorsProvider(private val project: Project) : KotlinDirectInheritorsProvider {
+class KspStandaloneDirectInheritorsProvider(private val project: Project) :
+    KotlinDirectInheritorsProvider {
     private val declarationProviderFactory by lazy {
-        (KotlinDeclarationProviderFactory.getInstance(project) as? IncrementalKotlinDeclarationProviderFactory)
+        (KotlinDeclarationProviderFactory.getInstance(project)
+            as? IncrementalKotlinDeclarationProviderFactory)
             ?: error(
                 "KotlinStandaloneDirectInheritorsProvider" +
                     "` expects the following declaration provider factory to be" +
@@ -46,29 +49,40 @@ class KspStandaloneDirectInheritorsProvider(private val project: Project) : Kotl
         val aliases = mutableSetOf(classId.shortClassName)
         calculateAliases(classId.shortClassName, aliases)
 
-        val possibleInheritors = aliases.flatMap { declarationProviderFactory.getDirectInheritorCandidates(it) }
+        val possibleInheritors = aliases.flatMap {
+            declarationProviderFactory.getDirectInheritorCandidates(it)
+        }
 
         if (possibleInheritors.isEmpty()) {
             return emptyList()
         }
 
-        // The index provides candidates from an original module, not dangling files. If we resolve the supertypes of a candidate in the
-        // context of its session, we will resolve to FIR classes from non-dangling, original modules. If `ktClass` is inside a dangling
-        // file, the FIR class for `ktClass` will come from the dangling module. So we'd compare the original FIR class for the supertype
-        // with the dangling FIR class for `ktClass`, resulting in a mismatch. To avoid such incompatible comparisons, we need to resolve
+        // The index provides candidates from an original module, not dangling files. If we resolve
+        // the supertypes of a candidate in the
+        // context of its session, we will resolve to FIR classes from non-dangling, original
+        // modules. If `ktClass` is inside a dangling
+        // file, the FIR class for `ktClass` will come from the dangling module. So we'd compare the
+        // original FIR class for the supertype
+        // with the dangling FIR class for `ktClass`, resulting in a mismatch. To avoid such
+        // incompatible comparisons, we need to resolve
         // `ktClass` to the original FIR class.
         //
-        // Note that this means we don't support providing inheritors based on the dangling file yet, for example if an inheritor was added
+        // Note that this means we don't support providing inheritors based on the dangling file
+        // yet, for example if an inheritor was added
         // or removed only in the dangling file.
-        val baseKtModule = when (
-            val ktModule = KaModuleProvider.getModule(project, ktClass, useSiteModule = null)
-        ) {
-            is KaDanglingFileModule -> ktModule.contextModule
-            else -> ktModule
-        }
+        val baseKtModule =
+            when (
+                val ktModule = KaModuleProvider.getModule(project, ktClass, useSiteModule = null)
+            ) {
+                is KaDanglingFileModule -> ktModule.contextModule
+                else -> ktModule
+            }
 
-        val baseFirClass = ktClass.toFirSymbol(classId, baseKtModule)?.fir as? FirClass ?: return emptyList()
-        return possibleInheritors.filter { isValidInheritor(it, baseFirClass, scope, includeLocalInheritors) }
+        val baseFirClass =
+            ktClass.toFirSymbol(classId, baseKtModule)?.fir as? FirClass ?: return emptyList()
+        return possibleInheritors.filter {
+            isValidInheritor(it, baseFirClass, scope, includeLocalInheritors)
+        }
     }
 
     private fun calculateAliases(aliasedName: Name, aliases: MutableSet<Name>) {
@@ -98,20 +112,25 @@ class KspStandaloneDirectInheritorsProvider(private val project: Project) : Kotl
 
         val candidateClassId = candidate.getClassId() ?: return false
         val candidateKtModule = KaModuleProvider.getModule(project, candidate, useSiteModule = null)
-        val candidateFirSymbol = candidate.toFirSymbol(candidateClassId, candidateKtModule) ?: return false
+        val candidateFirSymbol =
+            candidate.toFirSymbol(candidateClassId, candidateKtModule) ?: return false
         val candidateFirClass = candidateFirSymbol.fir as? FirClass ?: return false
 
         return isSubclassOf(
             candidateFirClass,
             baseFirClass,
             candidateFirClass.moduleData.session,
-            allowIndirectSubtyping = false
+            allowIndirectSubtyping = false,
         )
     }
 
     @OptIn(KaImplementationDetail::class)
-    private fun KtClassOrObject.toFirSymbol(classId: ClassId, ktModule: KaModule): FirClassLikeSymbol<*>? {
-        val session = LLFirSessionCache.getInstance(project).getSession(ktModule, preferBinary = true)
+    private fun KtClassOrObject.toFirSymbol(
+        classId: ClassId,
+        ktModule: KaModule,
+    ): FirClassLikeSymbol<*>? {
+        val session =
+            LLFirSessionCache.getInstance(project).getSession(ktModule, preferBinary = true)
         return session.symbolProvider.getClassLikeSymbolByClassId(classId)
     }
 }


### PR DESCRIPTION
This PR applies `ktfmt` to KSPs implementation. All tests are left as is.

We should probably wait with this until https://youtrack.jetbrains.com/issue/KT-87858/Source-code-formatting-affects-stack-and-local-variable-layout is fixed.