### PR TITLE
Add backing fields to API

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -290,6 +290,13 @@ package com.google.devtools.ksp.symbol {
     property @Nullable public abstract com.google.devtools.ksp.symbol.AnnotationUseSiteTarget useSiteTarget;
   }
 
+  public interface KSBackingField extends com.google.devtools.ksp.symbol.KSDeclaration {
+    method @InaccessibleFromKotlin @NonNull public com.google.devtools.ksp.symbol.KSPropertyDeclaration getProperty();
+    method @InaccessibleFromKotlin @NonNull public com.google.devtools.ksp.symbol.KSTypeReference getType();
+    property @NonNull public abstract com.google.devtools.ksp.symbol.KSPropertyDeclaration property;
+    property @NonNull public abstract com.google.devtools.ksp.symbol.KSTypeReference type;
+  }
+
   public interface KSCallableReference extends com.google.devtools.ksp.symbol.KSReferenceElement {
     method public default <D, R> R accept(@NonNull com.google.devtools.ksp.symbol.KSVisitor<D,R> visitor, D data);
     method @InaccessibleFromKotlin @NonNull public java.util.List<com.google.devtools.ksp.symbol.KSValueParameter> getFunctionParameters();
@@ -434,6 +441,7 @@ package com.google.devtools.ksp.symbol {
   public interface KSPropertyDeclaration extends com.google.devtools.ksp.symbol.KSDeclaration {
     method @NonNull public com.google.devtools.ksp.symbol.KSType asMemberOf(@NonNull com.google.devtools.ksp.symbol.KSType containing);
     method @Nullable public com.google.devtools.ksp.symbol.KSPropertyDeclaration findOverridee();
+    method @InaccessibleFromKotlin @Nullable public default com.google.devtools.ksp.symbol.KSBackingField getBackingField();
     method @InaccessibleFromKotlin @Nullable public com.google.devtools.ksp.symbol.KSTypeReference getExtensionReceiver();
     method @InaccessibleFromKotlin @Nullable public com.google.devtools.ksp.symbol.KSPropertyGetter getGetter();
     method @InaccessibleFromKotlin public boolean getHasBackingField();
@@ -441,6 +449,7 @@ package com.google.devtools.ksp.symbol {
     method @InaccessibleFromKotlin @NonNull public com.google.devtools.ksp.symbol.KSTypeReference getType();
     method public boolean isDelegated();
     method @InaccessibleFromKotlin public boolean isMutable();
+    property @Nullable public default com.google.devtools.ksp.symbol.KSBackingField backingField;
     property @Nullable public abstract com.google.devtools.ksp.symbol.KSTypeReference extensionReceiver;
     property @Nullable public abstract com.google.devtools.ksp.symbol.KSPropertyGetter getter;
     property public abstract boolean hasBackingField;

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBackingField.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSBackingField.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.symbol
+
+/**
+ * A backing field for a [KSPropertyDeclaration].
+ */
+interface KSBackingField : KSDeclaration {
+
+    /**
+     * The property that this backing field belongs to.
+     */
+    val property: KSPropertyDeclaration
+
+    /**
+     * The type of the backing field.
+     * This is guaranteed to be a subtype of the type of [property].
+     */
+    val type: KSTypeReference
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSPropertyDeclaration.kt
@@ -55,6 +55,16 @@ interface KSPropertyDeclaration : KSDeclaration {
      */
     val hasBackingField: Boolean
 
+    /**
+     * The property's backing field if it exists.
+     * Guaranteed to exist if [hasBackingField] holds.
+     *
+     * As with [hasBackingField], the backing field is specific to the current property,
+     * and does not check for overriding properties.
+     */
+    val backingField: KSBackingField?
+        get() = null
+
     /** Indicates whether this is a delegated property. */
     fun isDelegated(): Boolean
 


### PR DESCRIPTION
This PR adds `KSBackingField` and updates the `KSPropertyDeclaration` interface to include a `backingField` property. The `KSPropertyDeclaration.backingField` property has a default getter, thereby ensuring binary compatibility.

Supersedes https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2873