### PR TITLE
Update `AnnotationsInDependencies`

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2020 Google LLC
+ * Copyright 2010-2020 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.getClassDeclarationByName

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -2,7 +2,20 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
-import com.google.devtools.ksp.symbol.*
+import com.google.devtools.ksp.symbol.FileLocation
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSBackingField
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSNode
+import com.google.devtools.ksp.symbol.KSPropertyDeclaration
+import com.google.devtools.ksp.symbol.KSPropertyGetter
+import com.google.devtools.ksp.symbol.KSPropertySetter
+import com.google.devtools.ksp.symbol.KSTypeReference
+import com.google.devtools.ksp.symbol.KSValueParameter
+import com.google.devtools.ksp.symbol.Location
+import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -55,6 +55,7 @@ class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
             } ?: "no-name-value-parameter ${this.location.lineNumber}"
             is KSPropertyGetter -> "getter of ${receiver.toSignature()}" // lineNumber handled by recursive call
             is KSPropertySetter -> "setter of ${receiver.toSignature()}" // lineNumber handled by recursive call
+            is KSBackingField -> "field of ${property.toSignature()}" // lineNumber handled by recursive call
             else -> {
                 error("unexpected annotated")
             }


### PR DESCRIPTION
This PR moves the `AnnotationsInDependencies` test processor from the deprecated `test-utils` directory into `kotlin-analysis-api`.
Additionally, it handles the type `KSBackingField` in its `when` expression that matches on the declaration type.

Supersedes https://github.com/google/ksp/pull/2969
Related to #2873 