### PR TITLE
Move five kotlin-analysis-api dependencies to the version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,9 +21,7 @@ aa-jdom = "2.0.6"
 aa-coroutines = "1.10.2"
 aa-collections-immutable = "0.3.4"
 aa-caffeine = "2.9.3"
-aa-javaslang = "2.0.6"
 aa-javax-inject = "1"
-aa-kotlin-reflect = "1.6.10"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
@@ -53,9 +51,7 @@ aa-log4j = { module = "org.jetbrains.intellij.deps:log4j", version.ref = "aa-log
 aa-jdom = { module = "org.jetbrains.intellij.deps:jdom", version.ref = "aa-jdom" }
 aa-collectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "aa-collections-immutable" }
 aa-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "aa-caffeine" }
-aa-javaslang = { module = "io.javaslang:javaslang", version.ref = "aa-javaslang" }
 aa-javaxInject = { module = "javax.inject:javax.inject", version.ref = "aa-javax-inject" }
-aa-kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "aa-kotlin-reflect" }
 
 [plugins]
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,11 @@ aa-trove4j = "1.0.20200330"
 aa-log4j = "1.2.17.2"
 aa-jdom = "2.0.6"
 aa-coroutines = "1.10.2"
+aa-collections-immutable = "0.3.4"
+aa-caffeine = "2.9.3"
+aa-javaslang = "2.0.6"
+aa-javax-inject = "1"
+aa-kotlin-reflect = "1.6.10"
 
 [libraries]
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-base" }
@@ -46,6 +51,11 @@ aa-jnaPlatform = { module = "org.jetbrains.intellij.deps.jna:jna-platform", vers
 aa-trove4j = { module = "org.jetbrains.intellij.deps:trove4j", version.ref = "aa-trove4j" }
 aa-log4j = { module = "org.jetbrains.intellij.deps:log4j", version.ref = "aa-log4j" }
 aa-jdom = { module = "org.jetbrains.intellij.deps:jdom", version.ref = "aa-jdom" }
+aa-collectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "aa-collections-immutable" }
+aa-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "aa-caffeine" }
+aa-javaslang = { module = "io.javaslang:javaslang", version.ref = "aa-javaslang" }
+aa-javaxInject = { module = "javax.inject:javax.inject", version.ref = "aa-javax-inject" }
+aa-kotlinReflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "aa-kotlin-reflect" }
 
 [plugins]
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -157,7 +157,7 @@ dependencies {
             depSourceJars("$it:$aaKotlinBaseVersion:sources") { isTransitive = false }
         }
 
-    implementation("org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm:0.3.4")
+    implementation(libs.aa.collectionsImmutable)
     implementation(libs.kotlinx.serialization.json)
     compileOnly(kotlin("stdlib", aaKotlinBaseVersion))
 
@@ -166,16 +166,16 @@ dependencies {
     implementation(libs.aa.asm)
     implementation(libs.aa.stax2) { isTransitive = false }
     implementation(libs.aa.aalto.xml) { isTransitive = false }
-    implementation("com.github.ben-manes.caffeine:caffeine:2.9.3")
+    implementation(libs.aa.caffeine)
     implementation(libs.aa.jna) { isTransitive = false }
     implementation(libs.aa.jnaPlatform) { isTransitive = false }
     implementation(libs.aa.trove4j) { isTransitive = false }
     originalLog4j(libs.aa.log4j) { isTransitive = false }
     implementation(files(filteredLog4j))
     implementation(libs.aa.jdom) { isTransitive = false }
-    implementation("io.javaslang:javaslang:2.0.6")
-    implementation("javax.inject:javax.inject:1")
-    implementation("org.jetbrains.kotlin:kotlin-reflect:1.6.10")
+    implementation(libs.aa.javaslang)
+    implementation(libs.aa.javaxInject)
+    implementation(libs.aa.kotlinReflect)
     implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
     compileOnly(libs.kotlinx.coroutines.coreJvm)
     compileOnly(libs.kotlinx.coroutines.core)

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -173,9 +173,7 @@ dependencies {
     originalLog4j(libs.aa.log4j) { isTransitive = false }
     implementation(files(filteredLog4j))
     implementation(libs.aa.jdom) { isTransitive = false }
-    implementation(libs.aa.javaslang)
     implementation(libs.aa.javaxInject)
-    implementation(libs.aa.kotlinReflect)
     implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
     compileOnly(libs.kotlinx.coroutines.coreJvm)
     compileOnly(libs.kotlinx.coroutines.core)


### PR DESCRIPTION
Continuing the inline build file versions for #2968, following #3105.

Five hardcoded dependency versions in kotlin-analysis-api move to catalog accessors: kotlinx-collections-immutable, caffeine, javaslang, javax.inject, and kotlin-reflect.

Verified that resolution is unchanged: ./gradlew :kotlin-analysis-api:dependencies output for the compile and runtime classpaths is identical before and after this commit, 156 lines compared. :kotlin-analysis-api:compileKotlin passes.