### PR TITLE
Allow processors to opt in to new features in Resolver

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/processing/SymbolProcessorEnvironment.kt
@@ -45,7 +45,39 @@ class SymbolProcessorEnvironment(
 
     /** KSP version */
     val kspVersion: KotlinVersion,
+
+    /**
+     * Processors may call this lambda to opt in to upcoming features:
+     * backing fields and context parameters.
+     */
+    val registerProcessorForNewFeatures: (SymbolProcessor) -> Unit
 ) {
+
+    /**
+     * Secondary constructor for binary compatibility that assigns
+     * [registerProcessorForNewFeatures] a lambda without effect.
+     */
+    constructor(
+        options: Map<String, String>,
+        kotlinVersion: KotlinVersion,
+        codeGenerator: CodeGenerator,
+        logger: KSPLogger,
+        apiVersion: KotlinVersion,
+        compilerVersion: KotlinVersion,
+        platforms: List<PlatformInfo>,
+        kspVersion: KotlinVersion,
+    ) : this(
+        options,
+        kotlinVersion,
+        codeGenerator,
+        logger,
+        apiVersion,
+        compilerVersion,
+        platforms,
+        kspVersion,
+        registerProcessorForNewFeatures = { }
+    )
+
     // For compatibility with KSP 1.0.2 and earlier
     constructor(
         options: Map<String, String>,

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AAResolutionStrategy.kt
@@ -39,7 +39,11 @@ class AAResolutionStrategy(
     override val deferredSymbols: Map<SymbolProcessor, List<Restorable>>
 ) : AnnotationResolutionStrategy {
 
-    override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> =
+    override fun getSymbolsWithAnnotation(
+        annotationName: String,
+        inDepth: Boolean,
+        enableNewFeatures: Boolean
+    ): Sequence<KSAnnotated> =
         if (inDepth)
             annotationToSymbolsWithLocalsCache[annotationName]?.asSequence() ?: emptySequence()
         else

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/AnnotationResolutionStrategy.kt
@@ -43,8 +43,9 @@ interface AnnotationResolutionStrategy {
      *
      * @param annotationName is the fully qualified name of the fully expanded type (i.e. no type alias); using '.' as separator.
      * @param inDepth whether to check symbols in depth, i.e. check symbols from local declarations. Operation can be expensive if true.
+     * @param enableNewFeatures whether to return backing fields and context parameter symbols or operate in existing mode.
      * @return Elements annotated with the specified annotation.
      *
      */
-    fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated>
+    fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean, enableNewFeatures: Boolean): Sequence<KSAnnotated>
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/impl/PsiResolutionStrategy.kt
@@ -90,9 +90,13 @@ class PsiResolutionStrategy(
     /**
      * Returns all symbols annotated with [annotationName].
      */
-    override fun getSymbolsWithAnnotation(annotationName: String, inDepth: Boolean): Sequence<KSAnnotated> =
+    override fun getSymbolsWithAnnotation(
+        annotationName: String,
+        inDepth: Boolean,
+        enableNewFeatures: Boolean
+    ): Sequence<KSAnnotated> =
         if (inDepth)
-            aaResolutionStrategy.getSymbolsWithAnnotation(annotationName, inDepth = true)
+            aaResolutionStrategy.getSymbolsWithAnnotation(annotationName, inDepth = true, enableNewFeatures)
         else
             getAnnotatedSymbols(annotationName)
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -586,6 +586,7 @@ class KotlinSymbolProcessing(
                 ResolverAAImpl.instance.propertyAsMemberOfCache = mutableMapOf()
 
                 processors.forEach { processor ->
+                    resolver.currentProcessor = processor
                     incrementalContext.closeFilesOnException {
                         deferredSymbols[processor] =
                             processor.process(resolver)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -579,7 +579,8 @@ class KotlinSymbolProcessing(
                     allDirtyKSFiles,
                     project,
                     incrementalContext,
-                    resolutionStrategy
+                    resolutionStrategy,
+                    processorsRegisteredForUpcomingFeatures
                 )
                 ResolverAAImpl.instance = resolver
                 ResolverAAImpl.instance.functionAsMemberOfCache = mutableMapOf()

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -526,6 +526,7 @@ class KotlinSymbolProcessing(
             var newKSFiles = allDirtyKSFiles
 
             val targetPlatform = ResolverAAImpl.ktModule.targetPlatform
+            val processorsRegisteredForUpcomingFeatures = mutableSetOf<SymbolProcessor>()
             val symbolProcessorEnvironment = SymbolProcessorEnvironment(
                 kspConfig.processorOptions,
                 kspConfig.languageVersion.toKotlinVersion(),
@@ -534,7 +535,8 @@ class KotlinSymbolProcessing(
                 kspConfig.apiVersion.toKotlinVersion(),
                 KotlinCompilerVersion.getVersion().toKotlinVersion(),
                 targetPlatform.getPlatformInfo(kspConfig),
-                KotlinVersion(2, 0)
+                KotlinVersion(2, 0),
+                registerProcessorForNewFeatures = processorsRegisteredForUpcomingFeatures::add
             )
 
             // Load and instantiate processors

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -86,6 +86,7 @@ import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.KSBuiltIns
 import com.google.devtools.ksp.processing.KSPConfig
 import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
@@ -186,6 +187,8 @@ class ResolverAAImpl(
             kspConfig_prop.remove()
         }
     }
+
+    lateinit var currentProcessor: SymbolProcessor
 
     lateinit var propertyAsMemberOfCache: MutableMap<Pair<KSPropertyDeclaration, KSType>, KSType>
     lateinit var functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -90,6 +90,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSBackingField
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSClassifierReference
 import com.google.devtools.ksp.symbol.KSDeclaration
@@ -190,6 +191,8 @@ class ResolverAAImpl(
     }
 
     lateinit var currentProcessor: SymbolProcessor
+
+    private fun shouldEnableNewFeatures(): Boolean = currentProcessor in processorsRegisteredForNewFeatures
 
     lateinit var propertyAsMemberOfCache: MutableMap<Pair<KSPropertyDeclaration, KSType>, KSType>
     lateinit var functionAsMemberOfCache: MutableMap<Pair<KSFunctionDeclaration, KSType>, KSFunction>
@@ -721,7 +724,11 @@ class ResolverAAImpl(
         }
         val realAnnotationName = expandedIfAlias ?: annotationName
 
-        return resolutionStrategy.getSymbolsWithAnnotation(realAnnotationName, inDepth)
+        return resolutionStrategy.getSymbolsWithAnnotation(
+            realAnnotationName,
+            inDepth,
+            shouldEnableNewFeatures(),
+        )
     }
 
     override fun getTypeArgument(typeRef: KSTypeReference, variance: Variance): KSTypeArgument {
@@ -908,6 +915,8 @@ class ResolverAAImpl(
                     }
                 }
             }
+
+            is KSBackingField if shouldEnableNewFeatures() -> TODO("Backing fields are not yet supported in mapToJvmSignatureInternal")
 
             else -> null
         }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -158,6 +158,7 @@ class ResolverAAImpl(
     val project: Project,
     val incrementalContext: IncrementalContextAA,
     val resolutionStrategy: AnnotationResolutionStrategy,
+    val processorsRegisteredForNewFeatures: Set<SymbolProcessor>,
 ) : Resolver {
     companion object {
         private val instance_prop: ThreadLocal<ResolverAAImpl> = ThreadLocal()


### PR DESCRIPTION
This PR addresses the situation where a unchanged processor changes its behavior because it relies on `Resolver`. The idea is that the processor gets a lambda that registers it for new features in the `Resolver`. The new lambda is introduced in `SymbolProcessorEnvironment` but does not break binary compatibility. The reason is that `Resolver.getSymbolsWithAnnotation` could start returning backing fields and context parameters, however, this flag allows the Resolver to adapt its behavior (at runtime) depending on whether or not the current processor has registered itself for new features. In this design, a processor that has chosen *not* to opt in can coexist with a processor that *has* opted in.

- [x] Extends the `SymbolProcessorEnvironment` with a lambda that allows processors to register for new features in `Resolver`. This alleviates the problem that `Resolver.getSymbolsWithAnnotation` changes its behavior when `KSBackingField` and `KSContextParameter` is properly introduced.
- [x] Update `ResolverAAImpl` to adapt according to the current processor's opt-in choice.
- [x] Update `AnnotationResolutionStrategy` implementations with feature flag. See https://github.com/google/ksp/pull/3131
- [ ] Update test suites to be configured with this new mode of operation. See https://github.com/google/ksp/pull/3132

Related to https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2472
Related to https://github.com/google/ksp/issues/2873
