### PR TITLE
Fix suppressing compilation errors for dependencies in test framework

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -38,7 +38,6 @@ import org.jetbrains.kotlin.test.compileJavaFiles
 import org.jetbrains.kotlin.test.directives.ConfigurationDirectives
 import org.jetbrains.kotlin.test.directives.NativeEnvironmentConfigurationDirectives
 import org.jetbrains.kotlin.test.services.targetPlatformProvider
-import org.jetbrains.kotlin.test.compileJavaFiles
 import org.jetbrains.kotlin.test.kotlinPathsForDistDirectoryForTests
 import org.jetbrains.kotlin.test.model.FrontendKinds
 import org.jetbrains.kotlin.test.model.TestModule
@@ -112,9 +111,13 @@ abstract class AbstractKSPAATest(
         moduleName: String,
         jvmTarget: JvmTarget?
     ) {
+        val sourcesPathAsFile = File(sourcesPath)
+        if (!sourcesPathAsFile.containsKotlinFile()) {
+            return
+        }
         val classpath = mutableListOf<String>()
         classpath.addAll(dependencies.map { it.canonicalPath })
-        if (File(sourcesPath).isDirectory) {
+        if (sourcesPathAsFile.isDirectory) {
             classpath += sourcesPath
         }
         classpath += PathUtil.kotlinPathsForDistDirectoryForTests.stdlibPath.path
@@ -280,4 +283,10 @@ abstract class AbstractKSPAATest(
         }
         return testProcessor.toResult()
     }
+
+    /**
+     * Returns `true` if `this` is a directory and there is at least one Kotlin file in it
+     */
+    private fun File.containsKotlinFile(): Boolean =
+        this.isDirectory && this.walkTopDown().any { it.isFile && it.extension == "kt" }
 }

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AbstractKSPAATest.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.processing.KSPJsConfig
 import com.google.devtools.ksp.processing.KSPJvmConfig
 import com.google.devtools.ksp.processing.KSPNativeConfig
 import com.google.devtools.ksp.processor.AbstractTestProcessor
+import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.jvmModularRoots
@@ -138,7 +139,10 @@ abstract class AbstractKSPAATest(
         val compilerClass = URLClassLoader(arrayOf(), javaClass.classLoader).loadClass(K2JVMCompiler::class.java.name)
         val compiler = compilerClass.getDeclaredConstructor().newInstance()
         val execMethod = compilerClass.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
-        execMethod.invoke(compiler, PrintStream(outStream), args.toTypedArray())
+        val exitCode = execMethod.invoke(compiler, PrintStream(outStream), args.toTypedArray()) as ExitCode
+        if (exitCode != ExitCode.OK) {
+            throw IllegalStateException("Compilation failed with exit code $exitCode:\n$outStream")
+        }
     }
 
     override fun compileModule(module: TestModule, testServices: TestServices) {


### PR DESCRIPTION
This change throws an exception if the exit code of the Kotlin compiler is not "OK". In the test framework, when using dependencies/libraries, the Kotlin compiler must first compile those modules before KSP can run on the source module. However, if the module cannot compile KSP should not run and the test is invalid. The old code did not check the exit code and would silently suppress compilation errors. This change makes the compilation error explicit, so invalid test dependencies are caught.