### PR TITLE
Remove function-wide hash set from `effectiveJavaModifiers`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -245,9 +245,28 @@ class ResolverAAImpl(
         else -> null
     }
 
+    private fun KSAnnotation.resolvesTo(fqn: String): Boolean =
+        fqn.endsWith(shortName.asString()) &&
+            annotationType.resolve().declaration.qualifiedName?.asString() == fqn
+
+    private fun toJavaModifier(annotation: KSAnnotation): Modifier? = when {
+        annotation.resolvesTo(JVM_DEFAULT_ANNOTATION_FQN) -> Modifier.JAVA_DEFAULT
+        annotation.resolvesTo(JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN) -> Modifier.JAVA_DEFAULT
+        annotation.resolvesTo(JVM_STRICTFP_ANNOTATION_FQN) -> Modifier.JAVA_STRICT
+        annotation.resolvesTo(JVM_SYNCHRONIZED_ANNOTATION_FQN) -> Modifier.JAVA_SYNCHRONIZED
+        annotation.resolvesTo(JVM_TRANSIENT_ANNOTATION_FQN) -> Modifier.JAVA_TRANSIENT
+        annotation.resolvesTo(JVM_VOLATILE_ANNOTATION_FQN) -> Modifier.JAVA_VOLATILE
+        else -> null
+    }
+
+    private fun annotationsToJavaModifiers(annotations: Sequence<KSAnnotation>): Set<Modifier> =
+        annotations.fold(emptySet()) { acc, annotation ->
+            toJavaModifier(annotation)?.let { acc + it } ?: acc
+        }
+
     override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> = when (declaration.origin) {
         Origin.JAVA -> {
-           toJavaModifiers(declaration) + setOfNotNull(
+            toJavaModifiers(declaration) + setOfNotNull(
                 toVisibilityModifier(declaration),
                 if (declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE)
                     Modifier.ABSTRACT
@@ -270,19 +289,8 @@ class ResolverAAImpl(
                         modifiers.add(Modifier.JAVA_STATIC)
                 }
             }
+            modifiers.addAll(annotationsToJavaModifiers(declaration.annotations))
 
-            if (declaration.hasAnnotation(JVM_DEFAULT_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_DEFAULT)
-            if (declaration.hasAnnotation(JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_DEFAULT)
-            if (declaration.hasAnnotation(JVM_STRICTFP_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_STRICT)
-            if (declaration.hasAnnotation(JVM_SYNCHRONIZED_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_SYNCHRONIZED)
-            if (declaration.hasAnnotation(JVM_TRANSIENT_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_TRANSIENT)
-            if (declaration.hasAnnotation(JVM_VOLATILE_ANNOTATION_FQN))
-                modifiers.add(Modifier.JAVA_VOLATILE)
             when (declaration) {
                 is KSClassDeclaration -> {
                     if (declaration.isCompanionObject)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -42,6 +42,7 @@ import com.google.devtools.ksp.common.lazyMemoizedSequence
 import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.getDeclaredProperties
+import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.impl.symbol.java.KSAnnotationJavaImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.AbstractKSDeclarationImpl
 import com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationEnumEntryImpl
@@ -81,9 +82,6 @@ import com.google.devtools.ksp.impl.symbol.util.getVirtualFile
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.isOpen
-import com.google.devtools.ksp.isPrivate
-import com.google.devtools.ksp.isProtected
-import com.google.devtools.ksp.isPublic
 import com.google.devtools.ksp.isVisibleFrom
 import com.google.devtools.ksp.processing.KSBuiltIns
 import com.google.devtools.ksp.processing.KSPConfig
@@ -110,6 +108,7 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
+import com.google.devtools.ksp.symbol.Visibility
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiMethod
 import com.intellij.psi.impl.file.impl.JavaFileManager
@@ -149,7 +148,6 @@ import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.jvm.JvmPlatform
 import org.jetbrains.kotlin.psi.KtFile
-import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.org.objectweb.asm.Opcodes
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -232,16 +230,43 @@ class ResolverAAImpl(
         return KSTypeReferenceSyntheticImpl.getCached(type, null)
     }
 
-    private fun toJavaModifiers(declaration: KSDeclaration): Set<Modifier> =
-        HashSet(declaration.modifiers.filter { it in javaModifiers })
+    override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> = when (declaration.origin) {
+        Origin.JAVA, Origin.KOTLIN ->
+            existingJavaModifiers(declaration) +
+                kotlinAnnotationsToModifiersIfApplicableTo(declaration) +
+                setOfNotNull(
+                    visibilityModifier(declaration),
+                    abstractModifierIfApplicableTo(declaration),
+                    finalModifierIfApplicableTo(declaration),
+                    staticModifierIfApplicableTo(declaration),
+                )
 
-    private fun toVisibilityModifier(declaration: KSDeclaration): Modifier? = when {
+        Origin.JAVA_LIB, Origin.KOTLIN_LIB ->
+            existingJavaModifiers(declaration) +
+                annotationsToJavaModifiers(declaration.annotations) +
+                setOfNotNull(
+                    visibilityModifier(declaration),
+                    abstractModifierIfApplicableTo(declaration),
+                    transientModifierIfApplicableTo(declaration),
+                    volatileModifierIfApplicableTo(declaration),
+                    strictModifierIfApplicableTo(declaration),
+                    synchronizedModifierIfApplicableTo(declaration),
+                )
+
+        Origin.SYNTHETIC -> existingJavaModifiers(declaration)
+    }
+
+    private fun existingJavaModifiers(declaration: KSDeclaration): Set<Modifier> =
+        declaration.modifiers.filter { it in javaModifiers }.toSet()
+
+    private fun visibilityModifier(declaration: KSDeclaration): Modifier? = when (declaration.getVisibility()) {
+        // TODO: getVisibility might be inlined here or simplified here.
         // This is only needed by sources.
         // PUBLIC, PRIVATE, PROTECTED are already handled in descriptor based impls.
-        declaration.isPublic() -> Modifier.PUBLIC
-        declaration.isPrivate() -> Modifier.PRIVATE
-        declaration.isProtected() -> Modifier.PROTECTED
-        else -> null
+        Visibility.PUBLIC -> Modifier.PUBLIC
+        Visibility.PRIVATE -> Modifier.PRIVATE
+        Visibility.PROTECTED -> Modifier.PROTECTED
+        Visibility.INTERNAL, Visibility.LOCAL, Visibility.JAVA_PACKAGE -> null
     }
 
     private fun KSAnnotation.resolvesTo(fqn: String): Boolean =
@@ -264,78 +289,61 @@ class ResolverAAImpl(
             toJavaModifier(annotation)?.let { acc + it } ?: acc
         }
 
-    override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> = when (declaration.origin) {
-        Origin.JAVA -> when {
-            declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE ->
-                toJavaModifiers(declaration) + setOfNotNull(toVisibilityModifier(declaration), Modifier.ABSTRACT)
-
-            else ->
-                toJavaModifiers(declaration) + setOfNotNull(toVisibilityModifier(declaration))
-        }
-
-        Origin.KOTLIN -> {
-            val modifiers = HashSet(toJavaModifiers(declaration))
-            modifiers.addIfNotNull(toVisibilityModifier(declaration))
-            if (!declaration.isOpen())
-                modifiers.add(Modifier.FINAL)
-            (declaration as? KSClassDeclarationImpl)?.let {
-                analyze {
-                    if (
-                        it.ktClassOrObjectSymbol.staticMemberScope
-                            .declarations.contains(declaration.ktDeclarationSymbol)
-                    )
-                        modifiers.add(Modifier.JAVA_STATIC)
-                }
-            }
-            modifiers.addAll(annotationsToJavaModifiers(declaration.annotations))
-
-            when (declaration) {
-                is KSClassDeclaration -> {
-                    if (declaration.isCompanionObject)
-                        modifiers.add(Modifier.JAVA_STATIC)
-                    if (declaration.classKind == ClassKind.INTERFACE)
-                        modifiers.add(Modifier.ABSTRACT)
-                }
-
-                is KSPropertyDeclaration -> {
-                    if (declaration.isAbstract())
-                        modifiers.add(Modifier.ABSTRACT)
-                }
-
-                is KSFunctionDeclaration -> {
-                    if (declaration.isAbstract)
-                        modifiers.add(Modifier.ABSTRACT)
-                }
-            }
-            modifiers
-        }
-
-        Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
-            val modifiers = HashSet(toJavaModifiers(declaration))
-            modifiers.addIfNotNull(toVisibilityModifier(declaration))
-            modifiers.addAll(annotationsToJavaModifiers(declaration.annotations))
-            when (declaration) {
-                is KSPropertyDeclaration -> {
-                    if (declaration.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)
-                        modifiers.add(Modifier.JAVA_TRANSIENT)
-                    if (declaration.jvmAccessFlag and Opcodes.ACC_VOLATILE != 0)
-                        modifiers.add(Modifier.JAVA_VOLATILE)
-                }
-
-                is KSFunctionDeclaration -> {
-                    if (declaration.jvmAccessFlag and Opcodes.ACC_STRICT != 0)
-                        modifiers.add(Modifier.JAVA_STRICT)
-                    if (declaration.jvmAccessFlag and Opcodes.ACC_SYNCHRONIZED != 0)
-                        modifiers.add(Modifier.JAVA_SYNCHRONIZED)
-                }
-            }
-            modifiers
-        }
-
-        else -> toJavaModifiers(declaration)
+    private fun abstractModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        is KSClassDeclaration if declaration.classKind == ClassKind.INTERFACE -> Modifier.ABSTRACT
+        is KSFunctionDeclaration if declaration.isAbstract -> Modifier.ABSTRACT
+        is KSPropertyDeclaration if declaration.isAbstract() -> Modifier.ABSTRACT
+        else -> null
     }
 
+    private fun finalModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration.origin) {
+        Origin.KOTLIN if !declaration.isOpen() -> Modifier.FINAL
+        else -> null
+    }
+
+    private fun staticModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        // TODO: Remove this case, see https://github.com/google/ksp/issues/3125
+        is KSClassDeclaration if declaration.isCompanionObject -> Modifier.JAVA_STATIC
+        is KSClassDeclarationImpl -> analyze {
+            val isInStaticMemberScope = declaration.ktClassOrObjectSymbol.staticMemberScope
+                .declarations.contains(declaration.ktDeclarationSymbol)
+            if (isInStaticMemberScope)
+                Modifier.JAVA_STATIC
+            else
+                null
+        }
+
+        else -> null
+    }
+
+    private fun transientModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        is KSPropertyDeclaration if declaration.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0 -> Modifier.JAVA_TRANSIENT
+        else -> null
+    }
+
+    private fun volatileModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        is KSPropertyDeclaration if declaration.jvmAccessFlag and Opcodes.ACC_VOLATILE != 0 -> Modifier.JAVA_VOLATILE
+        else -> null
+    }
+
+    private fun strictModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        is KSFunctionDeclaration if declaration.jvmAccessFlag and Opcodes.ACC_STRICT != 0 -> Modifier.JAVA_STRICT
+        else -> null
+    }
+
+    private fun synchronizedModifierIfApplicableTo(declaration: KSDeclaration): Modifier? = when (declaration) {
+        is KSFunctionDeclaration if declaration.jvmAccessFlag and Opcodes.ACC_SYNCHRONIZED != 0 -> Modifier.JAVA_SYNCHRONIZED
+        else -> null
+    }
+
+    private fun kotlinAnnotationsToModifiersIfApplicableTo(declaration: KSDeclaration): Set<Modifier> =
+        when (declaration.origin) {
+            Origin.KOTLIN -> annotationsToJavaModifiers(declaration.annotations)
+            else -> emptySet()
+        }
+
     internal val KSPropertyDeclaration.jvmAccessFlag: Int
+        // TODO: Might be a good idea to cache this result? Let's hold off until we can measure it.
         get() = when (origin) {
             Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
                 val fileManager = instance.javaFileManager
@@ -353,6 +361,7 @@ class ResolverAAImpl(
         }
 
     internal val KSFunctionDeclaration.jvmAccessFlag: Int
+        // TODO: Might be a good idea to cache this result? Let's hold off until we can measure it.
         get() = when (origin) {
             Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
                 val jvmDesc = mapToJvmSignatureInternal(this)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -78,7 +78,6 @@ import com.google.devtools.ksp.impl.symbol.util.DeclarationOrdering
 import com.google.devtools.ksp.impl.symbol.util.extractThrowsFromClassFile
 import com.google.devtools.ksp.impl.symbol.util.getFileContent
 import com.google.devtools.ksp.impl.symbol.util.getVirtualFile
-import com.google.devtools.ksp.impl.symbol.util.hasAnnotation
 import com.google.devtools.ksp.isAbstract
 import com.google.devtools.ksp.isConstructor
 import com.google.devtools.ksp.isOpen
@@ -266,14 +265,12 @@ class ResolverAAImpl(
         }
 
     override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> = when (declaration.origin) {
-        Origin.JAVA -> {
-            toJavaModifiers(declaration) + setOfNotNull(
-                toVisibilityModifier(declaration),
-                if (declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE)
-                    Modifier.ABSTRACT
-                else
-                    null
-            )
+        Origin.JAVA -> when {
+            declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE ->
+                toJavaModifiers(declaration) + setOfNotNull(toVisibilityModifier(declaration), Modifier.ABSTRACT)
+
+            else ->
+                toJavaModifiers(declaration) + setOfNotNull(toVisibilityModifier(declaration))
         }
 
         Origin.KOTLIN -> {

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -256,6 +256,7 @@ class ResolverAAImpl(
         annotation.resolvesTo(JVM_SYNCHRONIZED_ANNOTATION_FQN) -> Modifier.JAVA_SYNCHRONIZED
         annotation.resolvesTo(JVM_TRANSIENT_ANNOTATION_FQN) -> Modifier.JAVA_TRANSIENT
         annotation.resolvesTo(JVM_VOLATILE_ANNOTATION_FQN) -> Modifier.JAVA_VOLATILE
+        annotation.resolvesTo(JVM_STATIC_ANNOTATION_FQN) -> Modifier.JAVA_STATIC
         else -> null
     }
 
@@ -315,9 +316,7 @@ class ResolverAAImpl(
         Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
             val modifiers = HashSet(toJavaModifiers(declaration))
             modifiers.addIfNotNull(toVisibilityModifier(declaration))
-            if (declaration.hasAnnotation(JVM_STATIC_ANNOTATION_FQN)) {
-                modifiers.add(Modifier.JAVA_STATIC)
-            }
+            modifiers.addAll(annotationsToJavaModifiers(declaration.annotations))
             when (declaration) {
                 is KSPropertyDeclaration -> {
                     if (declaration.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -150,6 +150,7 @@ import org.jetbrains.kotlin.name.FqNameUnsafe
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.jvm.JvmPlatform
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.utils.addIfNotNull
 import org.jetbrains.org.objectweb.asm.Opcodes
 
 @Suppress("MemberVisibilityCanBePrivate")
@@ -232,97 +233,102 @@ class ResolverAAImpl(
         return KSTypeReferenceSyntheticImpl.getCached(type, null)
     }
 
-    override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> {
-        val modifiers = HashSet<Modifier>(declaration.modifiers.filter { it in javaModifiers })
+    private fun toJavaModifiers(declaration: KSDeclaration): Set<Modifier> =
+        HashSet(declaration.modifiers.filter { it in javaModifiers })
 
+    private fun toVisibilityModifier(declaration: KSDeclaration): Modifier? = when {
         // This is only needed by sources.
         // PUBLIC, PRIVATE, PROTECTED are already handled in descriptor based impls.
-        fun addVisibilityModifiers() {
-            when {
-                declaration.isPublic() -> modifiers.add(Modifier.PUBLIC)
-                declaration.isPrivate() -> modifiers.add(Modifier.PRIVATE)
-                declaration.isProtected() -> modifiers.add(Modifier.PROTECTED)
-            }
-        }
+        declaration.isPublic() -> Modifier.PUBLIC
+        declaration.isPrivate() -> Modifier.PRIVATE
+        declaration.isProtected() -> Modifier.PROTECTED
+        else -> null
+    }
 
-        when (declaration.origin) {
-            Origin.JAVA -> {
-                addVisibilityModifiers()
+    override fun effectiveJavaModifiers(declaration: KSDeclaration): Set<Modifier> = when (declaration.origin) {
+        Origin.JAVA -> {
+           toJavaModifiers(declaration) + setOfNotNull(
+                toVisibilityModifier(declaration),
                 if (declaration is KSClassDeclaration && declaration.classKind == ClassKind.INTERFACE)
-                    modifiers.add(Modifier.ABSTRACT)
-            }
-
-            Origin.KOTLIN -> {
-                addVisibilityModifiers()
-                if (!declaration.isOpen())
-                    modifiers.add(Modifier.FINAL)
-                (declaration as? KSClassDeclarationImpl)?.let {
-                    analyze {
-                        if (
-                            it.ktClassOrObjectSymbol.staticMemberScope
-                                .declarations.contains(declaration.ktDeclarationSymbol)
-                        )
-                            modifiers.add(Modifier.JAVA_STATIC)
-                    }
-                }
-
-                if (declaration.hasAnnotation(JVM_DEFAULT_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_DEFAULT)
-                if (declaration.hasAnnotation(JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_DEFAULT)
-                if (declaration.hasAnnotation(JVM_STRICTFP_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_STRICT)
-                if (declaration.hasAnnotation(JVM_SYNCHRONIZED_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_SYNCHRONIZED)
-                if (declaration.hasAnnotation(JVM_TRANSIENT_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_TRANSIENT)
-                if (declaration.hasAnnotation(JVM_VOLATILE_ANNOTATION_FQN))
-                    modifiers.add(Modifier.JAVA_VOLATILE)
-                when (declaration) {
-                    is KSClassDeclaration -> {
-                        if (declaration.isCompanionObject)
-                            modifiers.add(Modifier.JAVA_STATIC)
-                        if (declaration.classKind == ClassKind.INTERFACE)
-                            modifiers.add(Modifier.ABSTRACT)
-                    }
-
-                    is KSPropertyDeclaration -> {
-                        if (declaration.isAbstract())
-                            modifiers.add(Modifier.ABSTRACT)
-                    }
-
-                    is KSFunctionDeclaration -> {
-                        if (declaration.isAbstract)
-                            modifiers.add(Modifier.ABSTRACT)
-                    }
-                }
-            }
-
-            Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
-                if (declaration.hasAnnotation(JVM_STATIC_ANNOTATION_FQN)) {
-                    modifiers.add(Modifier.JAVA_STATIC)
-                }
-                addVisibilityModifiers()
-                when (declaration) {
-                    is KSPropertyDeclaration -> {
-                        if (declaration.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)
-                            modifiers.add(Modifier.JAVA_TRANSIENT)
-                        if (declaration.jvmAccessFlag and Opcodes.ACC_VOLATILE != 0)
-                            modifiers.add(Modifier.JAVA_VOLATILE)
-                    }
-
-                    is KSFunctionDeclaration -> {
-                        if (declaration.jvmAccessFlag and Opcodes.ACC_STRICT != 0)
-                            modifiers.add(Modifier.JAVA_STRICT)
-                        if (declaration.jvmAccessFlag and Opcodes.ACC_SYNCHRONIZED != 0)
-                            modifiers.add(Modifier.JAVA_SYNCHRONIZED)
-                    }
-                }
-            }
-
-            else -> Unit
+                    Modifier.ABSTRACT
+                else
+                    null
+            )
         }
-        return modifiers
+
+        Origin.KOTLIN -> {
+            val modifiers = HashSet(toJavaModifiers(declaration))
+            modifiers.addIfNotNull(toVisibilityModifier(declaration))
+            if (!declaration.isOpen())
+                modifiers.add(Modifier.FINAL)
+            (declaration as? KSClassDeclarationImpl)?.let {
+                analyze {
+                    if (
+                        it.ktClassOrObjectSymbol.staticMemberScope
+                            .declarations.contains(declaration.ktDeclarationSymbol)
+                    )
+                        modifiers.add(Modifier.JAVA_STATIC)
+                }
+            }
+
+            if (declaration.hasAnnotation(JVM_DEFAULT_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_DEFAULT)
+            if (declaration.hasAnnotation(JVM_DEFAULT_WITHOUT_COMPATIBILITY_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_DEFAULT)
+            if (declaration.hasAnnotation(JVM_STRICTFP_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_STRICT)
+            if (declaration.hasAnnotation(JVM_SYNCHRONIZED_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_SYNCHRONIZED)
+            if (declaration.hasAnnotation(JVM_TRANSIENT_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_TRANSIENT)
+            if (declaration.hasAnnotation(JVM_VOLATILE_ANNOTATION_FQN))
+                modifiers.add(Modifier.JAVA_VOLATILE)
+            when (declaration) {
+                is KSClassDeclaration -> {
+                    if (declaration.isCompanionObject)
+                        modifiers.add(Modifier.JAVA_STATIC)
+                    if (declaration.classKind == ClassKind.INTERFACE)
+                        modifiers.add(Modifier.ABSTRACT)
+                }
+
+                is KSPropertyDeclaration -> {
+                    if (declaration.isAbstract())
+                        modifiers.add(Modifier.ABSTRACT)
+                }
+
+                is KSFunctionDeclaration -> {
+                    if (declaration.isAbstract)
+                        modifiers.add(Modifier.ABSTRACT)
+                }
+            }
+            modifiers
+        }
+
+        Origin.KOTLIN_LIB, Origin.JAVA_LIB -> {
+            val modifiers = HashSet(toJavaModifiers(declaration))
+            modifiers.addIfNotNull(toVisibilityModifier(declaration))
+            if (declaration.hasAnnotation(JVM_STATIC_ANNOTATION_FQN)) {
+                modifiers.add(Modifier.JAVA_STATIC)
+            }
+            when (declaration) {
+                is KSPropertyDeclaration -> {
+                    if (declaration.jvmAccessFlag and Opcodes.ACC_TRANSIENT != 0)
+                        modifiers.add(Modifier.JAVA_TRANSIENT)
+                    if (declaration.jvmAccessFlag and Opcodes.ACC_VOLATILE != 0)
+                        modifiers.add(Modifier.JAVA_VOLATILE)
+                }
+
+                is KSFunctionDeclaration -> {
+                    if (declaration.jvmAccessFlag and Opcodes.ACC_STRICT != 0)
+                        modifiers.add(Modifier.JAVA_STRICT)
+                    if (declaration.jvmAccessFlag and Opcodes.ACC_SYNCHRONIZED != 0)
+                        modifiers.add(Modifier.JAVA_SYNCHRONIZED)
+                }
+            }
+            modifiers
+        }
+
+        else -> toJavaModifiers(declaration)
     }
 
     internal val KSPropertyDeclaration.jvmAccessFlag: Int

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -485,11 +485,11 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/javaModifiers.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/3124", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3124", BugState.FIXED)
     @TestMetadata("javaModifiersJvmStaticAnnotation.kt")
     @Test
     fun testJavaModifiersJvmStaticAnnotation() {
-        runFailingTest("$AA_PATH/javaModifiersJvmStaticAnnotation.kt")
+        runTest("$AA_PATH/javaModifiersJvmStaticAnnotation.kt")
     }
 
     @TestMetadata("javaNonNullTypes.kt")

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -86,10 +86,10 @@
 // OuterKotlinClass.Companion.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterKotlinClass.Companion.companionField: CONST : FINAL PUBLIC
 // OuterKotlinClass.Companion.companionMethod: : FINAL PUBLIC
-// OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL PUBLIC
+// OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.customJvmStaticCompanionMethod: : FINAL PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.privateCompanionField: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion.privateCompanionMethod: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion: : FINAL JAVA_STATIC PUBLIC


### PR DESCRIPTION
This refactoring makes each branch of the when-expression mutually exclusive instead of mutating a shared hash map. This is done to make it easier to support upcoming backing field requirements. I might be a little slower due to joining immutable sets, but it makes it easier to make it correct. However, it's not clear if this is on a hot path so the correctness is preferred. I know this is a somewhat major change to the function internals, so feel free to request changes or reject the PR.

Related to https://github.com/google/ksp/pull/3110
Related to https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2873
Depends on https://github.com/google/ksp/pull/3126
Depends on https://github.com/google/ksp/pull/3130
Closes https://github.com/google/ksp/issues/3124