### PR TITLE
Add `KSVisitorNext`

### DIFF
--- a/api/api.base
+++ b/api/api.base
@@ -558,38 +558,43 @@ package com.google.devtools.ksp.symbol {
     property @NonNull public abstract com.google.devtools.ksp.symbol.KSTypeReference type;
   }
 
-  public interface KSVisitor<D, R> {
-    method public R visitAnnotated(@NonNull com.google.devtools.ksp.symbol.KSAnnotated annotated, D data);
-    method public R visitAnnotation(@NonNull com.google.devtools.ksp.symbol.KSAnnotation annotation, D data);
-    method public R visitCallableReference(@NonNull com.google.devtools.ksp.symbol.KSCallableReference reference, D data);
-    method public R visitClassDeclaration(@NonNull com.google.devtools.ksp.symbol.KSClassDeclaration classDeclaration, D data);
-    method public R visitClassifierReference(@NonNull com.google.devtools.ksp.symbol.KSClassifierReference reference, D data);
-    method public R visitDeclaration(@NonNull com.google.devtools.ksp.symbol.KSDeclaration declaration, D data);
-    method public R visitDeclarationContainer(@NonNull com.google.devtools.ksp.symbol.KSDeclarationContainer declarationContainer, D data);
-    method public R visitDefNonNullReference(@NonNull com.google.devtools.ksp.symbol.KSDefNonNullReference reference, D data);
-    method public R visitDynamicReference(@NonNull com.google.devtools.ksp.symbol.KSDynamicReference reference, D data);
-    method public R visitFile(@NonNull com.google.devtools.ksp.symbol.KSFile file, D data);
-    method public R visitFunctionDeclaration(@NonNull com.google.devtools.ksp.symbol.KSFunctionDeclaration function, D data);
-    method public R visitModifierListOwner(@NonNull com.google.devtools.ksp.symbol.KSModifierListOwner modifierListOwner, D data);
-    method public R visitNode(@NonNull com.google.devtools.ksp.symbol.KSNode node, D data);
-    method public R visitParenthesizedReference(@NonNull com.google.devtools.ksp.symbol.KSParenthesizedReference reference, D data);
-    method public R visitPropertyAccessor(@NonNull com.google.devtools.ksp.symbol.KSPropertyAccessor accessor, D data);
-    method public R visitPropertyDeclaration(@NonNull com.google.devtools.ksp.symbol.KSPropertyDeclaration property, D data);
-    method public R visitPropertyGetter(@NonNull com.google.devtools.ksp.symbol.KSPropertyGetter getter, D data);
-    method public R visitPropertySetter(@NonNull com.google.devtools.ksp.symbol.KSPropertySetter setter, D data);
-    method public R visitReferenceElement(@NonNull com.google.devtools.ksp.symbol.KSReferenceElement element, D data);
-    method public R visitTypeAlias(@NonNull com.google.devtools.ksp.symbol.KSTypeAlias typeAlias, D data);
-    method public R visitTypeArgument(@NonNull com.google.devtools.ksp.symbol.KSTypeArgument typeArgument, D data);
-    method public R visitTypeParameter(@NonNull com.google.devtools.ksp.symbol.KSTypeParameter typeParameter, D data);
-    method public R visitTypeReference(@NonNull com.google.devtools.ksp.symbol.KSTypeReference typeReference, D data);
-    method public R visitValueArgument(@NonNull com.google.devtools.ksp.symbol.KSValueArgument valueArgument, D data);
-    method public R visitValueParameter(@NonNull com.google.devtools.ksp.symbol.KSValueParameter valueParameter, D data);
+  @Deprecated public interface KSVisitor<D, R> {
+    method @Deprecated public R visitAnnotated(@NonNull com.google.devtools.ksp.symbol.KSAnnotated annotated, D data);
+    method @Deprecated public R visitAnnotation(@NonNull com.google.devtools.ksp.symbol.KSAnnotation annotation, D data);
+    method @Deprecated public R visitCallableReference(@NonNull com.google.devtools.ksp.symbol.KSCallableReference reference, D data);
+    method @Deprecated public R visitClassDeclaration(@NonNull com.google.devtools.ksp.symbol.KSClassDeclaration classDeclaration, D data);
+    method @Deprecated public R visitClassifierReference(@NonNull com.google.devtools.ksp.symbol.KSClassifierReference reference, D data);
+    method @Deprecated public R visitDeclaration(@NonNull com.google.devtools.ksp.symbol.KSDeclaration declaration, D data);
+    method @Deprecated public R visitDeclarationContainer(@NonNull com.google.devtools.ksp.symbol.KSDeclarationContainer declarationContainer, D data);
+    method @Deprecated public R visitDefNonNullReference(@NonNull com.google.devtools.ksp.symbol.KSDefNonNullReference reference, D data);
+    method @Deprecated public R visitDynamicReference(@NonNull com.google.devtools.ksp.symbol.KSDynamicReference reference, D data);
+    method @Deprecated public R visitFile(@NonNull com.google.devtools.ksp.symbol.KSFile file, D data);
+    method @Deprecated public R visitFunctionDeclaration(@NonNull com.google.devtools.ksp.symbol.KSFunctionDeclaration function, D data);
+    method @Deprecated public R visitModifierListOwner(@NonNull com.google.devtools.ksp.symbol.KSModifierListOwner modifierListOwner, D data);
+    method @Deprecated public R visitNode(@NonNull com.google.devtools.ksp.symbol.KSNode node, D data);
+    method @Deprecated public R visitParenthesizedReference(@NonNull com.google.devtools.ksp.symbol.KSParenthesizedReference reference, D data);
+    method @Deprecated public R visitPropertyAccessor(@NonNull com.google.devtools.ksp.symbol.KSPropertyAccessor accessor, D data);
+    method @Deprecated public R visitPropertyDeclaration(@NonNull com.google.devtools.ksp.symbol.KSPropertyDeclaration property, D data);
+    method @Deprecated public R visitPropertyGetter(@NonNull com.google.devtools.ksp.symbol.KSPropertyGetter getter, D data);
+    method @Deprecated public R visitPropertySetter(@NonNull com.google.devtools.ksp.symbol.KSPropertySetter setter, D data);
+    method @Deprecated public R visitReferenceElement(@NonNull com.google.devtools.ksp.symbol.KSReferenceElement element, D data);
+    method @Deprecated public R visitTypeAlias(@NonNull com.google.devtools.ksp.symbol.KSTypeAlias typeAlias, D data);
+    method @Deprecated public R visitTypeArgument(@NonNull com.google.devtools.ksp.symbol.KSTypeArgument typeArgument, D data);
+    method @Deprecated public R visitTypeParameter(@NonNull com.google.devtools.ksp.symbol.KSTypeParameter typeParameter, D data);
+    method @Deprecated public R visitTypeReference(@NonNull com.google.devtools.ksp.symbol.KSTypeReference typeReference, D data);
+    method @Deprecated public R visitValueArgument(@NonNull com.google.devtools.ksp.symbol.KSValueArgument valueArgument, D data);
+    method @Deprecated public R visitValueParameter(@NonNull com.google.devtools.ksp.symbol.KSValueParameter valueParameter, D data);
   }
 
-  public class KSVisitorVoid implements com.google.devtools.ksp.symbol.KSVisitor<kotlin.Unit,kotlin.Unit> {
+  public interface KSVisitorNext<D, R> extends com.google.devtools.ksp.symbol.KSVisitor<D,R> {
+    method public R visitBackingField(@NonNull com.google.devtools.ksp.symbol.KSBackingField backingField, D data);
+  }
+
+  public class KSVisitorVoid implements com.google.devtools.ksp.symbol.KSVisitorNext<kotlin.Unit,kotlin.Unit> {
     ctor public KSVisitorVoid();
     method public void visitAnnotated(@NonNull com.google.devtools.ksp.symbol.KSAnnotated annotated, @NonNull kotlin.Unit data);
     method public void visitAnnotation(@NonNull com.google.devtools.ksp.symbol.KSAnnotation annotation, @NonNull kotlin.Unit data);
+    method public void visitBackingField(@NonNull com.google.devtools.ksp.symbol.KSBackingField backingField, @NonNull kotlin.Unit data);
     method public void visitCallableReference(@NonNull com.google.devtools.ksp.symbol.KSCallableReference reference, @NonNull kotlin.Unit data);
     method public void visitClassDeclaration(@NonNull com.google.devtools.ksp.symbol.KSClassDeclaration classDeclaration, @NonNull kotlin.Unit data);
     method public void visitClassifierReference(@NonNull com.google.devtools.ksp.symbol.KSClassifierReference reference, @NonNull kotlin.Unit data);
@@ -703,11 +708,12 @@ package com.google.devtools.ksp.visitor {
     ctor public KSDefaultVisitor();
   }
 
-  public abstract class KSEmptyVisitor<D, R> implements com.google.devtools.ksp.symbol.KSVisitor<D,R> {
+  public abstract class KSEmptyVisitor<D, R> implements com.google.devtools.ksp.symbol.KSVisitorNext<D,R> {
     ctor public KSEmptyVisitor();
     method public abstract R defaultHandler(@NonNull com.google.devtools.ksp.symbol.KSNode node, D data);
     method public R visitAnnotated(@NonNull com.google.devtools.ksp.symbol.KSAnnotated annotated, D data);
     method public R visitAnnotation(@NonNull com.google.devtools.ksp.symbol.KSAnnotation annotation, D data);
+    method public R visitBackingField(@NonNull com.google.devtools.ksp.symbol.KSBackingField backingField, D data);
     method public R visitCallableReference(@NonNull com.google.devtools.ksp.symbol.KSCallableReference reference, D data);
     method public R visitClassDeclaration(@NonNull com.google.devtools.ksp.symbol.KSClassDeclaration classDeclaration, D data);
     method public R visitClassifierReference(@NonNull com.google.devtools.ksp.symbol.KSClassifierReference reference, D data);
@@ -742,6 +748,7 @@ package com.google.devtools.ksp.visitor {
     method @NonNull public Boolean defaultHandler(@NonNull com.google.devtools.ksp.symbol.KSNode node, @Nullable com.google.devtools.ksp.symbol.KSNode data);
     method @NonNull public Boolean visitAnnotated(@NonNull com.google.devtools.ksp.symbol.KSAnnotated annotated, @Nullable com.google.devtools.ksp.symbol.KSNode data);
     method @NonNull public Boolean visitAnnotation(@NonNull com.google.devtools.ksp.symbol.KSAnnotation annotation, @Nullable com.google.devtools.ksp.symbol.KSNode data);
+    method @NonNull public Boolean visitBackingField(@NonNull com.google.devtools.ksp.symbol.KSBackingField backingField, @Nullable com.google.devtools.ksp.symbol.KSNode data);
     method @NonNull public Boolean visitClassDeclaration(@NonNull com.google.devtools.ksp.symbol.KSClassDeclaration classDeclaration, @Nullable com.google.devtools.ksp.symbol.KSNode data);
     method @NonNull public Boolean visitDeclaration(@NonNull com.google.devtools.ksp.symbol.KSDeclaration declaration, @Nullable com.google.devtools.ksp.symbol.KSNode data);
     method @NonNull public Boolean visitDeclarationContainer(@NonNull com.google.devtools.ksp.symbol.KSDeclarationContainer declarationContainer, @Nullable com.google.devtools.ksp.symbol.KSNode data);

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
@@ -17,6 +17,15 @@
 package com.google.devtools.ksp.symbol
 
 /** A visitor for program elements */
+@Deprecated(
+    message = "KSVisitor is deprecated in favor of KSVisitorNext which supports backing fields.\n" +
+        "In the next KSP version, KSVisitorNext will be deprecated and implementations should move back to KSVisitor.\n" +
+        "This is done to preserve binary compatibility and to avoid breaking changes for users.",
+    replaceWith = ReplaceWith(
+        expression = "KSVisitorNext",
+        imports = ["com.google.devtools.ksp.symbol.KSVisitorNext"],
+    ),
+)
 interface KSVisitor<D, R> {
     fun visitNode(node: KSNode, data: D): R
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorNext.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorNext.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.devtools.ksp.symbol
+
+/**
+ *  A visitor for program elements.
+ *
+ *  This is similar to [KSVisitor], except that this interface
+ *  also contains methods for visiting backing fields.
+ */
+interface KSVisitorNext<D, R> : KSVisitor<D, R> {
+    fun visitBackingField(backingField: KSBackingField, data: D): R
+}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
@@ -17,7 +17,7 @@
 package com.google.devtools.ksp.symbol
 
 /** A visitor that doesn't pass or return anything. */
-open class KSVisitorVoid : KSVisitor<Unit, Unit> {
+open class KSVisitorVoid : KSVisitorNext<Unit, Unit> {
     override fun visitNode(node: KSNode, data: Unit) {}
 
     override fun visitAnnotated(annotated: KSAnnotated, data: Unit) {}
@@ -31,7 +31,8 @@ open class KSVisitorVoid : KSVisitor<Unit, Unit> {
     override fun visitDeclarationContainer(
         declarationContainer: KSDeclarationContainer,
         data: Unit,
-    ) {}
+    ) {
+    }
 
     override fun visitDynamicReference(reference: KSDynamicReference, data: Unit) {}
 
@@ -50,6 +51,8 @@ open class KSVisitorVoid : KSVisitor<Unit, Unit> {
     override fun visitPropertyGetter(getter: KSPropertyGetter, data: Unit) {}
 
     override fun visitPropertySetter(setter: KSPropertySetter, data: Unit) {}
+
+    override fun visitBackingField(backingField: KSBackingField, data: Unit) {}
 
     override fun visitClassifierReference(reference: KSClassifierReference, data: Unit) {}
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -70,6 +70,11 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
         return super.visitPropertySetter(setter, data)
     }
 
+    override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        this.visitDeclaration(backingField, data)
+        return super.visitBackingField(backingField, data)
+    }
+
     override fun visitTypeAlias(typeAlias: KSTypeAlias, data: D): R {
         this.visitDeclaration(typeAlias, data)
         return super.visitTypeAlias(typeAlias, data)

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.symbol.*
 /**
  * A visitor that methods fall back to [defaultHandler] if not overridden.
  */
-abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
+abstract class KSEmptyVisitor<D, R> : KSVisitorNext<D, R> {
     abstract fun defaultHandler(node: KSNode, data: D): R
 
     override fun visitNode(node: KSNode, data: D): R {
@@ -82,6 +82,10 @@ abstract class KSEmptyVisitor<D, R> : KSVisitor<D, R> {
 
     override fun visitPropertySetter(setter: KSPropertySetter, data: D): R {
         return defaultHandler(setter, data)
+    }
+
+    override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        return defaultHandler(backingField, data)
     }
 
     override fun visitClassifierReference(reference: KSClassifierReference, data: D): R {

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -27,6 +27,7 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
     private fun Sequence<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }
+
     private fun List<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }
@@ -38,6 +39,7 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
         property.extensionReceiver?.accept(data)
         property.getter?.accept(data)
         property.setter?.accept(data)
+        property.backingField?.accept(data)
         return super.visitPropertyDeclaration(property, data)
     }
 
@@ -94,6 +96,11 @@ abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
     override fun visitPropertySetter(setter: KSPropertySetter, data: D): R {
         setter.parameter.accept(data)
         return super.visitPropertySetter(setter, data)
+    }
+
+    override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        backingField.type.accept(data)
+        return super.visitBackingField(backingField, data)
     }
 
     override fun visitReferenceElement(element: KSReferenceElement, data: D): R {

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -98,6 +98,13 @@ open class KSValidateVisitor(
         return true
     }
 
+    override fun visitBackingField(backingField: KSBackingField, data: KSNode?): Boolean {
+        if (predicate(backingField, backingField.type) && !backingField.type.accept(this, data)) {
+            return false
+        }
+        return this.visitDeclaration(backingField, data)
+    }
+
     override fun visitValueArgument(valueArgument: KSValueArgument, data: KSNode?): Boolean {
         fun visitValue(value: Any?): Boolean = when (value) {
             is KSType -> this.validateType(value)


### PR DESCRIPTION
This PR adds the `KSVisitorNext<D, R> : KSVisitor<D, R>` interface that decorates the `KSVisitor` interface with a `visitBackingField` function. All existing implementations of `KSVisitor` move to `KSVisitorNext`. The `KSVisitor` interface is then deprecated to inform processor authors that they should move to `KSVisitorNext`. The deprecation is informative and actionable. Also, it uses the `ReplaceWith` annotation to allow IDEs to easily suggest a fix.

Depends on https://github.com/google/ksp/pull/3058
Supersedes https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2873