### PR TITLE
Reproduce incorrect parent of Java method overriding a Kotlin property

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ParentOfJavaMethodOverridingKotlinPropertyProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ParentOfJavaMethodOverridingKotlinPropertyProcessor.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.getDeclaredFunctions
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class ParentOfJavaMethodOverridingKotlinPropertyProcessor : AbstractTestProcessor() {
+    private val result = mutableListOf<String>()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val function = resolver.getClassDeclarationByName("MyInterfaceImplJava")!!
+            .getDeclaredFunctions()
+            .single { it.simpleName.asString() == "getProperty" }
+        result.add("parent of $function: ${function.parentDeclaration?.simpleName?.asString()}")
+        return emptyList()
+    }
+
+    override fun toResult(): List<String> = result
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -655,6 +655,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/parameterTypes.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/2498", BugState.OPEN)
+    @TestMetadata("parentOfJavaMethodOverridingKotlinProperty.kt")
+    @Test
+    fun testParentOfJavaMethodOverridingKotlinProperty() {
+        runFailingTest("$AA_PATH/parentOfJavaMethodOverridingKotlinProperty.kt")
+    }
+
     @TestMetadata("parent.kt")
     @Test
     fun testParent() {

--- a/kotlin-analysis-api/testData/parentOfJavaMethodOverridingKotlinProperty.kt
+++ b/kotlin-analysis-api/testData/parentOfJavaMethodOverridingKotlinProperty.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: ParentOfJavaMethodOverridingKotlinPropertyProcessor
+// EXPECTED:
+// parent of getProperty: MyInterfaceImplJava
+// END
+
+// FILE: K.kt
+interface MyInterface {
+    val property: Int
+}
+
+// FILE: MyInterfaceImplJava.java
+class MyInterfaceImplJava implements MyInterface {
+    public int getProperty() { return 0; }
+}


### PR DESCRIPTION
Reproduces #2498

I kept it in separate file instead of `kotlin-analysis-api/testData/parent.kt` to isolate the problem and use `runFailingTest` only for that exact problem so that all other cases in `kotlin-analysis-api/testData/parent.kt` will keep running normally.