### PR TITLE
Remove unused function

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSPropertyDeclarationImpl.kt
@@ -228,11 +228,3 @@ internal fun KaPropertySymbol.toModifiers(): Set<Modifier> {
     }
     return result
 }
-
-internal fun KSAnnotation.isValidOnProperty(): Boolean =
-    annotationType.resolve().declaration.annotations.none { metaAnnotation ->
-        metaAnnotation.annotationType.resolve().declaration.qualifiedName?.asString() == "kotlin.annotation.Target" &&
-            (metaAnnotation.arguments.singleOrNull()?.value as? ArrayList<*>)?.none {
-            (it as? KSClassDeclaration)?.qualifiedName?.asString() == "kotlin.annotation.AnnotationTarget.PROPERTY"
-        } ?: false
-    }


### PR DESCRIPTION
The file contained `KSAnnotation.isValidOnProperty` which was not used anywhere. Generally, use-site targets are handled by the Analysis API.