### PR TITLE
Fix PluginProblemReporterProcessor by adding required parameter

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/PluginProblemReporterProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/PluginProblemReporterProcessor.kt
@@ -21,7 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.intellij.diagnostic.PluginException
 
-class PluginProblemReporterProcessor : AbstractTestProcessor() {
+class PluginProblemReporterProcessor(override val enableNewFeatures: Boolean) : AbstractTestProcessor() {
     private val results = mutableListOf<String>()
 
     override fun toResult(): List<String> = results


### PR DESCRIPTION
The commit which changes test processors to be parametric over the feature toggle for backing fields, was not rebased on main before merging. At that point, main contained a commit that added a new test processor which was not parametric. Specifically, commit b9a936d65d537a46a4ee426145a9479f157b55ed is in conflict with commit d883d650a916bf3841984ad485fa9a8690a48741