### PR TITLE
Clean output directories instead of skipping tasks when processor classpath transitions to empty 

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -117,6 +117,12 @@ abstract class KspAATask @Inject constructor(
 
     @TaskAction
     fun execute(inputChanges: InputChanges) {
+        if (kspConfig.processorClasspath.isEmpty) {
+            kspConfig.outputBaseDir.get().asFile.deleteRecursively()
+            kspConfig.cachesDir.get().asFile.deleteRecursively()
+            return
+        }
+
         // FIXME: Create a class loader with clean classpath instead of shadowing existing ones. It'll require either:
         //  1. passing arguments by data structures in stdlib, or
         //  2. hoisting and publishing KspGradleConfig into another package.
@@ -215,9 +221,6 @@ abstract class KspAATask @Inject constructor(
             }
             val incomingProcessors = processorClasspath.incoming.artifactView { }.files
             val kspTaskProvider = project.tasks.register(kspTaskName, KspAATask::class.java) { kspAATask ->
-                kspAATask.onlyIf {
-                    !incomingProcessors.isEmpty
-                }
                 kspAATask.usesService(isolatedClassLoaderCacheBuildServiceProvider)
                 kspAATask.isolatedClassLoaderCacheBuildService.set(isolatedClassLoaderCacheBuildServiceProvider)
                 kspAATask.kspClasspath.from(kspAADepCfg.incoming.artifactView { }.files)

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -425,4 +425,54 @@ class GradleCompilationTest(isExperimentalPsiResolution: Boolean) {
             .withArguments("tasks", "-Pandroid.experimental.enableTestFixturesKotlinSupport=true")
             .build()
     }
+
+    /**
+     * Regression test for https://github.com/google/ksp/issues/3046
+     */
+    @Test
+    fun testStaleOutputCleanupWhenProcessorRemoved() {
+        testRule.setupAppAsJvmApp()
+        val processorDep = module(configuration = "ksp", testRule.processorModule)
+        testRule.appModule.dependencies.add(processorDep)
+        testRule.appModule.addSource(
+            "Foo.kt",
+            """
+            class Foo {
+                val x = ToBeGenerated()
+            }
+            """.trimIndent()
+        )
+        class MyProcessor(private val codeGenerator: CodeGenerator) : SymbolProcessor {
+            var count = 0
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                if (count == 0) {
+                    codeGenerator.createNewFile(Dependencies.ALL_FILES, "", "Generated").use {
+                        it.writer(Charsets.UTF_8).use {
+                            it.write("class ToBeGenerated")
+                        }
+                    }
+                    count += 1
+                }
+                return emptyList()
+            }
+        }
+
+        class Provider : TestSymbolProcessorProvider({ env -> MyProcessor(env.codeGenerator) })
+
+        testRule.addProvider(Provider::class)
+
+        testRule.runner().withArguments("app:assemble").build()
+
+        val generatedFile = testRule.appModule.moduleRoot.resolve("build/generated/ksp/main/kotlin/Generated.kt")
+        assertThat(generatedFile.exists()).isTrue()
+
+        // Remove KSP dependency and update source so it compiles without generated code
+        testRule.appModule.dependencies.remove(processorDep)
+        testRule.appModule.addSource("Foo.kt", "class Foo")
+
+        // Run an incremental build without clean and verify stale output directory is cleaned up
+        testRule.runner().withArguments("app:assemble").build()
+
+        assertThat(generatedFile.exists()).isFalse()
+    }
 }

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/SourceSetConfigurationsTest.kt
@@ -159,8 +159,8 @@ class SourceSetConfigurationsTest(isExperimentalPsiResolution: Boolean) {
                 require(kspKotlinJvm.outcome == TaskOutcome.SUCCESS)
                 // even though kspJs is not added, the task is created.
                 require(kspKotlinJs != null)
-                // kspKotlinJs has no dependencies, so task is skipped.
-                require(kspKotlinJs.outcome == TaskOutcome.SKIPPED)
+                // kspKotlinJs has no dependencies, so task executes no-op cleanup and succeeds.
+                require(kspKotlinJs.outcome == TaskOutcome.SUCCESS)
             }
     }
 


### PR DESCRIPTION
Previously, removing all KSP processors from a module caused Gradle to report the KSP task as SKIPPED via onlyIf. Because the task never ran, previously generated code under build/generated/ksp and cache directories remained untouched during incremental builds, forcing developers to run ./gradlew clean to prevent compilation or runtime conflicts.

Address #3046