### PR TITLE
Document collection values in KSValueArgument.value

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
@@ -50,7 +50,7 @@ interface KSValueArgument : KSAnnotated {
      * * [KSClassDeclaration] for annotation arguments of type [Enum] (in this
      *   case[KSClassDeclaration.classKind] equals to [ClassKind.ENUM_CLASS]);
      * * [KSAnnotation] for embedded annotation arguments;
-     * * [Array] of a possible type listed above.
+     * * [Array] or [List] of a possible type listed above.
      */
     val value: Any?
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSValueArgument.kt
@@ -50,7 +50,7 @@ interface KSValueArgument : KSAnnotated {
      * * [KSClassDeclaration] for annotation arguments of type [Enum] (in this
      *   case[KSClassDeclaration.classKind] equals to [ClassKind.ENUM_CLASS]);
      * * [KSAnnotation] for embedded annotation arguments;
-     * * [Array] or [List] of a possible type listed above.
+     * * [Array] or [Collection] of a possible type listed above.
      */
     val value: Any?
 }


### PR DESCRIPTION
## Summary

* Document that `KSValueArgument.value` may be represented as a `Collection` in addition to an `Array`.
* Align the API documentation with the behavior covered by #3023.

## Testing

Not run (documentation-only change).

Refs #3008
