### PR TITLE
Initializing PluginProblemReporter

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -46,6 +46,8 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.Origin
 import com.intellij.core.CoreApplicationEnvironment
+import com.intellij.diagnostic.PluginException
+import com.intellij.diagnostic.PluginProblemReporter
 import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -275,6 +277,12 @@ class KotlinSymbolProcessing(
             KaResolutionActivityTracker::class.java,
             LLFirResolutionActivityTracker::class.java
         )
+        kotlinCoreProjectEnvironment.registerApplicationServices(
+            PluginProblemReporter::class.java,
+            PluginProblemReporter { errorMessage, cause, _ ->
+                PluginException(errorMessage, cause, null)
+            }
+        )
 
         registerProjectServices(
             kotlinCoreProjectEnvironment,
@@ -295,6 +303,20 @@ class KotlinSymbolProcessing(
             kotlinCoreProjectEnvironment,
             modules
         )
+    }
+
+    private fun <T : Any> KotlinCoreProjectEnvironment.registerApplicationServices(
+        serviceInterface: Class<T>,
+        serviceImplementation: T
+    ) {
+        val application = environment.application
+        if (application.getServiceIfCreated(serviceInterface) == null) {
+            KotlinCoreEnvironment.underApplicationLock {
+                if (application.getServiceIfCreated(serviceInterface) == null) {
+                    application.registerService(serviceInterface, serviceImplementation)
+                }
+            }
+        }
     }
 
     private fun <T> KotlinCoreProjectEnvironment.registerApplicationServices(

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/FooBarProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/FooBarProcessor.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.impl.symbol.kotlin.KSErrorType
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFunctionDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.intellij.diagnostic.PluginException
+
+class FooBarProcessor(val annotationNames: List<String>) : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> = results.toList()
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        annotationNames.forEach { annotationName ->
+            resolver.getSymbolsWithAnnotation(annotationName).forEach { symbol ->
+                results.add("$annotationName: $symbol")
+                if (symbol is KSClassDeclaration) {
+                    symbol.declarations.filterIsInstance<KSFunctionDeclaration>().forEach { func ->
+                        func.parameters.forEach { param ->
+                            param.annotations.forEach { anno ->
+                                anno.arguments.forEach { arg ->
+                                    val valueStr = when (val v = arg.value) {
+                                        is KSType -> v.toString()
+                                        KSErrorType.Companion -> "<ERROR TYPE>"
+                                        else -> v?.toString()
+                                    }
+                                    results.add("Arg: ${arg.name?.asString()} = $valueStr")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Verify PluginProblemReporter and PluginException creation (reproducing b/545532844)
+        val exception = PluginException.createByClass("Test error", null, FooBarProcessor::class.java)
+        results.add("PluginProblemReporter: registered, created ${exception.javaClass.simpleName}")
+
+        return emptyList()
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -568,6 +568,12 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/getSymbolsWithAnnotation/localClasses.kt")
     }
 
+    @TestMetadata("getSymbolsWithAnnotation/deprecatedEnum.kt")
+    @Test
+    fun testDeprecatedEnum() {
+        runTest("$AA_PATH/getSymbolsWithAnnotation/deprecatedEnum.kt")
+    }
+
     @TestMetadata("locations.kt")
     @Test
     fun testLocations() {

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/deprecatedEnum.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/deprecatedEnum.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: FooBarProcessor
+// PROCESSOR INPUT: com.example.lib.BarAnno
+// EXPECTED:
+// com.example.lib.BarAnno: Foo
+// Arg: value = <ERROR TYPE>
+// PluginProblemReporter: registered, created PluginException
+// END
+
+// MODULE: lib
+// FILE: com/example/lib/lib.kt
+package com.example.lib
+
+// FILE: com/example/lib/FooEnum.java
+package com.example.lib;
+
+public enum FooEnum {
+    FOO_VAL1,
+    FOO_VAL2
+}
+
+// FILE: com/example/lib/FooAnno.java
+package com.example.lib;
+
+public @interface FooAnno {
+    FooEnum value() default FooEnum.FOO_VAL1;
+}
+
+// FILE: com/example/lib/BarAnno.java
+package com.example.lib;
+
+public @interface BarAnno {
+}
+
+// MODULE: main(lib)
+// FILE: com/example/main/main.kt
+package com.example.main
+
+// FILE: com/example/main/Foo.java
+package com.example.main;
+
+import com.example.lib.BarAnno;
+import com.example.lib.FooAnno;
+import com.example.lib.FooEnum;
+
+@BarAnno
+public class Foo {
+    public Foo(@FooAnno(FooEnum.DEPRECATED_VALUE) int x) {
+    }
+}


### PR DESCRIPTION
In order to fix null issue when analysis API
`KaFirNamedClassSymbolBase.equals` is used

I got a report with this stack trace. I believe part of the problem is KSP and this is a suggested fix please let me know if this makes sense

```
java.lang.NullPointerException: Cannot invoke "ksp.com.intellij.diagnostic.PluginProblemReporter.createPluginExceptionByClass(String, java.lang.Throwable, java.lang.Class)" because the return value of "ksp.com.intellij.diagnostic.PluginProblemReporter.getInstance()" is null
        at ksp2_impl.jar//ksp.com.intellij.diagnostic.PluginException.createByClass(PluginException.java:100)
        at ksp2_impl.jar//ksp.com.intellij.psi.util.PsiUtilCore.ensureValid(PsiUtilCore.java:508)
        at ksp2_impl.jar//ksp.com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:816)
        at ksp2_impl.jar//ksp.com.intellij.psi.impl.PsiImplUtil.multiResolveImpl(PsiImplUtil.java:803)
        at ksp2_impl.jar//ksp.com.intellij.psi.impl.source.PsiJavaCodeReferenceElementImpl.multiResolve(PsiJavaCodeReferenceElementImpl.java:420)
        at ksp2_impl.jar//ksp.com.intellij.psi.impl.source.PsiJavaCodeReferenceElementImpl.advancedResolve(PsiJavaCodeReferenceElementImpl.java:414)
        at ksp2_impl.jar//ksp.com.intellij.psi.impl.source.PsiJavaCodeReferenceElementImpl.resolve(PsiJavaCodeReferenceElementImpl.java:351)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil$ReferenceComparator.test(PsiEquivalenceUtil.java:49)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil$ReferenceComparator.test(PsiEquivalenceUtil.java:39)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areEquivalent(PsiEquivalenceUtil.java:92)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areEquivalent(PsiEquivalenceUtil.java:74)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areEquivalent(PsiEquivalenceUtil.java:74)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areEquivalent(PsiEquivalenceUtil.java:74)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areEquivalent(PsiEquivalenceUtil.java:29)
        at ksp2_impl.jar//ksp.com.intellij.codeInsight.PsiEquivalenceUtil.areElementsEquivalent(PsiEquivalenceUtil.java:98)
        at ksp2_impl.jar//ksp.org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirPsiSymbolKt.psiOrSymbolEquals(KaFirPsiSymbol.kt:106)
        at ksp2_impl.jar//ksp.org.jetbrains.kotlin.analysis.api.fir.symbols.KaFirNamedClassSymbolBase.equals(KaFirNamedClassSymbolBase.kt:38)
        at java.base/java.util.HashMap.getNode(HashMap.java:586)
        at java.base/java.util.LinkedHashMap.get(LinkedHashMap.java:537)
        at ksp2_impl.jar//com.google.devtools.ksp.impl.symbol.kotlin.KSClassDeclarationImpl$Companion.getCached(KSClassDeclarationImpl.kt:323)
        at ksp2_impl.jar//com.google.devtools.ksp.impl.symbol.kotlin.UtilKt.toKSClassDeclaration(util.kt:496)
        at ksp2_impl.jar//ksp.com.google.devtools.ksp.common.impl.PsiResolutionStrategy.resolve(PsiResolutionStrategy.kt:476)
```