### PR TITLE
Enable new features in SymbolCollector in IncrementalContextBase

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/common/IncrementalContextBase.kt
@@ -35,7 +35,7 @@ import java.io.File
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 
-object SymbolCollector : KSDefaultVisitor<(LookupSymbolWrapper) -> Unit, Unit>() {
+object SymbolCollector : KSDefaultVisitor<(LookupSymbolWrapper) -> Unit, Unit>(enableNewFeatures = true) {
     override fun defaultHandler(node: KSNode, data: (LookupSymbolWrapper) -> Unit) = Unit
 
     override fun visitDeclaration(declaration: KSDeclaration, data: (LookupSymbolWrapper) -> Unit) {


### PR DESCRIPTION
Leftover from 0c44025cc974840ca03d7adbb73b6c1dd713ecc9. The SymbolCollector used the old KSVisitorVoid constructor, thereby disabling upcoming features.