### PR TITLE
Move kotlin-analysis-api IntelliJ platform dependencies to the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,10 @@ aa-stax2 = "4.2.1"
 aa-aalto-xml = "1.3.0"
 aa-streamex = "0.7.2"
 aa-fastutil = "8.5.14-jb1"
+aa-jna = "5.9.0.26"
+aa-trove4j = "1.0.20200330"
+aa-log4j = "1.2.17.2"
+aa-jdom = "2.0.6"
 aa-coroutines = "1.10.2"
 
 [libraries]
@@ -37,6 +41,11 @@ aa-stax2 = { module = "org.codehaus.woodstox:stax2-api", version.ref = "aa-stax2
 aa-aalto-xml = { module = "com.fasterxml:aalto-xml", version.ref = "aa-aalto-xml" }
 aa-streamex = { module = "one.util:streamex", version.ref = "aa-streamex" }
 aa-fastutil = { module = "org.jetbrains.intellij.deps.fastutil:intellij-deps-fastutil", version.ref = "aa-fastutil" }
+aa-jna = { module = "org.jetbrains.intellij.deps.jna:jna", version.ref = "aa-jna" }
+aa-jnaPlatform = { module = "org.jetbrains.intellij.deps.jna:jna-platform", version.ref = "aa-jna" }
+aa-trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version.ref = "aa-trove4j" }
+aa-log4j = { module = "org.jetbrains.intellij.deps:log4j", version.ref = "aa-log4j" }
+aa-jdom = { module = "org.jetbrains.intellij.deps:jdom", version.ref = "aa-jdom" }
 
 [plugins]
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -167,12 +167,12 @@ dependencies {
     implementation(libs.aa.stax2) { isTransitive = false }
     implementation(libs.aa.aalto.xml) { isTransitive = false }
     implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
-    implementation("org.jetbrains.intellij.deps.jna:jna:5.9.0.26") { isTransitive = false }
-    implementation("org.jetbrains.intellij.deps.jna:jna-platform:5.9.0.26") { isTransitive = false }
-    implementation("org.jetbrains.intellij.deps:trove4j:1.0.20200330") { isTransitive = false }
-    originalLog4j("org.jetbrains.intellij.deps:log4j:1.2.17.2") { isTransitive = false }
+    implementation(libs.aa.jna) { isTransitive = false }
+    implementation(libs.aa.jnaPlatform) { isTransitive = false }
+    implementation(libs.aa.trove4j) { isTransitive = false }
+    originalLog4j(libs.aa.log4j) { isTransitive = false }
     implementation(files(filteredLog4j))
-    implementation("org.jetbrains.intellij.deps:jdom:2.0.6") { isTransitive = false }
+    implementation(libs.aa.jdom) { isTransitive = false }
     implementation("io.javaslang:javaslang:2.0.6")
     implementation("javax.inject:javax.inject:1")
     implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")


### PR DESCRIPTION
First slice of the inline build file versions remaining for #2968, continuing from #3102.

Five org.jetbrains.intellij.deps artifacts move from hardcoded versions to catalog accessors: jna, jna-platform, trove4j, log4j in the originalLog4j configuration, and jdom. The two jna artifacts share one version entry, and the jnaPlatform alias uses the camelCase leaf so no asProvider is needed, per the earlier reviews.

Verified that resolution is unchanged: ./gradlew :kotlin-analysis-api:dependencies output for the compile, runtime, and originalLog4j configurations is identical before and after this commit, 165 lines compared. :kotlin-analysis-api:compileKotlin passes.