### PR TITLE
Move remaining kotlin-analysis-api and gradle-plugin inline versions to the version catalog

### DIFF
--- a/gradle-plugin/build.gradle.kts
+++ b/gradle-plugin/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     testImplementation(libs.google.truth)
     testImplementation(gradleTestKit())
 
-    lintChecks("androidx.lint:lint-gradle:1.0.0-alpha05")
+    lintChecks(libs.androidx.lintGradle)
 }
 
 kotlin {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,10 @@ aa-trove4j = "1.0.20200330"
 aa-log4j = "1.2.17.2"
 aa-jdom = "2.0.6"
 aa-coroutines = "1.10.2"
+aa-annotations = "24.1.0"
+aa-lz4 = "1.7.1"
+aa-opentelemetry = "1.34.1"
+androidx-lintGradle = "1.0.0-alpha05"
 aa-collections-immutable = "0.3.4"
 aa-caffeine = "2.9.3"
 aa-javax-inject = "1"
@@ -52,6 +56,10 @@ aa-jdom = { module = "org.jetbrains.intellij.deps:jdom", version.ref = "aa-jdom"
 aa-collectionsImmutable = { module = "org.jetbrains.kotlinx:kotlinx-collections-immutable-jvm", version.ref = "aa-collections-immutable" }
 aa-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version.ref = "aa-caffeine" }
 aa-javaxInject = { module = "javax.inject:javax.inject", version.ref = "aa-javax-inject" }
+aa-annotations = { module = "org.jetbrains:annotations", version.ref = "aa-annotations" }
+aa-lz4 = { module = "org.lz4:lz4-java", version.ref = "aa-lz4" }
+aa-opentelemetry = { module = "io.opentelemetry:opentelemetry-api", version.ref = "aa-opentelemetry" }
+androidx-lintGradle = { module = "androidx.lint:lint-gradle", version.ref = "androidx-lintGradle" }
 
 [plugins]
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }

--- a/kotlin-analysis-api/build.gradle.kts
+++ b/kotlin-analysis-api/build.gradle.kts
@@ -174,7 +174,7 @@ dependencies {
     implementation(files(filteredLog4j))
     implementation(libs.aa.jdom) { isTransitive = false }
     implementation(libs.aa.javaxInject)
-    implementation("org.lz4:lz4-java:1.7.1") { isTransitive = false }
+    implementation(libs.aa.lz4) { isTransitive = false }
     compileOnly(libs.kotlinx.coroutines.coreJvm)
     compileOnly(libs.kotlinx.coroutines.core)
     implementation(
@@ -182,9 +182,9 @@ dependencies {
     ) {
         isTransitive = false
     }
-    implementation("org.jetbrains:annotations:24.1.0")
+    implementation(libs.aa.annotations)
 
-    implementation("io.opentelemetry:opentelemetry-api:1.34.1") { isTransitive = false }
+    implementation(libs.aa.opentelemetry) { isTransitive = false }
 
     compileOnly(project(":common-deps"))
 


### PR DESCRIPTION
Following #3127. This moves the last inline dependency versions in the production modules to the catalog, so no version literal remains in any non-fixture build file.

kotlin-analysis-api: annotations, lz4-java, opentelemetry-api. gradle-plugin: the lint-gradle lintChecks dependency.

Unlike the previous slice, all four are in use, so they are cataloged rather than removed: annotations is used directly in source, and lz4 and opentelemetry are isTransitive false runtime pins for the IntelliJ platform (opentelemetry is also relocated into the embeddable jar), so dropping them would risk a runtime NoClassDefFoundError.

Verified resolution is unchanged: :kotlin-analysis-api:dependencies for compile and runtime and :gradle-plugin:dependencies for lintChecks are identical before and after, 157 lines compared. Both modules compile.

The only versions still declared inline live in benchmark/exhaustive-processor, which I left alone as a benchmark fixture, consistent with excluding the examples and test resource projects. Happy to migrate it too if you would like it in scope for this issue.