### PR TITLE
Fix implicit task dependency error between KSP and Android Lint in Android KMP

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/KspSubplugin.kt
@@ -207,6 +207,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             kspExtension,
         )
 
+        val isAndroidKmp = project.isAndroidKmpProject() &&
+            kotlinCompilation is KotlinMultiplatformAndroidCompilation
+
         val generatedSources = arrayOf(
             project.files(kotlinOutputDir).builtBy(kspTaskProvider),
             project.files(javaOutputDir).builtBy(kspTaskProvider),
@@ -216,8 +219,9 @@ class KspGradleSubplugin @Inject internal constructor(private val registry: Tool
             // They will be observed by downstreams and violate current build scheme.
             kotlinCompileProvider.configure { it.source(*generatedSources) }
         } else {
-            val skipAddingSources = kotlinCompilation is KotlinJvmAndroidCompilation &&
-                project.isAgpBuiltInKotlinUsed() && project.canUseInternalKspApis()
+            val skipAddingSources = (kotlinCompilation is KotlinJvmAndroidCompilation &&
+                project.isAgpBuiltInKotlinUsed() && project.canUseInternalKspApis()) ||
+                isAndroidKmp
 
             if (!skipAddingSources) {
                 registerOutputWithKotlinSrcdirs(project, kotlinCompilation, kspTaskProvider, *generatedSources)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/MultiplatformIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/MultiplatformIT.kt
@@ -63,6 +63,10 @@ class MultiplatformIT(experimentalPsiResolution: Boolean) {
             gradleRunner.withArguments("--configuration-cache-problems=warn", "clean", "build").build()
 
         Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:build")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:kspAndroidHostTest")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:testAndroidHostTest")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:generateAndroidHostTestLintModel")?.outcome)
+        Assert.assertEquals(TaskOutcome.SUCCESS, resultCleanBuild.task(":workload:lintAnalyzeAndroidHostTest")?.outcome)
 
         val classesJar = File(
             project.root,

--- a/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform") apply false
     id("com.android.kotlin.multiplatform.library") apply false
+    id("com.android.lint") apply false
 }
 
 val testRepo: String by project

--- a/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/settings.gradle.kts
@@ -7,6 +7,7 @@ pluginManagement {
         id("com.google.devtools.ksp") version kspVersion apply false
         kotlin("multiplatform") version kotlinVersion apply false
         id("com.android.kotlin.multiplatform.library") version agpVersion apply false
+        id("com.android.lint") version agpVersion apply false
     }
     repositories {
         maven(testRepo)

--- a/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
+++ b/integration-tests/src/test/resources/playground-mpp/workload/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.kotlin.multiplatform.library")
+    id("com.android.lint")
     id("com.google.devtools.ksp")
 }
 
@@ -41,6 +42,11 @@ kotlin {
                 project.dependencies.add("kspAndroid", project(":test-processor"))
             }
             kotlin.srcDir("src/main/java")
+        }
+        val commonTest by getting {
+            dependencies {
+                implementation(kotlin("test"))
+            }
         }
     }
 }

--- a/integration-tests/src/test/resources/playground-mpp/workload/src/androidHostTest/kotlin/com/example/AndroidHostTest.kt
+++ b/integration-tests/src/test/resources/playground-mpp/workload/src/androidHostTest/kotlin/com/example/AndroidHostTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AndroidHostTest {
+    @Test
+    fun testGeneratedBuilder() {
+        val builder = AClassBuilder()
+        builder
+            .withA(1)
+            .withB("foo")
+            .withC(2.3)
+            .withD(hello.HELLO())
+        val aClass = builder.build()
+        assertNotNull(aClass)
+        assertEquals("1, foo, 2.3", aClass.p)
+    }
+}


### PR DESCRIPTION
For android-kmp projects, KSP is adding generated output directories directly to `defaultSourceSet.kotlin.srcDirs`, causing AGP to classify them as static (non-generated) sources. AGP Lint tasks collect all non-generated sources as inputs, leading Gradle to detect task inputs depending on KSP outputs without task dependencies.

Fixes #3128