### PR TITLE
Check Gradle wrapper jar sha256 on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,6 +30,9 @@
 *.sh text eol=lf
 gradlew text eol=lf
 
+# Checksum files (LF required for sha256sum --check)
+*.sha256sum text eol=lf
+
 # Windows batch files (Windows CRLF line endings required)
 *.bat text eol=crlf
 *.cmd text eol=crlf

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,6 @@ jobs:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
     - name: Check valid Gradle wrapper jar
-      if: matrix.os != 'windows-latest'
       run: sha256sum --check gradle-wrapper.jar.sha256sum
       working-directory: ./gradle/wrapper
 
@@ -78,7 +77,6 @@ jobs:
         key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
 
     - name: Check valid Gradle wrapper jar
-      if: matrix.os != 'windows-latest'
       run: sha256sum --check gradle-wrapper.jar.sha256sum
       working-directory: ./gradle/wrapper
 


### PR DESCRIPTION
## Summary
The CI workflow uses `sha256sum --check gradle-wrapper.jar.sha256sum` to verify the committed wrapper JAR.
However, this step is guarded by `if: matrix.os != 'windows-latest'`, so it has never run on Windows runners.

## Root cause
On Windows, the `.sha256sum` file is checked out with CRLF line endings.
There is no dedicated rule for `*.sha256sum` in `.gitattributes`, so it falls back to the catch-all `* text=auto`. Combined with Windows’ default `core.autocrlf=true`, the file gets converted to CRLF.
As a result, `sha256sum --check` treats the trailing `\r` as part of the filename and attempts to look for `gradle-wrapper.jar\r`, producing the error:
`sha256sum: 'gradle-wrapper.jar'$'\r': No such file or directory`

## Changes
- Add `*.sha256sum text eol=lf` to `.gitattributes` to ensure the checksum file is always checked out with LF line endings across all platforms for byte-identical content.
- Remove the `if: matrix.os != 'windows-latest'` condition so the verification step executes on Windows as well.

## Verification
- Confirm the committed JAR matches the recorded checksum (`497c8c2a…`).
- Running `sha256sum --check` against the LF-versioned file outputs `gradle-wrapper.jar: OK`.

Closes #3103.