### PR TITLE
Fix `KSBackingFieldImpl.origin`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldImpl.kt
@@ -32,6 +32,7 @@ import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSVisitor
 import com.google.devtools.ksp.symbol.KSVisitorNext
 import com.google.devtools.ksp.symbol.Modifier
+import com.google.devtools.ksp.symbol.Origin
 import org.jetbrains.kotlin.analysis.api.symbols.KaBackingFieldSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.types.abbreviationOrSelf
@@ -58,6 +59,9 @@ class KSBackingFieldImpl private constructor(val kaBackingFieldSymbol: KaBacking
             }
         }
     }
+
+    override val origin: Origin
+        get() = property.origin
 
     override val type: KSTypeReference by lazy {
         (kaBackingFieldSymbol.psiIfSource() as? KtBackingField)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -767,12 +767,7 @@ abstract class KSPUnitTestSuite(
     @TestMetadata("referenceElement.kt")
     @Test
     fun testReferenceElement() {
-        // TODO: Figure out what the correct expected output is
-        if (enableNewFeatures) {
-            runFailingTest("$AA_PATH/referenceElement.kt")
-        } else {
-            runTest("$AA_PATH/referenceElement.kt")
-        }
+        runTest("$AA_PATH/referenceElement.kt")
     }
 
     @TestMetadata("repeatedNonRepeatableAnnotations.kt")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -472,6 +472,9 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/isMutable.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/3123", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3125", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3155", BugState.OPEN)
     @TestMetadata("javaModifiers.kt")
     @Test
     fun testJavaModifiers() {

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -546,12 +546,7 @@ abstract class KSPUnitTestSuite(
     @TestMetadata("libOrigins.kt")
     @Test
     fun testLibOrigins() {
-        // TODO: Figure out what the expected result is here
-        if (enableNewFeatures) {
-            runFailingTest("$AA_PATH/libOrigins.kt")
-        } else {
-            runTest("$AA_PATH/libOrigins.kt")
-        }
+        runTest("$AA_PATH/libOrigins.kt")
     }
 
     @TestMetadata("localAnnotationClass")

--- a/kotlin-analysis-api/testData/implicitElements.kt
+++ b/kotlin-analysis-api/testData/implicitElements.kt
@@ -37,7 +37,7 @@
 // EXPECT NEXT: Test, p: [MyKotlinAnnotation: null]
 // EXPECT NEXT: Test, field: [MyJavaAnnotation: null]
 // EXPECT NEXT: lib.Test, p: [MyKotlinAnnotation: null]
-// EXPECT NEXT: lib.Test, field: [MyJavaAnnotation: FIELD]
+// EXPECT NEXT: lib.Test, field: [MyJavaAnnotation: null]
 // END
 // MODULE: lib
 // FILE: lib/MyJavaAnnotation.java

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -46,16 +46,16 @@
 // DependencyOuterJavaClass: OPEN PUBLIC : PUBLIC
 // DependencyOuterKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.<init>: FINAL PRIVATE : FINAL PRIVATE
-// EXPECT NEXT: DependencyOuterKotlinClass.Companion.companionField.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.Companion.companionField.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion.companionField: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.companionMethod: FINAL PUBLIC : FINAL PUBLIC
-// EXPECT NEXT: DependencyOuterKotlinClass.Companion.customJvmStaticCompanionField.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.Companion.customJvmStaticCompanionField.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion.customJvmStaticCompanionField: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
 // DependencyOuterKotlinClass.Companion.customJvmStaticCompanionMethod: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
-// EXPECT NEXT: DependencyOuterKotlinClass.Companion.jvmStaticCompanionField.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.Companion.jvmStaticCompanionField.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion.jvmStaticCompanionField: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
 // DependencyOuterKotlinClass.Companion.jvmStaticCompanionMethod: FINAL PUBLIC : FINAL JAVA_STATIC PUBLIC
-// EXPECT NEXT: DependencyOuterKotlinClass.Companion.privateCompanionField.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.Companion.privateCompanionField.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion.privateCompanionField: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.Companion.privateCompanionMethod: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.Companion: FINAL PUBLIC : FINAL PUBLIC
@@ -64,9 +64,9 @@
 // DependencyOuterKotlinClass.DependencyNestedKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // DependencyOuterKotlinClass.DependencyNestedKotlinClass: OPEN PUBLIC : PUBLIC
 // DependencyOuterKotlinClass.synchronizedFun: FINAL PUBLIC : FINAL JAVA_SYNCHRONIZED PUBLIC
-// EXPECT NEXT: DependencyOuterKotlinClass.transientProperty.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.transientProperty.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.transientProperty: FINAL PUBLIC : FINAL JAVA_TRANSIENT PUBLIC
-// EXPECT NEXT: DependencyOuterKotlinClass.volatileProperty.field: : FINAL
+// EXPECT NEXT: DependencyOuterKotlinClass.volatileProperty.field: FINAL PRIVATE : FINAL PRIVATE
 // DependencyOuterKotlinClass.volatileProperty: FINAL PUBLIC : FINAL JAVA_VOLATILE PUBLIC
 // DependencyOuterKotlinClass: OPEN PUBLIC : PUBLIC
 // HasTypeAliasFuns: Modifiers: []

--- a/kotlin-analysis-api/testData/referenceElement.kt
+++ b/kotlin-analysis-api/testData/referenceElement.kt
@@ -19,16 +19,21 @@
 // TEST PROCESSOR: ReferenceElementProcessor
 // EXPECTED:
 // KSClassifierReferenceImpl: Qualifier of B is A
+// EXPECT NEXT: KSClassifierReferenceImpl: Qualifier of B is A
 // KSClassifierReferenceImpl: Qualifier of C<INVARIANT Int> is A<INVARIANT String>
+// EXPECT NEXT: KSClassifierReferenceImpl: Qualifier of C<INVARIANT Int> is A<INVARIANT String>
 // KSClassifierReferenceImpl: Qualifier of ExampleAnnotation<INVARIANT ExampleParameter> is null
 // KSClassifierReferenceImpl: Qualifier of ExampleParameter is null
 // KSClassifierReferenceImpl: Qualifier of Int is null
+// EXPECT NEXT: KSClassifierReferenceImpl: Qualifier of Int is null
 // KSClassifierReferenceImpl: Qualifier of String is null
+// EXPECT NEXT: KSClassifierReferenceImpl: Qualifier of String is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of Int is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of String is null
 // KSClassifierReferenceDescriptorImpl: Qualifier of Y is X
 // KSClassifierReferenceDescriptorImpl: Qualifier of Z<INVARIANT Int> is X<INVARIANT String>
 // KSDefNonNullReferenceImpl: Enclosed type of T
+// EXPECT NEXT: KSDefNonNullReferenceImpl: Enclosed type of T
 // KSClassifierReferenceJavaImpl: Qualifier of Any is null
 // KSClassifierReferenceJavaImpl: Qualifier of Any is null
 // KSClassifierReferenceJavaImpl: Qualifier of Any is null


### PR DESCRIPTION
This commit fixes the origin for backing fields.
Previously the origin would always point to Kotlin sources regardless of whether the parent property was from a library.

Related to https://github.com/google/ksp/issues/2873