### PR TITLE
Enable parallel tooling Gradle sync

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@
 org.gradle.jvmargs=-Duser.country=US -Dkotlin.daemon.jvm.options=-Xmx4096m -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true
+
 # Duplicated in gradle/libs.versions.toml: gradle-plugin's TestConfig loads this
 # file directly at test runtime. Keep the two values in sync.
 kotlinBaseVersion=2.3.20


### PR DESCRIPTION
As per Android Studio Quail 1 2026, org.gradle.parallel=true does not imply org.gradle.tooling.parallel=true, so it must be manually set. See https://developer.android.com/studio/releases/past-releases/as-quail-1-release-notes?hl=en#android_studio_quail_1_202612_patch_1_june_2026