### PR TITLE
Move kotlin-analysis-api single-artifact aa dependencies to the version catalog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,7 @@ kotlinxSerializationVersion=1.6.3
 agpBaseVersion=9.3.0-alpha01
 aaKotlinBaseVersion=2.4.20-dev-6138
 aaIntellijVersion=251.27812.49
-aaGuavaVersion=33.2.0-jre
-aaAsmVersion=9.0
 aaFastutilVersion=8.5.14-jb1
-aaStax2Version=4.2.1
-aaAaltoXmlVersion=1.3.0
-aaStreamexVersion=0.7.2
 aaCoroutinesVersion=1.10.2
 
 kotlin.jvm.target.validation.mode=warning

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,11 @@ junit5 = "5.8.2"
 junit-platform = "1.8.2"
 google-truth = "1.4.5"
 aa-kotlin-base = "2.4.20-dev-6138"
+aa-guava = "33.2.0-jre"
+aa-asm = "9.0"
+aa-stax2 = "4.2.1"
+aa-aalto-xml = "1.3.0"
+aa-streamex = "0.7.2"
 aa-coroutines = "1.10.2"
 
 [libraries]
@@ -23,3 +28,8 @@ junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", vers
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junit5" }
 junit-platform-suite = { module = "org.junit.platform:junit-platform-suite", version.ref = "junit-platform" }
 google-truth = { module = "com.google.truth:truth", version.ref = "google-truth" }
+aa-guava = { module = "com.google.guava:guava", version.ref = "aa-guava" }
+aa-asm = { module = "org.jetbrains.intellij.deps:asm-all", version.ref = "aa-asm" }
+aa-stax2 = { module = "org.codehaus.woodstox:stax2-api", version.ref = "aa-stax2" }
+aa-aalto-xml = { module = "com.fasterxml:aalto-xml", version.ref = "aa-aalto-xml" }
+aa-streamex = { module = "one.util:streamex", version.ref = "aa-streamex" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -24,12 +24,7 @@ val libsForTestingCommon: Configuration by configurations.creating
 
 val aaKotlinBaseVersion: String by project
 val aaIntellijVersion: String by project
-val aaGuavaVersion: String by project
-val aaAsmVersion: String by project
 val aaFastutilVersion: String by project
-val aaStax2Version: String by project
-val aaAaltoXmlVersion: String by project
-val aaStreamexVersion: String by project
 val aaCoroutinesVersion: String by project
 
 plugins {
@@ -168,11 +163,11 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
     compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
 
-    implementation("com.google.guava:guava:$aaGuavaVersion")
-    implementation("one.util:streamex:$aaStreamexVersion")
-    implementation("org.jetbrains.intellij.deps:asm-all:$aaAsmVersion")
-    implementation("org.codehaus.woodstox:stax2-api:$aaStax2Version") { isTransitive = false }
-    implementation("com.fasterxml:aalto-xml:$aaAaltoXmlVersion") { isTransitive = false }
+    implementation(libs.aa.guava)
+    implementation(libs.aa.streamex)
+    implementation(libs.aa.asm)
+    implementation(libs.aa.stax2) { isTransitive = false }
+    implementation(libs.aa.aalto.xml) { isTransitive = false }
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
     implementation("org.jetbrains.intellij.deps.jna:jna:5.9.0.26") { isTransitive = false }
     implementation("org.jetbrains.intellij.deps.jna:jna-platform:5.9.0.26") { isTransitive = false }


### PR DESCRIPTION
Sixth slice of #2968 and the second of three for kotlin-analysis-api, following #3041.

The five single-artifact aa dependencies move to catalog accessors: guava, streamex, asm-all, stax2-api, and aalto-xml. Their five version properties are removed from gradle.properties since this module was their last reader.

Verified that resolution is unchanged: ./gradlew :kotlin-analysis-api:dependencies output for the compile and runtime classpaths is identical before and after this commit, 156 lines compared. :kotlin-analysis-api:compileKotlin passes.