### PR TITLE
Allow native and JS backend tests in testing infra

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -19,7 +19,10 @@ package com.google.devtools.ksp.test
 
 import com.google.devtools.ksp.impl.CommandLineKSPLogger
 import com.google.devtools.ksp.impl.KotlinSymbolProcessing
+import com.google.devtools.ksp.processing.KSPConfig
+import com.google.devtools.ksp.processing.KSPJsConfig
 import com.google.devtools.ksp.processing.KSPJvmConfig
+import com.google.devtools.ksp.processing.KSPNativeConfig
 import com.google.devtools.ksp.processor.AbstractTestProcessor
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
@@ -27,6 +30,13 @@ import org.jetbrains.kotlin.cli.jvm.config.jvmModularRoots
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.platform.JsPlatform
+import org.jetbrains.kotlin.platform.konan.NativePlatform
+import org.jetbrains.kotlin.test.TargetBackend
+import org.jetbrains.kotlin.test.compileJavaFiles
+import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
+import org.jetbrains.kotlin.test.directives.NativeEnvironmentConfigurationDirectives
+import org.jetbrains.kotlin.test.services.targetPlatformProvider
 import org.jetbrains.kotlin.test.compileJavaFiles
 import org.jetbrains.kotlin.test.kotlinPathsForDistDirectoryForTests
 import org.jetbrains.kotlin.test.model.FrontendKinds
@@ -173,27 +183,90 @@ abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : Abstr
 
         val testRoot = mainModule.testRoot
 
-        val kspConfig = KSPJvmConfig.Builder().apply {
-            moduleName = mainModule.findCompilerModuleName()
-            sourceRoots = listOf(mainModule.kotlinSrc)
-            javaSourceRoots = compilerConfiguration.javaSourceRoots.map { File(it) }.toList()
-            jdkHome = compilerConfiguration.get(JVMConfigurationKeys.JDK_HOME)
-            jvmTarget = (compilerConfiguration.get(JVMConfigurationKeys.JVM_TARGET) ?: JvmTarget.DEFAULT).description
-            languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString
-            apiVersion = compilerConfiguration.languageVersionSettings.apiVersion.versionString
-            libraries = mainModule.regularDependencies.map { it.dependencyModule.outDir } +
-                compilerConfiguration.jvmModularRoots
-            friends = mainModule.friendDependencies.map { it.dependencyModule.outDir }
-            projectBaseDir = testRoot
-            classOutputDir = File(testRoot, "kspTest/classes/main")
-            javaOutputDir = File(testRoot, "kspTest/src/main/java")
-            kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
-            resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
-            cachesDir = File(testRoot, "kspTest/kspCaches")
-            outputBaseDir = File(testRoot, "kspTest")
-            incremental = true
-            experimentalPsiResolution = this@AbstractKSPAATest.experimentalPsiResolution
-        }.build()
+        val targetBackend = mainModule.directives[ConfigurationDirectives.TARGET_BACKEND].firstOrNull()
+        val fixedNativeTarget =
+            mainModule.directives[NativeEnvironmentConfigurationDirectives.WITH_FIXED_TARGET].firstOrNull()
+        val targetPlatform = testServices.targetPlatformProvider.getTargetPlatform(mainModule)
+
+        val isNative = targetBackend == TargetBackend.NATIVE ||
+            targetPlatform.componentPlatforms.any { it is NativePlatform } ||
+            fixedNativeTarget != null
+
+        val isJs = targetBackend?.isTransitivelyCompatibleWith(TargetBackend.JS_IR) == true ||
+            targetBackend?.isTransitivelyCompatibleWith(TargetBackend.WASM) == true ||
+            targetPlatform.componentPlatforms.any { it is JsPlatform }
+
+        val kspConfig: KSPConfig = when {
+            isNative -> {
+                KSPNativeConfig.Builder().apply {
+                    target = fixedNativeTarget ?: "linux_x64"
+                    moduleName = mainModule.findCompilerModuleName()
+                    sourceRoots = listOf(mainModule.kotlinSrc)
+                    commonSourceRoots = emptyList()
+                    languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString
+                    apiVersion = compilerConfiguration.languageVersionSettings.apiVersion.versionString
+                    libraries = mainModule.regularDependencies.map { it.dependencyModule.outDir } +
+                        compilerConfiguration.jvmModularRoots
+                    friends = mainModule.friendDependencies.map { it.dependencyModule.outDir }
+                    projectBaseDir = testRoot
+                    classOutputDir = File(testRoot, "kspTest/classes/main")
+                    kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
+                    resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
+                    cachesDir = File(testRoot, "kspTest/kspCaches")
+                    outputBaseDir = File(testRoot, "kspTest")
+                    incremental = true
+                    experimentalPsiResolution = this@AbstractKSPAATest.experimentalPsiResolution
+                }.build()
+            }
+
+            isJs -> {
+                KSPJsConfig.Builder().apply {
+                    backend =
+                        if (targetBackend?.isTransitivelyCompatibleWith(TargetBackend.WASM) == true) "WASM" else "JS"
+                    moduleName = mainModule.findCompilerModuleName()
+                    sourceRoots = listOf(mainModule.kotlinSrc)
+                    commonSourceRoots = emptyList()
+                    languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString
+                    apiVersion = compilerConfiguration.languageVersionSettings.apiVersion.versionString
+                    libraries = mainModule.regularDependencies.map { it.dependencyModule.outDir } +
+                        compilerConfiguration.jvmModularRoots
+                    friends = mainModule.friendDependencies.map { it.dependencyModule.outDir }
+                    projectBaseDir = testRoot
+                    classOutputDir = File(testRoot, "kspTest/classes/main")
+                    kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
+                    resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
+                    cachesDir = File(testRoot, "kspTest/kspCaches")
+                    outputBaseDir = File(testRoot, "kspTest")
+                    incremental = true
+                    experimentalPsiResolution = this@AbstractKSPAATest.experimentalPsiResolution
+                }.build()
+            }
+
+            else -> {
+                KSPJvmConfig.Builder().apply {
+                    moduleName = mainModule.findCompilerModuleName()
+                    sourceRoots = listOf(mainModule.kotlinSrc)
+                    javaSourceRoots = compilerConfiguration.javaSourceRoots.map { File(it) }.toList()
+                    jdkHome = compilerConfiguration.get(JVMConfigurationKeys.JDK_HOME)
+                    jvmTarget =
+                        (compilerConfiguration.get(JVMConfigurationKeys.JVM_TARGET) ?: JvmTarget.DEFAULT).description
+                    languageVersion = compilerConfiguration.languageVersionSettings.languageVersion.versionString
+                    apiVersion = compilerConfiguration.languageVersionSettings.apiVersion.versionString
+                    libraries = mainModule.regularDependencies.map { it.dependencyModule.outDir } +
+                        compilerConfiguration.jvmModularRoots
+                    friends = mainModule.friendDependencies.map { it.dependencyModule.outDir }
+                    projectBaseDir = testRoot
+                    classOutputDir = File(testRoot, "kspTest/classes/main")
+                    javaOutputDir = File(testRoot, "kspTest/src/main/java")
+                    kotlinOutputDir = File(testRoot, "kspTest/src/main/kotlin")
+                    resourceOutputDir = File(testRoot, "kspTest/src/main/resources")
+                    cachesDir = File(testRoot, "kspTest/kspCaches")
+                    outputBaseDir = File(testRoot, "kspTest")
+                    incremental = true
+                    experimentalPsiResolution = this@AbstractKSPAATest.experimentalPsiResolution
+                }.build()
+            }
+        }
         val exitCode = KotlinSymbolProcessing(kspConfig, listOf(testProcessor), CommandLineKSPLogger()).execute()
         if (exitCode != KotlinSymbolProcessing.ExitCode.OK) {
             return listOf("KSP FAILED WITH EXIT CODE: ${exitCode.name}") + testProcessor.toResult()

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -40,8 +40,10 @@ import org.jetbrains.kotlin.test.builders.TestConfigurationBuilder
 import org.jetbrains.kotlin.test.builders.testConfiguration
 import org.jetbrains.kotlin.test.compileJavaFiles
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
+import org.jetbrains.kotlin.test.directives.JsEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.JvmEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.LanguageSettingsDirectives
+import org.jetbrains.kotlin.test.directives.NativeEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.model.DependencyKind
 import org.jetbrains.kotlin.test.model.FrontendKind
 import org.jetbrains.kotlin.test.model.ResultingArtifact
@@ -155,6 +157,9 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
         useDirectives(*AbstractKotlinCompilerTest.defaultDirectiveContainers.toTypedArray())
         useDirectives(JvmEnvironmentConfigurationDirectives)
         useDirectives(TargetPlatformDirectives)
+        useDirectives(ConfigurationDirectives)
+        useDirectives(NativeEnvironmentConfigurationDirectives)
+        useDirectives(JsEnvironmentConfigurationDirectives)
 
         defaultDirectives {
             +JvmEnvironmentConfigurationDirectives.FULL_JDK

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -954,4 +954,10 @@ abstract class KSPUnitTestSuite(
     fun testTypeAnnotationClassReference() {
         runTest("$AA_PATH/typeAnnotationClassReference.kt")
     }
+
+    @TestMetadata("nativeTest.kt")
+    @Test
+    fun testNativeTest() {
+        runTest("$AA_PATH/nativeTest.kt")
+    }
 }

--- a/kotlin-analysis-api/testData/nativeTest.kt
+++ b/kotlin-analysis-api/testData/nativeTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TARGET_BACKEND: NATIVE
+// WITH_FIXED_TARGET: linux_x64
+// WITH_RUNTIME
+// TEST PROCESSOR: HelloProcessor
+// EXPECTED:
+// 1
+// testnative.NativeFoo
+// END
+
+// FILE: Anno.kt
+package test
+
+annotation class Anno
+
+// FILE: NativeFoo.kt
+
+package testnative
+
+import test.Anno
+
+@Anno
+class NativeFoo {
+    val bar: String = "Hello Native"
+}


### PR DESCRIPTION
Allows tests in `KSPUnitTestSuite` to be compiled with a different Kotlin backend. This allows KSP to test behaviors on different platforms the same way as JVM tests are conducted.

This is an experiment that we can roll back if it's not needed.