### PR TITLE
On error run type checking to improve diagnostics

### DIFF
--- a/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
+++ b/gradle-plugin/src/test/kotlin/com/google/devtools/ksp/gradle/GradleCompilationTest.kt
@@ -82,6 +82,102 @@ class GradleCompilationTest(isExperimentalPsiResolution: Boolean) {
     }
 
     @Test
+    fun missingTypeReportedOnFailure() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.dependencies.add(
+            module(configuration = "ksp", testRule.processorModule)
+        )
+        testRule.appModule.addSource(
+            "TestFailure.kt",
+            """
+            package com.example
+
+            class TestFailure {
+                val field: UnresolvedClass = UnresolvedClass()
+            }
+            """.trimIndent()
+        )
+        class ErrorReporting(private val logger: KSPLogger) : SymbolProcessor {
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                logger.error("Fatal KSP processor error!")
+                return emptyList()
+            }
+        }
+
+        class Provider : TestSymbolProcessorProvider({ env -> ErrorReporting(env.logger) })
+
+        testRule.addProvider(Provider::class)
+        val failure = testRule.runner()
+            .withArguments("app:assemble")
+            .buildAndFail()
+        assertThat(failure.output).contains("Fatal KSP processor error!")
+        assertThat(failure.output).contains("TestFailure.kt:4: Unresolved reference \'UnresolvedClass\'")
+    }
+
+    @Test
+    fun onlyLastRoundFilesAreCheckedOnFailure() {
+        testRule.setupAppAsJvmApp()
+        testRule.appModule.dependencies.add(
+            module(configuration = "ksp", testRule.processorModule)
+        )
+        testRule.appModule.addSource(
+            "Round0File.kt",
+            """
+            package com.example
+
+            class Round0File {
+                val round0Field: UnresolvedInRound0 = UnresolvedInRound0()
+            }
+            """.trimIndent()
+        )
+        class MultiRoundProcessor(
+            private val codeGenerator: CodeGenerator,
+            private val logger: KSPLogger,
+        ) : SymbolProcessor {
+            private var round = 0
+
+            override fun process(resolver: Resolver): List<KSAnnotated> {
+                if (round == 0) {
+                    round++
+                    codeGenerator.createNewFile(
+                        Dependencies.ALL_FILES,
+                        "com.example",
+                        "GeneratedInRound0"
+                    ).use { stream ->
+                        stream.writer(Charsets.UTF_8).use {
+                            it.write(
+                                """
+                                package com.example
+
+                                class GeneratedInRound0 {
+                                    val round1Field: UnresolvedInRound1 = UnresolvedInRound1()
+                                }
+                                """.trimIndent()
+                            )
+                        }
+                    }
+                } else {
+                    logger.error("Fatal KSP processor error in round 1!")
+                }
+                return emptyList()
+            }
+        }
+
+        class Provider : TestSymbolProcessorProvider({ env ->
+            MultiRoundProcessor(env.codeGenerator, env.logger)
+        })
+
+        testRule.addProvider(Provider::class)
+        val failure = testRule.runner()
+            .withArguments("app:assemble")
+            .buildAndFail()
+
+        assertThat(failure.output).contains("Fatal KSP processor error in round 1!")
+        assertThat(failure.output).contains("GeneratedInRound0.kt:4: Unresolved reference 'UnresolvedInRound1'.")
+        assertThat(failure.output).doesNotContain("UnresolvedInRound0")
+    }
+
+    @Test
     fun applicationCanAccessGeneratedCode_multiplatform_withConfigCache() {
         testRule.setupAppAsMultiplatformApp(
             """

--- a/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
+++ b/integration-tests/src/test/kotlin/com/google/devtools/ksp/test/primary/KMPImplementedIT.kt
@@ -4,6 +4,9 @@ import com.google.devtools.ksp.test.fixtures.TemporaryTestProject
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.hasItem
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Ignore
@@ -117,7 +120,9 @@ class KMPImplementedIT(experimentalPsiResolution: Boolean) {
             ":workload-jvm:build"
         ).buildAndFail().let {
             val errors = it.output.lines().filter { it.startsWith("e: [ksp]") }
-            Assert.assertEquals("e: [ksp] java.lang.Exception: Test Exception in process", errors.first())
+
+            assertThat(errors, hasItem(containsString("Baz.kt:4: Unresolved reference 'Foo'.")))
+            assertThat(errors, hasItem("e: [ksp] java.lang.Exception: Test Exception in process"))
         }
         project.restore("workload-jvm/build.gradle.kts")
     }
@@ -239,7 +244,9 @@ class AnnoOnProperty {
             ":workload-js:build"
         ).buildAndFail().let {
             val errors = it.output.lines().filter { it.startsWith("e: [ksp]") }
-            Assert.assertEquals("e: [ksp] java.lang.Exception: Test Exception in process", errors.first())
+
+            assertThat(errors, hasItem(containsString("Baz.kt:4: Unresolved reference 'Foo'.")))
+            assertThat(errors, hasItem("e: [ksp] java.lang.Exception: Test Exception in process"))
         }
         project.restore("workload-js/build.gradle.kts")
     }

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KotlinSymbolProcessing.kt
@@ -493,6 +493,9 @@ class KotlinSymbolProcessing(
 
         val projectDisposable: Disposable = Disposer.newDisposable("StandaloneAnalysisAPISession.project")
         var kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment? = null
+        var newKSFiles = emptyList<KSFile>()
+        var codeGenerator: CodeGenerator? = null
+
         try {
             val (analysisAPISession, env, modules) =
                 createAASession(projectDisposable)
@@ -515,7 +518,7 @@ class KotlinSymbolProcessing(
             val allKSFiles =
                 prepareAllKSFiles(env, modules, javaFileManager)
             val anyChangesWildcard = AnyChanges(kspConfig.projectBaseDir)
-            val codeGenerator = CodeGeneratorImpl(
+            codeGenerator = CodeGeneratorImpl(
                 kspConfig.classOutputDir,
                 { if (kspConfig is KSPJvmConfig) kspConfig.javaOutputDir else kspConfig.kotlinOutputDir },
                 kspConfig.kotlinOutputDir,
@@ -540,7 +543,7 @@ class KotlinSymbolProcessing(
                 kspConfig.changedClasses,
             )
             var allDirtyKSFiles = incrementalContext.calcDirtyFiles(allKSFiles).toList()
-            var newKSFiles = allDirtyKSFiles
+            newKSFiles = allDirtyKSFiles
 
             val targetPlatform = ResolverAAImpl.ktModule.targetPlatform
             val processorsRegisteredForUpcomingFeatures = mutableSetOf<SymbolProcessor>()
@@ -654,6 +657,7 @@ class KotlinSymbolProcessing(
 
             // Call onError() or finish()
             if (logger.hasError) {
+                runTypeCheck(newKSFiles, project, logger)
                 processors.forEach(SymbolProcessor::onError)
             } else {
                 processors.forEach(SymbolProcessor::finish)
@@ -671,6 +675,10 @@ class KotlinSymbolProcessing(
 
             dropCaches()
             codeGenerator.closeFiles()
+        } catch (t: Throwable) {
+            val ktFiles = getFilesOnCrash(newKSFiles, kotlinCoreProjectEnvironment?.project)
+            runTypeCheck(ktFiles, logger)
+            throw t
         } finally {
             maybeRunInWriteAction {
                 (kotlinCoreProjectEnvironment?.environment?.jarFileSystem as? CoreJarFileSystem)?.clearHandlersCache()
@@ -681,6 +689,49 @@ class KotlinSymbolProcessing(
         }
 
         return if (logger.hasError) ExitCode.PROCESSING_ERROR else ExitCode.OK
+    }
+
+    companion object {
+        fun List<KSFile>.toKtFiles(project: Project): List<KtFile> {
+            val paths: Set<Path> = this.filter { it.origin == Origin.KOTLIN }.map { File(it.filePath).toPath() }.toSet()
+           return getPsiFilesFromPaths<KtFile>(project, paths)
+        }
+
+        /**
+         * Get Last Round files on execution crash
+         *
+         * Initially trys to return the latest newKSFiles (codeGenerated files)
+         * if it doesn't find any fallback into project files from ktModule. If project is null
+         * return an emptyList
+         *
+         * @param newKSFiles Last round KSFile list
+         * @param project The current project execution
+         */
+        @OptIn(KaExperimentalApi::class, KaPlatformInterface::class)
+        fun getFilesOnCrash(newKSFiles: List<KSFile>, project: Project?): List<KtFile> {
+            if (!newKSFiles.isEmpty()) return newKSFiles.toKtFiles(project!!)
+
+            if (project == null) return emptyList()
+
+            val ktModule = try {
+                ResolverAAImpl.ktModule
+            } catch (_: Throwable) {
+                return emptyList()
+            }
+
+            return ktModule.psiRoots.filterIsInstance<KtFile>()
+        }
+
+        fun runTypeCheck(ktFiles: List<KtFile>, logger: KSPLogger) {
+            try {
+                KspDiagnostics.runTypeCheck(ktFiles, logger)
+            } catch (_: Throwable) {
+                // ignore if type check cannot proceed to avoid masking original failure
+            }
+        }
+
+        fun runTypeCheck(newKSFiles: List<KSFile>, project: Project, logger: KSPLogger) =
+            runTypeCheck(newKSFiles.toKtFiles(project), logger)
     }
 }
 

--- a/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KspDiagnostics.kt
+++ b/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/impl/KspDiagnostics.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2026 Google LLC
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+
+package com.google.devtools.ksp.impl
+
+import com.google.devtools.ksp.impl.symbol.kotlin.analyze
+import com.google.devtools.ksp.processing.KSPLogger
+import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
+import org.jetbrains.kotlin.analysis.api.diagnostics.KaSeverity
+import org.jetbrains.kotlin.psi.KtFile
+
+/**
+ * Object that holds typeChecking utils
+ */
+object KspDiagnostics {
+
+    /**
+     * Run typeChecking on a list of Kotlin Files
+     *
+     * Some of the APIs in use could throw exceptions so you need to handler errors accordingly.
+     *
+     * @param ktFiles List of files to run typecheck
+     * @param logger If analysis finds type errors it's going to log them as errors
+     */
+    fun runTypeCheck(ktFiles: Collection<KtFile>, logger: KSPLogger) {
+        if (ktFiles.isEmpty()) return
+
+        analyze {
+            for (file in ktFiles) {
+                val diagnostics = file.collectDiagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS)
+                for (diagnostic in diagnostics) {
+                    if (diagnostic.severity == KaSeverity.ERROR) {
+                        val psi = diagnostic.psi
+                        val fileLoc = psi.containingFile?.virtualFile?.path ?: psi.containingFile?.name
+                        val line = psi.containingFile?.viewProvider?.document?.getLineNumber(psi.textOffset)?.plus(1)
+                        val prefix = if (fileLoc != null && line != null) {
+                            "$fileLoc:$line: "
+                        } else if (fileLoc != null) {
+                            "$fileLoc: "
+                        } else {
+                            ""
+                        }
+                        logger.error("$prefix${diagnostic.defaultMessage}", null)
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I'm getting a few reports related to Codegeneration throwing, when diving deeper into the issue, most of the time its due to a incorrect syntax at the application level. Showing the dismissible errors when KSP fails will improve diagnostic, reducing the number of application level syntax error reports. 