### PR TITLE
Update `KSVisitor` deprecation message

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitor.kt
@@ -19,8 +19,9 @@ package com.google.devtools.ksp.symbol
 /** A visitor for program elements */
 @Deprecated(
     message = "KSVisitor is deprecated in favor of KSVisitorNext which supports backing fields.\n" +
-        "In the next KSP version, KSVisitorNext will be deprecated and implementations should move back to KSVisitor.\n" +
-        "This is done to preserve binary compatibility and to avoid breaking changes for users.",
+        "In an upcoming KSP version, KSVisitorNext will be deprecated and implementations should move back to KSVisitor.\n" +
+        "This is done to preserve binary compatibility and to avoid breaking changes for users\n" +
+        "while giving library / processor authors time to support the new features.",
     replaceWith = ReplaceWith(
         expression = "KSVisitorNext",
         imports = ["com.google.devtools.ksp.symbol.KSVisitorNext"],


### PR DESCRIPTION
This commit changes wording from "next KSP version" to "an upcoming KSP version" and provides a bit more context as to why the interface is deprecated this way.
Related to #2873 