### PR TITLE
Move remaining kotlin-analysis-api versions to the version catalog

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,10 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
+# Duplicated in gradle/libs.versions.toml: gradle-plugin's TestConfig loads this
+# file directly at test runtime. Keep the two values in sync.
 kotlinBaseVersion=2.3.20
-kotlinxSerializationVersion=1.6.3
 agpBaseVersion=9.3.0-alpha01
-aaKotlinBaseVersion=2.4.20-dev-6138
-aaIntellijVersion=251.27812.49
-aaFastutilVersion=8.5.14-jb1
-aaCoroutinesVersion=1.10.2
 
 kotlin.jvm.target.validation.mode=warning
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,11 +7,13 @@ junit5 = "5.8.2"
 junit-platform = "1.8.2"
 google-truth = "1.4.5"
 aa-kotlin-base = "2.4.20-dev-6138"
+aa-intellij = "251.27812.49"
 aa-guava = "33.2.0-jre"
 aa-asm = "9.0"
 aa-stax2 = "4.2.1"
 aa-aalto-xml = "1.3.0"
 aa-streamex = "0.7.2"
+aa-fastutil = "8.5.14-jb1"
 aa-coroutines = "1.10.2"
 
 [libraries]
@@ -20,6 +22,7 @@ kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", ve
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin-base" }
 kotlin-compiler-embeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin-base" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "aa-coroutines" }
 kotlinx-coroutines-core-jvm = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm", version.ref = "aa-coroutines" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp-base" }
 junit4 = { module = "junit:junit", version.ref = "junit" }
@@ -33,3 +36,4 @@ aa-asm = { module = "org.jetbrains.intellij.deps:asm-all", version.ref = "aa-asm
 aa-stax2 = { module = "org.codehaus.woodstox:stax2-api", version.ref = "aa-stax2" }
 aa-aalto-xml = { module = "com.fasterxml:aalto-xml", version.ref = "aa-aalto-xml" }
 aa-streamex = { module = "one.util:streamex", version.ref = "aa-streamex" }
+aa-fastutil = { module = "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil", version.ref = "aa-fastutil" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -17,15 +17,13 @@ description = "Kotlin Symbol Processing implementation using Kotlin Analysis API
 val signingKey: String? by project
 val signingPassword: String? by project
 
-val kotlinBaseVersion: String by project
-val kotlinxSerializationVersion: String by project
+val kotlinBaseVersion = libs.versions.kotlin.base.get()
 val libsForTesting: Configuration by configurations.creating
 val libsForTestingCommon: Configuration by configurations.creating
 
-val aaKotlinBaseVersion: String by project
-val aaIntellijVersion: String by project
-val aaFastutilVersion: String by project
-val aaCoroutinesVersion: String by project
+val aaKotlinBaseVersion = libs.versions.aa.kotlin.base.get()
+val aaIntellijVersion = libs.versions.aa.intellij.get()
+val aaCoroutinesVersion = libs.versions.aa.coroutines.get()
 
 plugins {
     kotlin("jvm")
@@ -160,7 +158,7 @@ dependencies {
         }
 
     implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:$kotlinxSerializationVersion")
+    implementation(libs.kotlinx.serialization.json)
     compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
 
     implementation(libs.aa.guava)
@@ -179,10 +177,10 @@ dependencies {
     implementation("javax.inject:javax.inject:1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
     implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    compileOnly("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    compileOnly(libs.kotlinx.coroutines.core.jvm)
+    compileOnly(libs.kotlinx.coroutines.core.asProvider())
     implementation(
-        "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil:$aaFastutilVersion"
+        libs.aa.fastutil
     ) {
         isTransitive = false
     }
@@ -208,8 +206,8 @@ dependencies {
     testImplementation(project(":common-deps"))
     testImplementation(project(":test-utils"))
     testImplementation("org.jetbrains.kotlin:analysis-api-test-framework:$aaKotlinBaseVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:$aaCoroutinesVersion")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$aaCoroutinesVersion")
+    testImplementation(libs.kotlinx.coroutines.core.jvm)
+    testImplementation(libs.kotlinx.coroutines.core.asProvider())
 
     // See AbstractKSPTest's init block if you change any of the `libsForTesting` or
     // `libsForTestingCommon` dependencies.


### PR DESCRIPTION
Seventh slice of #2968 and the last of three for kotlin-analysis-api, following #3089.

fastutil, kotlinx-serialization-json, and the coroutines artifacts move to catalog accessors. The aa Kotlin and IntelliJ versions become catalog sourced local values since they version loop generated coordinates, kotlin() helper calls, and jar rename regexes that accessors cannot express. Five version properties with no remaining readers are removed from gradle.properties. kotlinBaseVersion and agpBaseVersion stay with a comment explaining the duplication: gradle-plugin's TestConfig loads gradle.properties directly at test runtime.

Verified that resolution is unchanged: ./gradlew :kotlin-analysis-api:dependencies output for the compile, runtime, and testRuntime classpaths is identical before and after this commit, 301 lines compared. :kotlin-analysis-api:compileTestKotlin and :symbol-processing-aa-embeddable:compileKotlin pass.