### PR TITLE
Fix CLI nontermination

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/KSPCmdLineOptionsIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/secondary/KSPCmdLineOptionsIT.kt
@@ -12,6 +12,8 @@ import java.io.File
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 import java.net.URLClassLoader
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
 
 @RunWith(Parameterized::class)
 class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
@@ -28,25 +30,31 @@ class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
         fun data(): Collection<Boolean> = listOf(true, false)
     }
 
-    private fun getKsp2Main(mainClassName: String): Method {
+    private fun getKspClasspath(): List<File> {
         val repoPath = "../build/repos/test/com/google/devtools/ksp/"
 
         val commonDepsJar = File("$repoPath/symbol-processing-common-deps/${System.getProperty("kspVersion")}")
             .listFiles()!!.filter {
-            it.name.matches(Regex(".*-\\d.jar"))
-        }.maxByOrNull { it.lastModified() }!!
+                it.name.matches(Regex(".*-\\d.jar"))
+            }.maxByOrNull { it.lastModified() }!!
         val kspMainJar = File("$repoPath/symbol-processing-aa-embeddable/${System.getProperty("kspVersion")}")
             .listFiles()!!.filter {
-            it.name.matches(Regex(".*-\\d.jar"))
-        }.maxByOrNull { it.lastModified() }!!
+                it.name.matches(Regex(".*-\\d.jar"))
+            }.maxByOrNull { it.lastModified() }!!
         val kspApiJar = File("$repoPath/symbol-processing-api/${System.getProperty("kspVersion")}")
             .listFiles()!!.filter {
-            it.name.matches(Regex(".*-\\d.jar"))
-        }.maxByOrNull { it.lastModified() }!!
+                it.name.matches(Regex(".*-\\d.jar"))
+            }.maxByOrNull { it.lastModified() }!!
 
-        val kspClasspath = listOf(
-            commonDepsJar, kspMainJar, kspApiJar
-        ).map { it.toURI().toURL() }.toTypedArray()
+        val stdlibJar = File(KotlinVersion::class.java.protectionDomain.codeSource.location.toURI())
+        val coroutinesJar =
+            File(kotlinx.coroutines.Dispatchers::class.java.protectionDomain.codeSource.location.toURI())
+
+        return listOf(commonDepsJar, kspMainJar, kspApiJar, stdlibJar, coroutinesJar)
+    }
+
+    private fun getKsp2Main(mainClassName: String): Method {
+        val kspClasspath = getKspClasspath().map { it.toURI().toURL() }.toTypedArray()
         val classLoader = URLClassLoader(kspClasspath)
         val kspMainClass = classLoader.loadClass(mainClassName)
 
@@ -74,15 +82,18 @@ class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
         )
     }
 
+    private fun buildProcessorJar(): String {
+        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
+        gradleRunner.withArguments("clean", ":processors:build").build()
+        return File(project.root, "processors/build/libs/processors-1.0-SNAPSHOT.jar").absolutePath
+    }
+
     fun testKsp2(mainClassName: String, platformArgs: List<String>) {
         Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
 
         val sharedArgs = getKsp2SharedArgs()
         val kspMain = getKsp2Main(mainClassName)
-
-        val gradleRunner = GradleRunner.create().withProjectDir(project.root)
-        gradleRunner.withArguments("clean", ":processors:build").build()
-        val processorJar = File(project.root, "processors/build/libs/processors-1.0-SNAPSHOT.jar").absolutePath
+        val processorJar = buildProcessorJar()
 
         val outDir = "${project.root.path}/build/out"
         val args = sharedArgs + platformArgs + listOf(processorJar)
@@ -139,6 +150,93 @@ class KSPCmdLineOptionsIT(experimentalPsiResolution: Boolean) {
     @Test
     fun testKSPNativeMain() {
         testKsp2(
+            "com.google.devtools.ksp.cmdline.KSPNativeMain",
+            listOf(
+                "-target=LinuxX64"
+            )
+        )
+    }
+
+    /**
+     * Parameterized test for checking that KSP exits correctly when a processor throws an
+     * exception. This test spawns a new process for the invocation to reproduce the exact
+     * setup where background threads are spawned.
+     *
+     * See GitHub issue 3120 for more information.
+     */
+    fun testKsp2ProcessTerminationOnCrash(mainClassName: String, platformArgs: List<String>) {
+        Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows", ignoreCase = true))
+
+        val sharedArgs = getKsp2SharedArgs()
+        val processorJar = buildProcessorJar()
+        val args = sharedArgs + platformArgs + listOf(processorJar, "-processor-options", "error=true")
+
+        val javaBinary = File(System.getProperty("java.home"), "bin/java").absolutePath
+        val cp = getKspClasspath().joinToString(File.pathSeparator) { it.absolutePath }
+        val process = ProcessBuilder(listOf(javaBinary, "-cp", cp, mainClassName) + args)
+            .redirectErrorStream(true)
+            .start()
+
+        // Drain stdout/stderr asynchronously:
+        // 1. Prevent deadlocks: If the child process output exceeds the OS pipe buffer capacity
+        //    (typically 64 KB on Linux), the child process will block on write, causing an artificial hang.
+        // 2. Avoid blocking the test thread: Reading synchronously would block forever if the process hangs.
+        // 3. Diagnostics: Retain the child process output for actionable debugging if the test fails.
+        val outputFuture = CompletableFuture.supplyAsync {
+            process.inputStream.bufferedReader().use { it.readText() }
+        }
+        val finished = process.waitFor(60, TimeUnit.SECONDS)
+        val output = try {
+            outputFuture.get(1, TimeUnit.SECONDS)
+        } catch (e: Exception) {
+            "<timed out reading output: ${e.message}>"
+        }
+        if (!finished) {
+            process.destroyForcibly()
+            Assert.fail("KSP CLI process hung indefinitely when a processor crashed. Process output:\n$output")
+        }
+        Assert.assertEquals("Expected exit code 1. Process output:\n$output", 1, process.exitValue())
+        Assert.assertTrue(
+            "Process output should contain processor exception. Process output:\n$output",
+            output.contains("Error on request")
+        )
+    }
+
+    @Test
+    fun testKSPJvmMainProcessTerminationOnCrash() {
+        val outDir = "${project.root.path}/build/out"
+        testKsp2ProcessTerminationOnCrash(
+            "com.google.devtools.ksp.cmdline.KSPJvmMain",
+            listOf(
+                "-java-output-dir", outDir,
+                "-jvm-target", "11",
+            )
+        )
+    }
+
+    @Test
+    fun testKSPCommonMainProcessTerminationOnCrash() {
+        testKsp2ProcessTerminationOnCrash(
+            "com.google.devtools.ksp.cmdline.KSPCommonMain",
+            listOf(
+                "-targets=common",
+            )
+        )
+    }
+
+    @Test
+    fun testKSPJsMainProcessTerminationOnCrash() {
+        testKsp2ProcessTerminationOnCrash(
+            "com.google.devtools.ksp.cmdline.KSPJsMain",
+            listOf(
+                "-backend=JS",
+            )
+        )
+    }
+
+    @Test
+    fun testKSPNativeMainProcessTerminationOnCrash() {
+        testKsp2ProcessTerminationOnCrash(
             "com.google.devtools.ksp.cmdline.KSPNativeMain",
             listOf(
                 "-target=LinuxX64"

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPCommonMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPCommonMain.kt
@@ -1,7 +1,15 @@
 package com.google.devtools.ksp.cmdline
 
+import com.google.devtools.ksp.impl.KotlinSymbolProcessing
+import com.google.devtools.ksp.processing.KSPConfig
+import com.google.devtools.ksp.processing.KspGradleLogger
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.processing.kspCommonArgParser
 import com.google.devtools.ksp.processing.kspCommonArgParserHelp
+import java.io.File
+import java.net.URLClassLoader
+import java.util.ServiceLoader
+import kotlin.system.exitProcess
 
 class KSPCommonMain {
     companion object {
@@ -13,5 +21,49 @@ class KSPCommonMain {
                 runWithArgs(args, ::kspCommonArgParser)
             }
         }
+    }
+}
+
+internal fun printHelpMsg(optionsList: String) {
+    println("Available options:")
+    println(optionsList)
+    println("where:")
+    println(" * is required")
+    println(" List is <path-separator> separated. E.g., arg1:arg2:arg3 on Linux/Mac, or arg1;arg2;arg3 on Windows")
+    println(" Map is in the form key1=value1:key2=value2 on Linux/Mac or key1=value1;key2=value2 on Windows")
+}
+
+internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSPConfig, List<String>>) {
+
+    val loggingVerbosity = System.getProperty("ksp.logging", "warn")
+    val loggingLevel = when (loggingVerbosity.lowercase()) {
+        "error" -> KspGradleLogger.LOGGING_LEVEL_ERROR
+        "warn" -> KspGradleLogger.LOGGING_LEVEL_WARN
+        "warning" -> KspGradleLogger.LOGGING_LEVEL_WARN
+        "info" -> KspGradleLogger.LOGGING_LEVEL_INFO
+        "debug" -> KspGradleLogger.LOGGING_LEVEL_LOGGING
+        else -> KspGradleLogger.LOGGING_LEVEL_WARN
+    }
+
+    val logger = KspGradleLogger(loggingLevel)
+
+    try {
+        val (config, classpath) = parse(args)
+        val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
+
+        @Suppress("UNCHECKED_CAST")
+        val processorProviders = ServiceLoader
+            .load(
+                processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
+                processorClassloader
+            )
+            .toList() as List<SymbolProcessorProvider>
+
+        val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
+        exitProcess(exitCode.code)
+    } catch (t: Throwable) {
+        logger.exception(t)
+        t.printStackTrace()
+        exitProcess(KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR.code)
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPCommonMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPCommonMain.kt
@@ -62,6 +62,8 @@ internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSP
         val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
         exitProcess(exitCode.code)
     } catch (t: Throwable) {
+        // Manually print stack trace and log the exception if error occurred.
+        // Then call exitProcess to ensure the process is halted.
         logger.exception(t)
         t.printStackTrace()
         exitProcess(KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR.code)

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -1,15 +1,7 @@
 package com.google.devtools.ksp.cmdline
 
-import com.google.devtools.ksp.impl.KotlinSymbolProcessing
-import com.google.devtools.ksp.processing.KSPConfig
-import com.google.devtools.ksp.processing.KspGradleLogger
-import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.processing.kspJvmArgParser
 import com.google.devtools.ksp.processing.kspJvmArgParserHelp
-import java.io.File
-import java.net.URLClassLoader
-import java.util.ServiceLoader
-import kotlin.system.exitProcess
 
 class KSPJvmMain {
     companion object {
@@ -21,49 +13,5 @@ class KSPJvmMain {
                 runWithArgs(args, ::kspJvmArgParser)
             }
         }
-    }
-}
-
-internal fun printHelpMsg(optionsList: String) {
-    println("Available options:")
-    println(optionsList)
-    println("where:")
-    println(" * is required")
-    println(" List is <path-separator> separated. E.g., arg1:arg2:arg3 on Linux/Mac, or arg1;arg2;arg3 on Windows")
-    println(" Map is in the form key1=value1:key2=value2 on Linux/Mac or key1=value1;key2=value2 on Windows")
-}
-
-internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSPConfig, List<String>>) {
-
-    val loggingVerbosity = System.getProperty("ksp.logging", "warn")
-    val loggingLevel = when (loggingVerbosity.lowercase()) {
-        "error" -> KspGradleLogger.LOGGING_LEVEL_ERROR
-        "warn" -> KspGradleLogger.LOGGING_LEVEL_WARN
-        "warning" -> KspGradleLogger.LOGGING_LEVEL_WARN
-        "info" -> KspGradleLogger.LOGGING_LEVEL_INFO
-        "debug" -> KspGradleLogger.LOGGING_LEVEL_LOGGING
-        else -> KspGradleLogger.LOGGING_LEVEL_WARN
-    }
-
-    val logger = KspGradleLogger(loggingLevel)
-
-    try {
-        val (config, classpath) = parse(args)
-        val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
-
-        @Suppress("UNCHECKED_CAST")
-        val processorProviders = ServiceLoader
-            .load(
-                processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
-                processorClassloader
-            )
-            .toList() as List<SymbolProcessorProvider>
-
-        val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
-        exitProcess(exitCode.code)
-    } catch (t: Throwable) {
-        logger.exception(t)
-        t.printStackTrace()
-        exitProcess(KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR.code)
     }
 }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/cmdline/KSPJvmMain.kt
@@ -47,17 +47,23 @@ internal fun runWithArgs(args: Array<String>, parse: (Array<String>) -> Pair<KSP
 
     val logger = KspGradleLogger(loggingLevel)
 
-    val (config, classpath) = parse(args)
-    val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
+    try {
+        val (config, classpath) = parse(args)
+        val processorClassloader = URLClassLoader(classpath.map { File(it).toURI().toURL() }.toTypedArray())
 
-    @Suppress("UNCHECKED_CAST")
-    val processorProviders = ServiceLoader
-        .load(
-            processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
-            processorClassloader
-        )
-        .toList() as List<SymbolProcessorProvider>
+        @Suppress("UNCHECKED_CAST")
+        val processorProviders = ServiceLoader
+            .load(
+                processorClassloader.loadClass("com.google.devtools.ksp.processing.SymbolProcessorProvider"),
+                processorClassloader
+            )
+            .toList() as List<SymbolProcessorProvider>
 
-    val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
-    exitProcess(exitCode.code)
+        val exitCode = KotlinSymbolProcessing(config, processorProviders, logger).execute()
+        exitProcess(exitCode.code)
+    } catch (t: Throwable) {
+        logger.exception(t)
+        t.printStackTrace()
+        exitProcess(KotlinSymbolProcessing.ExitCode.PROCESSING_ERROR.code)
+    }
 }


### PR DESCRIPTION
The background threads spawned by the Analysis API still continue unless the `exitProcess` function is called. This PR adds a parameterized test that checks for nontermination (with a 1 minute timeout). It then wraps all CLI entry points in a try-catch that manually prints the stack trace in the error case and calls `exitProcess` to ensure the process halts.

Closes https://github.com/google/ksp/issues/3120