### PR TITLE
  Fix effective Java modifiers for @JvmStatic members

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/ResolverAAImpl.kt
@@ -278,10 +278,10 @@ class ResolverAAImpl(
                     modifiers.add(Modifier.JAVA_TRANSIENT)
                 if (declaration.hasAnnotation(JVM_VOLATILE_ANNOTATION_FQN))
                     modifiers.add(Modifier.JAVA_VOLATILE)
+                if (declaration.hasAnnotation(JVM_STATIC_ANNOTATION_FQN))
+                    modifiers.add(Modifier.JAVA_STATIC)
                 when (declaration) {
                     is KSClassDeclaration -> {
-                        if (declaration.isCompanionObject)
-                            modifiers.add(Modifier.JAVA_STATIC)
                         if (declaration.classKind == ClassKind.INTERFACE)
                             modifiers.add(Modifier.ABSTRACT)
                     }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -485,11 +485,11 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/javaModifiers.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/3124", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3124", BugState.FIXED)
     @TestMetadata("javaModifiersJvmStaticAnnotation.kt")
     @Test
     fun testJavaModifiersJvmStaticAnnotation() {
-        runFailingTest("$AA_PATH/javaModifiersJvmStaticAnnotation.kt")
+        runTest("$AA_PATH/javaModifiersJvmStaticAnnotation.kt")
     }
 
     @TestMetadata("javaNonNullTypes.kt")

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -86,13 +86,13 @@
 // OuterKotlinClass.Companion.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterKotlinClass.Companion.companionField: CONST : FINAL PUBLIC
 // OuterKotlinClass.Companion.companionMethod: : FINAL PUBLIC
-// OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL PUBLIC
+// OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.customJvmStaticCompanionMethod: : FINAL PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL PUBLIC
-// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
+// OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.privateCompanionField: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion.privateCompanionMethod: PRIVATE : FINAL PRIVATE
-// OuterKotlinClass.Companion: : FINAL JAVA_STATIC PUBLIC
+// OuterKotlinClass.Companion: : FINAL PUBLIC
 // OuterKotlinClass.InnerKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterKotlinClass.InnerKotlinClass: INNER : FINAL PUBLIC
 // OuterKotlinClass.NestedKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC

--- a/kotlin-analysis-api/testData/javaModifiersJvmStaticAnnotation.kt
+++ b/kotlin-analysis-api/testData/javaModifiersJvmStaticAnnotation.kt
@@ -18,8 +18,8 @@
 // TEST PROCESSOR: JavaModifierJvmStaticAnnotationProcessor
 // PROCESSOR INPUT: A
 // EXPECTED:
-// A.Companion.bar : PUBLIC, JAVA_STATIC, FINAL
-// A.Companion.foo : PUBLIC, JAVA_STATIC, FINAL
+// A.Companion.bar : PUBLIC, FINAL, JAVA_STATIC
+// A.Companion.foo : PUBLIC, FINAL, JAVA_STATIC
 // END
 
 // FILE: A.kt


### PR DESCRIPTION
  ## Summary

  `Resolver.effectiveJavaModifiers()` reports the Java modifiers a Kotlin
  declaration exposes on the JVM. Two bugs in its `Origin.KOTLIN` branch:

  - **#3124** — `@JvmStatic` members were missing `JAVA_STATIC`. The branch
    already mapped `@JvmDefault`/`@JvmStrictfp`/`@JvmSynchronized`/
    `@JvmTransient`/`@JvmVolatile` to their Java modifiers, but never checked
    for `@JvmStatic`, so companion members annotated with it came back without
    `JAVA_STATIC`.
  - **#3125** — companion objects were incorrectly marked `JAVA_STATIC`. The
    branch added `JAVA_STATIC` to any `KSClassDeclaration` whose
    `isCompanionObject` was true. The companion class itself is *not* static on
    the JVM — only its `@JvmStatic` members are.

  ## Changes

  - Add a `JVM_STATIC_ANNOTATION_FQN` check in the `Origin.KOTLIN` branch that
    appends `Modifier.JAVA_STATIC`, mirroring the `KOTLIN_LIB`/`JAVA_LIB` branch.
  - Remove the `isCompanionObject` special case. Statically accessible nested
    declarations remain covered by the `staticMemberScope` check above.

  ## Tests

  - `javaModifiersJvmStaticAnnotation`: flip from `runFailingTest`
    (`BugState.OPEN`) to `runTest` (`BugState.FIXED`); expected output updated to
    the enum ordinal ordering `PUBLIC, FINAL, JAVA_STATIC`.
  - `javaModifiers`: `@JvmStatic` companion members now report
    `FINAL JAVA_STATIC PUBLIC`; the companion object reports `FINAL PUBLIC`.

  Verified with `:kotlin-analysis-api:test` — 286 passed, 0 failed, 23 skipped.

  Closes #3124, closes #3125.