### PR TITLE
Add test showing NPE when PluginProblemReporter is missing

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/PluginProblemReporterProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/PluginProblemReporterProcessor.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.intellij.diagnostic.PluginException
+
+class PluginProblemReporterProcessor : AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> = results
+
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val exception = RuntimeException("Dummy Exception")
+        val pluginException = PluginException.createByClass(
+            "Test error created by PluginException",
+            exception,
+            PluginProblemReporterProcessor::class.java
+        )
+        results.add(pluginException.toString())
+
+        return emptyList()
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -985,4 +985,11 @@ abstract class KSPUnitTestSuite(
     fun testPackageDeclarations() {
         runTest("$AA_PATH/packageDeclarations.kt")
     }
+
+    @Bug("https://github.com/google/ksp/issues/3140", BugState.OPEN)
+    @TestMetadata("pluginProblemReporter.kt")
+    @Test
+    fun testPluginProblemReporter() {
+        runThrowingTest("$AA_PATH/pluginProblemReporter.kt", expectedThrowableType = NullPointerException::class)
+    }
 }

--- a/kotlin-analysis-api/testData/pluginProblemReporter.kt
+++ b/kotlin-analysis-api/testData/pluginProblemReporter.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TEST PROCESSOR: PluginProblemReporterProcessor
+// EXPECTED:
+// END
+
+// FILE: MyClass.kt
+
+// Dummy class to have non-empty file
+class MyClass


### PR DESCRIPTION
PluginProblemReporter is not registered as an application service. This has the effect that if Kotlin or IntelliJ tries to obtain its instance, via the getInstance method, an NPE is thrown and KSP crashes.

Shows the bug described in #3140 