### PR TITLE
Regression test for #3050

### DIFF
--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -475,4 +475,54 @@ class GradleCompilationTest(isExperimentalPsiResolution: Boolean) {
 
         assertThat(generatedFile.exists()).isFalse()
     }
+
+    /**
+     * Regression test for https://github.com/google/ksp/issues/3050
+     */
+    @Test
+    fun testKspDebugAndroidTestKotlinExecution() {
+        testRule.setupAndroidLibraryModule(enableAgpBuiltInKotlinSupport = true)
+        testRule.appModule.buildFileAdditions.add(
+            """
+            configurations.matching { it.name == "kspAndroidTestDebug" }.all {
+                project.dependencies.add(name, project(":processor"))
+            }
+            """.trimIndent()
+        )
+        testRule.appModule.addAndroidTestSource(
+            "FooTest.kt",
+            """
+            class FooTest {
+                val x = ToBeGenerated()
+            }
+            """.trimIndent()
+        )
+        class MyProcessor(private val codeGenerator: CodeGenerator) : SymbolProcessor {
+            var processed = false
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                if (!processed) {
+                    codeGenerator.createNewFile(Dependencies.ALL_FILES, "", "Generated").use {
+                        it.writer(Charsets.UTF_8).use {
+                            it.write("class ToBeGenerated")
+                        }
+                    }
+                    processed = true
+                }
+                return emptyList()
+            }
+        }
+
+        class Provider : TestSymbolProcessorProvider({ env -> MyProcessor(env.codeGenerator) })
+
+        testRule.addProvider(Provider::class)
+
+        val result = testRule.runner().withArguments(":app:kspDebugAndroidTestKotlin", "--info").build()
+        val task = result.task(":app:kspDebugAndroidTestKotlin")
+        require(task != null)
+        require(task.outcome == TaskOutcome.SUCCESS)
+
+        val generatedFile = testRule.appModule.moduleRoot.resolve("build/generated/ksp/debugAndroidTest/kotlin/Generated.kt")
+        assertThat(generatedFile.exists()).isTrue()
+    }
 }
+

--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/testing/KspIntegrationTestRule.kt
@@ -135,6 +135,39 @@ class KspIntegrationTestRule(
     }
 
     /**
+     * Sets up the module as an Android library module.
+     */
+    fun setupAndroidLibraryModule(
+        enableAgpBuiltInKotlinSupport: Boolean = false,
+        applyKspPluginFirst: Boolean = false
+    ) {
+        testProject.appModule.plugins.addAll(
+            if (applyKspPluginFirst) {
+                listOf(
+                    PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion),
+                    PluginDeclaration.id("com.android.library", testConfig.androidBaseVersion)
+                )
+            } else {
+                listOf(
+                    PluginDeclaration.id("com.android.library", testConfig.androidBaseVersion),
+                    PluginDeclaration.id("com.google.devtools.ksp", testConfig.kspVersion)
+                )
+            }
+        )
+
+        if (!enableAgpBuiltInKotlinSupport) {
+            val contents = """
+            android.builtInKotlin=false
+            android.newDsl=false
+            
+            """.trimIndent()
+            testProject.rootDir.resolve("gradle.properties").appendText(contents)
+            testProject.appModule.plugins.add(PluginDeclaration.kotlin("android", testConfig.kotlinBaseVersion))
+        }
+        addAndroidBoilerplate()
+    }
+
+    /**
      * Sets up the app module as a multiplatform app with the specified [targets], wrapped in a kotlin { } block.
      */
     fun setupAppAsMultiplatformApp(targets: String) {


### PR DESCRIPTION
Add regression test for premature androidTest task skipping

Verify that Android library modules utilizing AGP built-in Kotlin support correctly execute KSP tasks for androidTest variant configurations (e.g. kspAndroidTestDebug) without being prematurely aborted by configuration-time onlyIf predicates