### PR TITLE
Separate Android tests from secondary integration tests

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-agp, gradle-check ]
+        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-android, integration-test-agp, gradle-check ]
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-agp' }}
+    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-android' || matrix.test-suite == 'integration-test-agp' }}
     permissions:
       contents: write
 
@@ -105,13 +105,17 @@ jobs:
         if: matrix.test-suite == 'integration-test-secondary'
         run: ./gradlew :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
+      - name: Run android integration tests
+        if: matrix.test-suite == 'integration-test-android'
+        run: ./gradlew :integration-tests:androidTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+
       - name: Run agp integration tests
         if: matrix.test-suite == 'integration-test-agp'
         run: ./gradlew :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
       - name: Run remaining tests and checks
         if: matrix.test-suite == 'gradle-check'
-        run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+        run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:androidTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-agp, gradle-check ]
+        test-suite: [ api-check, unit-test, integration-test-primary, integration-test-secondary, integration-test-android, integration-test-agp, gradle-check ]
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-agp' }}
+    continue-on-error: ${{ matrix.test-suite == 'integration-test-secondary' || matrix.test-suite == 'integration-test-android' || matrix.test-suite == 'integration-test-agp' }}
     defaults:
       run:
         shell: bash
@@ -86,13 +86,17 @@ jobs:
       if: matrix.test-suite == 'integration-test-secondary'
       run: ./gradlew :integration-tests:secondaryTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
+    - name: Run android integration tests
+      if: matrix.test-suite == 'integration-test-android'
+      run: ./gradlew :integration-tests:androidTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+
     - name: Run agp integration tests
       if: matrix.test-suite == 'integration-test-agp'
       run: ./gradlew :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
     - name: Run remaining tests and checks
       if: matrix.test-suite == 'gradle-check'
-      run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
+      run: ./gradlew check -x :kotlin-analysis-api:test -x :integration-tests:primaryTest -x :integration-tests:secondaryTest -x :integration-tests:androidTest -x :integration-tests:agpTest --stacktrace --info --max-workers=1 --no-parallel -Dorg.gradle.vfs.watch=false -Dorg.gradle.jvmargs="-Xmx20248m -Dkotlin.daemon.jvm.options=-Xmx2048m"
 
     - name: Upload test results
       if: always()

--- a/integration-tests/build.gradle.kts
+++ b/integration-tests/build.gradle.kts
@@ -60,7 +60,20 @@ val secondaryTest by
         configureCommonSettings()
     }
 
-// Create a new test task for the secondary package
+// Create a new test task for the android package
+val androidTest by
+    tasks.registering(Test::class) {
+        description = "Runs integration tests in the android package"
+        group = "verification"
+        include("com/google/devtools/ksp/test/android/*.class")
+        // Set maxParallelForks to 1 to avoid race conditions when downloading SDKs with old AGPs
+        maxParallelForks = 1
+        testClassesDirs = sourceSets["test"].output.classesDirs
+        classpath = sourceSets["test"].runtimeClasspath
+        configureCommonSettings()
+    }
+
+// Create a new test task for the agp package
 val agpTest by
     tasks.registering(Test::class) {
         description = "Runs integration tests in the agp package"
@@ -75,7 +88,7 @@ val agpTest by
 
 tasks.test {
     exclude("**/*")
-    dependsOn(primaryTest, secondaryTest, agpTest)
+    dependsOn(primaryTest, secondaryTest, androidTest, agpTest)
 }
 
 java {

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidBuiltInKotlinIT.kt
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.android
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import com.google.devtools.ksp.test.utils.assertContainsNonNullEntry

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidDataBindingBuiltInKotlinIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidDataBindingBuiltInKotlinIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.android
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
@@ -9,12 +9,11 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class AndroidDataBindingIT(experimentalPsiResolution: Boolean) {
-
+class AndroidDataBindingBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
-        "android-data-binding",
+        "android-data-binding-builtinkotlin",
         experimentalPsiResolution = experimentalPsiResolution
     )
 
@@ -34,7 +33,7 @@ class AndroidDataBindingIT(experimentalPsiResolution: Boolean) {
             ":app:assemble",
             "--configuration-cache-problems=warn",
             "--info",
-            "--stacktrace"
+            "--stacktrace",
         )
             .build().let { result ->
                 val output = result.output.lines()

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidDataBindingIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidDataBindingIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.android
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
@@ -9,11 +9,12 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class AndroidViewBindingIT(experimentalPsiResolution: Boolean) {
+class AndroidDataBindingIT(experimentalPsiResolution: Boolean) {
+
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
-        "android-view-binding",
+        "android-data-binding",
         experimentalPsiResolution = experimentalPsiResolution
     )
 

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.android
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import com.google.devtools.ksp.test.utils.assertContainsNonNullEntry

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidViewBindingIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/android/AndroidViewBindingIT.kt
@@ -1,4 +1,4 @@
-package com.google.devtools.ksp.test.secondary
+package com.google.devtools.ksp.test.android
 
 import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.GradleRunner
@@ -9,11 +9,11 @@ import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
-class AndroidDataBindingBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
+class AndroidViewBindingIT(experimentalPsiResolution: Boolean) {
     @Rule
     @JvmField
     val project: TemporaryTestProject = TemporaryTestProject(
-        "android-data-binding-builtinkotlin",
+        "android-view-binding",
         experimentalPsiResolution = experimentalPsiResolution
     )
 
@@ -33,7 +33,7 @@ class AndroidDataBindingBuiltInKotlinIT(experimentalPsiResolution: Boolean) {
             ":app:assemble",
             "--configuration-cache-problems=warn",
             "--info",
-            "--stacktrace",
+            "--stacktrace"
         )
             .build().let { result ->
                 val output = result.output.lines()


### PR DESCRIPTION
## Summary

The secondary integration test suite can take up to ~1 hour in CI and is on the critical path. This follows the same approach as #2923 (AGP split): move Android-heavy TestKit tests into their own package and run them in a parallel CI matrix cell.

## Approach

Integration tests are already split by Java package + Gradle task + GitHub Actions matrix:

- `primaryTest` — merge-blocking
- `secondaryTest` — soft-fail
- `agpTest` — soft-fail (#2923)

This adds `androidTest` — soft-fail — for the slow Android/AGP TestKit builds (SDK resolution, full `build`, R8, databinding/viewbinding, built-in Kotlin). No test logic or fixtures changed; only package moves and CI/Gradle wiring.

## Partition

| Suite | Task | CI key | Classes |
|-------|------|--------|---------|
| **android** (new) | `:integration-tests:androidTest` | `integration-test-android` | `AndroidIT`, `AndroidBuiltInKotlinIT`, `AndroidDataBindingIT`, `AndroidDataBindingBuiltInKotlinIT`, `AndroidViewBindingIT` |
| **secondary** | `:integration-tests:secondaryTest` | `integration-test-secondary` | 12 remaining (KAPT, incremental, HMPP, OnError, CLI, etc.) |

## Changes

- Move 5 `Android*.kt` from `test/secondary/` → `test/android/`; update package to `com.google.devtools.ksp.test.android`
- Register `androidTest` in `integration-tests/build.gradle.kts`; add to `tasks.test` dependsOn
- Add `integration-test-android` matrix cell in `main.yml` and `auto-merge.yml`; extend `continue-on-error`; exclude from `gradle-check` `-x` list

## Expected CI impact

One ~1h secondary job becomes two parallel soft-fail jobs (`android` + `secondary`). Span should drop to roughly `max(android, secondary)` instead of both in one cell. `main.yml`: 18 → 21 matrix cells (3 OS × 7 suites).

## Validation

- `./gradlew :integration-tests:compileTestKotlin`
- `./gradlew :integration-tests:androidTest --tests 'com.google.devtools.ksp.test.android.AndroidIT'`
- `./gradlew :integration-tests:secondaryTest --tests 'com.google.devtools.ksp.test.secondary.KAPT3IT'`

Full suites not run locally; CI confirms span improvement.


##Closes
Closes #3060 