### PR TITLE
Remove outdated FIXME comment

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -628,7 +628,6 @@ class ResolverAAImpl(
         return KSNameImpl.getCached(name)
     }
 
-    // FIXME: correct implementation after incremental is ready.
     override fun getNewFiles(): Sequence<KSFile> {
         return resolutionStrategy.newKSFiles.asSequence()
     }


### PR DESCRIPTION
The comment was introduced in commit 744122550994b2d60523215cb1ba1368c368630f which was clearly the wrong implementation. The implementation seems to be fixed in commit e250af5e0bd131431ec86536bd61a33c3d58e189 but the comment was not removed.