### PR TITLE
Fix visibility for Kotlin-based backing fields

### DIFF
--- a/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
+++ b/api/src/main/kotlin/com/google/devtools/ksp/utils.kt
@@ -21,6 +21,7 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSAnnotation
+import com.google.devtools.ksp.symbol.KSBackingField
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
 import com.google.devtools.ksp.symbol.KSFile
@@ -196,6 +197,7 @@ fun KSDeclaration.getVisibility(): Visibility {
             } ?: Visibility.PUBLIC
         }
 
+        this.isKotlinBackingField() -> Visibility.PRIVATE
         this.isLocal() -> Visibility.LOCAL
         this.modifiers.contains(Modifier.PRIVATE) -> Visibility.PRIVATE
         this.modifiers.contains(Modifier.PROTECTED) || this.modifiers.contains(Modifier.OVERRIDE) ->
@@ -213,6 +215,11 @@ fun KSDeclaration.getVisibility(): Visibility {
             else Visibility.JAVA_PACKAGE
     }
 }
+
+internal fun KSDeclaration.isKotlinBackingField(): Boolean =
+    this is KSBackingField && (
+        origin == Origin.KOTLIN || origin == Origin.KOTLIN_LIB
+        )
 
 /**
  * get all super types for a class declaration Calling [getAllSuperTypes] requires type resolution

--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -228,7 +228,7 @@ abstract class KSPUnitTestSuite(
         BugState.FIXED,
         "This test asserts that resolver behavior change (when calling the enableNewFeatures lambda) is observable and not just a property of KSP's test framework."
     )
-    @Bug("https://github.com/google/ksp/issues/3185", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3185", BugState.FIXED)
     @TestMetadata("changingBehavior.kt")
     @Test
     fun testChangingBehavior() {
@@ -513,7 +513,7 @@ abstract class KSPUnitTestSuite(
     @Bug("https://github.com/google/ksp/issues/3123", BugState.OPEN)
     @Bug("https://github.com/google/ksp/issues/3125", BugState.FIXED)
     @Bug("https://github.com/google/ksp/issues/3155", BugState.OPEN)
-    @Bug("https://github.com/google/ksp/issues/3185", BugState.OPEN)
+    @Bug("https://github.com/google/ksp/issues/3185", BugState.FIXED)
     @TestMetadata("javaModifiers.kt")
     @Test
     fun testJavaModifiers() {

--- a/kotlin-analysis-api/testData/changingBehavior.kt
+++ b/kotlin-analysis-api/testData/changingBehavior.kt
@@ -31,7 +31,7 @@
 // MyClass.x.annotations = Anno, PropAnno
 // MyClass.x.modifiers = FINAL, PUBLIC
 // MyClass.x.field.annotations = FieldAnno
-// MyClass.x.field.modifiers = FINAL
+// MyClass.x.field.modifiers = FINAL, PRIVATE
 // END
 
 // FILE: Anno.kt

--- a/kotlin-analysis-api/testData/javaModifiers.kt
+++ b/kotlin-analysis-api/testData/javaModifiers.kt
@@ -103,16 +103,16 @@
 // OuterJavaClass: PUBLIC : PUBLIC
 // OuterKotlinClass.<init>: FINAL PUBLIC : FINAL PUBLIC
 // OuterKotlinClass.Companion.<init>: FINAL PUBLIC : FINAL PUBLIC
-// EXPECT NEXT: OuterKotlinClass.Companion.companionField.field: : FINAL
+// EXPECT NEXT: OuterKotlinClass.Companion.companionField.field: : FINAL PRIVATE
 // OuterKotlinClass.Companion.companionField: CONST : FINAL PUBLIC
 // OuterKotlinClass.Companion.companionMethod: : FINAL PUBLIC
-// EXPECT NEXT: OuterKotlinClass.Companion.customJvmStaticCompanionField.field: : FINAL
+// EXPECT NEXT: OuterKotlinClass.Companion.customJvmStaticCompanionField.field: : FINAL PRIVATE
 // OuterKotlinClass.Companion.customJvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.customJvmStaticCompanionMethod: : FINAL PUBLIC
-// EXPECT NEXT: OuterKotlinClass.Companion.jvmStaticCompanionField.field: : FINAL
+// EXPECT NEXT: OuterKotlinClass.Companion.jvmStaticCompanionField.field: : FINAL PRIVATE
 // OuterKotlinClass.Companion.jvmStaticCompanionField: : FINAL JAVA_STATIC PUBLIC
 // OuterKotlinClass.Companion.jvmStaticCompanionMethod: : FINAL JAVA_STATIC PUBLIC
-// EXPECT NEXT: OuterKotlinClass.Companion.privateCompanionField.field: : FINAL
+// EXPECT NEXT: OuterKotlinClass.Companion.privateCompanionField.field: : FINAL PRIVATE
 // OuterKotlinClass.Companion.privateCompanionField: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion.privateCompanionMethod: PRIVATE : FINAL PRIVATE
 // OuterKotlinClass.Companion: : FINAL PUBLIC
@@ -123,9 +123,9 @@
 // OuterKotlinClass.synchronizedFun: : FINAL JAVA_SYNCHRONIZED PUBLIC
 // EXPECT CURRENT: OuterKotlinClass.transientProperty: : FINAL JAVA_TRANSIENT PUBLIC
 // EXPECT CURRENT: OuterKotlinClass.volatileProperty: : FINAL JAVA_VOLATILE PUBLIC
-// EXPECT NEXT: OuterKotlinClass.transientProperty.field: : FINAL JAVA_TRANSIENT
+// EXPECT NEXT: OuterKotlinClass.transientProperty.field: : FINAL JAVA_TRANSIENT PRIVATE
 // EXPECT NEXT: OuterKotlinClass.transientProperty: : FINAL PUBLIC
-// EXPECT NEXT: OuterKotlinClass.volatileProperty.field: : FINAL JAVA_VOLATILE
+// EXPECT NEXT: OuterKotlinClass.volatileProperty.field: : FINAL JAVA_VOLATILE PRIVATE
 // EXPECT NEXT: OuterKotlinClass.volatileProperty: : FINAL PUBLIC
 // OuterKotlinClass: OPEN : PUBLIC
 // TypeAliasInKt: Modifiers: [PRIVATE]


### PR DESCRIPTION
Depends on https://github.com/google/ksp/pull/3181
Related to https://github.com/google/ksp/issues/3155
Closes https://github.com/google/ksp/issues/3185
