### PR TITLE
Remove konanHome

### DIFF
--- a/gradle-plugin/lint-baseline.xml
+++ b/gradle-plugin/lint-baseline.xml
@@ -8,30 +8,30 @@
         errorLine2="                                                             ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt"
-            line="109"
+            line="127"
             column="62"/>
     </issue>
 
     <issue
         id="EagerGradleConfiguration"
         message="Avoid using method get"
-        errorLine1="                                    kotlinCompileProvider.get().libraries.filter {"
-        errorLine2="                                                          ~~~">
+        errorLine1="                                cfg.libraries.from(kotlinCompileProvider.get().libraries)"
+        errorLine2="                                                                         ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="226"
-            column="59"/>
+            line="282"
+            column="74"/>
     </issue>
 
     <issue
         id="EagerGradleConfiguration"
         message="Avoid using method get"
-        errorLine1="                        cfg.konanHome.value((kotlinCompileProvider.get() as KotlinNativeCompile).konanHome)"
-        errorLine2="                                                                   ~~~">
+        errorLine1="                                        kotlinCompileProvider.get().libraries.filter {"
+        errorLine2="                                                              ~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt"
-            line="347"
-            column="68"/>
+            line="291"
+            column="63"/>
     </issue>
 
     <issue
@@ -41,7 +41,7 @@
         errorLine2="                                                             ~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="28"
+            line="30"
             column="62"/>
     </issue>
 
@@ -52,7 +52,7 @@
         errorLine2="                                      ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="47"
+            line="49"
             column="39"/>
     </issue>
 
@@ -63,7 +63,7 @@
         errorLine2="                                                 ~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspConfigurations.kt"
-            line="122"
+            line="126"
             column="50"/>
     </issue>
 
@@ -74,7 +74,7 @@
         errorLine2="                                   ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="157"
+            line="169"
             column="36"/>
     </issue>
 
@@ -85,7 +85,7 @@
         errorLine2="                                                     ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="175"
+            line="186"
             column="54"/>
     </issue>
 
@@ -96,7 +96,7 @@
         errorLine2="                                                                  ~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="183"
+            line="194"
             column="67"/>
     </issue>
 
@@ -107,7 +107,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt"
-            line="35"
+            line="40"
             column="1"/>
     </issue>
 
@@ -118,7 +118,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="40"
+            line="46"
             column="1"/>
     </issue>
 
@@ -129,7 +129,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="41"
+            line="47"
             column="1"/>
     </issue>
 
@@ -140,7 +140,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="42"
+            line="48"
             column="1"/>
     </issue>
 
@@ -151,7 +151,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="43"
+            line="49"
             column="1"/>
     </issue>
 
@@ -162,7 +162,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="44"
+            line="50"
             column="1"/>
     </issue>
 
@@ -173,7 +173,7 @@
         errorLine2="~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="45"
+            line="51"
             column="1"/>
     </issue>
 
@@ -184,7 +184,7 @@
         errorLine2="                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="328"
+            line="386"
             column="26"/>
     </issue>
 
@@ -195,7 +195,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="343"
+            line="401"
             column="9"/>
     </issue>
 
@@ -206,7 +206,7 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="347"
+            line="405"
             column="9"/>
     </issue>
 
@@ -217,7 +217,7 @@
         errorLine2="                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="355"
+            line="413"
             column="29"/>
     </issue>
 
@@ -228,7 +228,7 @@
         errorLine2="                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="396"
+            line="453"
             column="36"/>
     </issue>
 
@@ -239,8 +239,19 @@
         errorLine2="        ~~~~~~~~~~~~~~~~~~~~~~">
         <location
             file="src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt"
-            line="397"
+            line="454"
             column="9"/>
+    </issue>
+
+    <issue
+        id="UseTomlInstead"
+        message="Use version catalog instead"
+        errorLine1="    lintChecks(&quot;androidx.lint:lint-gradle:1.0.0-alpha05&quot;)"
+        errorLine2="               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~">
+        <location
+            file="build.gradle.kts"
+            line="36"
+            column="16"/>
     </issue>
 
 </issues>

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspAATask.kt
@@ -79,7 +79,6 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinCommonCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinJvmAndroidCompilation
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeCompilation
 import org.jetbrains.kotlin.gradle.tasks.AbstractKotlinCompileTool
-import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.konan.target.HostManager
 import org.jetbrains.kotlin.tooling.core.KotlinToolingVersion
 import java.io.ByteArrayOutputStream
@@ -456,7 +455,6 @@ abstract class KspAATask @Inject constructor(
                     if (kotlinCompilation is KotlinNativeCompilation) {
                         val konanTargetName = kotlinCompilation.target.konanTarget.name
                         cfg.konanTargetName.value(konanTargetName)
-                        cfg.konanHome.set(kotlinCompileProvider.flatMap { (it as KotlinNativeCompile).konanHome })
 
                         val isHostSupported = HostManager().enabled.any {
                             it.name == konanTargetName
@@ -714,10 +712,6 @@ abstract class KspGradleConfig @Inject constructor() {
     @get:Optional
     abstract val konanTargetName: Property<String>
 
-    @get:Input
-    @get:Optional
-    abstract val konanHome: Property<String>
-
     @get:Internal
     abstract val profilingMode: Property<Boolean>
 }
@@ -832,20 +826,6 @@ abstract class KspAAWorkerAction : WorkAction<KspAAWorkParameter> {
                 KSPNativeConfig.Builder().apply {
                     this.setupSuper()
                     target = gradleCfg.konanTargetName.get()
-
-                    // Unlike other platforms, K/N sets up stdlib in the compiler, not KGP,
-                    // meaning that KotlinNativeCompile doesn't have stdlib.
-                    // FIXME: find a solution with KGP, K/N and AA owners
-                    val konanHome = File(gradleCfg.konanHome.get())
-                    val klib = File(konanHome, "klib")
-                    val common = File(klib, "common")
-                    val stdlib = File(common, "stdlib")
-                    libraries += stdlib
-                    val platform = File(klib, "platform")
-                    val targetLibDir = File(platform, target)
-                    targetLibDir.listFiles()?.let {
-                        libraries += it
-                    }
                 }.build()
             }
 


### PR DESCRIPTION
Remove deprecated `(it as KotlinNativeCompile).konanHome` property and manual Native klib resolution from KspAATask.

Since Kotlin 2.0 (`KT-61559`), KGP automatically includes the Kotlin/Native stdlib and platform klibs in kotlinCompilation.compileDependencyFiles.
Because KSP populates cfg.libraries directly from kotlinCompilation.compileDependencyFiles for Native targets, manually reading konanHome is no longer required.