### PR TITLE
Update error message for ksp.useKSP2 property

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -145,7 +145,8 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
         if (useKsp2.not()) {
             throw RuntimeException(
                 "KSP1 is no longer available. Please use KSP2 instead and do not explicitly set ksp.useKsp2 to false " +
-                    "via the DSL or the Gradle property please"
+                    "via the DSL or the Gradle property please. " +
+                    "The ksp.useKSP2 property will be removed in the future."
             )
         }
         return true


### PR DESCRIPTION
Adds a sentence noting that the property will be removed in the future so users know they shouldn't rely on it.

What do you think about this @hfmehmed?

Related to https://github.com/google/ksp/issues/3067