### PR TITLE
Simplify `KSDeclaration.isLocal`

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -135,9 +135,7 @@ fun KSClassDeclaration.getConstructors(): Sequence<KSFunctionDeclaration> {
 }
 
 /** Check whether this is a local declaration, or namely, declared in a function. */
-fun KSDeclaration.isLocal(): Boolean {
-    return this.parentDeclaration != null && this.parentDeclaration !is KSClassDeclaration
-}
+fun KSDeclaration.isLocal(): Boolean = parentDeclaration is KSFunctionDeclaration
 
 /**
  * Perform a validation on a given symbol to check if all interested types in symbols enclosed scope

--- a/kotlin-analysis-api/testData/declarationUtil.kt
+++ b/kotlin-analysis-api/testData/declarationUtil.kt
@@ -18,14 +18,14 @@
 // TEST PROCESSOR: DeclarationUtilProcessor
 // EXPECTED:
 // Cls: internal
-// EXPECT NEXT: Cls.b.field: local
+// EXPECT NEXT: Cls.b.field: private
 // Cls.b: public open
-// EXPECT NEXT: Cls.prop.field: local
+// EXPECT NEXT: Cls.prop.field: private
 // Cls.prop: public open
-// EXPECT NEXT: Cls.protectedProp.field: local
+// EXPECT NEXT: Cls.protectedProp.field: private
 // Cls.protectedProp: protected open
 // Cls.abstractITFFun: public open
-// EXPECT NEXT: Cls.pri.field: local
+// EXPECT NEXT: Cls.pri.field: private
 // Cls.pri: private
 // Cls / <init>: public
 // Cls / <init>: public
@@ -39,17 +39,17 @@
 // ITF.nonAbstractITFFun / aa: local
 // NestedClassSubjects: public open
 // NestedClassSubjects.NestedDataClass: public
-// EXPECT NEXT: NestedClassSubjects.NestedDataClass.field.field: local
+// EXPECT NEXT: NestedClassSubjects.NestedDataClass.field.field: private
 // NestedClassSubjects.NestedDataClass.field: public
 // NestedClassSubjects.NestedDataClass.component1: public
 // NestedClassSubjects.NestedDataClass.copy: public
 // NestedClassSubjects.NestedDataClass / <init>: public
 // NestedClassSubjects.NestedFinalClass: public
-// EXPECT NEXT: NestedClassSubjects.NestedFinalClass.field.field: local
+// EXPECT NEXT: NestedClassSubjects.NestedFinalClass.field.field: private
 // NestedClassSubjects.NestedFinalClass.field: public
 // NestedClassSubjects.NestedFinalClass / <init>: public
 // NestedClassSubjects.NestedOpenClass: public open
-// EXPECT NEXT: NestedClassSubjects.NestedOpenClass.field.field: local
+// EXPECT NEXT: NestedClassSubjects.NestedOpenClass.field.field: private
 // NestedClassSubjects.NestedOpenClass.field: public
 // NestedClassSubjects.NestedOpenClass / <init>: public
 // NestedClassSubjects.NestedInterface: public open


### PR DESCRIPTION
The now checks whether the parentDeclaration is KSFunctionDeclaration. Doing so is equivalent to first checking for non-null and then checking the instance. It also now checks that it is an instance of KSFunctionDeclaration instead of checking it is NOT a KSClassDeclaration. This style is more direct and resilient if the universe of possible declarations change.
Depends on https://github.com/google/ksp/pull/3181