### PR TITLE
Support `org.gradle.isolated-projects` for project isolation

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/kgpUtils.kt
@@ -29,5 +29,7 @@ fun Project.canUseGeneratedKotlinApi(): Boolean {
 fun Project.enableProjectIsolationCompatibleCodepath(): Boolean {
     return providers.gradleProperty("ksp.project.isolation.enabled").orNull == "true" ||
         providers.gradleProperty("org.gradle.unsafe.isolated-projects").orNull == "true" ||
-        providers.systemProperty("org.gradle.unsafe.isolated-projects").orNull == "true"
+        providers.systemProperty("org.gradle.unsafe.isolated-projects").orNull == "true" ||
+        providers.gradleProperty("org.gradle.isolated-projects").orNull == "true" ||
+        providers.systemProperty("org.gradle.isolated-projects").orNull == "true"
 }

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/ProjectIsolationIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/ProjectIsolationIT.kt
@@ -6,10 +6,16 @@ import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import java.io.File
 import java.util.jar.JarFile
 
-class ProjectIsolationIT {
+@RunWith(Parameterized::class)
+class ProjectIsolationIT(
+    private val propertyName: String,
+    private val gradleVersion: String?
+) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
@@ -17,12 +23,24 @@ class ProjectIsolationIT {
         experimentalPsiResolution = true
     )
 
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}, Gradle: {1}")
+        fun data(): Collection<Array<String?>> {
+            return listOf(
+                arrayOf("org.gradle.unsafe.isolated-projects", null),
+                arrayOf("org.gradle.isolated-projects", "9.7.0-rc-1")
+            )
+        }
+    }
+
     @Test
     fun testProjectIsolationResources() {
         val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleVersion?.let { gradleRunner.withGradleVersion(it) }
 
         val result = gradleRunner.withArguments(
-            "clean", "build", "-Dorg.gradle.unsafe.isolated-projects=true",
+            "clean", "build", "-D$propertyName=true",
             "--configuration-cache", "--info", "--stacktrace"
         ).build()
 


### PR DESCRIPTION
Updates `enableProjectIsolationCompatibleCodepath` to recognize the stable [`org.gradle.isolated-projects`](https://docs.gradle.org/9.7.0-rc-1/release-notes.html#isolated-projects) property as both a Gradle and system property.

Maybe it's better to wait for 9.7.0 version to go stable.