### PR TITLE
Add tests for `getDeclarationsFromPackage` across multiple rounds

### DIFF
--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
@@ -444,12 +444,27 @@ class AnnoOnProperty {
             Assert.assertEquals(TaskOutcome.SUCCESS, it.task(":workload-klib:kspKotlinLinuxX64")?.outcome)
             Assert.assertTrue(
                 it.output.contains(
-                    "w: [ksp] com.somedependency package declarations: [com.somedependency.AnotherDepClass, com.somedependency.SomeDepClass]"
+                    "w: [ksp] round 0 com.somedependency package declarations: [com.somedependency.AnotherDepClass, com.somedependency.SomeDepClass]"
                 )
             )
             Assert.assertTrue(
                 it.output.contains(
-                    "w: [ksp] com.myapp package declarations: [com.myapp.AnotherAppClass, com.myapp.MyAppClass, com.myapp.anotherAppFunction, com.myapp.myAppFunction]"
+                    "w: [ksp] round 1 com.somedependency package declarations: [com.somedependency.AnotherDepClass, com.somedependency.SomeDepClass]"
+                )
+            )
+            Assert.assertTrue(
+                it.output.contains(
+                    "w: [ksp] round 0 com.myapp package declarations: [com.myapp.AnotherAppClass, com.myapp.MyAppClass, com.myapp.anotherAppFunction, com.myapp.myAppFunction]"
+                )
+            )
+            Assert.assertTrue(
+                it.output.contains(
+                    "w: [ksp] round 1 com.myapp package declarations: [com.myapp.AnotherAppClass, com.myapp.MyAppClass, com.myapp.anotherAppFunction, com.myapp.myAppFunction]"
+                )
+            )
+            Assert.assertTrue(
+                it.output.contains(
+                    "w: [ksp] round 1 com.example package declarations: [com.example.Foo]"
                 )
             )
         }

--- a/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
+++ b/integration-tests/src/test/resources/kmp/test-processor/src/main/kotlin/TestProcessor.kt
@@ -12,29 +12,18 @@ class TestProcessor(
     val logger: KSPLogger,
     val env: SymbolProcessorEnvironment
 ) : SymbolProcessor {
-    var invoked = false
+    var round = 0
 
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val allFiles = resolver.getAllFiles().map { it.fileName }
         logger.warn(allFiles.toList().toString())
-        if (invoked) {
-            return emptyList()
-        }
-        invoked = true
-
-        logger.warn("language version: ${env.kotlinVersion}")
-        logger.warn("api version: ${env.apiVersion}")
-        logger.warn("compiler version: ${env.compilerVersion}")
-        val platforms = env.platforms.map { it.toString() }
-        logger.warn("platforms: $platforms")
-        val list = resolver.getClassDeclarationByName("kotlin.collections.List")
-        logger.warn("List has superTypes: ${list!!.superTypes.count() > 0}")
 
         val someDepDecls = resolver.getDeclarationsFromPackage("com.somedependency")
             .mapNotNull { it.qualifiedName?.asString() }
             .sorted()
             .toList()
         if (someDepDecls.isNotEmpty()) {
+            logger.warn("round $round com.somedependency package declarations: $someDepDecls")
             logger.warn("com.somedependency package declarations: $someDepDecls")
         }
 
@@ -43,6 +32,7 @@ class TestProcessor(
             .sorted()
             .toList()
         if (myAppDecls.isNotEmpty()) {
+            logger.warn("round $round com.myapp package declarations: $myAppDecls")
             logger.warn("com.myapp package declarations: $myAppDecls")
         }
 
@@ -51,8 +41,22 @@ class TestProcessor(
             .sorted()
             .toList()
         if (exampleDecls.isNotEmpty()) {
+            logger.warn("round $round com.example package declarations: $exampleDecls")
             logger.warn("com.example package declarations: $exampleDecls")
         }
+
+        if (round > 0) {
+            return emptyList()
+        }
+        round++
+
+        logger.warn("language version: ${env.kotlinVersion}")
+        logger.warn("api version: ${env.apiVersion}")
+        logger.warn("compiler version: ${env.compilerVersion}")
+        val platforms = env.platforms.map { it.toString() }
+        logger.warn("platforms: $platforms")
+        val list = resolver.getClassDeclarationByName("kotlin.collections.List")
+        logger.warn("List has superTypes: ${list!!.superTypes.count() > 0}")
 
         codeGenerator.createNewFile(
             Dependencies(true, *resolver.getAllFiles().toList().toTypedArray()),

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/MultiRoundPackageDeclarationProcessor.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/processor/MultiRoundPackageDeclarationProcessor.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.devtools.ksp.processor
+
+import com.google.devtools.ksp.KspExperimental
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.symbol.KSAnnotated
+
+class MultiRoundPackageDeclarationProcessor(
+    val packageNames: List<String>,
+    override val enableNewFeatures: Boolean
+) : AbstractTestProcessor() {
+    val results = mutableListOf<String>()
+    private lateinit var env: SymbolProcessorEnvironment
+    private var round = 0
+
+    override fun toResult(): List<String> {
+        return results
+    }
+
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        super.create(environment)
+        env = environment
+        return this
+    }
+
+    @OptIn(KspExperimental::class)
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        results.add("Round $round:")
+        packageNames.forEach { pkgName ->
+            val decls = resolver.getDeclarationsFromPackage(pkgName)
+                .map { it.qualifiedName?.asString() ?: it.simpleName.asString() }
+                .sorted()
+                .toList()
+            results.add("$pkgName: $decls")
+        }
+
+        if (round == 0) {
+            generateDummyFileToAdvanceToNextRound()
+        }
+
+        round++
+        return emptyList()
+    }
+
+    private fun generateDummyFileToAdvanceToNextRound() {
+        val dependencies = Dependencies(aggregating = true, sources = arrayOf())
+        env.codeGenerator.createNewFile(dependencies, "com.example.generated", "GeneratedClass", "kt").use {
+            it.write("package com.example.generated\n\nclass GeneratedClass\n".toByteArray())
+        }
+    }
+}

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -1012,6 +1012,13 @@ abstract class KSPUnitTestSuite(
         runTest("$AA_PATH/native/packageDeclarations.kt")
     }
 
+    @Bug("https://github.com/google/ksp/issues/2396", BugState.FIXED)
+    @TestMetadata("native/packageDeclarationsMultiRound.kt")
+    @Test
+    fun testNativePackageDeclarationsMultiRound() {
+        runTest("$AA_PATH/native/packageDeclarationsMultiRound.kt")
+    }
+
     @Bug(
         "https://github.com/google/ksp/issues/2396",
         BugState.FIXED,

--- a/kotlin-analysis-api/testData/native/packageDeclarationsMultiRound.kt
+++ b/kotlin-analysis-api/testData/native/packageDeclarationsMultiRound.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// TARGET_BACKEND: NATIVE
+// WITH_FIXED_TARGET: linux_x64
+// TEST PROCESSOR: MultiRoundPackageDeclarationProcessor
+// PROCESSOR INPUT: com.example.test, com.example.app, com.example.generated
+// EXPECTED:
+// Round 0:
+// com.example.test: [com.example.test.LibDeclaration]
+// com.example.app: [com.example.app.Foo]
+// com.example.generated: []
+// Round 1:
+// com.example.test: [com.example.test.LibDeclaration]
+// com.example.app: [com.example.app.Foo]
+// com.example.generated: [com.example.generated.GeneratedClass]
+// END
+
+// MODULE: lib
+// FILE: LibDeclaration.kt
+
+package com.example.test
+
+class LibDeclaration
+
+// MODULE: main(lib)
+// FILE: Foo.kt
+
+package com.example.app
+
+import com.example.test.LibDeclaration
+
+class Foo(val decl: LibDeclaration)


### PR DESCRIPTION
KSP drops its AA caches across rounds to ensure new files are correct indexed. Issue #2396 was recently closed, but these tests assert that declarations in packages in klibs are still accessible across rounds, i.e., the cache drops do not affect the `Resolver.getDeclarationsFromPackage` function.

Related to #2396 