### PR TITLE
Qualify receiver in `InternalKSPException`

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/errors/InternalKSPException.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/errors/InternalKSPException.kt
@@ -51,7 +51,7 @@ internal class InternalKSPException(
         // N.B.: Override the toString method to prevent the big error message being printed in the
         // stack trace.
         return buildString {
-            append(javaClass.name)
+            append(this@InternalKSPException.javaClass.name)
             append(": ")
             append("Internal KSP Error")
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/InternalKSPException.kt
@@ -52,7 +52,7 @@ internal class InternalKSPException(
     override fun toString(): String {
         // N.B.: Override the toString method to prevent the big error message being printed in the stack trace.
         return buildString {
-            append(javaClass.name)
+            append(this@InternalKSPException.javaClass.name)
             append(": ")
             append("Internal KSP Error")
         }


### PR DESCRIPTION
Without the qualifier, the receiver refers to the StringBuilder currently in use. Hence, the stacktrace always prints `java.lang.StringBuilder: Internal KSP Error`.