### PR TITLE
Update AGP min version to 8.12.0

### DIFF
--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/AndroidPluginIntegration.kt
@@ -28,7 +28,6 @@ import com.android.build.api.variant.impl.FlatSourceDirectoriesImpl
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.api.SourceKind
 import com.android.build.gradle.internal.component.ComponentCreationConfig
-import com.google.devtools.ksp.gradle.utils.canUseAddGeneratedSourceDirectoriesApi
 import com.google.devtools.ksp.gradle.utils.canUseInternalKspApis
 import com.google.devtools.ksp.gradle.utils.isAgpBuiltInKotlinUsed
 import com.google.devtools.ksp.gradle.utils.isLegacyKaptPluginApplied
@@ -159,7 +158,6 @@ object AndroidPluginIntegration {
         androidComponent: Component?,
     ) {
         if (androidComponent != null &&
-            project.canUseAddGeneratedSourceDirectoriesApi() &&
             project.isAgpBuiltInKotlinUsed()
         ) {
             if (project.canUseInternalKspApis()) {

--- a/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
+++ b/gradle-plugin/src/main/kotlin/com/google/devtools/ksp/gradle/utils/agpUtils.kt
@@ -26,15 +26,6 @@ fun checkMinimumAgpVersion(pluginVersion: AndroidPluginVersion) {
     }
 }
 
-/**
- * Returns true for AGP version is 8.12.0-alpha06 or higher.
- * That is the version where addGeneratedSourceDirectories API was fixed
- */
-fun Project.canUseAddGeneratedSourceDirectoriesApi(): Boolean {
-    val agpVersion = project.getAgpVersion() ?: return false
-    return agpVersion >= AndroidPluginVersion(8, 12, 0).alpha(6)
-}
-
 fun Project.canUseInternalKspApis(): Boolean {
     val agpVersion = project.getAgpVersion() ?: return false
     return agpVersion >= AndroidPluginVersion(9, 0, 0).alpha(14)
@@ -46,4 +37,4 @@ fun Project.canUseInternalKspApis(): Boolean {
  * KSP aims to support AGP versions released approximately within the last year
  * from the current KSP release date.
  */
-val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 10, 0)
+val MINIMUM_SUPPORTED_AGP_VERSION = AndroidPluginVersion(8, 12, 0)

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/agp/AGPVersionIT.kt
@@ -34,19 +34,11 @@ class AGPVersionIT(
                 arrayOf(null, null, null),
 
                 // Alpha/beta versions
-                arrayOf("8.12.0-alpha06", "2.2.10", "8.13"),
-                arrayOf("8.12.0-alpha06", "2.3.0-RC", "8.13"),
                 arrayOf("9.0.0-alpha12", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha12", "2.3.0-RC", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.2.10", "9.1.0"),
                 arrayOf("9.0.0-alpha14", "2.3.0-RC", "9.1.0"),
 
-                // AGP 8.10.0
-                arrayOf("8.10.0", "2.3.0-RC", "8.11.1"),
-                arrayOf("8.10.0", "2.2.10", "8.11.1"),
-                // AGP 8.11.0
-                arrayOf("8.11.0", "2.3.0-RC", "8.13"),
-                arrayOf("8.11.0", "2.2.10", "8.13"),
                 // AGP 8.12.0
                 arrayOf("8.12.0", "2.3.0-RC", "8.13"),
                 arrayOf("8.12.0", "2.2.10", "8.13"),


### PR DESCRIPTION
AGP 8.12.0 was released roughly more than 1 year ago so based on our support guidelines, moving the minimum level to it.
