### PR TITLE
Allow processor to opt in to new features in `KSVisitor`s

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
@@ -17,7 +17,7 @@
 package com.google.devtools.ksp.symbol
 
 /** A visitor that doesn't pass or return anything. */
-open class KSVisitorVoid : KSVisitorNext<Unit, Unit> {
+open class KSVisitorVoid(val enableNewFeatures: Boolean) : KSVisitorNext<Unit, Unit> {
     override fun visitNode(node: KSNode, data: Unit) {}
 
     override fun visitAnnotated(annotated: KSAnnotated, data: Unit) {}

--- a/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/symbol/KSVisitorVoid.kt
@@ -16,8 +16,18 @@
  */
 package com.google.devtools.ksp.symbol
 
-/** A visitor that doesn't pass or return anything. */
+import com.google.devtools.ksp.errors.InternalKSPException
+
+/**
+ * A visitor that doesn't pass or return anything.
+ *
+ * @param enableNewFeatures A boolean flag toggling on or off new features: Backing fields and context parameters.
+ */
 open class KSVisitorVoid(val enableNewFeatures: Boolean) : KSVisitorNext<Unit, Unit> {
+
+    // For binary compatibility
+    constructor() : this(enableNewFeatures = false)
+
     override fun visitNode(node: KSNode, data: Unit) {}
 
     override fun visitAnnotated(annotated: KSAnnotated, data: Unit) {}
@@ -52,7 +62,15 @@ open class KSVisitorVoid(val enableNewFeatures: Boolean) : KSVisitorNext<Unit, U
 
     override fun visitPropertySetter(setter: KSPropertySetter, data: Unit) {}
 
-    override fun visitBackingField(backingField: KSBackingField, data: Unit) {}
+    override fun visitBackingField(backingField: KSBackingField, data: Unit) {
+        if (!enableNewFeatures) {
+            throw InternalKSPException(
+                "Unexpected call to visitBackingField in ${javaClass.simpleName} with enabledNewFeatures = false",
+                backingField.location,
+                javaClass
+            )
+        }
+    }
 
     override fun visitClassifierReference(reference: KSClassifierReference, data: Unit) {}
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -145,8 +145,11 @@ fun KSDeclaration.isLocal(): Boolean {
  * @param predicate A lambda for filtering interested symbols for performance purpose. Default
  *   checks all.
  */
-fun KSNode.validate(predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true }): Boolean {
-    return this.accept(KSValidateVisitor(predicate), null)
+fun KSNode.validate(
+    predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true },
+    enableNewFeatures: Boolean = false,
+): Boolean {
+    return this.accept(KSValidateVisitor(predicate, enableNewFeatures), null)
 }
 
 /** Find the KSClassDeclaration that the alias points to, recursively. */
@@ -221,6 +224,7 @@ fun KSClassDeclaration.getAllSuperTypes(): Sequence<KSType> {
                         is KSTypeAlias -> it.findActualType().getAllSuperTypes()
                         is KSTypeParameter ->
                             it.getTypesUpperBound().flatMap { it.getAllSuperTypes() }
+
                         else ->
                             throw InternalKSPException(
                                 "Unhandled super type kind",
@@ -257,7 +261,7 @@ fun KSDeclaration.isOpen() =
             this.modifiers.contains(Modifier.SEALED) ||
             (this !is KSClassDeclaration &&
                 (this.parentDeclaration as? KSClassDeclaration)?.classKind ==
-                    ClassKind.INTERFACE) ||
+                ClassKind.INTERFACE) ||
             (!this.modifiers.contains(Modifier.FINAL) && this.origin == Origin.JAVA))
 
 fun KSDeclaration.isPublic() = this.getVisibility() == Visibility.PUBLIC
@@ -367,7 +371,7 @@ fun <T : Annotation> KSAnnotated.getAnnotationsByType(annotationKClass: KClass<T
         .filter {
             it.shortName.getShortName() == annotationKClass.simpleName &&
                 it.annotationType.resolve().declaration.qualifiedName?.asString() ==
-                    annotationKClass.qualifiedName
+                annotationKClass.qualifiedName
         }
         .map { it.toAnnotation(annotationKClass.java) }
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -147,7 +147,21 @@ fun KSDeclaration.isLocal(): Boolean {
  */
 fun KSNode.validate(
     predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true },
-    enableNewFeatures: Boolean = false,
+): Boolean {
+    return this.accept(KSValidateVisitor(predicate), null)
+}
+
+/**
+ * Perform a validation on a given symbol to check if all interested types in symbols enclosed scope
+ * are valid, i.e. resolvable.
+ *
+ * @param predicate A lambda for filtering interested symbols for performance purpose. Default
+ *   checks all.
+ *   @param enableNewFeatures A boolean flag toggling new features in [KSValidateVisitor].
+ */
+fun KSNode.validate(
+    predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true },
+    enableNewFeatures: Boolean,
 ): Boolean {
     return this.accept(KSValidateVisitor(predicate, enableNewFeatures), null)
 }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -21,8 +21,13 @@ import com.google.devtools.ksp.symbol.*
 
 /**
  * A visitor that delegates to super types for methods that are not overridden.
+ *
+ * @param enableNewFeatures A boolean flag toggling on or off new features: Backing fields and context parameters.
  */
 abstract class KSDefaultVisitor<D, R>(enableNewFeatures: Boolean) : KSEmptyVisitor<D, R>(enableNewFeatures) {
+
+    // For binary compatibility
+    constructor() : this(enableNewFeatures = false)
 
     override fun visitDynamicReference(reference: KSDynamicReference, data: D): R {
         this.visitReferenceElement(reference, data)
@@ -75,9 +80,9 @@ abstract class KSDefaultVisitor<D, R>(enableNewFeatures: Boolean) : KSEmptyVisit
     override fun visitBackingField(backingField: KSBackingField, data: D): R {
         if (!enableNewFeatures) {
             throw InternalKSPException(
-                "Unexpected call to visitBackingField in ${this.javaClass.simpleName} while enableNewFeatures = false",
+                "Unexpected call to visitBackingField in ${javaClass.simpleName} with enabledNewFeatures = false",
                 backingField.location,
-                backingField.javaClass
+                javaClass
             )
         }
         this.visitDeclaration(backingField, data)

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSDefaultVisitor.kt
@@ -16,12 +16,14 @@
  */
 package com.google.devtools.ksp.visitor
 
+import com.google.devtools.ksp.errors.InternalKSPException
 import com.google.devtools.ksp.symbol.*
 
 /**
  * A visitor that delegates to super types for methods that are not overridden.
  */
-abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
+abstract class KSDefaultVisitor<D, R>(enableNewFeatures: Boolean) : KSEmptyVisitor<D, R>(enableNewFeatures) {
+
     override fun visitDynamicReference(reference: KSDynamicReference, data: D): R {
         this.visitReferenceElement(reference, data)
         return super.visitDynamicReference(reference, data)
@@ -71,6 +73,13 @@ abstract class KSDefaultVisitor<D, R> : KSEmptyVisitor<D, R>() {
     }
 
     override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        if (!enableNewFeatures) {
+            throw InternalKSPException(
+                "Unexpected call to visitBackingField in ${this.javaClass.simpleName} while enableNewFeatures = false",
+                backingField.location,
+                backingField.javaClass
+            )
+        }
         this.visitDeclaration(backingField, data)
         return super.visitBackingField(backingField, data)
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.symbol.*
 /**
  * A visitor that methods fall back to [defaultHandler] if not overridden.
  */
-abstract class KSEmptyVisitor<D, R> : KSVisitorNext<D, R> {
+abstract class KSEmptyVisitor<D, R>(val enableNewFeatures: Boolean) : KSVisitorNext<D, R> {
     abstract fun defaultHandler(node: KSNode, data: D): R
 
     override fun visitNode(node: KSNode, data: D): R {

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSEmptyVisitor.kt
@@ -16,12 +16,19 @@
  */
 package com.google.devtools.ksp.visitor
 
+import com.google.devtools.ksp.errors.InternalKSPException
 import com.google.devtools.ksp.symbol.*
 
 /**
  * A visitor that methods fall back to [defaultHandler] if not overridden.
+ *
+ * @param enableNewFeatures A boolean flag toggling on or off new features: Backing fields and context parameters.
  */
 abstract class KSEmptyVisitor<D, R>(val enableNewFeatures: Boolean) : KSVisitorNext<D, R> {
+
+    // For binary compatibility
+    constructor() : this(enableNewFeatures = false)
+
     abstract fun defaultHandler(node: KSNode, data: D): R
 
     override fun visitNode(node: KSNode, data: D): R {
@@ -85,6 +92,13 @@ abstract class KSEmptyVisitor<D, R>(val enableNewFeatures: Boolean) : KSVisitorN
     }
 
     override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        if (!enableNewFeatures) {
+            throw InternalKSPException(
+                "Unexpected call to visitBackingField in ${javaClass.simpleName} with enabledNewFeatures = false",
+                backingField.location,
+                javaClass
+            )
+        }
         return defaultHandler(backingField, data)
     }
 

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.*
  *
  * For subclasses overriding a function, remember to call the corresponding super method.
  */
-abstract class KSTopDownVisitor<D, R> : KSDefaultVisitor<D, R>() {
+abstract class KSTopDownVisitor<D, R>(enableNewFeatures: Boolean) : KSDefaultVisitor<D, R>(enableNewFeatures) {
     private fun Sequence<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSTopDownVisitor.kt
@@ -16,14 +16,21 @@
  */
 package com.google.devtools.ksp.visitor
 
+import com.google.devtools.ksp.errors.InternalKSPException
 import com.google.devtools.ksp.symbol.*
 
 /**
  * Visit all elements recursively.
  *
  * For subclasses overriding a function, remember to call the corresponding super method.
+ *
+ * @param enableNewFeatures A boolean flag toggling on or off new features: Backing fields and context parameters.
  */
 abstract class KSTopDownVisitor<D, R>(enableNewFeatures: Boolean) : KSDefaultVisitor<D, R>(enableNewFeatures) {
+
+    // For binary compatibility
+    constructor() : this(enableNewFeatures = false)
+
     private fun Sequence<KSNode>.accept(data: D) {
         forEach { it.accept(this@KSTopDownVisitor, data) }
     }
@@ -39,7 +46,9 @@ abstract class KSTopDownVisitor<D, R>(enableNewFeatures: Boolean) : KSDefaultVis
         property.extensionReceiver?.accept(data)
         property.getter?.accept(data)
         property.setter?.accept(data)
-        property.backingField?.accept(data)
+        if (enableNewFeatures) {
+            property.backingField?.accept(data)
+        }
         return super.visitPropertyDeclaration(property, data)
     }
 
@@ -99,6 +108,13 @@ abstract class KSTopDownVisitor<D, R>(enableNewFeatures: Boolean) : KSDefaultVis
     }
 
     override fun visitBackingField(backingField: KSBackingField, data: D): R {
+        if (!enableNewFeatures) {
+            throw InternalKSPException(
+                "Unexpected call to visitBackingField in ${javaClass.simpleName} with enabledNewFeatures = false",
+                backingField.location,
+                javaClass
+            )
+        }
         backingField.type.accept(data)
         return super.visitBackingField(backingField, data)
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -3,8 +3,9 @@ package com.google.devtools.ksp.visitor
 import com.google.devtools.ksp.symbol.*
 
 open class KSValidateVisitor(
-    private val predicate: (KSNode?, KSNode) -> Boolean
-) : KSDefaultVisitor<KSNode?, Boolean>() {
+    private val predicate: (KSNode?, KSNode) -> Boolean,
+    enableNewFeatures: Boolean
+) : KSDefaultVisitor<KSNode?, Boolean>(enableNewFeatures) {
     private fun validateType(type: KSType): Boolean {
         return !type.isError && !type.arguments.any { it.type?.accept(this, null) == false }
     }

--- a/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/visitor/KSValidateVisitor.kt
@@ -1,11 +1,16 @@
 package com.google.devtools.ksp.visitor
 
+import com.google.devtools.ksp.errors.InternalKSPException
 import com.google.devtools.ksp.symbol.*
 
 open class KSValidateVisitor(
     private val predicate: (KSNode?, KSNode) -> Boolean,
     enableNewFeatures: Boolean
 ) : KSDefaultVisitor<KSNode?, Boolean>(enableNewFeatures) {
+
+    // For binary compatibility
+    constructor(predicate: (KSNode?, KSNode) -> Boolean) : this(predicate, enableNewFeatures = false)
+
     private fun validateType(type: KSType): Boolean {
         return !type.isError && !type.arguments.any { it.type?.accept(this, null) == false }
     }
@@ -100,6 +105,13 @@ open class KSValidateVisitor(
     }
 
     override fun visitBackingField(backingField: KSBackingField, data: KSNode?): Boolean {
+        if (!enableNewFeatures) {
+            throw InternalKSPException(
+                "Unexpected call to visitBackingField in ${javaClass.simpleName} with enabledNewFeatures = false",
+                backingField.location,
+                javaClass
+            )
+        }
         if (predicate(backingField, backingField.type) && !backingField.type.accept(this, data)) {
             return false
         }


### PR DESCRIPTION
The idea in this PR is that a processor must opt-in to the new features such as backing fields. This is all done without breaking binary compatibility, so processor authors can upgrade to new features and users can still build their projects.
Specifically, this PR addresses the situation where a processor uses one of the built-in `KSVisitor` implementations provided by KSP. An existing processor will not see any change and will continue to work. An existing processor may opt-in to the new features.

This is similar and related to https://github.com/google/ksp/pull/3110. Note that the flag introduced in this PR is decoupled from the one in #3110.

Related to https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2472
Related to https://github.com/google/ksp/issues/2873