### PR TITLE
Reproduce failure on getting functionKind on overriden Kotlin property in Java

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -46,6 +46,12 @@ class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = f
         runFailingTest("$AA_PATH/getSymbolsWithAnnotation/explicitBackingFields.kt")
     }
 
+    @TestMetadata("functionKindsJavaInheritsKotlin.kt")
+    @Test
+    override fun testFunctionKindsJavaInheritsKotlin() {
+        runThrowingTest("$AA_PATH/functionKindsJavaInheritsKotlin.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -386,6 +386,9 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/functionKinds.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/2496", BugState.OPEN)
+    abstract fun testFunctionKindsJavaInheritsKotlin()
+
     @TestMetadata("getAnnotationByTypeWithInnerDefault.kt")
     @Test
     fun testGetAnnotationByTypeWithInnerDefault() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -46,6 +46,12 @@ class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = 
         runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/explicitBackingFields.kt")
     }
 
+    @TestMetadata("functionKindsJavaInheritsKotlin.kt")
+    @Test
+    override fun testFunctionKindsJavaInheritsKotlin() {
+        runFailingTest("$AA_PATH/functionKindsJavaInheritsKotlin.kt")
+    }
+
     @TestMetadata("javaSubtypeOfKotlinInterface.kt")
     @Test
     override fun testJavaSubtypeOfKotlinInterface() {

--- a/kotlin-analysis-api/testData/functionKindsJavaInheritsKotlin.kt
+++ b/kotlin-analysis-api/testData/functionKindsJavaInheritsKotlin.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: FunctionKindProcessor
+// EXPECTED:
+// MyInterface.method: MEMBER
+// MyInterfaceImplJava.<init>: MEMBER
+// MyInterfaceImplJava.getProperty: MEMBER
+// MyInterfaceImplJava.method: MEMBER
+// END
+
+// FILE: K.kt
+interface MyInterface {
+    val property: Int
+    fun method()
+}
+
+// FILE: MyInterfaceImplJava.java
+class MyInterfaceImplJava implements MyInterface {
+    @Override
+    public void method() {}
+
+    @Override
+    public int getProperty() { return 0; }
+}


### PR DESCRIPTION
~~`KSPPluginProblemReporter` was added in order to fix NPE with the following stacktrace:~~
<details>
  <summary>Stacktrace</summary>

  ```
  java.lang.NullPointerException: Cannot invoke "com.intellij.diagnostic.PluginProblemReporter.createPluginExceptionByClass(String, java.lang.Throwable, java.lang.Class)" because the return value of "com.intellij.diagnostic.PluginProblemReporter.getInstance()" is null
      at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:100)
      at com.intellij.psi.util.PsiUtilCore.ensureValid(PsiUtilCore.java:508)
      at com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:816)
      at com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:803)
      at com.intellij.psi.impl.source.PsiJavaCodeReferenceElementImpl.multiResolve(PsiJavaCodeReferenceElementImpl.java:420)
      ...
      at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirPsiSymbolKt.psiOrSymbolEquals(KaFirPsiSymbol.kt:106)
      at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirNamedClassSymbolBase.equals(KaFirNamedClassSymbolBase.kt:38)
      at java.base/java.util.HashMap.getNode(HashMap.java:570)
      at java.base/java.util.LinkedHashMap.get(LinkedHashMap.java:441)
      at com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl$Companion.getCached(KSClassDeclarationImpl.kt:323)
      at com.google.devtools.ksp.impl.symbol.kotlin.KSFileJavaImpl$declarations$2$1.invoke(KSFileJav
        at com.intellij.diagnostic.PluginException.createByClass(PluginException.java:100)
        at com.intellij.psi.util.PsiUtilCore.ensureValid(PsiUtilCore.java:508)
        at com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:816)
        at com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:803)
        at com.intellij.psi.impl.source.PsiJavaCodeReferenceElementImpl.multiResolve(PsiJavaCodeReferenceElementImpl.java:420)
        ...
        at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirPsiSymbolKt.psiOrSymbolEquals(KaFirPsiSymbol.kt:106)
        at org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirNamedClassSymbolBase.equals(KaFirNamedClassSymbolBase.kt:38)
        at java.base/java.util.HashMap.getNode(HashMap.java:570)
        at java.base/java.util.LinkedHashMap.get(LinkedHashMap.java:441)
        at com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl$Companion.getCached(KSClassDeclarationImpl.kt:323)
        at com.google.devtools.ksp.impl.symbol.kotlin.KSFileJavaImpl$declarations$2$1.invoke(KSFileJavaImpl.kt:49)
        ...
        at com.google.devtools.ksp.impl.KotlinSymbolProcessing.execute(KotlinSymbolProcessing.kt:525)
  ```

</details>