### PR TITLE
Fix qualified names for `KSBackingFieldJavaImpl`

### DIFF
--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldJavaImpl.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/symbol/kotlin/KSBackingFieldJavaImpl.kt
@@ -24,6 +24,7 @@ import com.google.devtools.ksp.impl.symbol.kotlin.resolved.KSTypeReferenceResolv
 import com.google.devtools.ksp.symbol.KSBackingField
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSName
+import com.google.devtools.ksp.symbol.KSNode
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.KSTypeReference
 import com.google.devtools.ksp.symbol.KSVisitor
@@ -59,6 +60,12 @@ class KSBackingFieldJavaImpl private constructor(
     override val type: KSTypeReference by lazy {
         KSTypeReferenceResolvedImpl.getCached(ktJavaFieldSymbol.returnType, this)
     }
+
+    override val parentDeclaration: KSDeclaration
+        get() = property
+
+    override val parent: KSNode
+        get() = property
 
     override val simpleName: KSName by lazy {
         KSNameImpl.getCached("field")

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/AAConfiguredUnitTestSuite.kt
@@ -61,18 +61,6 @@ abstract class AAConfiguredUnitTestSuiteBase(
     }
 }
 
-class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
-    @TestMetadata("getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    @Test
-    override fun testJavaBackingFieldsParents() {
-        runTest("$AA_PATH/getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    }
-}
+class AAConfiguredUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = false)
 
-class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
-    @TestMetadata("getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    @Test
-    override fun testJavaBackingFieldsParents() {
-        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    }
-}
+class AAConfiguredNewFeaturesUnitTestSuite : AAConfiguredUnitTestSuiteBase(enableNewFeatures = true)

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -520,10 +520,12 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/javaNonNullTypes.kt")
     }
 
-    @Bug("https://github.com/google/ksp/issues/3166", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3166", BugState.FIXED)
     @TestMetadata("getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
     @Test
-    abstract fun testJavaBackingFieldsParents()
+    fun testJavaBackingFieldsParents() {
+        runTest("$AA_PATH/getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
+    }
 
     @TestMetadata("javaSubtype.kt")
     @Test

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/PsiConfiguredUnitTestSuite.kt
@@ -61,18 +61,6 @@ abstract class PsiConfiguredUnitTestSuiteBase(
     }
 }
 
-class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false) {
-    @TestMetadata("getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    @Test
-    override fun testJavaBackingFieldsParents() {
-        runTest("$AA_PATH/getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    }
-}
+class PsiConfiguredUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = false)
 
-class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true) {
-    @TestMetadata("getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    @Test
-    override fun testJavaBackingFieldsParents() {
-        runFailingTest("$AA_PATH/getSymbolsWithAnnotation/javaBackingFieldsParents.kt")
-    }
-}
+class PsiConfiguredNewFeaturesUnitTestSuite : PsiConfiguredUnitTestSuiteBase(enableNewFeatures = true)

--- a/kotlin-analysis-api/testData/getSymbolsWithAnnotation/backingFieldsPackageName.kt
+++ b/kotlin-analysis-api/testData/getSymbolsWithAnnotation/backingFieldsPackageName.kt
@@ -22,7 +22,7 @@
 // EXPECT CURRENT: annotations.Select: MyJavaClass.x: com.example.jcl
 // EXPECT CURRENT: annotations.Select: Other.myOtherProp: my.other.test
 // EXPECT NEXT: annotations.Select: MyClass.myProp.field: test
-// EXPECT NEXT: annotations.Select: MyJavaClass.field: com.example.jcl
+// EXPECT NEXT: annotations.Select: MyJavaClass.x.field: com.example.jcl
 // EXPECT NEXT: annotations.Select: MyJavaClass.x: com.example.jcl
 // EXPECT NEXT: annotations.Select: Other.myOtherProp.field: my.other.test
 // END

--- a/kotlin-analysis-api/testData/parent.kt
+++ b/kotlin-analysis-api/testData/parent.kt
@@ -35,7 +35,7 @@
 // parent of (T..T?): t
 // EXPECT NEXT: parent of T: (T..T?)
 // EXPECT NEXT: parent of (T..T?): field
-// EXPECT NEXT: parent of field: B
+// EXPECT NEXT: parent of field: t
 // parent of t: B
 // parent of T: (T..T?)
 // parent of (T..T?): t


### PR DESCRIPTION
This PR overrides the `parentDeclaration` and `parent` properties in `KSBackingFieldJavaImpl` to delegate to the owning `KSPropertyDeclaration` passed to `KSBackingFieldJavaImpl` in the constructor.

Closes #3166 