### PR TITLE
Update docString test

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -17,8 +17,6 @@
 
 package com.google.devtools.ksp.test
 
-import com.google.devtools.ksp.test.annotations.Bug
-import com.google.devtools.ksp.test.annotations.BugState
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Test
 
@@ -75,6 +73,19 @@ abstract class AAConfiguredUnitTestSuiteBase(
     }
 }
 
-class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false)
+class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
 
-class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true)
+    @TestMetadata("docString.kt")
+    @Test
+    override fun testDocString() {
+        runTest("$AA_PATH/docString.kt")
+    }
+}
+
+class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
+    @TestMetadata("docString.kt")
+    @Test
+    override fun testDocString() {
+        runFailingTest("$AA_PATH/docString.kt")
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -306,9 +306,7 @@ abstract class KSPUnitTestSuite(
 
     @TestMetadata("docString.kt")
     @Test
-    fun testDocString() {
-        runTest("$AA_PATH/docString.kt")
-    }
+    abstract fun testDocString()
 
     @TestMetadata("equals.kt")
     @Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -17,8 +17,6 @@
 
 package com.google.devtools.ksp.test
 
-import com.google.devtools.ksp.test.annotations.Bug
-import com.google.devtools.ksp.test.annotations.BugState
 import org.jetbrains.kotlin.test.TestMetadata
 import org.junit.jupiter.api.Test
 
@@ -71,6 +69,12 @@ abstract class PsiConfiguredUnitTestSuiteBase(
 
 class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
 
+    @TestMetadata("docString.kt")
+    @Test
+    override fun testDocString() {
+        runTest("$AA_PATH/docString.kt")
+    }
+
     @TestMetadata("hello.kt")
     @Test
     override fun testHello() {
@@ -79,6 +83,12 @@ class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatu
 }
 
 class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
+
+    @TestMetadata("docString.kt")
+    @Test
+    override fun testDocString() {
+        runFailingTest("$AA_PATH/docString.kt")
+    }
 
     @TestMetadata("hello.kt")
     @Test

--- a/kotlin-analysis-api/testData/docString.kt
+++ b/kotlin-analysis-api/testData/docString.kt
@@ -27,25 +27,28 @@
 // TopClass: \n top level class\n\n doc can have multiple lines\n\n third non-empty line\n
 // f1: \n top level function\n
 // f2: \n member function\n
-// EXPECT NEXT: field:  Irregular doc comment 1
-// EXPECT NEXT: field: Irregular doc comment 3 *\n
-// EXPECT NEXT: field: \n Irregular doc comment 2
-// EXPECT NEXT: field: \n member property\n
-// EXPECT NEXT: field: \n owned doc comment\n
-// EXPECT NEXT: field: \n\n top level property\n\n
-// EXPECT NEXT: field: null
-// EXPECT NEXT: field: null
 // foo: \n\n\n member function\n\n
+// EXPECT NEXT: j1.field: \n field\n
 // j1: \n field\n
+// EXPECT NEXT: j2.field: null
 // j2: null
+// EXPECT NEXT: j3.field: null
 // j3: null
+// EXPECT NEXT: v1.field: \n\n top level property\n\n
 // v1: \n\n top level property\n\n
+// EXPECT NEXT: v2.field:  Irregular doc comment 1
 // v2:  Irregular doc comment 1
+// EXPECT NEXT: v3.field: \n Irregular doc comment 2
 // v3: \n Irregular doc comment 2
+// EXPECT NEXT: v4.field: Irregular doc comment 3 *\n
 // v4: Irregular doc comment 3 *\n
+// EXPECT NEXT: v5.field: \n owned doc comment\n
 // v5: \n owned doc comment\n
+// EXPECT NEXT: v6.field: null
 // v6: null
+// EXPECT NEXT: v7.field: null
 // v7: null
+// EXPECT NEXT: v8.field: \n member property\n
 // v8: \n member property\n
 // END
 // FILE: KotlinSrc.kt
@@ -61,7 +64,6 @@ fun f1() = 0
  *
  */
 val v1 = 0
-
 
 /** * Irregular doc comment 1***/
 val v2 = 0
@@ -132,7 +134,8 @@ class JavaSrc {
      * member function
      *
      */
-    int foo() {
+    int foo()
+    {
         return 0;
     }
 

--- a/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DocStringProcessor.kt
+++ b/test-utils/src/main/kotlin/com/google/devtools/ksp/processor/DocStringProcessor.kt
@@ -19,6 +19,7 @@ package com.google.devtools.ksp.processor
 
 import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.google.devtools.ksp.symbol.KSBackingField
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.visitor.KSTopDownVisitor
@@ -35,8 +36,18 @@ class DocStringProcessor(override val enableNewFeatures: Boolean) : AbstractTest
         override fun defaultHandler(node: KSNode, data: MutableCollection<String>) = Unit
 
         override fun visitDeclaration(declaration: KSDeclaration, data: MutableCollection<String>) {
-            data.add("${declaration.simpleName.asString()}: ${declaration.docString?.lines()?.joinToString("\\n")}")
+            data.add("${declaration.simpleName.asString()}: ${declaration.renderDocString()}")
         }
+
+        override fun visitBackingField(backingField: KSBackingField, data: MutableCollection<String>) {
+            // Override this method to also render parent property's name
+            data.add(
+                "${backingField.property.simpleName.asString()}.${backingField.simpleName.asString()}: " +
+                    "${backingField.renderDocString()}"
+            )
+        }
+
+        private fun KSDeclaration.renderDocString(): String? = this.docString?.lines()?.joinToString("\\n")
     }
 
     override fun process(resolver: Resolver): List<KSAnnotated> {


### PR DESCRIPTION
This change makes the test easier to read as the parent property of backing fields are printed. Thus, if a doc comment is `null`, it clearly reference which field that `null` originated from, instead of expecting a handful of consectutive `field: null` lines.

Related to #2873
Related to https://github.com/google/ksp/pull/3158