### PR TITLE
remove link to "why ksp"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ on [kotlinlang.org](https://kotlinlang.org/docs/ksp-overview.html). Here are som
 * [Overview](https://kotlinlang.org/docs/ksp-overview.html)
 * [Quickstart](https://kotlinlang.org/docs/ksp-quickstart.html)
 * [Libraries that support KSP](https://kotlinlang.org/docs/ksp-overview.html#supported-libraries)
-* [Why KSP?](https://kotlinlang.org/docs/ksp-why-ksp.html)
 * [Examples](https://kotlinlang.org/docs/ksp-examples.html)
 * [How KSP models Kotlin code](https://kotlinlang.org/docs/ksp-additional-details.html)
 * [Reference for Java annotation processor authors](https://kotlinlang.org/docs/ksp-reference.html)


### PR DESCRIPTION
"Why KSP" page was deleted from the docs as per Kotlin docs issue [KEDOC-323](https://youtrack.jetbrains.com/issue/KEDOC-323/Delete-Why-KSP-from-KSP-docs)