### PR TITLE
Parameterize test processors with feature toggle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,14 +55,19 @@ The form of the test itself is flexible as long as the logic is covered.
 > [!NOTE]
 > The `test-utils` directory is deprecated. Unit tests should be placed in `kotlin-analysis-api`.
 
-Here are some [sample test processors](compiler-plugin/src/test/kotlin/com/google/devtools/ksp/processor) for your reference.
+Here are some [sample test processors](kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor) for your reference.
 
 #### Steps for writing a test
 * KSP needs to be built with JDK 11+, because of test dependencies.
 * Create a test processor under the sample processor folder.
 * Write your logic by overriding corresponding functions. 
     * Test is performed by running test processor and getting a collection of test results in the form of `List<String>`.
-    * Make sure you override `toResult()` function to collect test results. 
+    * [required] Ensure your test processor is in the package `com.google.devtools.ksp.processor`.
+    * [required] The test processor must extend the `AbstractTestProcessor` class.
+    * [required] Make sure you override `toResult()` function to collect test results.
+    * [required] The test processor must have a constructor parameter of type boolean.
+      Specifically, it must override the `enableNewFeatures` property in `AbstractTestProcessor`.
+      In other words, the constructor parameter list must be as follows: `class MyProcessor(override val enableNewFeatures: Boolean)`.
     * Leverage visitors for easy traversal of the test case.
     * To help with easy testing, you can create an annotation for test, and annotate the specific part of the code to avoid doing excess filtering when traveling along the program.
 * Write your test case to work with the test processor.
@@ -74,6 +79,7 @@ Here are some [sample test processors](compiler-plugin/src/test/kotlin/com/googl
         * [optional] Add `// PROCESSOR INPUT: <input/predicate>` to specify inputs or predicates for the test processor (e.g. `// PROCESSOR INPUT: Anno` or `// PROCESSOR INPUT: kotlin.annotation.Retention, kotlin.annotation.Target`, as in [`aliasedAnnotation.kt`](kotlin-analysis-api/testData/getSymbolsWithAnnotation/aliasedAnnotation.kt)).
           Note: for a processor to accept input, its constructor must have a single `List<String>` parameter.
           This is a handy way of writing a parametric test processor.
+          The `List<String>` parameter list must come before the `enableNewFeatures` property.
         * Immediately after the test processor line(s), start your expected result lines. Every line should start with `// ` (with a space after `//`).
         * Add `// END` to indicate the end of expected test results.
         * Then follows the virtual files section till the end of the test file.
@@ -83,7 +89,9 @@ Here are some [sample test processors](compiler-plugin/src/test/kotlin/com/googl
     * Annotate the test with `@Bug` and `@BugState`.
     * The `@Bug` annotation requires a link to an open or existing GitHub issue (e.g., `@Bug("https://github.com/google/ksp/issues/<issue_number>", BugState.OPEN)`).
     * Use the `@Negative` marker annotation if applicable.
-* Run generated tests with `:compiler-plugin:test` and `:kotlin-analysis-api:test` gradle tasks.
+* Run generated tests with the `:kotlin-analysis-api:test` gradle task.
     * This will execute all tests in the KSP test suite. To run your test only, specify the test name with 
     `--tests "com.google.devtools.ksp.test.KSPUnitTestSuite.<name of your test>"`
     * Make sure your change is not breaking any existing test as well :).
+* [optional] You can run the `./gradlew check` task as well to run all tests.
+    * This task runs all integration tests as well, so it might take a while to complete.

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueTypeProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class AnnotationArrayValueTypeProcessor : AbstractTestProcessor() {
+class AnnotationArrayValueTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/AnnotationsInDependenciesProcessor.kt
@@ -35,7 +35,7 @@ import com.google.devtools.ksp.symbol.Location
 import com.google.devtools.ksp.symbol.NonExistLocation
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
+class AnnotationsInDependenciesProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val results = mutableListOf<String>()
     override fun toResult() = results
 
@@ -69,7 +69,7 @@ class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
     private fun collectAnnotations(resolver: Resolver, qName: String): Map<KSAnnotated, List<KSAnnotation>> {
         val output = mutableMapOf<KSAnnotated, List<KSAnnotation>>()
         resolver.getClassDeclarationByName(qName)?.accept(
-            AnnotationVisitor(),
+            AnnotationVisitor(enableNewFeatures),
             output
         )
         return output
@@ -83,6 +83,7 @@ class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
             is KSValueParameter -> name?.let {
                 "parameter ${it.asString()} ${this.location.lineNumber}"
             } ?: "no-name-value-parameter ${this.location.lineNumber}"
+
             is KSPropertyGetter -> "getter of ${receiver.toSignature()}" // lineNumber handled by recursive call
             is KSPropertySetter -> "setter of ${receiver.toSignature()}" // lineNumber handled by recursive call
             is KSBackingField -> "field of ${property.toSignature()}" // lineNumber handled by recursive call
@@ -108,7 +109,8 @@ class AnnotationsInDependenciesProcessor : AbstractTestProcessor() {
             is NonExistLocation -> "<no line>"
         }
 
-    class AnnotationVisitor : KSTopDownVisitor<MutableMap<KSAnnotated, List<KSAnnotation>>, Unit>() {
+    class AnnotationVisitor(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableMap<KSAnnotated, List<KSAnnotation>>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableMap<KSAnnotated, List<KSAnnotation>>) {
         }
 

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/DefaultKClassValueProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/DefaultKClassValueProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.KSTypeImpl
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class DefaultKClassValueProcessor : AbstractTestProcessor() {
+class DefaultKClassValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/EnumModifierProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/EnumModifierProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class EnumModifierProcessor(val declarationNames: List<String>) : AbstractTestProcessor() {
+class EnumModifierProcessor(val declarationNames: List<String>, override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val result: MutableList<String> = mutableListOf()
 
     override fun toResult(): List<String> = result.sorted()

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/EquivalentJavaWildcardProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/EquivalentJavaWildcardProcessor.kt
@@ -25,14 +25,14 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class EquivalentJavaWildcardProcessor : AbstractTestProcessor() {
+open class EquivalentJavaWildcardProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     @OptIn(KspExperimental::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
             resolver.getNewFiles().forEach {
-                it.accept(RefVisitor(results, resolver), "")
+                it.accept(RefVisitor(results, resolver, enableNewFeatures), "")
             }
         }
 
@@ -43,10 +43,8 @@ open class EquivalentJavaWildcardProcessor : AbstractTestProcessor() {
         return results
     }
 
-    private class RefVisitor(
-        val results: MutableList<String>,
-        val resolver: Resolver
-    ) : KSTopDownVisitor<String, Unit>() {
+    private class RefVisitor(val results: MutableList<String>, val resolver: Resolver, enableNewFeatures: Boolean) :
+        KSTopDownVisitor<String, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: String) = Unit
 
         private fun KSTypeReference.pretty(): String {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ExplicitBackingFieldsSubtypingProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ExplicitBackingFieldsSubtypingProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 
-class ExplicitBackingFieldsSubtypingProcessor : AbstractTestProcessor() {
+class ExplicitBackingFieldsSubtypingProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetDeclarationsProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetDeclarationsProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class GetDeclarationsProcessor(val declarationNames: List<String>) : AbstractTestProcessor() {
+class GetDeclarationsProcessor(val declarationNames: List<String>, override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 
     override fun toResult(): List<String> = result

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetSymbolsWithAnnotationProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 
-class GetSymbolsWithAnnotationProcessor(val annotationNames: List<String>) : AbstractTestProcessor() {
+class GetSymbolsWithAnnotationProcessor(val annotationNames: List<String>, override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/HelloProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/HelloProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class HelloProcessor : AbstractTestProcessor() {
+class HelloProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val visitor = HelloVisitor()
 
@@ -35,7 +35,7 @@ class HelloProcessor : AbstractTestProcessor() {
         return results.sorted()
     }
 
-    inner class HelloVisitor : KSVisitorVoid() {
+    inner class HelloVisitor : KSVisitorVoid(enableNewFeatures) {
         override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
             results.add(classDeclaration.qualifiedName?.asString() ?: "<error>")
         }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ImplicitElementProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ImplicitElementProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class ImplicitElementProcessor : AbstractTestProcessor() {
+class ImplicitElementProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result: MutableList<String> = mutableListOf()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaBackingFieldProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaBackingFieldProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class JavaBackingFieldProcessor : AbstractTestProcessor() {
+class JavaBackingFieldProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaModifierJvmStaticAnnotationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaModifierJvmStaticAnnotationProcessor.kt
@@ -23,7 +23,8 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class JavaModifierJvmStaticAnnotationProcessor(val classNames: List<String>) : AbstractTestProcessor() {
+class JavaModifierJvmStaticAnnotationProcessor(val classNames: List<String>, override val enableNewFeatures: Boolean) :
+    AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaModifierProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class JavaModifierProcessor : AbstractTestProcessor() {
+class JavaModifierProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -59,7 +59,7 @@ class JavaModifierProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    inner class ModifierVisitor(val resolver: Resolver) : KSTopDownVisitor<Unit, Unit>() {
+    inner class ModifierVisitor(val resolver: Resolver) : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: Unit) {
         }
 

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaWildcard2Processor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/JavaWildcard2Processor.kt
@@ -22,14 +22,14 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class JavaWildcard2Processor : AbstractTestProcessor() {
+open class JavaWildcard2Processor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     @OptIn(KspExperimental::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
             resolver.getNewFiles().forEach {
-                it.accept(RefVisitor(results, resolver), "")
+                it.accept(RefVisitor(results, resolver, enableNewFeatures), "")
             }
         }
 
@@ -40,10 +40,8 @@ open class JavaWildcard2Processor : AbstractTestProcessor() {
         return results
     }
 
-    private class RefVisitor(
-        val results: MutableList<String>,
-        val resolver: Resolver
-    ) : KSTopDownVisitor<String, Unit>() {
+    private class RefVisitor(val results: MutableList<String>, val resolver: Resolver, enableNewFeatures: Boolean) :
+        KSTopDownVisitor<String, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: String) = Unit
 
         private fun KSTypeReference.pretty(): String {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/NativePackageDeclarationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/NativePackageDeclarationProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class NativePackageDeclarationProcessor(val packageNames: List<String>) : AbstractTestProcessor() {
+class NativePackageDeclarationProcessor(val packageNames: List<String>, override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/NestedAnnotationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/NestedAnnotationProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class NestedAnnotationProcessor : AbstractTestProcessor() {
+class NestedAnnotationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ParentOfJavaMethodOverridingKotlinPropertyProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ParentOfJavaMethodOverridingKotlinPropertyProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class ParentOfJavaMethodOverridingKotlinPropertyProcessor : AbstractTestProcessor() {
+class ParentOfJavaMethodOverridingKotlinPropertyProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaAsMemberOfProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class RecordJavaAsMemberOfProcessor : AbstractTestProcessor() {
+class RecordJavaAsMemberOfProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaGetAllMembersProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class RecordJavaGetAllMembersProcessor : AbstractTestProcessor() {
+class RecordJavaGetAllMembersProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaOverridesProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class RecordJavaOverridesProcessor : AbstractTestProcessor() {
+class RecordJavaOverridesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.validate
 
-class RecordJavaProcessor : AbstractTestProcessor() {
+class RecordJavaProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/RecordJavaSupertypesProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.impl.ResolverAAImpl
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class RecordJavaSupertypesProcessor : AbstractTestProcessor() {
+class RecordJavaSupertypesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -33,7 +33,7 @@ class RecordJavaSupertypesProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val types = mutableSetOf<KSType>()
         resolver.getAllFiles().forEach {
-            it.accept(TypeCollectorNoAccessor(), types)
+            it.accept(TypeCollectorNoAccessor(enableNewFeatures), types)
         }
         types.forEach {
             resolver.builtIns.anyType.isAssignableFrom(it)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/TypeAnnotationClassReferenceProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/TypeAnnotationClassReferenceProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class TypeAnnotationClassReferenceProcessor : AbstractTestProcessor() {
+class TypeAnnotationClassReferenceProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ValueParameterProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/ValueParameterProcessor.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class ValueParameterProcessor : AbstractTestProcessor() {
+class ValueParameterProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -20,7 +20,9 @@ package com.google.devtools.ksp.test
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Test
 
-class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = false) {
+abstract class AAConfiguredUnitTestSuiteBase(
+    enableNewFeatures: Boolean
+) : KSPUnitTestSuite(experimentalPsiResolution = false, enableNewFeatures) {
 
     @TestMetadata("getSymbolsWithAnnotation/aliasedAnnotation.kt")
     @Test
@@ -58,3 +60,7 @@ class AAConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = f
         runTest("$AA_PATH/javaSubtypeOfKotlinInterface.kt")
     }
 }
+
+class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false)
+
+class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -52,7 +52,10 @@ import java.io.File
 import java.io.PrintStream
 import java.net.URLClassLoader
 
-abstract class AbstractKSPAATest(val experimentalPsiResolution: Boolean) : AbstractKSPTest(FrontendKinds.FIR) {
+abstract class AbstractKSPAATest(
+    val experimentalPsiResolution: Boolean,
+    enableNewFeatures: Boolean,
+) : AbstractKSPTest(FrontendKinds.FIR, enableNewFeatures) {
 
     val TestModule.kotlinSrc
         get() = File(testRoot, "kotlinSrc")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -303,8 +303,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
         val fileContents = mainModule.files.first().originalFile.readLines()
 
         val processorArguments = parseProcessorArguments(fileContents)
-        val testProcessorName = parseTestProcessorName(fileContents)
-        val processorClass = mkTestProcessorClass(testProcessorName)
+        val processorClass = mkTestProcessorClass(parseTestProcessorName(fileContents))
         val testProcessor = mkProcessor(processorArguments, processorClass)
 
         val expected = parseExpectedOutput(fileContents)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -80,7 +80,7 @@ abstract class DisposableTest {
     }
 }
 
-abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
+abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures: Boolean) : DisposableTest() {
     companion object {
         const val TEST_PROCESSOR = "// TEST PROCESSOR:"
         const val PROCESSOR_INPUT = "// PROCESSOR INPUT:"
@@ -317,15 +317,15 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>) : DisposableTest() {
 
         val testProcessor: AbstractTestProcessor =
             if (testAnnotationNames == null) {
-                // Instantiate processor class without constructor params
+                // Instantiate processor class with enableNewFeatures param
                 processorClass
-                    .getDeclaredConstructor()
-                    .newInstance() as AbstractTestProcessor
+                    .getDeclaredConstructor(Boolean::class.java)
+                    .newInstance(this.enableNewFeatures) as AbstractTestProcessor
             } else {
                 // Instantiate parameterized processor class
                 processorClass
-                    .getDeclaredConstructor(List::class.java)
-                    .newInstance(testAnnotationNames) as AbstractTestProcessor
+                    .getDeclaredConstructor(List::class.java, Boolean::class.java)
+                    .newInstance(testAnnotationNames, this.enableNewFeatures) as AbstractTestProcessor
             }
 
         val expected = fileContents

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -307,7 +307,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
             .substringAfter(TEST_PROCESSOR)
             .trim()
 
-        val testAnnotationNames = fileContents
+        val processorArguments = fileContents
             .find { it.startsWith(PROCESSOR_INPUT) }
             ?.substringAfter(PROCESSOR_INPUT)
             ?.split(',')
@@ -316,7 +316,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
         val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
 
         val testProcessor: AbstractTestProcessor =
-            if (testAnnotationNames == null) {
+            if (processorArguments == null) {
                 // Instantiate processor class with enableNewFeatures param
                 processorClass
                     .getDeclaredConstructor(Boolean::class.java)
@@ -325,7 +325,7 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
                 // Instantiate parameterized processor class
                 processorClass
                     .getDeclaredConstructor(List::class.java, Boolean::class.java)
-                    .newInstance(testAnnotationNames, this.enableNewFeatures) as AbstractTestProcessor
+                    .newInstance(processorArguments, this.enableNewFeatures) as AbstractTestProcessor
             }
 
         val expected = fileContents

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPTest.kt
@@ -302,40 +302,12 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
 
         val fileContents = mainModule.files.first().originalFile.readLines()
 
-        val testProcessorName = fileContents
-            .single { it.startsWith(TEST_PROCESSOR) }
-            .substringAfter(TEST_PROCESSOR)
-            .trim()
+        val processorArguments = parseProcessorArguments(fileContents)
+        val testProcessorName = parseTestProcessorName(fileContents)
+        val processorClass = mkTestProcessorClass(testProcessorName)
+        val testProcessor = mkProcessor(processorArguments, processorClass)
 
-        val processorArguments = fileContents
-            .find { it.startsWith(PROCESSOR_INPUT) }
-            ?.substringAfter(PROCESSOR_INPUT)
-            ?.split(',')
-            ?.map { it.trim() }
-
-        val processorClass = Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
-
-        val testProcessor: AbstractTestProcessor =
-            if (processorArguments == null) {
-                // Instantiate processor class with enableNewFeatures param
-                processorClass
-                    .getDeclaredConstructor(Boolean::class.java)
-                    .newInstance(this.enableNewFeatures) as AbstractTestProcessor
-            } else {
-                // Instantiate parameterized processor class
-                processorClass
-                    .getDeclaredConstructor(List::class.java, Boolean::class.java)
-                    .newInstance(processorArguments, this.enableNewFeatures) as AbstractTestProcessor
-            }
-
-        val expected = fileContents
-            .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
-            .drop(1)
-            .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
-            .joinToString("\n") {
-                // Remove '// ' prefix
-                it.substring(3).trim()
-            }
+        val expected = parseExpectedOutput(fileContents)
 
         val actual = {
             runTest(
@@ -346,7 +318,45 @@ abstract class AbstractKSPTest(frontend: FrontendKind<*>, val enableNewFeatures:
             ).joinToString("\n")
         }
 
-        return Pair(expected, actual)
+        return expected to actual
+    }
+
+    private fun mkTestProcessorClass(testProcessorName: String): Class<*> =
+        Class.forName("com.google.devtools.ksp.processor.$testProcessorName")
+
+    private fun parseTestProcessorName(fileContents: List<String>): String = fileContents
+        .single { it.startsWith(TEST_PROCESSOR) }
+        .substringAfter(TEST_PROCESSOR)
+        .trim()
+
+    private fun parseProcessorArguments(fileContents: List<String>): List<String>? = fileContents
+        .find { it.startsWith(PROCESSOR_INPUT) }
+        ?.substringAfter(PROCESSOR_INPUT)
+        ?.split(',')
+        ?.map { it.trim() }
+
+    private fun parseExpectedOutput(fileContents: List<String>): String = fileContents
+        .dropWhile { !it.startsWith(EXPECTED_RESULTS) }
+        .drop(1)
+        .takeWhile { !it.startsWith(EXPECTED_RESULTS_END) }
+        .joinToString("\n") {
+            // Remove '// ' prefix
+            it.substring(3).trim()
+        }
+
+    private fun mkProcessor(
+        processorArguments: List<String>?,
+        processorClass: Class<*>
+    ): AbstractTestProcessor = if (processorArguments == null) {
+        // Instantiate processor class with enableNewFeatures param
+        processorClass
+            .getDeclaredConstructor(Boolean::class.java)
+            .newInstance(this.enableNewFeatures) as AbstractTestProcessor
+    } else {
+        // Instantiate parameterized processor class
+        processorClass
+            .getDeclaredConstructor(List::class.java, Boolean::class.java)
+            .newInstance(processorArguments, this.enableNewFeatures) as AbstractTestProcessor
     }
 }
 

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -30,8 +30,9 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 
 @Execution(ExecutionMode.SAME_THREAD)
 abstract class KSPUnitTestSuite(
-    experimentalPsiResolution: Boolean
-) : AbstractKSPAATest(experimentalPsiResolution) {
+    experimentalPsiResolution: Boolean,
+    enableNewFeatures: Boolean
+) : AbstractKSPAATest(experimentalPsiResolution, enableNewFeatures) {
 
     companion object {
         internal const val AA_PATH: String = "../kotlin-analysis-api/testData"

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -20,7 +20,9 @@ package com.google.devtools.ksp.test
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Test
 
-class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = true) {
+abstract class PsiConfiguredUnitTestSuiteBase(
+    enableNewFeatures: Boolean
+) : KSPUnitTestSuite(experimentalPsiResolution = true, enableNewFeatures) {
 
     @TestMetadata("getSymbolsWithAnnotation/aliasedAnnotation.kt")
     @Test
@@ -58,3 +60,7 @@ class PsiConfiguredUnitTestSuite : KSPUnitTestSuite(experimentalPsiResolution = 
         runFailingTest("$AA_PATH/javaSubtypeOfKotlinInterface.kt")
     }
 }
+
+class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false)
+
+class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true)

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AbstractFunctionsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AbstractFunctionsProcessor.kt
@@ -6,8 +6,8 @@ import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class AbstractFunctionsProcessor : AbstractTestProcessor() {
-    private val visitor = Visitor()
+class AbstractFunctionsProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
+    private val visitor = Visitor(enableNewFeatures)
 
     override fun toResult(): List<String> {
         return visitor.abstractFunctionNames.sorted()
@@ -18,7 +18,7 @@ class AbstractFunctionsProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+    private class Visitor(enableNewFeatures: Boolean) : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
         val abstractFunctionNames = arrayListOf<String>()
 
         override fun defaultHandler(node: KSNode, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AbstractTestProcessor.kt
@@ -22,7 +22,13 @@ import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 
 abstract class AbstractTestProcessor : SymbolProcessor, SymbolProcessorProvider {
+    abstract val enableNewFeatures: Boolean
     abstract fun toResult(): List<String>
 
-    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor = this
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        if (enableNewFeatures) {
+            environment.registerProcessorForNewFeatures(this)
+        }
+        return this
+    }
 }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AllFunctionsProcessor.kt
@@ -20,8 +20,8 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class AllFunctionsProcessor : AbstractTestProcessor() {
-    val visitor = AllFunctionsVisitor()
+class AllFunctionsProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
+    val visitor = AllFunctionsVisitor(enableNewFeatures)
 
     override fun toResult(): List<String> {
         return visitor.toResult()
@@ -32,7 +32,7 @@ class AllFunctionsProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    class AllFunctionsVisitor : KSVisitorVoid() {
+    class AllFunctionsVisitor(enableNewFeatures: Boolean) : KSVisitorVoid(enableNewFeatures) {
         private val declarationsByClass = mutableMapOf<String, MutableList<String>>()
         fun toResult(): List<String> {
             return declarationsByClass.entries
@@ -42,19 +42,22 @@ class AllFunctionsProcessor : AbstractTestProcessor() {
                     listOf(it.key) + it.value
                 }
         }
+
         fun KSFunctionDeclaration.toSignature(): String {
             return this.simpleName.asString() +
-                "(${this.parameters.map {
-                    buildString {
-                        append(it.type.resolve().declaration.qualifiedName?.asString())
-                        if (it.hasDefault) {
-                            append("(hasDefault)")
+                "(${
+                    this.parameters.map {
+                        buildString {
+                            append(it.type.resolve().declaration.qualifiedName?.asString())
+                            if (it.hasDefault) {
+                                append("(hasDefault)")
+                            }
+                            if (it.isVararg) {
+                                append(" ...")
+                            }
                         }
-                        if (it.isVararg) {
-                            append(" ...")
-                        }
-                    }
-                }.joinToString(",")})" +
+                    }.joinToString(",")
+                })" +
                 ": ${this.returnType?.resolve()?.declaration?.qualifiedName?.asString() ?: ""}"
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotatedUtilProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 import kotlin.reflect.KClass
 
-class AnnotatedUtilProcessor : AbstractTestProcessor() {
+class AnnotatedUtilProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     private val annotationKClasses = listOf(
         ParametersTestAnnotation::class,
@@ -34,7 +34,7 @@ class AnnotatedUtilProcessor : AbstractTestProcessor() {
         ParametersTestWithNegativeDefaultsAnnotation::class,
         OuterAnnotation::class
     )
-    private val visitors = listOf(IsAnnotationPresentVisitor(), GetAnnotationsByTypeVisitor())
+    private val visitors = listOf(IsAnnotationPresentVisitor(enableNewFeatures), GetAnnotationsByTypeVisitor(enableNewFeatures))
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getSymbolsWithAnnotation("com.google.devtools.ksp.processor.Test", true).forEach {
@@ -48,7 +48,7 @@ class AnnotatedUtilProcessor : AbstractTestProcessor() {
         return results
     }
 
-    inner class IsAnnotationPresentVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+    inner class IsAnnotationPresentVisitor(enableNewFeatures: Boolean)  : KSTopDownVisitor<MutableCollection<String>, Unit>(enableNewFeatures) {
         @OptIn(KspExperimental::class)
         override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
             annotationKClasses.forEach { clazz ->
@@ -62,7 +62,7 @@ class AnnotatedUtilProcessor : AbstractTestProcessor() {
         }
     }
 
-    inner class GetAnnotationsByTypeVisitor : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+    inner class GetAnnotationsByTypeVisitor(enableNewFeatures: Boolean)  : KSTopDownVisitor<MutableCollection<String>, Unit>(enableNewFeatures) {
         @OptIn(KspExperimental::class)
         override fun visitAnnotated(annotated: KSAnnotated, data: MutableCollection<String>) {
             annotationKClasses.forEach { clazz ->

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArbitraryClassValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArbitraryClassValueProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import kotlin.reflect.KClass
 
 @KspExperimental
-class AnnotationArbitraryClassValueProcessor : AbstractTestProcessor() {
+class AnnotationArbitraryClassValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArgumentProcessor.kt
@@ -21,14 +21,14 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class AnnotationArgumentProcessor : AbstractTestProcessor() {
+class AnnotationArgumentProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val visitor = ArgumentVisitor()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         listOf("MyClass", "MyClassInLib").forEach { clsName ->
             resolver.getClassDeclarationByName(clsName)?.let { cls ->
-                cls.annotations.forEach() { annotation ->
+                cls.annotations.forEach { annotation ->
                     results.add(
                         "$clsName: ${annotation.annotationType.resolve().declaration.qualifiedName?.asString()}"
                     )
@@ -135,7 +135,7 @@ class AnnotationArgumentProcessor : AbstractTestProcessor() {
         return results
     }
 
-    inner class ArgumentVisitor : KSVisitorVoid() {
+    inner class ArgumentVisitor : KSVisitorVoid(enableNewFeatures) {
         override fun visitValueArgument(valueArgument: KSValueArgument, data: Unit) {
             if (valueArgument.value is KSType) {
                 results.add((valueArgument.value as KSType).declaration.toString())

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationArrayValueProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class AnnotationArrayValueProcessor : AbstractTestProcessor() {
+class AnnotationArrayValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValueProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class AnnotationDefaultValueProcessor : AbstractTestProcessor() {
+class AnnotationDefaultValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValuesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationDefaultValuesProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class AnnotationDefaultValuesProcessor : AbstractTestProcessor() {
+class AnnotationDefaultValuesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationJavaTypeValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationJavaTypeValueProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class AnnotationJavaTypeValueProcessor : AbstractTestProcessor() {
+class AnnotationJavaTypeValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationNestedClassValueProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationNestedClassValueProcessor.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import kotlin.reflect.KClass
 
 @KspExperimental
-class AnnotationNestedClassValueProcessor : AbstractTestProcessor() {
+class AnnotationNestedClassValueProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationOnConstructorParameterProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationOnConstructorParameterProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class AnnotationOnConstructorParameterProcessor : AbstractTestProcessor() {
+class AnnotationOnConstructorParameterProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationOnReceiverProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationOnReceiverProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class AnnotationOnReceiverProcessor : AbstractTestProcessor() {
+class AnnotationOnReceiverProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationTargetsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationTargetsProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class AnnotationTargetsProcessor : AbstractTestProcessor() {
+class AnnotationTargetsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsRepeatableProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AnnotationsRepeatableProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class AnnotationsRepeatableProcessor : AbstractTestProcessor() {
+open class AnnotationsRepeatableProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/AsMemberOfProcessor.kt
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
 @Suppress("unused") // used by generated tests
-class AsMemberOfProcessor : AbstractTestProcessor() {
+class AsMemberOfProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     // keep a list of all signatures we generate and ensure equals work as expected
     private val functionsBySignature = mutableMapOf<String, MutableSet<KSFunction>>()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BackingFieldProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 @Suppress("unused") // used in tests
 @OptIn(KspExperimental::class)
-open class BackingFieldProcessor : AbstractTestProcessor() {
+open class BackingFieldProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     lateinit var results: List<String>
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -34,7 +34,7 @@ open class BackingFieldProcessor : AbstractTestProcessor() {
             resolver.getDeclarationsFromPackage(pkg)
                 .flatMap { declaration ->
                     val properties = mutableListOf<KSPropertyDeclaration>()
-                    declaration.accept(AllMembersVisitor(), properties)
+                    declaration.accept(AllMembersVisitor(enableNewFeatures), properties)
                     properties
                 }.map {
                     "${it.qualifiedName?.asString()}: ${it.hasBackingField}"
@@ -43,7 +43,8 @@ open class BackingFieldProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class AllMembersVisitor : KSTopDownVisitor<MutableList<KSPropertyDeclaration>, Unit>() {
+    private class AllMembersVisitor(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableList<KSPropertyDeclaration>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableList<KSPropertyDeclaration>) {
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BaseVisitor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BaseVisitor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 
-open class BaseVisitor : KSVisitorVoid() {
+open class BaseVisitor(enableNewFeatures: Boolean) : KSVisitorVoid(enableNewFeatures) {
     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
         for (declaration in classDeclaration.declarations) {
             declaration.accept(this, Unit)

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BuiltInTypesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/BuiltInTypesProcessor.kt
@@ -20,9 +20,9 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class BuiltInTypesProcessor : AbstractTestProcessor() {
+open class BuiltInTypesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollectorNoAccessor()
+    val typeCollector = TypeCollectorNoAccessor(enableNewFeatures)
     val types = mutableSetOf<KSType>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/CheckOverrideProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class CheckOverrideProcessor : AbstractTestProcessor() {
+class CheckOverrideProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassKindsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassKindsProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class ClassKindsProcessor : AbstractTestProcessor() {
+open class ClassKindsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -30,7 +30,7 @@ open class ClassKindsProcessor : AbstractTestProcessor() {
         val files = resolver.getNewFiles()
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassWithCompanionProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ClassWithCompanionProcessor.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 
-class ClassWithCompanionProcessor : AbstractTestProcessor() {
+class ClassWithCompanionProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val visitor = CompanionVisitor()
 
@@ -38,7 +38,7 @@ class ClassWithCompanionProcessor : AbstractTestProcessor() {
         return results
     }
 
-    inner class CompanionVisitor : KSVisitorVoid() {
+    inner class CompanionVisitor : KSVisitorVoid(enableNewFeatures) {
         override fun visitFile(file: KSFile, data: Unit) {
             file.declarations.forEach { it.accept(this, Unit) }
         }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstPropertiesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstPropertiesProcessor.kt
@@ -8,8 +8,8 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class ConstPropertiesProcessor : AbstractTestProcessor() {
-    private val visitor = Visitor()
+class ConstPropertiesProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
+    private val visitor = Visitor(enableNewFeatures)
 
     override fun toResult(): List<String> {
         return visitor.constPropertiesNames.sorted()
@@ -24,7 +24,7 @@ class ConstPropertiesProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+    private class Visitor(enableNewFeatures: Boolean) : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
         val constPropertiesNames = arrayListOf<String>()
 
         override fun defaultHandler(node: KSNode, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ConstructorDeclarationsProcessor.kt
@@ -22,8 +22,8 @@ import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
-    val visitor = ConstructorsVisitor()
+class ConstructorDeclarationsProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
+    val visitor = ConstructorsVisitor(enableNewFeatures)
     lateinit var result: List<String>
 
     override fun toResult(): List<String> {
@@ -44,7 +44,7 @@ class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    class ConstructorsVisitor : KSVisitorVoid() {
+    class ConstructorsVisitor(enableNewFeatures: Boolean) : KSVisitorVoid(enableNewFeatures) {
         private val declarationsByClass = LinkedHashMap<KSClassDeclaration, MutableList<String>>()
         fun classNames() = declarationsByClass.keys
         fun toResult(): List<String> {
@@ -58,18 +58,23 @@ class ConstructorDeclarationsProcessor : AbstractTestProcessor() {
                     listOf("class: " + it.key.qualifiedName!!.asString()) + it.value
                 }
         }
+
         fun KSFunctionDeclaration.toSignature(): String {
             return this.simpleName.asString() +
-                "(${this.parameters.map {
-                    buildString {
-                        append(it.type.resolve().declaration.qualifiedName?.asString())
-                        if (it.hasDefault) {
-                            append("(hasDefault)")
+                "(${
+                    this.parameters.map {
+                        buildString {
+                            append(it.type.resolve().declaration.qualifiedName?.asString())
+                            if (it.hasDefault) {
+                                append("(hasDefault)")
+                            }
                         }
-                    }
-                }.joinToString(",")})" +
-                ": ${this.returnType?.resolve()?.declaration?.qualifiedName?.asString()
-                    ?: "<no-return>"}"
+                    }.joinToString(",")
+                })" +
+                ": ${
+                    this.returnType?.resolve()?.declaration?.qualifiedName?.asString()
+                        ?: "<no-return>"
+                }"
         }
 
         override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/CrossModuleTypeAliasTestProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/CrossModuleTypeAliasTestProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class CrossModuleTypeAliasTestProcessor : AbstractTestProcessor() {
+class CrossModuleTypeAliasTestProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results
@@ -32,7 +32,7 @@ class CrossModuleTypeAliasTestProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val target = resolver.getClassDeclarationByName("TestTarget")
         val classes = mutableSetOf<KSClassDeclaration>()
-        val classCollector = object : BaseVisitor() {
+        val classCollector = object : BaseVisitor(enableNewFeatures) {
             override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
                 if (classes.add(classDeclaration)) {
                     super.visitClassDeclaration(classDeclaration, data)

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationInconsistencyProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationInconsistencyProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class DeclarationInconsistencyProcessor : AbstractTestProcessor() {
+class DeclarationInconsistencyProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationOrderProcessor.kt
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
 @KspExperimental
-class DeclarationOrderProcessor : AbstractTestProcessor() {
+class DeclarationOrderProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val result = mutableListOf<String>()
     override fun toResult() = result
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationPackageNameProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationPackageNameProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class DeclarationPackageNameProcessor : AbstractTestProcessor() {
+class DeclarationPackageNameProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -29,7 +29,7 @@ class DeclarationPackageNameProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val visitor = NameCollector()
+        val visitor = NameCollector(enableNewFeatures)
         resolver.getNewFiles().forEach { it.accept(visitor, result) }
         listOf("lib.H1", "K1", "J1").mapNotNull {
             resolver.getClassDeclarationByName(resolver.getKSNameFromString(it))
@@ -40,7 +40,7 @@ class DeclarationPackageNameProcessor : AbstractTestProcessor() {
     }
 }
 
-class NameCollector : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+class NameCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableCollection<String>, Unit>(enableNewFeatures) {
 
     override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {}
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationUtilProcessor.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class DeclarationUtilProcessor : AbstractTestProcessor() {
+class DeclarationUtilProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -32,13 +32,13 @@ class DeclarationUtilProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val visitor = DeclarationCollector()
+        val visitor = DeclarationCollector(enableNewFeatures)
         resolver.getNewFiles().forEach { it.accept(visitor, result) }
         return emptyList()
     }
 }
 
-class DeclarationCollector : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+class DeclarationCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableCollection<String>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableCollection<String>) {
     }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationsInClassProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclarationsInClassProcessor.kt
@@ -25,7 +25,7 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class DeclarationsInClassProcessor : AbstractTestProcessor() {
+class DeclarationsInClassProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result.sorted()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclaredProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeclaredProcessor.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class DeclaredProcessor : AbstractTestProcessor() {
+class DeclaredProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DefaultFunctionProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DefaultFunctionProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class DefaultFunctionProcessor : AbstractTestProcessor() {
+class DefaultFunctionProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
 
     private val result = mutableListOf<String>()
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeferredSymbolsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DeferredSymbolsProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class DeferredSymbolsProcessor : AbstractTestProcessor() {
+class DeferredSymbolsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result.sorted()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DocStringProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DocStringProcessor.kt
@@ -23,14 +23,15 @@ import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class DocStringProcessor : AbstractTestProcessor() {
+class DocStringProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
         return result
     }
 
-    private class DeclarationCollector : KSTopDownVisitor<MutableCollection<String>, Unit>() {
+    private class DeclarationCollector(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableCollection<String>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableCollection<String>) = Unit
 
         override fun visitDeclaration(declaration: KSDeclaration, data: MutableCollection<String>) {
@@ -39,7 +40,7 @@ class DocStringProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val visitor = DeclarationCollector()
+        val visitor = DeclarationCollector(enableNewFeatures)
         resolver.getNewFiles().forEach { it.accept(visitor, result) }
         result.sort()
         return emptyList()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/EqualsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/EqualsProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class EqualsProcessor : AbstractTestProcessor() {
+open class EqualsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ErrorTypeProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 
-class ErrorTypeProcessor : AbstractTestProcessor() {
+class ErrorTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ExitCodeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ExitCodeProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class ExitCodeProcessor : AbstractTestProcessor() {
+class ExitCodeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     override fun toResult(): List<String> = emptyList()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionKindProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionKindProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class FunctionKindProcessor : AbstractTestProcessor() {
+open class FunctionKindProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -43,7 +43,7 @@ open class FunctionKindProcessor : AbstractTestProcessor() {
         val files = resolver.getNewFiles()
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitFunctionDeclaration(function: KSFunctionDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAliasProcessor.kt
@@ -21,9 +21,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class FunctionTypeAliasProcessor : AbstractTestProcessor() {
+open class FunctionTypeAliasProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeRefCollector = RefCollector()
+    val typeRefCollector = RefCollector(enableNewFeatures)
     val refs = mutableSetOf<KSTypeReference>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -48,7 +48,7 @@ open class FunctionTypeAliasProcessor : AbstractTestProcessor() {
     }
 }
 
-open class RefCollector : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>() {
+open class RefCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableCollection<KSTypeReference>) = Unit
 
     override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSTypeReference>) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeAnnotationProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class FunctionTypeAnnotationProcessor : AbstractTestProcessor() {
+class FunctionTypeAnnotationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -18,7 +18,7 @@ class FunctionTypeAnnotationProcessor : AbstractTestProcessor() {
 
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/FunctionTypeProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class FunctionTypeProcessor : AbstractTestProcessor() {
+open class FunctionTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val types = mutableSetOf<KSType>()
 
@@ -30,7 +30,7 @@ open class FunctionTypeProcessor : AbstractTestProcessor() {
 
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeProcessor.kt
@@ -17,7 +17,7 @@ annotation class KotlinAnnotationWithInnerDefaults(
     }
 }
 
-class GetAnnotationByTypeProcessor : AbstractTestProcessor() {
+class GetAnnotationByTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     private val annotationKClass = KotlinAnnotationWithInnerDefaults::class
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetByNameProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetByNameProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.getPropertyDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class GetByNameProcessor : AbstractTestProcessor() {
+class GetByNameProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetPackageProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetPackageProcessor.kt
@@ -4,7 +4,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class GetPackageProcessor : AbstractTestProcessor() {
+class GetPackageProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/GetSymbolsFromAnnotationProcessor.kt
@@ -3,7 +3,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class GetSymbolsFromAnnotationProcessor : AbstractTestProcessor() {
+class GetSymbolsFromAnnotationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<List<String>>()
     override fun toResult(): List<String> = result.flatten()
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ImplicitPropertyAccessorProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ImplicitPropertyAccessorProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class ImplicitPropertyAccessorProcessor : AbstractTestProcessor() {
+class ImplicitPropertyAccessorProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InheritedTypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InheritedTypeAliasProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class InheritedTypeAliasProcessor : AbstractTestProcessor() {
+class InheritedTypeAliasProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InnerTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InnerTypeProcessor.kt
@@ -22,9 +22,9 @@ import com.google.devtools.ksp.outerType
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class InnerTypeProcessor : AbstractTestProcessor() {
+open class InnerTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollector()
+    val typeCollector = TypeCollector(enableNewFeatures)
     val types = mutableSetOf<KSType>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InternalOfFriendsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/InternalOfFriendsProcessor.kt
@@ -20,7 +20,7 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class InternalOfFriendsProcessor : AbstractTestProcessor() {
+open class InternalOfFriendsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/IsMutableProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/IsMutableProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 @Suppress("unused") // used in tests
 @OptIn(KspExperimental::class)
-open class IsMutableProcessor : AbstractTestProcessor() {
+open class IsMutableProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     lateinit var results: List<String>
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -34,7 +34,7 @@ open class IsMutableProcessor : AbstractTestProcessor() {
             resolver.getDeclarationsFromPackage(pkg)
                 .flatMap { declaration ->
                     val properties = mutableListOf<KSPropertyDeclaration>()
-                    declaration.accept(AllMembersVisitor(), properties)
+                    declaration.accept(AllMembersVisitor(enableNewFeatures), properties)
                     properties
                 }.map {
                     "${it.qualifiedName?.asString()}: ${it.isMutable}"
@@ -43,7 +43,8 @@ open class IsMutableProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class AllMembersVisitor : KSTopDownVisitor<MutableList<KSPropertyDeclaration>, Unit>() {
+    private class AllMembersVisitor(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableList<KSPropertyDeclaration>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableList<KSPropertyDeclaration>) {
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaNonNullProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaNonNullProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class JavaNonNullProcessor : AbstractTestProcessor() {
+class JavaNonNullProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -36,7 +36,7 @@ class JavaNonNullProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) {
                     }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaSubtypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaSubtypeProcessor.kt
@@ -8,7 +8,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Variance
 
-class JavaSubtypeProcessor : AbstractTestProcessor() {
+class JavaSubtypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     var isOk = true
     override fun toResult(): List<String> {
         return listOf(isOk.toString())

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JavaToKotlinMapProcessor.kt
@@ -25,9 +25,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
 @KspExperimental
-open class JavaToKotlinMapProcessor : AbstractTestProcessor() {
+open class JavaToKotlinMapProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollectorNoAccessor()
+    val typeCollector = TypeCollectorNoAccessor(enableNewFeatures)
     val types = mutableSetOf<KSType>()
 
     val javaClasses = listOf(

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JvmNameProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JvmNameProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class JvmNameProcessor : AbstractTestProcessor() {
+class JvmNameProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JvmNameRecordProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/JvmNameRecordProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 
-class JvmNameRecordProcessor : AbstractTestProcessor() {
+class JvmNameRecordProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LateinitPropertiesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LateinitPropertiesProcessor.kt
@@ -8,8 +8,8 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Modifier
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class LateinitPropertiesProcessor : AbstractTestProcessor() {
-    private val visitor = Visitor()
+class LateinitPropertiesProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
+    private val visitor = Visitor(enableNewFeatures)
 
     override fun toResult(): List<String> {
         return visitor.lateinitPropertiesNames.sorted()
@@ -24,7 +24,7 @@ class LateinitPropertiesProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class Visitor : KSTopDownVisitor<Unit, Unit>() {
+    private class Visitor(enableNewFeatures: Boolean) : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
         val lateinitPropertiesNames = arrayListOf<String>()
 
         override fun defaultHandler(node: KSNode, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LibOriginsProcessor.kt
@@ -18,12 +18,11 @@
 package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.KspExperimental
-import com.google.devtools.ksp.containingFile
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class LibOriginsProcessor : AbstractTestProcessor() {
+class LibOriginsProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val result = mutableListOf<String>()
     private val visited = mutableSetOf<KSNode>()
 
@@ -31,7 +30,7 @@ class LibOriginsProcessor : AbstractTestProcessor() {
         return result
     }
 
-    inner class MyCollector : KSTopDownVisitor<Origin, Unit>() {
+    inner class MyCollector : KSTopDownVisitor<Origin, Unit>(enableNewFeatures) {
         private fun KSNode.pretty(): String {
             val parents: MutableList<KSNode> = mutableListOf(this)
             var curr: KSNode = this

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocalDeclarationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocalDeclarationProcessor.kt
@@ -4,20 +4,20 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSEmptyVisitor
 
-class LocalDeclarationProcessor : AbstractTestProcessor() {
+class LocalDeclarationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val visitor = LocalDeclarationVisitor()
+        val visitor = LocalDeclarationVisitor(enableNewFeatures)
         resolver.getAllFiles().forEach { it.accept(visitor, result) }
         return emptyList()
     }
 }
 
-class LocalDeclarationVisitor : KSEmptyVisitor<MutableList<String>, Unit>() {
+class LocalDeclarationVisitor(enableNewFeatures: Boolean) : KSEmptyVisitor<MutableList<String>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableList<String>) {
         data.add(node.toString())
     }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocationsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/LocationsProcessor.kt
@@ -8,7 +8,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.NonExistLocation
 import java.io.File
 
-class LocationsProcessor : AbstractTestProcessor() {
+class LocationsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result.sorted()

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MakeNullableProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MakeNullableProcessor.kt
@@ -20,9 +20,9 @@ package com.google.devtools.ksp.processor
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class MakeNullableProcessor : AbstractTestProcessor() {
+open class MakeNullableProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollector()
+    val typeCollector = TypeCollector(enableNewFeatures)
     val types = mutableSetOf<KSType>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MangledNamesProcessor.kt
@@ -8,25 +8,25 @@ import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 @KspExperimental
 @Suppress("unused") // used by the test code
-class MangledNamesProcessor : AbstractTestProcessor() {
+class MangledNamesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
     override fun toResult() = results
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val mangleSourceNames = mutableMapOf<String, String?>()
         resolver.getAllFiles().sortedBy { it.fileName }.forEach {
-            it.accept(MangledNamesVisitor(resolver), mangleSourceNames)
+            it.accept(MangledNamesVisitor(resolver, enableNewFeatures), mangleSourceNames)
         }
         val mangledDependencyNames = LinkedHashMap<String, String?>()
         // also collect results from library dependencies to ensure we resolve module name property
         resolver.getClassDeclarationByName("libPackage.Foo")?.accept(
-            MangledNamesVisitor(resolver), mangledDependencyNames
+            MangledNamesVisitor(resolver, enableNewFeatures), mangledDependencyNames
         )
         resolver.getClassDeclarationByName("libPackage.AbstractKotlinClass")?.accept(
-            MangledNamesVisitor(resolver), mangledDependencyNames
+            MangledNamesVisitor(resolver, enableNewFeatures), mangledDependencyNames
         )
         resolver.getClassDeclarationByName("libPackage.MyInterface")?.accept(
-            MangledNamesVisitor(resolver), mangledDependencyNames
+            MangledNamesVisitor(resolver, enableNewFeatures), mangledDependencyNames
         )
         results.addAll(
             mangleSourceNames.entries.map { (decl, name) ->
@@ -41,9 +41,7 @@ class MangledNamesProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    private class MangledNamesVisitor(
-        val resolver: Resolver
-    ) : KSTopDownVisitor<MutableMap<String, String?>, Unit>() {
+    private class MangledNamesVisitor(val resolver: Resolver, enableNewFeatures: Boolean) : KSTopDownVisitor<MutableMap<String, String?>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableMap<String, String?>) {
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MapSignatureProcessor.kt
@@ -24,7 +24,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 
 @KspExperimental
-class MapSignatureProcessor : AbstractTestProcessor() {
+class MapSignatureProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultiModuleTestProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultiModuleTestProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class MultiModuleTestProcessor : AbstractTestProcessor() {
+class MultiModuleTestProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results
@@ -30,7 +30,7 @@ class MultiModuleTestProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val target = resolver.getClassDeclarationByName("TestTarget")
         val classes = mutableSetOf<KSClassDeclaration>()
-        val classCollector = object : BaseVisitor() {
+        val classCollector = object : BaseVisitor(enableNewFeatures) {
             override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {
                 if (classes.add(classDeclaration)) {
                     super.visitClassDeclaration(classDeclaration, data)

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/MultipleroundProcessor.kt
@@ -8,7 +8,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.validate
 
-class MultipleroundProcessor : AbstractTestProcessor() {
+class MultipleroundProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/NestedClassTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/NestedClassTypeProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class NestedClassTypeProcessor : AbstractTestProcessor() {
+class NestedClassTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/NullableTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/NullableTypeProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class NullableTypeProcessor : AbstractTestProcessor() {
+open class NullableTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val types = mutableSetOf<KSType>()
 
@@ -30,7 +30,7 @@ open class NullableTypeProcessor : AbstractTestProcessor() {
 
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitPropertyDeclaration(property: KSPropertyDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ObjCacheAProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ObjCacheAProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-open class ObjCacheAProcessor : AbstractTestProcessor() {
+open class ObjCacheAProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ObjCacheBProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ObjCacheBProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-open class ObjCacheBProcessor : AbstractTestProcessor() {
+open class ObjCacheBProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/OverrideeProcessor.kt
@@ -23,7 +23,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
 @Suppress("unused") // used by tests
-class OverrideeProcessor : AbstractTestProcessor() {
+class OverrideeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun toResult() = results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageAnnotationProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSVisitorVoid
 
-class PackageAnnotationProcessor : AbstractTestProcessor() {
+class PackageAnnotationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result
@@ -16,7 +16,7 @@ class PackageAnnotationProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getAllFiles().forEach {
             it.accept(
-                object : KSVisitorVoid() {
+                object : KSVisitorVoid(enableNewFeatures) {
                     override fun visitFile(file: KSFile, data: Unit) {
                         result.add(
                             "${file.fileName}:${resolver.getPackageAnnotations(file.packageName.asString())

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageProviderForGeneratedProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PackageProviderForGeneratedProcessor.kt
@@ -7,7 +7,7 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class PackageProviderForGeneratedProcessor : AbstractTestProcessor() {
+class PackageProviderForGeneratedProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParameterTypeProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class ParameterTypeProcessor : AbstractTestProcessor() {
+class ParameterTypeProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -16,7 +16,7 @@ class ParameterTypeProcessor : AbstractTestProcessor() {
     override fun process(resolver: Resolver): List<KSAnnotated> {
         resolver.getNewFiles().forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) {
                     }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParentProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ParentProcessor.kt
@@ -6,7 +6,7 @@ import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class ParentProcessor : AbstractTestProcessor() {
+class ParentProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {
@@ -14,7 +14,7 @@ class ParentProcessor : AbstractTestProcessor() {
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val collector = AllSymbolProcessor()
+        val collector = AllSymbolProcessor(enableNewFeatures)
         val nodes = mutableSetOf<KSNode>()
         resolver.getAllFiles().sortedBy { it.fileName }.forEach { it.accept(collector, nodes) }
         for (e in listOf("YUV", "HSV")) {
@@ -26,7 +26,8 @@ class ParentProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    class AllSymbolProcessor : KSTopDownVisitor<MutableSet<KSNode>, Unit>() {
+    class AllSymbolProcessor(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableSet<KSNode>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableSet<KSNode>) {
             data.add(node)
         }

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/PlatformDeclarationProcessor.kt
@@ -23,9 +23,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class PlatformDeclarationProcessor : AbstractTestProcessor() {
+open class PlatformDeclarationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val collector = EverythingVisitor()
+    val collector = EverythingVisitor(enableNewFeatures)
     val declarations = mutableListOf<KSDeclaration>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -59,7 +59,7 @@ open class PlatformDeclarationProcessor : AbstractTestProcessor() {
     }
 }
 
-class EverythingVisitor : KSTopDownVisitor<MutableList<KSDeclaration>, Unit>() {
+class EverythingVisitor(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableList<KSDeclaration>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableList<KSDeclaration>) = Unit
 
     override fun visitDeclaration(declaration: KSDeclaration, data: MutableList<KSDeclaration>) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/RawTypesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/RawTypesProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class RawTypesProcessor : AbstractTestProcessor() {
+class RawTypesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     private val rawTypedEntityNames = arrayListOf<String>()
 
     override fun toResult(): List<String> {
@@ -14,7 +14,7 @@ class RawTypesProcessor : AbstractTestProcessor() {
 
     @OptIn(KspExperimental::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        val visitor = object : KSTopDownVisitor<Unit, Unit>() {
+        val visitor = object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
             private val KSType.isRawType
                 get() = resolver.isJavaRawType(this)
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ReferenceElementProcessor.kt
@@ -22,9 +22,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class ReferenceElementProcessor : AbstractTestProcessor() {
+open class ReferenceElementProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val collector = ReferenceCollector()
+    val collector = ReferenceCollector(enableNewFeatures)
     val references = mutableSetOf<KSTypeReference>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -86,7 +86,7 @@ open class ReferenceElementProcessor : AbstractTestProcessor() {
     }
 }
 
-class ReferenceCollector : KSTopDownVisitor<MutableSet<KSTypeReference>, Unit>() {
+class ReferenceCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableSet<KSTypeReference>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableSet<KSTypeReference>) = Unit
 
     override fun visitTypeReference(typeReference: KSTypeReference, data: MutableSet<KSTypeReference>) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ReplaceWithErrorTypeArgsProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class ReplaceWithErrorTypeArgsProcessor : AbstractTestProcessor() {
+open class ReplaceWithErrorTypeArgsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ResolveJavaTypeProcessor.kt
@@ -28,7 +28,7 @@ import com.google.devtools.ksp.symbol.Origin
 import com.google.devtools.ksp.symbol.Variance
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-class ResolveJavaTypeProcessor : AbstractTestProcessor() {
+class ResolveJavaTypeProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val visitor = ResolveJavaTypeVisitor()
 
@@ -49,7 +49,7 @@ class ResolveJavaTypeProcessor : AbstractTestProcessor() {
         return emptyList()
     }
 
-    inner class ResolveJavaTypeVisitor : KSTopDownVisitor<Unit, Unit>() {
+    inner class ResolveJavaTypeVisitor : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: Unit) {
         }
 
@@ -75,14 +75,16 @@ class ResolveJavaTypeProcessor : AbstractTestProcessor() {
         val sb = StringBuilder(this.resolve().declaration.qualifiedName?.asString() ?: "<ERROR>")
         if (this.resolve().arguments.toList().isNotEmpty()) {
             sb.append(
-                "<${this.resolve().arguments.map {
-                    when (it.variance) {
-                        Variance.STAR -> "*"
-                        Variance.INVARIANT -> ""
-                        Variance.CONTRAVARIANT -> "in "
-                        Variance.COVARIANT -> "out "
-                    } + (it.type?.render() ?: "")
-                }.joinToString(", ")}>"
+                "<${
+                    this.resolve().arguments.map {
+                        when (it.variance) {
+                            Variance.STAR -> "*"
+                            Variance.INVARIANT -> ""
+                            Variance.CONTRAVARIANT -> "in "
+                            Variance.COVARIANT -> "out "
+                        } + (it.type?.render() ?: "")
+                    }.joinToString(", ")
+                }>"
             )
         }
         if (this.resolve().nullability != Nullability.NOT_NULL) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SealedClassProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SealedClassProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-class SealedClassProcessor : AbstractTestProcessor() {
+class SealedClassProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SuperTypesProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/SuperTypesProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class SuperTypesProcessor : AbstractTestProcessor() {
+open class SuperTypesProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ThrowListProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ThrowListProcessor.kt
@@ -10,7 +10,7 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSType
 
 @KspExperimental
-class ThrowListProcessor : AbstractTestProcessor() {
+class ThrowListProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TopLevelMemberProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TopLevelMemberProcessor.kt
@@ -27,7 +27,7 @@ import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
 @OptIn(KspExperimental::class)
-open class TopLevelMemberProcessor : AbstractTestProcessor() {
+open class TopLevelMemberProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     lateinit var results: List<String>
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -35,7 +35,7 @@ open class TopLevelMemberProcessor : AbstractTestProcessor() {
             resolver.getDeclarationsFromPackage(pkg)
                 .flatMap { declaration ->
                     val declarations = mutableListOf<KSDeclaration>()
-                    declaration.accept(AllMembersVisitor(), declarations)
+                    declaration.accept(AllMembersVisitor(enableNewFeatures), declarations)
                     declarations
                 }.map {
                     "$pkg : ${it.simpleName.asString()} -> ${resolver.getSyntheticJvmClass(it)}"
@@ -52,7 +52,8 @@ open class TopLevelMemberProcessor : AbstractTestProcessor() {
         else -> error("unexpected declaration $declaration")
     }
 
-    private class AllMembersVisitor : KSTopDownVisitor<MutableList<KSDeclaration>, Unit>() {
+    private class AllMembersVisitor(enableNewFeatures: Boolean) :
+        KSTopDownVisitor<MutableList<KSDeclaration>, Unit>(enableNewFeatures) {
         override fun defaultHandler(node: KSNode, data: MutableList<KSDeclaration>) {
         }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasComparisonProcessor.kt
@@ -21,9 +21,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class TypeAliasComparisonProcessor : AbstractTestProcessor() {
+open class TypeAliasComparisonProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeRefCollector = TypeRefCollector()
+    val typeRefCollector = TypeRefCollector(enableNewFeatures)
     val refs = mutableSetOf<KSTypeReference>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -55,7 +55,7 @@ open class TypeAliasComparisonProcessor : AbstractTestProcessor() {
     }
 }
 
-open class TypeRefCollector : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>() {
+open class TypeRefCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableCollection<KSTypeReference>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableCollection<KSTypeReference>) = Unit
 
     override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSTypeReference>) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAliasProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class TypeAliasProcessor : AbstractTestProcessor() {
+open class TypeAliasProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     val types = mutableListOf<KSType>()
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAnnotationProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeAnnotationProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class TypeAnnotationProcessor : AbstractTestProcessor() {
+class TypeAnnotationProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeArgumentVarianceProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeArgumentVarianceProcessor.kt
@@ -22,7 +22,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class TypeArgumentVarianceProcessor : AbstractTestProcessor() {
+class TypeArgumentVarianceProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<String>()
     override fun toResult(): List<String> {
         return result

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComparison2Processor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComparison2Processor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.getClassDeclarationByName
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class TypeComparison2Processor : AbstractTestProcessor() {
+open class TypeComparison2Processor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComparisonProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComparisonProcessor.kt
@@ -21,9 +21,9 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class TypeComparisonProcessor : AbstractTestProcessor() {
+open class TypeComparisonProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val typeCollector = TypeCollector()
+    val typeCollector = TypeCollector(enableNewFeatures)
     val types = mutableSetOf<KSType>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -60,7 +60,7 @@ open class TypeComparisonProcessor : AbstractTestProcessor() {
     }
 }
 
-class TypeCollectorNoAccessor : TypeCollector() {
+class TypeCollectorNoAccessor(enableNewFeatures: Boolean) : TypeCollector(enableNewFeatures) {
     override fun visitPropertyGetter(getter: KSPropertyGetter, data: MutableCollection<KSType>) {
     }
 
@@ -68,7 +68,7 @@ class TypeCollectorNoAccessor : TypeCollector() {
     }
 }
 
-open class TypeCollector : KSTopDownVisitor<MutableCollection<KSType>, Unit>() {
+open class TypeCollector(enableNewFeatures: Boolean) : KSTopDownVisitor<MutableCollection<KSType>, Unit>(enableNewFeatures) {
     override fun defaultHandler(node: KSNode, data: MutableCollection<KSType>) = Unit
 
     override fun visitTypeReference(typeReference: KSTypeReference, data: MutableCollection<KSType>) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComposureProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeComposureProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
 
-open class TypeComposureProcessor : AbstractTestProcessor() {
+open class TypeComposureProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
@@ -31,7 +31,7 @@ open class TypeComposureProcessor : AbstractTestProcessor() {
 
         files.forEach {
             it.accept(
-                object : KSTopDownVisitor<Unit, Unit>() {
+                object : KSTopDownVisitor<Unit, Unit>(enableNewFeatures) {
                     override fun defaultHandler(node: KSNode, data: Unit) = Unit
 
                     override fun visitClassDeclaration(classDeclaration: KSClassDeclaration, data: Unit) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterEqualsProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterEqualsProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.getDeclaredProperties
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class TypeParameterEqualsProcessor : AbstractTestProcessor() {
+class TypeParameterEqualsProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val result = mutableListOf<Boolean>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterReferenceProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterReferenceProcessor.kt
@@ -22,9 +22,9 @@ import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.*
 
-open class TypeParameterReferenceProcessor : AbstractTestProcessor() {
+open class TypeParameterReferenceProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
-    val collector = ReferenceCollector()
+    val collector = ReferenceCollector(enableNewFeatures)
     val references = mutableSetOf<KSTypeReference>()
 
     override fun process(resolver: Resolver): List<KSAnnotated> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterVarianceProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/TypeParameterVarianceProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSDeclaration
 
-class TypeParameterVarianceProcessor : AbstractTestProcessor() {
+class TypeParameterVarianceProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
     override fun toResult(): List<String> {
         return results

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ValidateProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/ValidateProcessor.kt
@@ -9,7 +9,7 @@ import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.validate
 
-class ValidateProcessor : AbstractTestProcessor() {
+class ValidateProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     private fun validate(symbol: KSDeclaration, predicate: (KSNode?, KSNode) -> Boolean = { _, _ -> true }) {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VarargProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VarargProcessor.kt
@@ -5,7 +5,7 @@ import com.google.devtools.ksp.getDeclaredFunctions
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 
-class VarargProcessor : AbstractTestProcessor() {
+class VarargProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/VisibilityProcessor.kt
@@ -26,7 +26,7 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSFunctionDeclaration
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 
-class VisibilityProcessor : AbstractTestProcessor() {
+class VisibilityProcessor(override val enableNewFeatures: Boolean): AbstractTestProcessor() {
     val results = mutableListOf<String>()
 
     override fun toResult(): List<String> {


### PR DESCRIPTION
This PR allows the test framework to instantiate test processors with and without the feature toggle for backing fields.

Split out from https://github.com/google/ksp/pull/3132
Related to https://github.com/google/ksp/pull/2969
Related to https://github.com/google/ksp/issues/2472
Related to https://github.com/google/ksp/issues/2873