### PR TITLE
Verify Gradle wrapper jar in all GitHub workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -75,6 +75,10 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
 
+      - name: Check valid Gradle wrapper jar
+        run: sha256sum --check gradle-wrapper.jar.sha256sum
+        working-directory: ./gradle/wrapper
+
       # Build cache
       - name: Cache Gradle Cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -89,6 +93,10 @@ jobs:
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+      - name: Check valid Gradle wrapper jar
+        run: sha256sum --check gradle-wrapper.jar.sha256sum
+        working-directory: ./gradle/wrapper
 
       # Check API compatibility
       - name: API compatibility check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,11 @@ jobs:
     # Checkout
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+    - name: Check valid Gradle wrapper jar
+      if: matrix.os != 'windows-latest'
+      run: sha256sum --check gradle-wrapper.jar.sha256sum
+      working-directory: ./gradle/wrapper
+
     # Build cache
     - name: Cache Gradle Cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
     # Checkout
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
+    - name: Check valid Gradle wrapper jar
+      run: sha256sum --check gradle-wrapper.jar.sha256sum
+      working-directory: ./gradle/wrapper
+
     # Build cache
     - name: Cache Gradle Cache
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
@@ -39,6 +43,11 @@ jobs:
       with:
         path: ~/.gradle/wrapper
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+
+    - name: Check valid Gradle wrapper jar
+      run: sha256sum --check gradle-wrapper.jar.sha256sum
+      working-directory: ./gradle/wrapper
+
     # Build KSP artifacts
     - name: build
       run: |


### PR DESCRIPTION
Also adds a verification step before and after cache and wrapper has been restored from cache.