### PR TITLE
fix: resolve annotation default values from KMP metadata

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/util.kt
@@ -126,6 +126,7 @@ import org.jetbrains.kotlin.codegen.state.md5base64
 import org.jetbrains.kotlin.fir.declarations.FirRegularClass
 import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.fir.declarations.utils.moduleName
+import org.jetbrains.kotlin.fir.expressions.impl.FirExpressionStub
 import org.jetbrains.kotlin.fir.java.JavaTypeParameterStack
 import org.jetbrains.kotlin.fir.java.toFirExpression
 import org.jetbrains.kotlin.fir.resolve.getContainingClassSymbol
@@ -779,33 +780,39 @@ internal fun KaValueParameterSymbol.getDefaultValue(): KaAnnotationValue? {
             }
             // ClsMethodImpl means the psi is decompiled psi.
             null, is ClsMemberImpl<*> -> {
-                // TODO: multiplatform
-                if (!ResolverAAImpl.instance.isJvm)
-                    return@let null
-                val fileManager = ResolverAAImpl.instance.javaFileManager
-                val parentClass = this.getContainingKSSymbol()!!.findParentOfType<KSClassDeclaration>()
-                val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
-                    ?: return@let null
+                val firValueParameter = this as? KaFirValueParameterSymbol ?: return@let null
+                firValueParameter.firSymbol.fir.defaultValue
+                    ?.takeUnless { it is FirExpressionStub }
+                    ?.let { defaultValue ->
+                        return@let FirAnnotationValueConverter.toConstantValue(defaultValue, firValueParameter.builder)
+                    }
 
-                val defaultValue: JavaAnnotationArgument? = analyze {
-                    val jc = fileManager.findClass(classId, analysisScope) ?: return@analyze null
-                    jc.methods.firstOrNull { it.name == name }?.annotationParameterDefaultValue
+                val defaultValue: JavaAnnotationArgument? = if (ResolverAAImpl.instance.isJvm) {
+                    val fileManager = ResolverAAImpl.instance.javaFileManager
+                    val parentClass = this.getContainingKSSymbol()!!.findParentOfType<KSClassDeclaration>()
+                    val classId = (parentClass as KSClassDeclarationImpl).ktClassOrObjectSymbol.classId
+                        ?: return@let null
+                    analyze {
+                        val jc = fileManager.findClass(classId, analysisScope) ?: return@analyze null
+                        jc.methods.firstOrNull { it.name == name }?.annotationParameterDefaultValue
+                    }
+                } else {
+                    if (!firValueParameter.isVararg) return@let null
+                    null
                 }
 
-                (this as? KaFirValueParameterSymbol)?.let {
-                    val firSession = it.firSymbol.fir.moduleData.session
-                    val symbolBuilder = it.builder
-                    val expectedTypeRef = it.firSymbol.fir.returnTypeRef
-                    // when no default value is declared in the class file, ideally users should
-                    // apply a value for such property at use site, therefore value obtained here should not be
-                    // returned. In case of a user failed to do so, we try our best to return values
-                    // to ensure no annotation argument is missing from KSP side.
-                    // Supplying `JavaUnknownAnnotationArgumentImpl` as the expression base
-                    // will produce empty array for array type values and `null` for the rest of value types.
-                    val expression = (defaultValue ?: JavaUnknownAnnotationArgumentImpl(null))
-                        .toFirExpression(firSession, JavaTypeParameterStack.EMPTY, expectedTypeRef, null)
-                    FirAnnotationValueConverter.toConstantValue(expression, symbolBuilder)
-                }
+                val firSession = firValueParameter.firSymbol.fir.moduleData.session
+                val symbolBuilder = firValueParameter.builder
+                val expectedTypeRef = firValueParameter.firSymbol.fir.returnTypeRef
+                // when no default value is declared in the class file, ideally users should
+                // apply a value for such property at use site, therefore value obtained here should not be
+                // returned. In case of a user failed to do so, we try our best to return values
+                // to ensure no annotation argument is missing from KSP side.
+                // Supplying `JavaUnknownAnnotationArgumentImpl` as the expression base
+                // will produce empty array for array type values and `null` for the rest of value types.
+                val expression = (defaultValue ?: JavaUnknownAnnotationArgumentImpl(null))
+                    .toFirExpression(firSession, JavaTypeParameterStack.EMPTY, expectedTypeRef, null)
+                FirAnnotationValueConverter.toConstantValue(expression, symbolBuilder)
             }
 
             else -> throw InternalKSPException(

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeKmpDefaultProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/GetAnnotationByTypeKmpDefaultProcessor.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.getAnnotationsByType
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+
+annotation class KmpAnnotationDefaults(
+    val required: String,
+    val enabled: Boolean = true,
+    vararg val values: String,
+)
+
+class GetAnnotationByTypeKmpDefaultProcessor(
+    override val enableNewFeatures: Boolean,
+) : AbstractTestProcessor() {
+    private val results = mutableListOf<String>()
+
+    override fun toResult(): List<String> = results
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        resolver.getAllFiles().single().declarations
+            .filterIsInstance<KSClassDeclaration>()
+            .sortedBy { it.simpleName.asString() }
+            .forEach { declaration ->
+                val annotation = declaration.getAnnotationsByType(KmpAnnotationDefaults::class).single()
+                val defaultNames = declaration.annotations.single().defaultArguments
+                    .map { it.name!!.asString() }
+                    .sorted()
+                results.add(
+                    "${declaration.simpleName.asString()}: " +
+                        "required=${annotation.required}, enabled=${annotation.enabled}, " +
+                        "values=${annotation.values.contentToString()}, defaults=$defaultNames"
+                )
+            }
+        return emptyList()
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -396,6 +396,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/getAnnotationByTypeWithInnerDefault.kt")
     }
 
+    @TestMetadata("native/getAnnotationByTypeWithDefault.kt")
+    @Test
+    @Bug("https://github.com/google/ksp/issues/2356", BugState.FIXED)
+    fun testGetAnnotationByTypeWithKmpDefault() {
+        runTest("$AA_PATH/native/getAnnotationByTypeWithDefault.kt")
+    }
+
     @TestMetadata("getPackage.kt")
     @Test
     fun testGetPackage() {

--- a/kotlin-analysis-api/testData/native/getAnnotationByTypeWithDefault.kt
+++ b/kotlin-analysis-api/testData/native/getAnnotationByTypeWithDefault.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TARGET_BACKEND: NATIVE
+// WITH_FIXED_TARGET: linux_x64
+// WITH_RUNTIME
+// TEST PROCESSOR: GetAnnotationByTypeKmpDefaultProcessor
+// EXPECTED:
+// OverridesDefault: required=override, enabled=false, values=[], defaults=[enabled, values]
+// UsesDefaults: required=default, enabled=true, values=[], defaults=[enabled, values]
+// END
+
+// MODULE: lib
+// FILE: KmpAnnotationDefaults.kt
+package com.google.devtools.ksp.processor
+
+annotation class KmpAnnotationDefaults(
+    val required: String,
+    val enabled: Boolean = true,
+    vararg val values: String,
+)
+
+// MODULE: main(lib)
+// FILE: UsesDefaults.kt
+package com.google.devtools.ksp.processor
+
+@KmpAnnotationDefaults(required = "default")
+class UsesDefaults
+
+@KmpAnnotationDefaults(required = "override", enabled = false)
+class OverridesDefault


### PR DESCRIPTION
Update the existing default-value conversion in `util.kt` to consume a deserialized FIR value parameter's metadata-backed default expression on every target, converting it through the same FIR annotation-value machinery already used for JVM defaults. KSP2 omits default arguments declared by annotation classes in compiled Kotlin libraries when processing a non-JVM KMP target.

On a Native target, read an annotation from a compiled library through `getAnnotationsByType` and verify an omitted Boolean member returns its declared value instead of throwing; Omit a vararg annotation member and verify the proxy exposes an empty array, covering the empty-collection failure reported in the thread.

Fixes #2356
