### PR TITLE
Mark bug 2873 as fixed in `testBackingFieldsLateinit`

### DIFF
--- a/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
+++ b/kotlin-analysis-api/src/test/kotlin/com/google/devtools/ksp/test/KSPUnitTestSuite.kt
@@ -198,7 +198,7 @@ abstract class KSPUnitTestSuite(
     @Test
     @Bug(
         "https://github.com/google/ksp/issues/2873",
-        BugState.OPEN,
+        BugState.FIXED,
         "Minimal reproduction of error observed in integration test AndroidDataBindingIT"
     )
     fun testBackingFieldsLateinit() {


### PR DESCRIPTION
The bug was already fixed, but the annotation carried the wrong value for test `testBackingFieldsLateinit`.
Related to #2873