### PR TITLE
Fix NPE caused by missing `PluginProblemReporter` instance

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -46,6 +46,8 @@ import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.Origin
 import com.intellij.core.CoreApplicationEnvironment
+import com.intellij.diagnostic.PluginException
+import com.intellij.diagnostic.PluginProblemReporter
 import com.intellij.mock.MockProject
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -274,6 +276,13 @@ class KotlinSymbolProcessing(
         kotlinCoreProjectEnvironment.registerApplicationServices(
             KaResolutionActivityTracker::class.java,
             LLFirResolutionActivityTracker::class.java
+        )
+
+        kotlinCoreProjectEnvironment.registerApplicationServices(
+            PluginProblemReporter::class.java,
+            PluginProblemReporter { message, cause, _ ->
+                PluginException(message, cause, null)
+            }::class.java
         )
 
         registerProjectServices(

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -987,10 +987,10 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/packageDeclarations.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/3140", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3140", BugState.FIXED)
     @TestMetadata("pluginProblemReporter.kt")
     @Test
     fun testPluginProblemReporter() {
-        runThrowingTest("$AA_PATH/pluginProblemReporter.kt", expectedThrowableType = NullPointerException::class)
+        runTest("$AA_PATH/pluginProblemReporter.kt")
     }
 }

--- a/kotlin-analysis-api/testData/pluginProblemReporter.kt
+++ b/kotlin-analysis-api/testData/pluginProblemReporter.kt
@@ -17,6 +17,7 @@
 
 // TEST PROCESSOR: PluginProblemReporterProcessor
 // EXPECTED:
+// com.intellij.diagnostic.PluginException: Test error created by PluginException
 // END
 
 // FILE: MyClass.kt


### PR DESCRIPTION
Fixes NPE by registering `PluginProblemReporter` as application service in `KotlinSymbolProcessing`.

Depends on https://github.com/google/ksp/pull/3141
Fixes #3140