### PR TITLE
Use Kotlin interpolation prefix instead of escaping the dollar character

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.parallel.Execution
 import org.junit.jupiter.api.parallel.ExecutionMode
 
 @Execution(ExecutionMode.SAME_THREAD)
-@TestDataPath("\$CONTENT_ROOT/testData")
+@TestDataPath($$"$CONTENT_ROOT/testData")
 abstract class KSPUnitTestSuite(
     experimentalPsiResolution: Boolean,
     enableNewFeatures: Boolean,


### PR DESCRIPTION
This was a change suggested by IntelliJ.