### PR TITLE
Add test for explicit backing fields subtyping

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ExplicitBackingFieldsSubtypingProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ExplicitBackingFieldsSubtypingProcessor.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.getClassDeclarationByName
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSFile
+import com.google.devtools.ksp.symbol.KSNode
+
+class ExplicitBackingFieldsSubtypingProcessor : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> {
+        return results.toList()
+    }
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        listOf("MyClass", "lib.Other").forEach { name ->
+            resolver.getClassDeclarationByName(name)!!.let { clazz ->
+                clazz.getAllProperties().forEach { property ->
+                    val pType = property.type.resolve()
+                    property.backingField?.let { field ->
+                        val fType = field.type.resolve()
+                        results.add("${property.fqn}: $pType")
+                        results.add("${field.fqn}: $fType")
+                    }
+                }
+            }
+        }
+        return emptyList()
+    }
+
+    private val KSAnnotated.fqn: String
+        get() = findAllQualifiers(this).joinToString(separator = ".")
+
+    private fun findAllQualifiers(node: KSNode): List<KSNode> {
+        val result = mutableListOf(node)
+        var current = node.parent
+        while (current != null && current !is KSFile) {
+            result.add(current)
+            current = current.parent
+        }
+        result.reverse()
+        return result
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -340,6 +340,17 @@ abstract class KSPUnitTestSuite(
         )
     }
 
+    @TestMetadata("explicitBackingFieldsSubtyping.kt")
+    @Test
+    @Bug(
+        "https://github.com/google/ksp/issues/2873",
+        BugState.OPEN,
+        "KEEP 430: Backing fields can be a subtype of the property."
+    )
+    fun testExplicitBackingFieldsSubtyping() {
+        runFailingTest("$AA_PATH/explicitBackingFieldsSubtyping.kt")
+    }
+
     @TestMetadata("functionTypeAlias.kt")
     @Test
     fun testFunctionTypeAlias() {

--- a/kotlin-analysis-api/testData/explicitBackingFieldsSubtyping.kt
+++ b/kotlin-analysis-api/testData/explicitBackingFieldsSubtyping.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: ExplicitBackingFieldsSubtypingProcessor
+// EXPECTED:
+// MyClass.prop1: List<String>
+// MyClass.prop1.field: MutableList<String>
+// MyClass.prop2: List<String>
+// MyClass.prop2.field: List<String>
+// MyClass.prop3: List<String>
+// MyClass.prop3.field: MutableList<String>
+// MyClass.prop4: List<Int>
+// MyClass.prop4.field: MutableList<Int>
+// MyClass.propA: A
+// MyClass.propA.field: B
+// Other.prop1: List<String>
+// Other.prop1.field: List<String>
+// Other.prop2: List<String>
+// Other.prop2.field: List<String>
+// Other.prop3: List<String>
+// Other.prop3.field: List<String>
+// Other.prop4: List<Int>
+// Other.prop4.field: List<Int>
+// Other.propA: A
+// Other.propA.field: A
+// END
+
+// MODULE: lib
+// FILE: lib/Other.kt
+
+package lib
+
+class Other {
+
+    val prop1: List<String>
+        field: MutableList<String>
+
+    val prop2: List<String>
+        field: List<String>
+
+    val prop3: List<String>
+        field = mutableListOf("")
+
+    val prop4: List<Int>
+        field: MutableList<Int> = mutableListOf(42)
+
+    val propA: A
+        field: B = B()
+
+    val propX get() = propA.x
+
+    init {
+        prop1 = mutableListOf("")
+        prop2 = mutableListOf("")
+    }
+
+    fun append(n: Int) {
+        prop4.add(n)
+    }
+
+    fun add(n: Int) {
+        propA.add(n)
+    }
+}
+
+open class A {
+    var x = 42
+}
+
+class B : A() {
+    fun add(n: Int) {
+        x = x + n
+    }
+}
+
+// MODULE: main(lib)
+// FILE: MyClass.kt
+
+class MyClass {
+
+    val prop1: List<String>
+        field: MutableList<String>
+
+    val prop2: List<String>
+        field: List<String>
+
+    val prop3: List<String>
+        field = mutableListOf("")
+
+    val prop4: List<Int>
+        field: MutableList<Int> = mutableListOf(42)
+
+    val propA: A
+        field: B = B()
+
+    val propX get() = propA.x
+
+    init {
+        prop1 = mutableListOf("")
+        prop2 = mutableListOf("")
+    }
+
+    fun append(n: Int) {
+        prop4.add(n)
+    }
+
+    fun add(n: Int) {
+        propA.add(n)
+    }
+}
+
+open class A {
+    var x = 42
+}
+
+class B : A() {
+    fun add(n: Int) {
+        x = x + n
+    }
+}


### PR DESCRIPTION
This PR adds the `explicitBackingFieldsSubtyping` test from https://github.com/google/ksp/pull/2969.
Context: An EBF in Kotlin can be a subtype of the corresponding property.

Related to #2873 