### PR TITLE
Fix missing `packageName` in `KSBackingFieldImpl`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldImpl.kt
@@ -25,6 +25,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolv
 import com.google.devtools.ksp.symbol.KSAnnotation
 import com.google.devtools.ksp.symbol.KSBackingField
 import com.google.devtools.ksp.symbol.KSExpectActual
+import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSName
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSTypeReference
@@ -90,6 +91,9 @@ class KSBackingFieldImpl private constructor(val kaBackingFieldSymbol: KaBacking
         kaBackingFieldSymbol.annotations.asSequence()
             .map { KSAnnotationResolvedImpl.getCached(it, this, definitionOrigin) }
     }
+
+    override val containingFile: KSFile?
+        get() = property.containingFile
 
     override val location by lazy {
         // N.B.: Use psi?.toLocation() instead of psi.toLocation() even though toLocation handles a nullable receiver.

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -61,18 +61,6 @@ abstract class AAConfiguredUnitTestSuiteBase(
     }
 }
 
-class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
-    @TestMetadata("getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    @Test
-    override fun testBackingFieldsPackageName() {
-        runTest("$AA_PATH/getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    }
-}
+class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false)
 
-class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
-    @TestMetadata("getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    @Test
-    override fun testBackingFieldsPackageName() {
-        runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    }
-}
+class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -353,12 +353,14 @@ abstract class KSPUnitTestSuite(
 
     @Bug(
         "https://github.com/google/ksp/issues/3165",
-        BugState.OPEN,
+        BugState.FIXED,
         "Obtaining package name of implicit backing field could throw exception."
     )
     @TestMetadata("getSymbolsWithAnnotation/backingFieldsPackageName.kt")
     @Test
-    abstract fun testBackingFieldsPackageName()
+    fun testBackingFieldsPackageName() {
+        runTest("$AA_PATH/getSymbolsWithAnnotation/backingFieldsPackageName.kt")
+    }
 
     @TestMetadata("getSymbolsWithAnnotation/negative/fieldAndPropertyUseSiteTargetOnConstructorParameters.kt")
     @Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -61,18 +61,6 @@ abstract class PsiConfiguredUnitTestSuiteBase(
     }
 }
 
-class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
-    @TestMetadata("getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    @Test
-    override fun testBackingFieldsPackageName() {
-        runTest("$AA_PATH/getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    }
-}
+class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false)
 
-class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
-    @TestMetadata("getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    @Test
-    override fun testBackingFieldsPackageName() {
-        runThrowingTest("$AA_PATH/getSymbolsWithAnnotation/backingFieldsPackageName.kt")
-    }
-}
+class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true)


### PR DESCRIPTION
Depends on https://github.com/google/ksp/pull/3164
Fixes https://github.com/google/ksp/issues/3165